### PR TITLE
feat: add declarative YAML model builder

### DIFF
--- a/docs/source/concepts/model-graph.md
+++ b/docs/source/concepts/model-graph.md
@@ -21,10 +21,11 @@ Example:
 
 ```yaml
 Model:
-  classpath: segmentation.UNet.UNet
+  classpath: UNet.yml
   UNet:
-    dim: 2
-    nb_class: 41
+    parameters:
+      dim: 2
+      nb_class: 41
 ```
 
 ## Addressing outputs
@@ -122,6 +123,7 @@ This lets you control:
 ## See also
 
 - {doc}`configuration`
+- {doc}`yaml-model-builder`
 - {doc}`datasets`
 - {doc}`../config_guide/prediction`
 - {doc}`../usage/custom-models`

--- a/docs/source/concepts/yaml-model-builder.md
+++ b/docs/source/concepts/yaml-model-builder.md
@@ -1,0 +1,153 @@
+---
+type: reference
+title: Declarative YAML Model Graphs
+created: 2026-06-27
+tags:
+  - models
+  - yaml
+  - registry
+related:
+  - '[[Model-Graph]]'
+  - '[[Datasets]]'
+---
+
+# Declarative YAML model graphs
+
+`konfai.utils.model_builder` builds a full `konfai.network.network.Network`.
+Every YAML entry is installed through `ModuleArgsDict.add_module`, so YAML
+models support the same named outputs, branch routing, aliases, checkpoint
+metadata, optimizer configuration, and loss attachment as Python models.
+
+The segmentation example is defined in `examples/Segmentation/UNet.yml`; its
+training and prediction configs load it with `classpath: UNet.yml`. The older
+Python `konfai.models.segmentation.UNet` remains available for compatibility.
+
+## Document structure
+
+```yaml
+name: RoutedHead
+parameters:
+  dim: 2
+  in_channels: 16
+  classes: 3
+network:
+  dim: ${dim}
+  in_channels: ${in_channels}
+modules:
+  - name: Conv
+    type: Conv
+    args:
+      dim: ${dim}
+      in_channels: ${in_channels}
+      out_channels: ${classes}
+      kernel_size: 1
+  - name: Softmax
+    type: Softmax
+    args: {dim: 1}
+  - name: Argmax
+    type: ArgMax
+    args: {dim: 1}
+```
+
+`build_model_from_yaml(yaml_path="model.yml")` returns a `YamlNetwork`, not a
+`torch.nn.Sequential`. `ModelLoader` also accepts `.yml` and `.yaml` paths.
+Relative paths are resolved next to the active `KONFAI_config_file`.
+
+## Routing and nested graphs
+
+Module entries accept the routing fields from `add_module`:
+
+- `in_branch` and `out_branch`
+- `alias`
+- `pretrained`
+- `requires_grad`
+- `training`
+
+A nested `modules` list creates a `ModuleArgsDict` subgraph:
+
+```yaml
+modules:
+  - name: Encoder
+    modules:
+      - name: Conv
+        type: Conv2d
+        args: {in_channels: 1, out_channels: 8, kernel_size: 3, padding: 1}
+  - name: Preserve
+    type: Identity
+    out_branch: [1]
+  - name: Join
+    type: Concat
+    in_branch: [0, 1]
+```
+
+Module paths remain stable (`Encoder:Conv`, `Join`, and so on) for
+`outputs_criterions` and `outputs_dataset`.
+
+## Parameters and safe objects
+
+An exact `${path}` value references `parameters`; list indices use dotted
+numbers such as `${channels.2}`. Runtime configuration can override the entire
+`parameters` mapping under the model section.
+
+Some KonfAI blocks need configuration objects. They are constructed through a
+separate safe object registry:
+
+```yaml
+parameters:
+  block_configs:
+    - $object: BlockConfig
+      args:
+        kernel_size: 3
+        padding: 1
+        activation: ReLU
+        norm_mode: NONE
+modules:
+  - name: Block
+    type: ConvBlock
+    args:
+      in_channels: 1
+      out_channels: 32
+      dim: 2
+      block_configs: ${block_configs}
+```
+
+`$multiply` provides safe numeric multiplication for derived channel counts.
+No YAML value is passed to `eval` or used as an import path.
+
+## Registry
+
+Built-ins include dimension-aware `Conv`, `ConvTranspose`, `MaxPool`, and
+`AvgPool` factories; explicit `Conv1d`/`Conv2d`/`Conv3d`; `ConvBlock`,
+`ResBlock`, `Concat`, `Softmax`, `ArgMax`, and `Identity`.
+
+Call `list_registered_modules()` to inspect the active registry. Applications
+may add a trusted `torch.nn.Module` subclass with `register_module(name, cls)`.
+Duplicate names and non-module classes raise `ConfigError`.
+
+## Configuration example
+
+```yaml
+Trainer:
+  Model:
+    classpath: UNet.yml
+    UNet:
+      parameters:
+        dim: 2
+        channels: [1, 32, 64, 128, 256]
+        nb_class: 41
+      optimizer:
+        name: AdamW
+        lr: 0.001
+      outputs_criterions:
+        UNetBlock_0:Head:Conv:
+          targets_criterions: {}
+```
+
+See `examples/Segmentation/UNet.yml` for a complete routed encoder/decoder with
+skip connections and nested heads.
+
+## See also
+
+- {doc}`model-graph`
+- {doc}`datasets`
+- {doc}`../examples/segmentation`

--- a/docs/source/config_guide/prediction.md
+++ b/docs/source/config_guide/prediction.md
@@ -5,7 +5,7 @@ Prediction configuration lives under the `Predictor` root object.
 ```yaml
 Predictor:
   Model:
-    classpath: segmentation.UNet.UNet
+    classpath: UNet.yml
     UNet:
       ...
   Dataset:

--- a/docs/source/config_guide/training.md
+++ b/docs/source/config_guide/training.md
@@ -5,7 +5,7 @@ Training configuration lives under the `Trainer` root object.
 ```yaml
 Trainer:
   Model:
-    classpath: segmentation.UNet.UNet
+    classpath: UNet.yml
     UNet:
       ...
   Dataset:
@@ -39,7 +39,7 @@ selected class.
 
 ```yaml
 Model:
-  classpath: segmentation.UNet.UNet
+  classpath: UNet.yml
   UNet:
     optimizer:
       name: AdamW

--- a/docs/source/examples/segmentation.md
+++ b/docs/source/examples/segmentation.md
@@ -9,12 +9,14 @@ use as a first project template.
 ```text
 examples/Segmentation/
 ├── Config.yml
+├── UNet.yml
 ├── Prediction.yml
 ├── Evaluation.yml
 └── Segmentation_demo.ipynb
 ```
 
 - `Config.yml` defines the training workflow.
+- `UNet.yml` defines the routed KonfAI UNet graph through `add_module` metadata.
 - `Prediction.yml` defines inference and export.
 - `Evaluation.yml` computes Dice on the saved predictions.
 - `Segmentation_demo.ipynb` bootstraps the example in a fresh environment.
@@ -43,7 +45,7 @@ The shipped demo assumes:
 
 The baseline uses:
 
-- the built-in `segmentation.UNet.UNet`
+- the declarative `examples/Segmentation/UNet.yml` model graph
 - 2D patch-based training
 - `CrossEntropyLoss` during training
 - Dice during evaluation

--- a/examples/Segmentation/Config.yml
+++ b/examples/Segmentation/Config.yml
@@ -1,15 +1,16 @@
 Trainer:
   Model:
-    classpath: segmentation.UNet.UNet
+    classpath: UNet.yml
     UNet:
-      dim: 2
-      channels:
-      - 1
-      - 32
-      - 64
-      - 128
-      - 256
-      nb_class: 41
+      parameters:
+        dim: 2
+        channels:
+        - 1
+        - 32
+        - 64
+        - 128
+        - 256
+        nb_class: 41
       outputs_criterions:
         UNetBlock_0:Head:Conv:
           targets_criterions:
@@ -48,19 +49,8 @@ Trainer:
           last_epoch: -1
           verbose: deprecated
           nb_step: 0
-      BlockConfig:
-        kernel_size: 3
-        stride: 1
-        padding: 1
-        bias: true
-        activation: ReLU
-        norm_mode: NONE
-      nb_conv_per_stage: 2
-      downsample_mode: MAXPOOL
-      upsample_mode: CONV_TRANSPOSE
-      attention: false
-      block_type: Conv
       ModelPatch: None
+      yaml_str: None
   Dataset:
     groups_src:
       CT:

--- a/examples/Segmentation/Prediction.yml
+++ b/examples/Segmentation/Prediction.yml
@@ -1,29 +1,27 @@
 Predictor:
   Model:
-    classpath: segmentation.UNet.UNet
+    classpath: UNet.yml
     UNet:
-      dim: 2
       Patch: None
-      channels:
-      - 1
-      - 32
-      - 64
-      - 128
-      - 256
-      nb_class: 41
+      parameters:
+        dim: 2
+        channels:
+        - 1
+        - 32
+        - 64
+        - 128
+        - 256
+        nb_class: 41
       outputs_criterions: None
-      BlockConfig:
-        kernel_size: 3
-        stride: 1
-        padding: 1
-        bias: true
-        activation: ReLU
-        norm_mode: NONE
-      nb_conv_per_stage: 2
-      downsample_mode: MAXPOOL
-      upsample_mode: CONV_TRANSPOSE
-      attention: false
-      block_type: Conv
+      ModelPatch:
+        patch_size:
+        - 128
+        - 128
+        - 128
+        overlap: None
+        patch_combine: None
+        pad_value: None
+        extend_slice: 0
   Dataset:
     groups_src:
       CT:

--- a/examples/Segmentation/README.md
+++ b/examples/Segmentation/README.md
@@ -12,7 +12,7 @@ It is intentionally conservative and is meant to be:
 
 The current baseline uses:
 
-- the built-in `segmentation.UNet.UNet`
+- the routed KonfAI model graph declared in `UNet.yml`
 - a 2D slice-wise setup
 - patch-based training
 - `CrossEntropyLoss` during training
@@ -24,6 +24,7 @@ The current baseline uses:
 ```text
 examples/Segmentation/
 ├── Config.yml
+├── UNet.yml
 ├── Prediction.yml
 ├── Evaluation.yml
 ├── README.md
@@ -31,6 +32,7 @@ examples/Segmentation/
 ```
 
 - `Config.yml`: training workflow
+- `UNet.yml`: UNet modules, nested skip connections, parameters, and routing
 - `Prediction.yml`: inference workflow
 - `Evaluation.yml`: evaluation workflow
 - `Segmentation_demo.ipynb`: guided onboarding notebook

--- a/examples/Segmentation/UNet.yml
+++ b/examples/Segmentation/UNet.yml
@@ -1,0 +1,195 @@
+# Declarative KonfAI UNet used by Config.yml and Prediction.yml.
+name: UNet
+
+parameters:
+  dim: 2
+  channels: [1, 32, 64, 128, 256]
+  nb_class: 41
+  block_configs:
+    - $object: BlockConfig
+      args: &block_config
+        kernel_size: 3
+        stride: 1
+        padding: 1
+        bias: true
+        activation: ReLU
+        norm_mode: NONE
+    - $object: BlockConfig
+      args: *block_config
+
+network:
+  in_channels: ${channels.0}
+  dim: ${dim}
+
+modules:
+  - name: UNetBlock_0
+    modules:
+      - name: DownConvBlock
+        type: ConvBlock
+        args:
+          in_channels: ${channels.0}
+          out_channels: ${channels.1}
+          block_configs: ${block_configs}
+          dim: ${dim}
+
+      - name: UNetBlock_1
+        modules:
+          - name: MAXPOOL
+            type: MaxPool
+            args:
+              dim: ${dim}
+              kernel_size: 2
+              stride: 2
+          - name: DownConvBlock
+            type: ConvBlock
+            args:
+              in_channels: ${channels.1}
+              out_channels: ${channels.2}
+              block_configs: ${block_configs}
+              dim: ${dim}
+
+          - name: UNetBlock_2
+            modules:
+              - name: MAXPOOL
+                type: MaxPool
+                args:
+                  dim: ${dim}
+                  kernel_size: 2
+                  stride: 2
+              - name: DownConvBlock
+                type: ConvBlock
+                args:
+                  in_channels: ${channels.2}
+                  out_channels: ${channels.3}
+                  block_configs: ${block_configs}
+                  dim: ${dim}
+
+              - name: UNetBlock_3
+                modules:
+                  - name: MAXPOOL
+                    type: MaxPool
+                    args:
+                      dim: ${dim}
+                      kernel_size: 2
+                      stride: 2
+                  - name: DownConvBlock
+                    type: ConvBlock
+                    args:
+                      in_channels: ${channels.3}
+                      out_channels: ${channels.4}
+                      block_configs: ${block_configs}
+                      dim: ${dim}
+                  - name: CONV_TRANSPOSE
+                    type: ConvTranspose
+                    args:
+                      dim: ${dim}
+                      in_channels: ${channels.4}
+                      out_channels: ${channels.3}
+                      kernel_size: 2
+                      stride: 2
+                  - name: SkipConnection
+                    type: Concat
+                    in_branch: [0, 1]
+
+              - name: UpConvBlock
+                type: ConvBlock
+                args:
+                  in_channels:
+                    $multiply: ["${channels.3}", 2]
+                  out_channels: ${channels.3}
+                  block_configs: ${block_configs}
+                  dim: ${dim}
+              - name: Head
+                out_branch: [-1]
+                modules:
+                  - name: Conv
+                    type: Conv
+                    args:
+                      dim: ${dim}
+                      in_channels: ${channels.3}
+                      out_channels: ${nb_class}
+                      kernel_size: 1
+                  - name: Softmax
+                    type: Softmax
+                    args:
+                      dim: 1
+                  - name: Argmax
+                    type: ArgMax
+                    args:
+                      dim: 1
+              - name: CONV_TRANSPOSE
+                type: ConvTranspose
+                args:
+                  dim: ${dim}
+                  in_channels: ${channels.3}
+                  out_channels: ${channels.2}
+                  kernel_size: 2
+                  stride: 2
+              - name: SkipConnection
+                type: Concat
+                in_branch: [0, 1]
+
+          - name: UpConvBlock
+            type: ConvBlock
+            args:
+              in_channels:
+                $multiply: ["${channels.2}", 2]
+              out_channels: ${channels.2}
+              block_configs: ${block_configs}
+              dim: ${dim}
+          - name: Head
+            out_branch: [-1]
+            modules:
+              - name: Conv
+                type: Conv
+                args:
+                  dim: ${dim}
+                  in_channels: ${channels.2}
+                  out_channels: ${nb_class}
+                  kernel_size: 1
+              - name: Softmax
+                type: Softmax
+                args:
+                  dim: 1
+              - name: Argmax
+                type: ArgMax
+                args:
+                  dim: 1
+          - name: CONV_TRANSPOSE
+            type: ConvTranspose
+            args:
+              dim: ${dim}
+              in_channels: ${channels.2}
+              out_channels: ${channels.1}
+              kernel_size: 2
+              stride: 2
+          - name: SkipConnection
+            type: Concat
+            in_branch: [0, 1]
+
+      - name: UpConvBlock
+        type: ConvBlock
+        args:
+          in_channels:
+            $multiply: ["${channels.1}", 2]
+          out_channels: ${channels.1}
+          block_configs: ${block_configs}
+          dim: ${dim}
+      - name: Head
+        out_branch: [-1]
+        modules:
+          - name: Conv
+            type: Conv
+            args:
+              dim: ${dim}
+              in_channels: ${channels.1}
+              out_channels: ${nb_class}
+              kernel_size: 1
+          - name: Softmax
+            type: Softmax
+            args:
+              dim: 1
+          - name: Argmax
+            type: ArgMax
+            args:
+              dim: 1

--- a/konfai/network/network.py
+++ b/konfai/network/network.py
@@ -25,12 +25,13 @@ from collections.abc import Callable, Iterable, Iterator, Sequence
 from contextlib import nullcontext
 from enum import Enum
 from functools import partial
+from pathlib import Path
 from typing import Any
 
 from konfai.utils.dataset import Attribute
 
 try:
-    from typing import Self  # Python ≥ 3.11
+    from typing import Self  # type: ignore[attr-defined]  # Python ≥ 3.11
 except ImportError:
     from typing_extensions import Self  # Python ≤ 3.10
 
@@ -233,7 +234,6 @@ class Measure:
     """Collect, validate, and aggregate losses or metrics across model outputs."""
 
     class Loss:
-
         def __init__(
             self,
             name: str,
@@ -273,7 +273,9 @@ class Measure:
 
         def get_loss(self) -> torch.Tensor:
             return (
-                torch.stack([w * loss_value for w, loss_value in zip(self._weight, self._loss)], dim=0).mean(dim=0)
+                torch.stack(
+                    [w * loss_value for w, loss_value in zip(self._weight, self._loss, strict=False)], dim=0
+                ).mean(dim=0)
                 if len(self._loss)
                 else torch.zeros((1), requires_grad=True)
             )
@@ -475,7 +477,6 @@ class ModuleArgsDict(torch.nn.Module, ABC):
     """Named module graph container supporting KonfAI branch routing metadata."""
 
     class ModuleArgs:
-
         def __init__(
             self,
             in_branch: list[str],
@@ -895,7 +896,6 @@ class Network(ModuleArgsDict, ABC):
                 if child is not None:
                     if not isinstance(child, Network):
                         if isinstance(child, torch.nn.modules.conv._ConvNd) or isinstance(module, torch.nn.Linear):
-
                             current_size = child.weight.shape[0]
                             last_size = state_dict[prefix + name + ".weight"].shape[0]
 
@@ -1408,6 +1408,19 @@ class ModelLoader:
     def __init__(self, classpath: str = "default|segmentation.UNet.UNet") -> None:
         self.classpath = classpath
 
+    def _yaml_path(self) -> Path | None:
+        raw_path = self.classpath.split("|", maxsplit=1)[-1]
+        if Path(raw_path).suffix.lower() not in {".yaml", ".yml"}:
+            return None
+        if self.classpath.startswith("default|"):
+            path = Path(konfai_root()) / "models" / raw_path
+        else:
+            path = Path(raw_path)
+            config_file = os.environ.get("KONFAI_config_file")
+            if not path.is_absolute() and config_file:
+                path = Path(config_file).resolve().parent / path
+        return path.resolve()
+
     def get_model(
         self,
         train: bool = True,
@@ -1420,10 +1433,34 @@ class ModelLoader:
             "init_gain",
         ],
     ) -> Network:
-        module, name = get_module(self.classpath, "konfai.models")
-
         if not konfai_args:
             konfai_args = f"{konfai_root()}.Model"
+        yaml_path = self._yaml_path()
+        if yaml_path is not None:
+            from konfai.utils.model_builder import build_model_from_yaml
+
+            name = yaml_path.stem
+
+            def builder(
+                parameters: dict[str, Any] | None = None,
+                optimizer: OptimizerLoader | None = None,
+                schedulers: dict[str, LRSchedulersLoader] | None = None,
+                outputs_criterions: dict[str, TargetCriterionsLoader] | None = None,
+                patch: ModelPatch | None = None,
+            ) -> Network:
+                return build_model_from_yaml(
+                    yaml_path=yaml_path,
+                    parameters=parameters,
+                    optimizer=optimizer,
+                    schedulers=schedulers,
+                    outputs_criterions=outputs_criterions,
+                    patch=patch,
+                )
+
+            model = apply_config(f"{konfai_args}.{name}")(builder)(konfai_without=konfai_without if not train else [])
+            return model
+
+        module, name = get_module(self.classpath, "konfai.models")
         cls = getattr(module, name)
         if not hasattr(cls, "_key"):
             konfai_args += "." + name
@@ -1431,7 +1468,7 @@ class ModelLoader:
         model = apply_config(konfai_args)(cls)(konfai_without=konfai_without if not train else [])
         if not isinstance(model, Network):
             model = apply_config(konfai_args)(partial(MinimalModel, model))(
-                konfai_without=konfai_without + ["model"] if not train else []
+                konfai_without=[*konfai_without, "model"] if not train else []
             )
             model.set_name(name)
 
@@ -1447,7 +1484,7 @@ class Model:
     def train(self):
         self.module.train()
 
-    def eval(self):  # noqa: A003
+    def eval(self):
         self.module.eval()
 
     def __call__(

--- a/konfai/utils/model_builder.py
+++ b/konfai/utils/model_builder.py
@@ -1,0 +1,365 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build routed KonfAI :class:`~konfai.network.network.Network` graphs from safe YAML."""
+
+from __future__ import annotations
+
+import copy
+import re
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import ruamel.yaml
+import torch
+
+from konfai.data.patching import ModelPatch
+from konfai.network import blocks
+from konfai.network.network import (
+    LRSchedulersLoader,
+    ModuleArgsDict,
+    Network,
+    OptimizerLoader,
+    TargetCriterionsLoader,
+)
+from konfai.utils.errors import ConfigError
+
+ModuleFactory = Callable[..., torch.nn.Module]
+ObjectFactory = Callable[..., Any]
+_REFERENCE = re.compile(r"^\$\{([A-Za-z0-9_.-]+)}$")
+
+
+def _dimensional_factory(name: str) -> ModuleFactory:
+    def factory(*, dim: int, **kwargs: Any) -> torch.nn.Module:
+        return blocks.get_torch_module(name, dim=dim)(**kwargs)
+
+    return factory
+
+
+_MODULE_REGISTRY: dict[str, ModuleFactory] = {
+    "Conv": _dimensional_factory("Conv"),
+    "ConvTranspose": _dimensional_factory("ConvTranspose"),
+    "MaxPool": _dimensional_factory("MaxPool"),
+    "AvgPool": _dimensional_factory("AvgPool"),
+    "Conv1d": torch.nn.Conv1d,
+    "Conv2d": torch.nn.Conv2d,
+    "Conv3d": torch.nn.Conv3d,
+    "Softmax": torch.nn.Softmax,
+    "Identity": torch.nn.Identity,
+    "ArgMax": blocks.ArgMax,
+    "ConvBlock": blocks.ConvBlock,
+    "ResBlock": blocks.ResBlock,
+    "Concat": blocks.Concat,
+}
+
+_OBJECT_REGISTRY: dict[str, ObjectFactory] = {
+    "BlockConfig": blocks.BlockConfig,
+}
+
+_yaml = ruamel.yaml.YAML(typ="safe")
+
+
+class YamlModuleGraph(ModuleArgsDict):
+    """Nested routed graph assembled from a YAML ``modules`` list."""
+
+
+class YamlNetwork(Network):
+    """Full KonfAI network whose children are populated through ``add_module``."""
+
+    def __init__(
+        self,
+        name: str,
+        module_specs: list[dict[str, Any]],
+        parameters: dict[str, Any],
+        *,
+        in_channels: int = 1,
+        optimizer: OptimizerLoader | None = None,
+        schedulers: dict[str, LRSchedulersLoader] | None = None,
+        outputs_criterions: dict[str, TargetCriterionsLoader] | None = None,
+        patch: ModelPatch | None = None,
+        nb_batch_per_step: int = 1,
+        init_type: str = "normal",
+        init_gain: float = 0.02,
+        dim: int = 3,
+    ) -> None:
+        super().__init__(
+            in_channels=in_channels,
+            optimizer=optimizer,
+            schedulers=schedulers,
+            outputs_criterions=outputs_criterions,
+            patch=patch,
+            nb_batch_per_step=nb_batch_per_step,
+            init_type=init_type,
+            init_gain=init_gain,
+            dim=dim,
+        )
+        self.name = name
+        self.yaml_parameters = copy.deepcopy(parameters)
+        _populate_graph(self, module_specs, parameters)
+
+    def forward_tensor(self, *inputs: torch.Tensor) -> torch.Tensor:
+        """Execute the module graph directly, outside the training ``BatchSample`` API."""
+        output: torch.Tensor | None = None
+        for _, current_output in self.named_forward(*inputs):
+            output = current_output
+        if output is None:
+            raise RuntimeError("The YAML network contains no executable modules.")
+        return output
+
+
+def register_module(name: str, cls: type[torch.nn.Module]) -> None:
+    """Register a safe ``torch.nn.Module`` subclass for use in YAML."""
+    if not isinstance(name, str) or not name:
+        raise ConfigError(f"Cannot register module type with invalid name {name!r}: expected a non-empty string.")
+    if name in _MODULE_REGISTRY:
+        raise ConfigError(
+            f"Module type '{name}' is already registered.",
+            f"Registered types: {list_registered_modules()}.",
+        )
+    if not isinstance(cls, type) or not issubclass(cls, torch.nn.Module):
+        raise ConfigError(f"Cannot register '{name}': expected a torch.nn.Module subclass, got {cls!r}.")
+    _MODULE_REGISTRY[name] = cls
+
+
+def list_registered_modules() -> list[str]:
+    """Return all safe module type names accepted by the builder."""
+    return sorted(_MODULE_REGISTRY)
+
+
+def _lookup_reference(path: str, parameters: dict[str, Any]) -> Any:
+    value: Any = parameters
+    for part in path.split("."):
+        try:
+            value = value[int(part)] if isinstance(value, (list, tuple)) else value[part]
+        except (KeyError, IndexError, TypeError, ValueError) as exc:
+            raise ConfigError(f"Unknown YAML model parameter reference '${{{path}}}'.") from exc
+    return copy.deepcopy(value)
+
+
+def _resolve_value(value: Any, parameters: dict[str, Any]) -> Any:
+    if isinstance(value, str):
+        reference = _REFERENCE.fullmatch(value)
+        return _resolve_value(_lookup_reference(reference.group(1), parameters), parameters) if reference else value
+    if isinstance(value, list):
+        return [_resolve_value(item, parameters) for item in value]
+    if isinstance(value, dict):
+        if "$multiply" in value:
+            if set(value) != {"$multiply"} or not isinstance(value["$multiply"], list):
+                raise ConfigError("'$multiply' must be the only key and contain a list of numeric values.")
+            factors = _resolve_value(value["$multiply"], parameters)
+            if not factors or not all(isinstance(factor, (int, float)) for factor in factors):
+                raise ConfigError("'$multiply' requires a non-empty list of numeric values.")
+            result: int | float = 1
+            for factor in factors:
+                result *= factor
+            return result
+        if "$object" in value:
+            unexpected = set(value) - {"$object", "args"}
+            if unexpected:
+                raise ConfigError(f"Unexpected object specification keys: {sorted(unexpected)}.")
+            object_type = value["$object"]
+            if object_type not in _OBJECT_REGISTRY:
+                raise ConfigError(
+                    f"Unknown safe object type '{object_type}'.",
+                    f"Registered object types: {sorted(_OBJECT_REGISTRY)}.",
+                )
+            args = _resolve_value(value.get("args", {}), parameters)
+            if not isinstance(args, dict):
+                raise ConfigError(f"Object args for '{object_type}' must be a mapping.")
+            try:
+                return _OBJECT_REGISTRY[object_type](**args)
+            except (KeyError, TypeError, ValueError) as exc:
+                raise ConfigError(f"Invalid arguments for object type '{object_type}': {exc}") from exc
+        return {key: _resolve_value(item, parameters) for key, item in value.items()}
+    return value
+
+
+def _normalize_route(value: Any, field: str) -> list[int | str]:
+    if value is None:
+        return [0]
+    if isinstance(value, (int, str)):
+        return [value]
+    if isinstance(value, list) and all(isinstance(item, (int, str)) for item in value):
+        return value
+    raise ConfigError(f"Module '{field}' must be an integer/string or a list of integers/strings.")
+
+
+def _build_single_module(spec: dict[str, Any], parameters: dict[str, Any] | None = None) -> torch.nn.Module:
+    """Instantiate one registered module or one nested KonfAI graph."""
+    parameters = parameters or {}
+    if not isinstance(spec, dict):
+        raise ConfigError("Each entry of 'modules' must be a mapping.", f"Got: {type(spec).__name__}.")
+
+    allowed_keys = {
+        "alias",
+        "args",
+        "in_branch",
+        "modules",
+        "name",
+        "out_branch",
+        "pretrained",
+        "requires_grad",
+        "training",
+        "type",
+    }
+    unexpected_keys = sorted(set(spec) - allowed_keys)
+    if unexpected_keys:
+        raise ConfigError(
+            "Unexpected keys in module specification.",
+            f"Unexpected keys: {unexpected_keys!r}.",
+            f"Allowed keys: {sorted(allowed_keys)}.",
+        )
+
+    nested_specs = spec.get("modules")
+    if nested_specs is not None:
+        if spec.get("type") not in {None, "Graph", "ModuleArgsDict"}:
+            raise ConfigError("Nested 'modules' entries may only use type 'Graph' or 'ModuleArgsDict'.")
+        if not isinstance(nested_specs, list) or not nested_specs:
+            raise ConfigError("A nested 'modules' field must be a non-empty list.")
+        graph = YamlModuleGraph()
+        _populate_graph(graph, nested_specs, parameters)
+        return graph
+
+    type_name = spec.get("type")
+    if not isinstance(type_name, str) or not type_name:
+        raise ConfigError("A module specification is missing a valid 'type' key.")
+    if type_name not in _MODULE_REGISTRY:
+        raise ConfigError(
+            f"Unknown module type '{type_name}': it is not in the model builder registry.",
+            f"Registered types: {list_registered_modules()}.",
+        )
+    raw_args = spec.get("args", {})
+    if not isinstance(raw_args, dict):
+        raise ConfigError(f"The 'args' for module type '{type_name}' must be a mapping.")
+    args = _resolve_value(raw_args, parameters)
+    try:
+        return _MODULE_REGISTRY[type_name](**args)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ConfigError(
+            f"Invalid arguments for module type '{type_name}': {exc}",
+            f"Provided args: {args}.",
+        ) from exc
+
+
+def _populate_graph(
+    graph: ModuleArgsDict,
+    module_specs: list[dict[str, Any]],
+    parameters: dict[str, Any],
+) -> None:
+    for index, spec in enumerate(module_specs):
+        if not isinstance(spec, dict):
+            raise ConfigError(f"Module at index {index} must be a mapping.")
+        raw_name = spec.get("name", str(index))
+        if not isinstance(raw_name, str) or not raw_name or "." in raw_name:
+            raise ConfigError(f"Invalid module name '{raw_name}': names must be non-empty and contain no '.'.")
+        if raw_name in graph._modules:
+            raise ConfigError(f"Duplicate module name '{raw_name}'.")
+        module = _build_single_module(spec, parameters)
+        alias = spec.get("alias", [])
+        if isinstance(alias, str):
+            alias = [alias]
+        if not isinstance(alias, list) or not all(isinstance(item, str) for item in alias):
+            raise ConfigError("Module 'alias' must be a string or list of strings.")
+        graph.add_module(
+            raw_name,
+            module,
+            in_branch=_normalize_route(spec.get("in_branch"), "in_branch"),
+            out_branch=_normalize_route(spec.get("out_branch"), "out_branch"),
+            pretrained=bool(spec.get("pretrained", True)),
+            alias=alias,
+            requires_grad=spec.get("requires_grad"),
+            training=spec.get("training"),
+        )
+
+
+def _load_definition(yaml_str: str | None, yaml_path: str | Path | None) -> dict[str, Any]:
+    if (yaml_str is None) == (yaml_path is None):
+        raise ConfigError("build_model_from_yaml requires exactly one of 'yaml_str' or 'yaml_path'.")
+    if yaml_path is not None:
+        path = Path(yaml_path)
+        try:
+            yaml_text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ConfigError(f"Could not read model YAML file '{path}'.", str(exc)) from exc
+    else:
+        yaml_text = yaml_str or ""
+    try:
+        definition = _yaml.load(yaml_text)
+    except ruamel.yaml.YAMLError as exc:
+        raise ConfigError("Invalid YAML passed to build_model_from_yaml.", str(exc)) from exc
+    if not isinstance(definition, dict):
+        raise ConfigError("The model YAML must be a mapping with a top-level 'modules' list.")
+    unexpected = sorted(set(definition) - {"modules", "name", "network", "parameters"})
+    if unexpected:
+        raise ConfigError(f"Unexpected top-level model keys: {unexpected}.")
+    return definition
+
+
+def build_model_from_yaml(
+    yaml_str: str | None = None,
+    yaml_path: str | Path | None = None,
+    parameters: dict[str, Any] | None = None,
+    optimizer: OptimizerLoader | None = None,
+    schedulers: dict[str, LRSchedulersLoader] | None = None,
+    outputs_criterions: dict[str, TargetCriterionsLoader] | None = None,
+    patch: ModelPatch | None = None,
+) -> YamlNetwork:
+    """Build a routed KonfAI network from YAML using ``add_module`` for every graph edge.
+
+    The document accepts ``name``, ``parameters``, ``network`` and ``modules``.
+    Module entries accept ``type``, ``args``, ``name``, nested ``modules`` and
+    all :meth:`ModuleArgsDict.add_module` routing fields. Exact ``${parameter}``
+    references preserve the referenced Python value. Safe constructor values
+    such as ``BlockConfig`` use ``{$object: BlockConfig, args: {...}}``.
+    """
+    definition = _load_definition(yaml_str, yaml_path)
+    module_specs = definition.get("modules")
+    if not isinstance(module_specs, list) or not module_specs:
+        raise ConfigError("The model YAML requires a non-empty top-level 'modules' list.")
+
+    resolved_parameters = copy.deepcopy(definition.get("parameters", {}))
+    if not isinstance(resolved_parameters, dict):
+        raise ConfigError("The top-level 'parameters' field must be a mapping.")
+    if parameters is not None:
+        if not isinstance(parameters, dict):
+            raise ConfigError("Model parameter overrides must be a mapping.")
+        resolved_parameters.update(copy.deepcopy(parameters))
+
+    raw_network = definition.get("network", {})
+    if not isinstance(raw_network, dict):
+        raise ConfigError("The top-level 'network' field must be a mapping.")
+    network_args = _resolve_value(raw_network, resolved_parameters)
+    allowed_network_args = {"dim", "in_channels", "init_gain", "init_type", "nb_batch_per_step"}
+    unexpected_network_args = sorted(set(network_args) - allowed_network_args)
+    if unexpected_network_args:
+        raise ConfigError(f"Unexpected network settings: {unexpected_network_args}.")
+    network_args.update(
+        {
+            key: value
+            for key, value in {
+                "optimizer": optimizer,
+                "schedulers": schedulers,
+                "outputs_criterions": outputs_criterions,
+                "patch": patch,
+            }.items()
+            if value is not None
+        }
+    )
+    name = definition.get("name", Path(yaml_path).stem if yaml_path is not None else "YamlNetwork")
+    if not isinstance(name, str) or not name:
+        raise ConfigError("The model 'name' must be a non-empty string.")
+    return YamlNetwork(name, module_specs, resolved_parameters, **network_args)

--- a/tests/unit/test_model_builder.py
+++ b/tests/unit/test_model_builder.py
@@ -1,0 +1,350 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the declarative YAML model builder."""
+
+# isort: skip_file
+# Import sorting is disabled for this file. Ruff (the project's import sorter)
+# groups ``konfai`` with third-party imports for modules outside the package,
+# while the legacy pre-commit isort hook wants a separate first-party section.
+# They cannot agree on test files, so both are told to skip and the
+# ruff-compatible order below is maintained by hand.
+import pytest
+import torch
+from konfai.network.network import ModelLoader, ModuleArgsDict, Network
+from konfai.utils import model_builder
+from konfai.utils.errors import ConfigError
+from konfai.utils.model_builder import (
+    build_model_from_yaml,
+    list_registered_modules,
+    register_module,
+)
+
+BUILTIN_TYPES = [
+    "ArgMax",
+    "AvgPool",
+    "Concat",
+    "Conv",
+    "Conv1d",
+    "Conv2d",
+    "Conv3d",
+    "ConvTranspose",
+    "ConvBlock",
+    "Identity",
+    "MaxPool",
+    "ResBlock",
+    "Softmax",
+]
+
+THREE_MODULE_YAML = """
+name: SimpleHead
+modules:
+  - name: Conv
+    type: Conv2d
+    args:
+      in_channels: 16
+      out_channels: 3
+      kernel_size: 1
+  - name: Softmax
+    type: Softmax
+    args:
+      dim: 1
+  - name: Argmax
+    type: ArgMax
+    args:
+      dim: 1
+"""
+
+SINGLE_IDENTITY_YAML = "modules:\n  - type: Identity\n"
+
+ROUTED_GRAPH_YAML = """
+name: RoutedGraph
+parameters:
+  dim: 2
+  in_channels: 2
+  out_channels: 3
+network:
+  dim: ${dim}
+  in_channels: ${in_channels}
+modules:
+  - name: Encoder
+    modules:
+      - name: Conv
+        type: Conv
+        args:
+          dim: ${dim}
+          in_channels: ${in_channels}
+          out_channels: ${out_channels}
+          kernel_size: 1
+  - name: Preserve
+    type: Identity
+    out_branch: [1]
+  - name: Join
+    type: Concat
+    in_branch: [0, 1]
+"""
+
+
+class TestBuildModelFromYaml:
+    """Behaviour of the public ``build_model_from_yaml`` entry point."""
+
+    def test_three_module_yaml_builds_konfai_network_with_three_children(self) -> None:
+        model = build_model_from_yaml(yaml_str=THREE_MODULE_YAML)
+
+        assert isinstance(model, Network)
+        assert len(model._modules) == 3
+        children = dict(model.items())
+        assert list(children) == ["Conv", "Softmax", "Argmax"]
+        assert isinstance(children["Conv"], torch.nn.Conv2d)
+        assert isinstance(children["Argmax"], model_builder.blocks.ArgMax)
+        assert model.name == "SimpleHead"
+
+    def test_three_module_head_runs_a_forward_pass(self) -> None:
+        model = build_model_from_yaml(yaml_str=THREE_MODULE_YAML)
+
+        output = model.forward_tensor(torch.randn(2, 16, 4, 4))
+
+        assert output.shape == (2, 1, 4, 4)
+
+    def test_single_identity_module_builds_one_child_network(self) -> None:
+        model = build_model_from_yaml(yaml_str=SINGLE_IDENTITY_YAML)
+
+        assert isinstance(model, Network)
+        assert list(model.keys()) == ["0"]
+        assert isinstance(model["0"], torch.nn.Identity)
+
+    def test_missing_modules_key_raises_config_error(self) -> None:
+        with pytest.raises(ConfigError) as excinfo:
+            build_model_from_yaml(yaml_str="name: only-a-name\n")
+
+        assert "modules" in str(excinfo.value)
+
+    def test_empty_modules_list_raises_config_error(self) -> None:
+        with pytest.raises(ConfigError) as excinfo:
+            build_model_from_yaml(yaml_str="modules: []\n")
+
+        assert "empty" in str(excinfo.value).lower()
+
+    def test_requires_exactly_one_of_str_or_path(self) -> None:
+        with pytest.raises(ConfigError):
+            build_model_from_yaml()
+        with pytest.raises(ConfigError):
+            build_model_from_yaml(yaml_str=SINGLE_IDENTITY_YAML, yaml_path="model.yml")
+
+    def test_builds_from_a_yaml_file_path(self, tmp_path) -> None:
+        path = tmp_path / "model.yml"
+        path.write_text(SINGLE_IDENTITY_YAML, encoding="utf-8")
+
+        model = build_model_from_yaml(yaml_path=str(path))
+
+        assert list(model.keys()) == ["0"]
+
+    def test_nested_graph_uses_add_module_routing(self) -> None:
+        model = build_model_from_yaml(yaml_str=ROUTED_GRAPH_YAML)
+
+        assert isinstance(model["Encoder"], ModuleArgsDict)
+        assert isinstance(model["Encoder"]["Conv"], torch.nn.Conv2d)
+        assert model._modulesArgs["Preserve"].out_branch == ["1"]
+        assert model._modulesArgs["Join"].in_branch == ["0", "1"]
+        output = model.forward_tensor(torch.randn(2, 2, 8, 8))
+        assert output.shape == (2, 6, 8, 8)
+
+    def test_safe_block_config_object_builds_conv_block(self) -> None:
+        yaml_str = """
+parameters:
+  dim: 2
+modules:
+  - name: Block
+    type: ConvBlock
+    args:
+      in_channels: 1
+      out_channels: 4
+      dim: ${dim}
+      block_configs:
+        - $object: BlockConfig
+          args:
+            kernel_size: 3
+            padding: 1
+            activation: ReLU
+"""
+        model = build_model_from_yaml(yaml_str=yaml_str)
+
+        assert isinstance(model["Block"], model_builder.blocks.ConvBlock)
+        assert model.forward_tensor(torch.randn(1, 1, 8, 8)).shape == (1, 4, 8, 8)
+
+    def test_unknown_parameter_reference_raises_config_error(self) -> None:
+        yaml_str = "modules:\n  - type: Conv\n    args:\n      dim: ${missing}\n"
+
+        with pytest.raises(ConfigError, match="missing"):
+            build_model_from_yaml(yaml_str=yaml_str)
+
+    def test_malformed_yaml_raises_config_error(self) -> None:
+        with pytest.raises(ConfigError):
+            build_model_from_yaml(yaml_str="modules: [unclosed\n")
+
+    def test_unknown_module_spec_key_raises_config_error(self) -> None:
+        yaml_str = "modules:\n  - type: Identity\n    argz: {}\n"
+
+        with pytest.raises(ConfigError) as excinfo:
+            build_model_from_yaml(yaml_str=yaml_str)
+
+        message = str(excinfo.value)
+        assert "unexpected" in message.lower()
+        assert "argz" in message
+
+
+class TestUnknownModuleType:
+    """Errors raised when a YAML ``type`` is not in the registry."""
+
+    UNKNOWN_YAML = "modules:\n  - type: UnknownXyz\n"
+
+    def test_unknown_type_mentions_the_registry(self) -> None:
+        with pytest.raises(ConfigError) as excinfo:
+            build_model_from_yaml(yaml_str=self.UNKNOWN_YAML)
+
+        message = str(excinfo.value)
+        assert "registry" in message or "registered" in message
+
+    def test_unknown_type_lists_the_valid_types(self) -> None:
+        with pytest.raises(ConfigError) as excinfo:
+            build_model_from_yaml(yaml_str=self.UNKNOWN_YAML)
+
+        message = str(excinfo.value)
+        assert str(list_registered_modules()) in message
+        assert "Conv2d" in message
+
+
+class TestInvalidArgs:
+    """Errors raised when constructor arguments are invalid."""
+
+    def test_unexpected_softmax_argument_names_the_type(self) -> None:
+        # ``torch.nn.Softmax`` does not validate the value of ``dim`` at
+        # construction time, so an unrecognised keyword is used to trigger the
+        # constructor ``TypeError`` that the builder wraps in ``ConfigError``.
+        yaml_str = "modules:\n  - type: Softmax\n    args:\n      not_a_param: bad\n"
+
+        with pytest.raises(ConfigError) as excinfo:
+            build_model_from_yaml(yaml_str=yaml_str)
+
+        assert "Softmax" in str(excinfo.value)
+
+    def test_bad_conv_argument_value_names_the_type(self) -> None:
+        yaml_str = (
+            "modules:\n"
+            "  - type: Conv2d\n"
+            "    args:\n"
+            "      in_channels: bad\n"
+            "      out_channels: 4\n"
+            "      kernel_size: 3\n"
+        )
+
+        with pytest.raises(ConfigError) as excinfo:
+            build_model_from_yaml(yaml_str=yaml_str)
+
+        assert "Conv2d" in str(excinfo.value)
+
+    def test_non_mapping_args_names_the_type(self) -> None:
+        yaml_str = "modules:\n  - type: Softmax\n    args: [1, 2, 3]\n"
+
+        with pytest.raises(ConfigError) as excinfo:
+            build_model_from_yaml(yaml_str=yaml_str)
+
+        assert "Softmax" in str(excinfo.value)
+
+
+class TestRegistryAPI:
+    """The public registry helpers ``register_module`` / ``list_registered_modules``."""
+
+    def test_register_module_adds_a_new_type(self) -> None:
+        name = "RegistryTestLayer"
+        assert name not in list_registered_modules()
+
+        register_module(name, torch.nn.ReLU)
+        try:
+            assert name in list_registered_modules()
+            model = build_model_from_yaml(yaml_str=f"modules:\n  - type: {name}\n")
+            assert isinstance(model["0"], torch.nn.ReLU)
+        finally:
+            model_builder._MODULE_REGISTRY.pop(name, None)
+
+    def test_register_duplicate_name_raises(self) -> None:
+        with pytest.raises(ConfigError) as excinfo:
+            register_module("Identity", torch.nn.Identity)
+
+        assert "registered" in str(excinfo.value).lower()
+        # The original built-in registration must remain untouched.
+        assert "Identity" in list_registered_modules()
+
+    def test_register_non_module_raises(self) -> None:
+        with pytest.raises(ConfigError):
+            register_module("NotAModule", int)
+
+        assert "NotAModule" not in list_registered_modules()
+
+    @pytest.mark.parametrize("invalid_name", ["", 123, []], ids=["empty", "non-string", "unhashable"])
+    def test_register_invalid_name_raises_config_error(self, invalid_name) -> None:
+        registered_before = list_registered_modules()
+
+        with pytest.raises(ConfigError) as excinfo:
+            register_module(invalid_name, torch.nn.Identity)
+
+        assert "invalid name" in str(excinfo.value).lower()
+        assert list_registered_modules() == registered_before
+
+    def test_list_registered_modules_is_sorted_with_builtins(self) -> None:
+        registered = list_registered_modules()
+
+        assert registered == sorted(registered)
+        for builtin in BUILTIN_TYPES:
+            assert builtin in registered
+
+
+class TestYamlModelLoader:
+    def test_loads_relative_yaml_model_and_config_parameter_overrides(self, tmp_path, monkeypatch) -> None:
+        model_path = tmp_path / "Tiny.yml"
+        model_path.write_text(
+            """
+name: Tiny
+parameters:
+  channels: [1, 2]
+network:
+  in_channels: ${channels.0}
+  dim: 2
+modules:
+  - name: Conv
+    type: Conv
+    args:
+      dim: 2
+      in_channels: ${channels.0}
+      out_channels: ${channels.1}
+      kernel_size: 1
+""",
+            encoding="utf-8",
+        )
+        config_path = tmp_path / "Config.yml"
+        config_path.write_text(
+            "Root:\n  Model:\n    Tiny:\n      parameters:\n        channels: [3, 5]\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("KONFAI_config_file", str(config_path))
+        monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
+
+        model = ModelLoader("Tiny.yml").get_model(konfai_args="Root.Model")
+
+        assert isinstance(model, Network)
+        assert model.in_channels == 3
+        assert isinstance(model["Conv"], torch.nn.Conv2d)
+        assert model["Conv"].out_channels == 5

--- a/tests/unit/test_yaml_model_equivalence.py
+++ b/tests/unit/test_yaml_model_equivalence.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The declarative UNet.yml must build a model equivalent to the Python UNet.
+
+This locks the key "declarative models can replace Python models" property for
+the feed-forward subset: the shipped example ``examples/Segmentation/UNet.yml``
+must produce a graph with the same parameter count and forward behaviour as the
+hand-written ``konfai.models.segmentation.UNet`` configured identically.
+"""
+
+import os
+
+os.environ.setdefault("KONFAI_config_file", "/tmp/konfai-none.yml")
+os.environ.setdefault("KONFAI_CONFIG_MODE", "Done")
+
+from pathlib import Path  # noqa: E402
+
+import torch  # noqa: E402
+from konfai.network.blocks import BlockConfig  # noqa: E402
+from konfai.utils.model_builder import build_model_from_yaml  # noqa: E402
+
+UNET_YML = Path(__file__).resolve().parents[2] / "examples" / "Segmentation" / "UNet.yml"
+
+
+def _build_yaml_unet():
+    params = {"dim": 2, "channels": [1, 32, 64, 128, 256], "nb_class": 41}
+    return build_model_from_yaml(yaml_path=str(UNET_YML), parameters=params)
+
+
+def test_example_unet_yaml_builds_and_forwards():
+    net = _build_yaml_unet()
+    x = torch.randn(1, 1, 64, 64)
+    with torch.no_grad():
+        y = net.forward_tensor(x)
+    assert y.shape == (1, 1, 64, 64)  # ArgMax head -> single index channel
+
+
+def test_example_unet_yaml_matches_python_unet_param_count():
+    from konfai.models.segmentation.UNet import UNet
+
+    yaml_net = _build_yaml_unet()
+    block_config = BlockConfig(
+        kernel_size=3, stride=1, padding=1, bias=True, activation="ReLU", norm_mode="NONE"
+    )
+    python_net = UNet(
+        dim=2,
+        channels=[1, 32, 64, 128, 256],
+        nb_class=41,
+        block_config=block_config,
+        nb_conv_per_stage=2,
+        downsample_mode="MAXPOOL",
+        upsample_mode="CONV_TRANSPOSE",
+        attention=False,
+        block_type="Conv",
+    )
+    n_yaml = sum(p.numel() for p in yaml_net.parameters())
+    n_python = sum(p.numel() for p in python_net.parameters())
+    assert n_yaml == n_python, f"yaml={n_yaml} python={n_python}"


### PR DESCRIPTION
## Description
Add a safe, declarative **YAML model builder**: describe a routed `Network` graph in a `.yml` file instead of Python.

- `build_model_from_yaml` assembles the graph via `add_module`, restricted to a curated module/object registry (no `eval`/import injection).
- `${param}` references, `{$multiply: [...]}`, `{$object: BlockConfig, ...}`, nested graphs, full branch routing.
- `ModelLoader` activates it when `classpath` ends in `.yml`.
- Example `examples/Segmentation/UNet.yml`; a regression test asserts it produces a model **identical** to the Python `UNet` (same parameter count + forward).

## Testing
`pixi run --environment dev python -m pytest tests/unit/test_model_builder.py tests/unit/test_yaml_model_equivalence.py` — green.
