### PR TITLE
Audit fixes, validation_augmentations, and konfai-apps dependency decoupling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,14 @@ Both are first-class dataset backends, dispatched by `file_format` and reachable
 
 So: **the YAML builder complements `models/` today and can replace the feed-forward subset after the registry is expanded.** See AUDIT.md for the migration plan.
 
+**Model → YAML migration matrix** (how much of each zoo model the builder can express today):
+
+| Model | Migratable now? | Blocker |
+|---|---|---|
+| UNet, NestedUNet/UNet++, ResNet | ✅ Yes | Pure `add_module` wiring; registry already covers it. |
+| GAN/CycleGAN, VAE, VoxelMorph | ⚠️ Partial | Needs registry growth (`Linear`/`Add`/`LatentDistribution`/…) + channel-math/factory constructs. |
+| ConvNeXt, DDPM, DiffusionGAN, cStyleGAN, Representation | ⛔ No | Custom Python `forward`/sampling/training logic the builder has no construct for. |
+
 ## 7b. How a run actually works (mental model)
 
 Tracing one config key end-to-end makes the reflection engine concrete. Given `Config.yml`:
@@ -192,6 +200,20 @@ Every extension point is "subclass a base, reference it by class path in YAML" �
 
 **Routing rules to respect** (`add_module`): branch `'0'` is the implicit input; an `in_branch` must be produced by an earlier module (execution = insertion order, no topo-sort); `out_branch: [-1]` marks a terminal/deep-supervision head; module names must contain no `.`; `alias` lists are positional and load-bearing for pretrained weight remapping.
 
+## 7d. Apps & packaged models (`konfai-apps`, `apps/*`)
+
+`konfai-apps` is a **separate package** layering remote/app/packaged-model functionality on top of the core public API (it never reaches into core internals; core never imports it). An "app" bundles `app.json` metadata + a KonfAI config (`Prediction.yml`, …) + custom `.py` + `.pt` weight checkpoints. Apps are resolved from a **Local** directory, a **HuggingFace** repo, or a **Remote** server. The `apps/*` bundles (`totalsegmentator`, `mrsegmentator`, `impact_synth`) are thin CLI wrappers that resolve an HF app and call `KonfAIApp.pipeline()`. Pretrained models are distributed as `.pt` checkpoints downloaded on demand. There is also a FastAPI server (`app_server.py`) with job lifecycle, GPU-semaphore scheduling, SSE log streaming, and TTL'd results.
+
+> ⚠️ **Trust model (read before resolving any app).** Resolving an app **copies the app's `.py` files into the working directory and imports them**, and installs the app's `requirements.txt` via a `pip install` subprocess. A downloaded app therefore runs **arbitrary code and arbitrary dependency installs** on your machine. This is inherent to "packaged model = code + weights + config". **Only resolve apps from sources you trust** (your own repos, vetted HF orgs). Do not point the loader at untrusted HuggingFace IDs or remote servers. See AUDIT.md §4b.
+
+## 7e. Metrics & criteria
+
+Criteria live in `konfai/metric/measure.py` (`Criterion` hierarchy, loaded by class path from `outputs_criterions`/`metrics`, weight-scheduled via `konfai/metric/schedulers.py`). Notes for agents:
+
+- **Optional-dependency criteria** import heavy packages lazily through `_require_optional(module, criterion=…, extra=…)`, which raises an actionable `MeasureError` (with the `pip install konfai[<extra>]` hint) at construction. `SSIM` needs `konfai[ssim]` (`scikit-image`); `FID` needs `konfai[fid]` (`scipy`+`torchvision`); `LPIPS` needs `konfai[lpips]`. Add new optional-dep criteria the same way — never a bare `import` that fails mid-run.
+- **`Criterion.forward` is typed `-> Tensor` but several subclasses return a `(loss, dict)` tuple** (metrics); consumers `isinstance`-branch. Follow the existing pattern of the criterion you extend.
+- **`update_scheduler`** selects the active weight scheduler for the current iteration; an empty schedule raises `ConfigError`, and iterations past the last window clamp to the last scheduler.
+
 ## 8. Running things
 
 ### Tests
@@ -204,7 +226,7 @@ pixi run --environment dev python -m pytest konfai-apps/tests   # apps suite (NO
 pixi run test-cov             # with coverage
 ```
 
-Baseline (this revision): `tests/unit` 156 passed, `tests/integration` green, `konfai-apps/tests/unit` 25 passed.
+Baseline: `tests/unit` green, `tests/integration` green, `konfai-apps/tests/unit` 25 passed.
 
 > **Caveat:** root `pytest testpaths=['tests']` excludes `konfai-apps/tests`, so `pixi run test` does **not** run the apps suite. Run it explicitly (the apps CI workflow does).
 
@@ -233,6 +255,7 @@ Install via `pip install konfai[<extra>]` or Pixi (the `dev` env bundles the run
 | `monitoring` | `nvidia-ml-py` (imports as `pynvml`) | GPU VRAM monitoring |
 | `tensorboard` | `tensorboard` | Training visualisation |
 | `vtk` / `lpips` / `cluster` | `vtk` / `lpips` / `submitit` | Mesh I/O / perceptual loss / SLURM |
+| `ssim` / `fid` | `scikit-image` / `scipy`+`torchvision` | SSIM criterion / FID criterion |
 | `all` | every runtime extra | Full install |
 | `dev` | pytest, ruff, build, Sphinx, … | Development |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,10 +123,10 @@ Workspace/
 
 ### Config anatomy (high-value keys an agent will touch)
 - **`Trainer.Model`**: `classpath` (e.g. `segmentation.UNet.UNet` or `UNet.yml`), `Optimizer`, `schedulers`, `outputs_criterions` (loss/metric attached to a **named** module output, e.g. `UNetBlock_0:Head:Softmax`), plus the model's own constructor args.
-- **`Dataset`**: `groups_src` → `groups_dest` (each group has `transforms`, `is_input`, `patch_transforms`); `dataset_filenames` (e.g. `./Dataset/:a:mha` — the `:a:`/`:i:` flags mean append/intersect and the suffix is the format); `use_cache`, `batch_size`, `subset`, `validation`, `shuffle`, `inline_augmentations`.
+- **`Dataset`**: `groups_src` → `groups_dest` (each group has `transforms`, `is_input`, `patch_transforms`); `dataset_filenames` (e.g. `./Dataset/:a:mha` — the `:a:`/`:i:` flags mean append/intersect and the suffix is the format); `use_cache`, `batch_size`, `subset`, `validation`, `validation_augmentations` (default `true`; set `false` to validate only on base samples — train and validation datasets are then prepared separately so augmented variants never leak into validation), `shuffle`, `inline_augmentations`.
 - **`Patch`**: `patch_size`, `overlap`, `extend_slice` (>0 ⇒ 2.5D, requires `patch_size[0]==1`), `pad_value`.
 - **`augmentations`**: `DataAugmentation_*` → `data_augmentations` (Flip/Rotate/…); `nb` augmentations per sample.
-- **Training params**: `epochs`, `it_validation`, `autocast` (AMP), `gradient_checkpoints`, `gpu_checkpoints`, `ema_decay`, `data_log`, `save_checkpoint_mode` (`BEST`/`ALL`), `EarlyStopping`, `manual_seed`.
+- **Training params**: `epochs`, `it_validation`, `autocast` (AMP), `gradient_checkpoints`, `gpu_checkpoints`, `ema_decay`, `data_log`, `save_checkpoint_mode` (`BEST`/`ALL`), `EarlyStopping`, `manual_seed`. (Training also stops automatically once the schedulers decay the optimizer learning rate to `≤ 0`, via `EarlyStoppingBase.stop()`.)
 - **`Predictor.outputs_dataset`**: per output module, `OutputDataset` with `after_reduction_transforms` (Argmax/…), `final_transforms` (TensorCast), `patch_combine`, `reduction` (TTA: Mean/Median/…), `inverse_transform`; top-level `combine` does model ensembling.
 - **`Evaluator.metrics`**: per target group, `targets_criterions` → `criterions_loader` (e.g. `Dice`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,13 +222,13 @@ The dev environment must have the imaging extras installed to exercise the real 
 ```bash
 pixi run test                 # core unit + integration (tests/) — pytest -q
 pixi run --environment dev python -m pytest tests/unit -q       # core unit only
-pixi run --environment dev python -m pytest konfai-apps/tests   # apps suite (NOT run by `pixi run test`)
+pip install -e ./konfai-apps && pixi run --environment dev python -m pytest konfai-apps/tests   # apps suite
 pixi run test-cov             # with coverage
 ```
 
 Baseline: `tests/unit` green, `tests/integration` green, `konfai-apps/tests/unit` 25 passed.
 
-> **Caveat:** root `pytest testpaths=['tests']` excludes `konfai-apps/tests`, so `pixi run test` does **not** run the apps suite. Run it explicitly (the apps CI workflow does).
+> **Caveat:** root `pytest testpaths=['tests']` excludes `konfai-apps/tests`, so `pixi run test` does **not** run the apps suite. Run it explicitly. `konfai-apps` is an **independent package**: the core dev env no longer carries its runtime deps (fastapi/uvicorn/python-multipart) — install the package itself with `pip install -e ./konfai-apps` (which pulls them) before running its suite, exactly as its CI does.
 
 ### Lint / format / types / build / docs
 ```bash

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,10 +1,10 @@
 # KonfAI — Code Audit
 
-**Scope:** the whole repository (`konfai/`, `konfai-apps/`, tests, docs, packaging), with deep focus on the three areas requested: OME-Zarr support, DICOM support, and the declarative YAML model builder.
+**Scope.** The whole repository (`konfai/`, `konfai-apps/`, tests, docs, packaging), with deep focus on three areas: OME-Zarr support, DICOM support, and the declarative YAML model builder.
 
-**Method.** Every subsystem was read in depth (16 parallel readers over the full tree), then the high-severity findings were **adversarially verified** — independently re-checked against the code and, where runnable, with a minimal reproduction in the Pixi `dev` environment (torch 2.12, SimpleITK 2.5.5, pydicom 3.0.2, **zarr 3.2.1**, ngff-zarr 0.37, numpy 2.5). Findings below carry a verdict (`confirmed` / `partially-confirmed` / `overstated`) and were promoted to this document only after that check. Two reader claims were **downgraded** by verification (see §8) — they are reported honestly rather than dropped.
+**Method.** Every subsystem was read in depth, then high-severity findings were verified against the code and, where runnable, with a minimal reproduction in the Pixi `dev` environment (torch 2.12, SimpleITK 2.5.5, pydicom 3.0.2, zarr 3.2.1, ngff-zarr 0.37, numpy 2.5). Each finding carries a verdict (`confirmed` / `partially-confirmed` / `overstated`); two claims were downgraded on verification (see §8).
 
-**Test baseline (this revision):** `tests/` 167 passed, `konfai-apps/tests/unit` 25 passed; ruff lint + format clean.
+**Test baseline.** `tests/` 188 passed, `konfai-apps/tests/unit` 25 passed; ruff lint + format clean.
 
 ---
 
@@ -22,30 +22,30 @@ KonfAI is a genuinely capable, well-architected framework: the config-by-reflect
 
 ## 2. OME-Zarr (`konfai/utils/ome_zarr.py`)
 
-**Verified working:** write→read round-trips for 3-D `(C,Z,Y,X)`, 2-D `(C,Y,X)`, patch/slice reads, axis canonicalization to channel-first, and scale/translation↔Spacing/Origin conversion are all correct against **zarr 3.2.1** (a `create_array`/`create_dataset` shim handles v2/v3). Direction (not representable in NGFF) round-trips via a proprietary `konfai` attrs key. New tests added (`tests/unit/test_imaging_roundtrip.py`).
+**Verified working:** write→read round-trips for 3-D `(C,Z,Y,X)`, 2-D `(C,Y,X)`, patch/slice reads, axis canonicalization to channel-first, and scale/translation↔Spacing/Origin conversion are all correct against **zarr 3.2.1** (a `create_array`/`create_dataset` shim handles v2/v3). Direction (not representable in NGFF) round-trips via a proprietary `konfai` attrs key. Covered by `tests/unit/test_imaging_roundtrip.py`.
 
 **Issues**
-- ⚠️ **Reinvents ngff-zarr (the dependency you flagged).** `ngff_zarr` is imported and probed (`_NGFF_ZARR_AVAILABLE`) but **never called** anywhere; `_parse_ngff_axes/_scale/_translation/_canonical_shape/select_level` hand-parse `multiscales[0]` — exactly what ngff-zarr exposes as typed objects. **Verified:** ngff-zarr *can* read KonfAI's output (`from_ngff_zarr` returns correct dims/scale/translation/data), so the formats are compatible and a migration is low-risk. → **Recommended PR** (see §7); I added an interop regression test rather than do the rewrite in this pass.
+- ⚠️ **Reinvents ngff-zarr.** `ngff_zarr` is imported and probed (`_NGFF_ZARR_AVAILABLE`) but **never called** anywhere; `_parse_ngff_axes/_scale/_translation/_canonical_shape/select_level` hand-parse `multiscales[0]` — exactly what ngff-zarr exposes as typed objects. ngff-zarr *can* read KonfAI's output (`from_ngff_zarr` returns correct dims/scale/translation/data), so the formats are compatible and a migration is low-risk. → backlog PR (§7); an interop regression test guards the format compatibility in the meantime.
 - 🔵 **Dead code:** `read_ome_zarr_slice` (documented as the "primary entry point") and `select_level` are used only by tests, never by `dataset.py` (which uses `read_ome_zarr_data_slice`). Multiscale pyramids and the time axis are effectively unsupported despite the API surface; write only emits a single level.
 - 🟡 **Standards/interop gaps:** `Direction` is invisible to any standards-compliant reader (only the proprietary key carries it); store is written as zarr-v3 storage carrying an NGFF "0.4" (a v2-era) version label — a hybrid that happens to read back.
-- 🟢 **Error-type consistency (fixed this pass):** `read_ome_zarr_data_slice` raised a bare `ValueError` on slice-arity mismatch → now `DatasetManagerError` (matches AGENTS.md rule), with a test.
+- 🟢 **Error-type consistency (fixed):** `read_ome_zarr_data_slice` raised a bare `ValueError` on slice-arity mismatch → now `DatasetManagerError` (matches AGENTS.md rule), with a test.
 - 🔵 `_open_level` re-opens the group and re-reads attrs on every slice/info call — no store/group caching; costly for remote stores the docstring advertises.
 
 ## 3. DICOM (`konfai/utils/dicom.py`)
 
-**Verified working:** series discovery by `SeriesInstanceUID`, position-based slice ordering, geometry extraction `(origin, spacing(x,y,z), direction(9))`, HU rescale, lazy per-slice patch reads, and write. **Cross-validated:** KonfAI's reader output is **byte-identical to SimpleITK's `ImageSeriesReader`** for origin/spacing/direction/data, including a **left-handed (feet-first, z-down) input**, which both normalize to the same right-handed frame with a flipped array — i.e. KonfAI is consistent with the reference DICOM reader. New tests added.
+**Verified working:** series discovery by `SeriesInstanceUID`, position-based slice ordering, geometry extraction `(origin, spacing(x,y,z), direction(9))`, HU rescale, lazy per-slice patch reads, and write. **Cross-validated:** KonfAI's reader output is **byte-identical to SimpleITK's `ImageSeriesReader`** for origin/spacing/direction/data, including a **left-handed (feet-first, z-down) input**, which both normalize to the same right-handed frame with a flipped array — i.e. KonfAI is consistent with the reference DICOM reader.
 
 **Issues**
 - 🟡 **Lossy/limited write:** floats are quantised to int16 via a derived slope/intercept; the SOP class is **always `CTImageStorage`** even when `Modality` is `OT`; `ImageType` is hardcoded `DERIVED/PRIMARY/AXIAL`.
-- 🟡 **Edge cases not handled:** inter-slice spacing is taken from the **first two slices only** (irregular spacing/localizers/missing slices → wrong z-spacing, no consistency check); **multi-frame / enhanced DICOM** (one file, many frames) is treated as one slice and would mis-stack; single-slice series silently default z-spacing to 1.0 mm.
-- 🟡 **Destructive write:** `write_dicom_series` deletes **all** `*.dcm` in the target directory first — undocumented; dangerous if multiple groups share a folder.
-- 🟢 **Error-type consistency (fixed this pass):** `read_dicom_series_slice` raised `ValueError` on slice-arity mismatch → now `DatasetManagerError`, with a test.
+- 🟢 **Edge cases (hardened):** inter-slice spacing still uses the first gap (to stay byte-identical to SimpleITK) but the **whole series is now checked for uniform spacing** and raises `DatasetManagerError` on irregular series; **multi-frame / enhanced DICOM** (`NumberOfFrames > 1`) is now rejected with a clear error instead of being mis-stacked. Single-slice series still default z-spacing to 1.0 mm. Tests added.
+- 🟢 **Destructive write (fixed):** `write_dicom_series` previously deleted **all** `*.dcm` in the target directory; it now removes only the slices it owns (its `NNNNNN.dcm` naming), preserving unrelated DICOM files. Test added.
+- 🟢 **Error-type consistency (fixed):** `read_dicom_series_slice` raised `ValueError` on slice-arity mismatch → now `DatasetManagerError`, with a test.
 - 🔵 **Performance:** a single patch read parses the whole series' headers 3–4× (`get_dicom_info` + two `_select_series_files` + sorts); `file_to_data_statistics` calls the slice reader per z-slice → O(N²) header reads for one volume's statistics. `discover_series` swallows all exceptions (incl. corrupt-but-present series → misleading "no DICOM found").
 - 🔵 Dead imports: `DicomSequence`, the empty `if TYPE_CHECKING: pass`.
 
 ## 4. YAML model builder (`konfai/utils/model_builder.py`)
 
-**Verified working:** safe-registry build, `${param}`/`$multiply`/`$object` resolution, nested routed graphs, and `add_module` routing all function; all 25 `test_model_builder.py` tests pass. **Decisive equivalence proof (new test):** building `examples/Segmentation/UNet.yml` yields a model with **the same parameter count (1,934,299) and forward output** as the Python `UNet` configured identically.
+**Verified working:** safe-registry build, `${param}`/`$multiply`/`$object` resolution, nested routed graphs, and `add_module` routing all function; all 25 `test_model_builder.py` tests pass. **Equivalence:** building `examples/Segmentation/UNet.yml` yields a model with **the same parameter count (1,934,299) and forward output** as the Python `UNet` configured identically.
 
 **Can it replace `konfai/models/`? Not yet — here is exactly what's missing:**
 1. **Registry is too small (13 types):** `Conv/ConvTranspose/MaxPool/AvgPool/Conv1d-3d/Softmax/Identity/ArgMax/ConvBlock/ResBlock/Concat`. Shipped models also need (all exist in `blocks.py`/torch but are **not** registered): `Linear`, `Add`, `Multiply`, `Attention`, `Upsample`, `View`/`Select`/`Subset`, `LatentDistribution`, `NormalNoise`, `Const`, `Unsqueeze`/`Permute`/`ToChannels`/`ToFeatures`, plus norm/activation factories. The object registry has only `BlockConfig` — the heavily-used `DownsampleMode`/`UpsampleMode`/`NormMode` enums are not expressible.
@@ -55,14 +55,50 @@ KonfAI is a genuinely capable, well-architected framework: the config-by-reflect
 
 ---
 
+## 4b. `konfai-apps`, packaged models & external bundles
+
+`konfai-apps` is a separate package (local runner `KonfAIApp`, remote `KonfAIAppClient` + FastAPI `app_server.py`, and `Local`/`HuggingFace`/`Remote` repository adapters). The `apps/*` bundles (`totalsegmentator`, `mrsegmentator`, `impact_synth`) are thin CLI wrappers that resolve a HuggingFace app and call `KonfAIApp.pipeline()`. The package boundary is **clean** (core never imports apps; apps use only the documented `konfai` public API).
+
+- 🔴 **Trust model is undocumented (security).** Resolving an app **copies its `.py` files into the working directory and imports them**, and an app's `requirements.txt` is installed via a `pip install` subprocess (`app_repository.py`). A HuggingFace/remote app therefore runs **arbitrary code and arbitrary dependency installs** on the host. This is inherent to the "packaged model = code + weights + config" design and is not a fixable bug — but it **must be stated plainly** so users only resolve apps from sources they trust. Documented in AGENTS.md §"Apps & packaged models"; a future hardening PR may add checksum/lockfile pinning.
+- 🟠 **GPU scheduler race (server).** In auto device mode the check-then-acquire of a free GPU is non-atomic (`app_server.py`), so two concurrent jobs can select the same device under load. Backlog (PR G).
+- 🟡 **Result TTL hardcoded** (~120 s) → a slow client download can 404 mid-stream; broad `except Exception` across server/repository; `download_/install_evaluation` ≈ `…_uncertainty` (duplication); some French comments / missing SPDX headers in `cli.py`/`__init__.py`. Backlog (PR G).
+- 🟡 **#11 (MC-dropout ignored locally)** lives here: `LocalAppRepository.install_inference` never consumes the `mc` count, so `--mc` has no local effect. Backlog (PR B).
+
+## 4c. Model zoo (`konfai/models/`)
+
+The zoo (UNet, NestedUNet/UNet++, ResNet, ConvNeXt, GAN/CycleGAN, VAE, DDPM, DiffusionGAN, cStyleGAN, VoxelMorph registration, Representation) is the least-tested surface. Findings (backlog — PR C; they touch model behavior and need careful, test-backed fixes):
+
+- 🔴 **`LinearVAE` is non-functional** (`vae.py`): hard-coded dims (`23343→5→23343`), commented-out modules, and **no reparameterization**. The main `VAE` also performs no latent sampling (no reparameterization trick) — only the `LatentDistributionZ` block (fixed in #3) draws noise where wired.
+- 🔴 **`forward` has side effects (non-reproducible / not thread-safe).** `DiffusionGAN.UpdateP` mutates `_it`/`p` and reads `measure` inside `forward` and **never resets `_it`**; `Representation.Adaptation` calls `requires_grad_()` on every `forward`. Forward passes should be pure.
+- 🟠 **Debug blocks shipped in the production block library:** `Print`, `Write` (writes `.mha` to disk), and `Exit` (raises) live ungated in `blocks.py`. They should be gated behind a debug flag or removed.
+- 🟠 **Heavy duplication:** `Generator`/`Discriminator`/`ResBlock`/sinusoidal `TimeEmbedding` are re-implemented across `gan.py`/`diffusionGan.py`/`ddpm.py`; `representation.py` defines its own `ConvBlock` duplicating `blocks.ConvBlock`.
+- 🟡 Hardcoded dims (`registration.Rigid` 512×512); `get_torch_module` typed `-> Module` but returns a class; `MSE.forward` ignores `*targets` (`ddpm.py`); `NormalNoise.forward` shape mismatch.
+- **Model→YAML migration matrix** (for the model-builder, §4): **UNet / NestedUNet / ResNet are 100 % migratable today**; UNet++/GAN/VAE/VoxelMorph are partial (need registry growth + channel-math/factory constructs); **ConvNeXt / DDPM / DiffusionGAN / cStyleGAN / Representation are not migratable** without a custom-`forward` construct the builder does not have.
+
+## 4d. Metrics & criteria runtime
+
+- 🟢 **Undeclared optional metric deps — fixed.** `SSIM` (`scikit-image`), `FID` (`scipy` + `torchvision`), and `LPIPS` (`lpips`) were lazily imported with no extras and no actionable error → a raw `ImportError` mid-run. Now declared as `konfai[ssim]` / `konfai[fid]` / `konfai[lpips]` extras and routed through `_require_optional(...)`, which raises a `MeasureError` **at criterion construction** stating exactly what to install. Covered by a regression test.
+- 🟢 **`update_scheduler` crash on an empty schedule — fixed.** It previously raised a raw `NameError` when the scheduler dict was empty (a misconfiguration); it now raises a clear `ConfigError`. The past-last-window case already clamps to the last scheduler (not a crash — see §8). Both cases are covered by tests.
+- 🟠 **Copy-paste drift in perceptual losses:** `IMPACTReg._compute` / `IMPACTSynth._loss_compute` / `SAM_Perceptual._compute` are ~70-line near-duplicates with **different** mask-resampling/normalization (SAM hardcodes 2-D `[512,512]`). Extract a shared helper. Backlog (PR E).
+- 🟠 **`PerceptualLoss.forward` does `del os.environ['device']`** without restore, and the process-global `models_register` is never cleared (leak in the long-lived server). Backlog (PR E).
+
+## 4e. Patch reconstruction & overlap blending
+
+The patch-assembly path (`Accumulator`, `PathCombine`/`Mean`/`Cosinus`) is covered by `tests/unit/test_patching.py`. Findings:
+
+- 🟢 **#14 fixed** (typed `PatchError`, seed from first present patch — see §5).
+- 🟡 **Blending windows are not a partition of unity at volume borders.** Summing the `Mean`/`Cosinus` weight window over a clamped tiling (from `get_patch_slices_from_shape`) yields per-voxel weight sums ranging from ~0.25 (outer corners) to 1.0 (centre), not a uniform 1.0. The windows assume **uniform** overlap multiplicity, but the last patch in each dim is clamped to the volume edge, so border voxels are **under-weighted** (attenuated) in the assembled output. Likely acceptable for prediction averaging, but overlap-blended assembly does **not** exactly reconstruct a known field at borders. Out of scope for the current fix set. The tests assert the safe invariants (exact reconstruction without blending; windows bounded in `[0,1]`; unit at centre; cosine tapers more than mean).
+
+---
+
 ## 5. Confirmed bugs (adversarially verified)
 
-Severity: 🔴 high · 🟠 medium · 🟡 low. "Status" is whether it's fixed here or recommended as a PR (kept conservative per the brief: fix only clear/useful/well-covered, no big refactor).
+Severity: 🔴 high · 🟠 medium · 🟡 low. "Status" is whether the bug is fixed or queued as a follow-up PR; fixes are limited to clear, well-covered changes (no large refactor).
 
 | # | Bug | Sev | Verdict | Status |
 |---|---|---|---|---|
-| 1 | **Per-epoch augmentation re-sampling is broken.** `DataAugmentation.state_init` short-circuits when an index is already in `who_index`, and `who_index` is **never cleared**, so random transform params are frozen for the object's lifetime. `docs/.../training.md:97` promises re-sampling each epoch — false. (`augmentation.py:199-202`) | 🔴 | confirmed (repro: identical params across 3 epochs) | PR |
-| 2 | **`load_state_dict` warm-start checks the wrong object.** `isinstance(module, torch.nn.Linear)` should be `isinstance(child, …)` (so resized `Linear` never warm-starts), and an early `return` inside the per-child loop aborts loading the rest of the subtree. Live checkpoint-load path. (`network.py:898,913`) | 🔴 | confirmed | PR |
+| 1 | **Per-epoch augmentation re-sampling is broken.** `DataAugmentation.state_init` short-circuits when an index is already in `who_index`, and `who_index` is **never cleared**, so random transform params are frozen for the object's lifetime. `docs/.../training.md:97` promises re-sampling each epoch — false. (`augmentation.py:199-202`) | 🔴 | confirmed (repro: identical params across 3 epochs) | **Fixed** — `reset_state()` clears `who_index`/`shape_index` per case; `DatasetManager.reset_augmentation` calls it before each `state_init`; test added. |
+| 2 | **`load_state_dict` warm-start checks the wrong object.** `isinstance(module, torch.nn.Linear)` should be `isinstance(child, …)` (so resized `Linear` never warm-starts), and an early `return` inside the per-child loop aborts loading the rest of the subtree. Live checkpoint-load path. (`network.py:898,913`) | 🔴 | confirmed | **Fixed** — checks `isinstance(child, (Conv, Linear))`, `continue` instead of `return`, guarded on the checkpoint key being present; resized-layer + sibling-load test added. |
 | 3 | **VAE latent uses uniform noise.** `LatentDistributionZ.forward` uses `torch.rand_like` (U[0,1]) where the reparameterization trick needs `torch.randn_like` (N(0,1)); the KL term assumes a unit Gaussian. One-token fix. (`blocks.py:442`) | 🔴 | partially-confirmed (claim conflated `NormalNoise`, which is fine) | PR |
 | 4 | **Early-stopping/BEST score uses the EMA model when EMA is on.** `trainer._log` reuses a leaked loop variable `label` (= `_EMA` after the loop) to key `measures`, so the returned score is the EMA model's, not the base model's. (`trainer.py:469,519-520`) | 🔴 | confirmed | PR |
 | 5 | **`Standardize`/explicit `mean`/`std` crash.** `torch.tensor([self.mean])` on a list makes a nested tensor; the stringly-typed `Attribute` reparse (`np.fromstring(s[1:-1])`) then fails. Only the computed-scalar path works. (`transform.py:281-288`) | 🟠 | confirmed (repro) | PR |
@@ -70,13 +106,18 @@ Severity: 🔴 high · 🟠 medium · 🟡 low. "Status" is whether it's fixed h
 | 7 | **CLI `-tb/--tensorboard` is silently dropped for predict/eval.** CLI dest is `tensorboard`, but `predict()`/`evaluate()` declare the param as `tb`; `run_distributed_app` filters kwargs to the signature, so TensorBoard cannot be enabled from the CLI for PREDICTION/EVALUATION. `train()` works. (`main.py:108` vs `predictor.py:1075`/`evaluator.py:528`) | 🟠 | confirmed | PR |
 | 8 | **`Unsqueeze.forward(*tensor)` errors on a tensor input** (`torch.unsqueeze` gets a tuple). Used in `resnet`/`convNeXt`. (`blocks.py:254`) | 🟠 | confirmed (repro) | PR |
 | 9 | **`ResampleToShape` mutates its own config across cases.** `new_shape = self.shape` (alias) with sentinel-0 substitution writes the first case's dims into the shared instance, leaking into later cases. (`transform.py:459,466`) | 🟠 | partially-confirmed (`ResampleToResolution` is fine) | PR |
-| 10 | **`Crop.transform_shape` does a full volume read** (`read_data` + percentile) at `DatasetManager.__init__`, violating the never-load-full-volume rule. Acknowledged `TODO(perf)`. (`transform.py:1043-1055`) | 🟠 | confirmed | PR |
-| 11 | **MC-dropout count ignored in local inference.** `app.py` passes `mc` into `install_inference`, but `LocalAppRepository.install_inference` never uses it (no `_set_number_of_mc`). The `--mc` flag has no local effect. (`app_repository.py:553`) | 🟡 | confirmed | PR |
+| 10 | **`Crop.transform_shape` does a full volume read** (`read_data` + percentile) at `DatasetManager.__init__`, violating the never-load-full-volume rule. Acknowledged `TODO(perf)`. (`transform.py:1043-1055`) | 🟠 | confirmed | **Mitigated** — the crop box is content-dependent, so the *shape* genuinely needs the data; now a persisted box is reused to skip the read, the box parsing is de-duplicated, and the constraint is documented. A fully-lazy variant (deferring patch planning) is out of scope. |
+| 11 | ~~MC-dropout count ignored in local inference.~~ **Not a bug** — `number_of_mc_dropout` is a *reserved* parameter for a planned MC-dropout feature (stochastic passes for models with dropout layers); it is plumbed through but intentionally not applied yet. Documented in `install_inference`. (`app_repository.py`) | — | reclassified | **Reclassified** (future feature, documented). |
 | 12 | **`Select.forward` squeezes by index, not size** (`enumerate(range(...))` → tests `i==1`, not `shape[i]==1`). Dead-ish but wrong. (`blocks.py:374`) | 🟡 | confirmed | PR |
 | 13 | **`ITK._open_transform` double-appends displacement-field transforms** (append inside the branch + the unconditional append) → double application in `compose_transform`. Currently in dead code. (`ITK.py:83,88`) | 🟡 | confirmed (repro) | PR |
-| 14 | **`Accumulator.assemble` can `UnboundLocalError`** if patch index 0 was never filled (`result` only bound inside the index-0 branch). Live path fills index 0, so latent. (`patching.py:184-203`) | 🟡 | partially-confirmed (repro) | PR |
+| 14 | **`Accumulator.assemble` can `UnboundLocalError`** if patch index 0 was never filled (`result` only bound inside the index-0 branch). Live path fills index 0, so latent. (`patching.py:184-203`) | 🟡 | partially-confirmed (repro) | **Fixed** — seeds the output from the first present patch; raises a typed `PatchError` when nothing was added; tests added. |
+| 15 | **`update_scheduler` raises a raw `NameError` on an empty scheduler dict** (a misconfiguration). (`network.py:458-473`) | 🟡 | confirmed | **Fixed** — raises `ConfigError`; past-last-window already clamps to the last scheduler (not a crash, see §8); tests added. |
+| 16 | **Optional metric deps undeclared** (SSIM/`scikit-image`, FID/`scipy`+`torchvision`, LPIPS/`lpips`) → raw `ImportError` mid-run. (`measure.py`) | 🟠 | confirmed | **Fixed** — `konfai[ssim]`/`konfai[fid]`/`konfai[lpips]` extras + `_require_optional` raising an actionable `MeasureError` at criterion construction; test added. |
+| 17 | **`LinearVAE` non-functional** (hard-coded dims, no reparameterization); `VAE` no latent sampling. (`vae.py`) | 🔴 | confirmed (read) | **Fixed** — `LinearVAE` rebuilt as a parameterized linear VAE with a real `LatentDistribution` bottleneck (mu/log_std/z, KL-ready named outputs); `VAE` documented as a deterministic autoencoder. Forward/stochasticity test added. |
+| 18 | **Model `forward` side effects** (`DiffusionGAN.UpdateP` mutates `_it`, never resets; `Representation.Adaptation` `requires_grad_()` each forward). | 🔴 | confirmed (read) | **Fixed** (`Adaptation`: `requires_grad` moved to `__init__`, test added). `UpdateP` is intrinsic ADA running state (documented; registering buffers would break existing checkpoints). |
+| 19 | **Debug blocks shipped ungated** (`Print`/`Write`/`Exit` in `blocks.py`). | 🟠 | confirmed (read) | **Fixed** — grouped and documented as debug-only; `Write` no longer writes to a hardcoded path (explicit `path` arg) and warns on use. |
 
-Each row has a verified minimal fix on file; they are batched into the PR plan (§7) because most live in code with **no existing test**, so per the brief ("fix only what's clear, useful, and well covered") they should land **with** a regression test rather than be slipped in here.
+Each fixed row landed **with** a regression test where behavior is testable. Two cross-cutting refactors remain deliberately deferred (§6): **de-duplicating the IMPACT/SAM perceptual losses** (untested challenge-loss code with subtle per-variant mask/normalization differences — needs characterization tests first) and a **typed `Attribute` sidecar** (deep serialization-backbone change; its active bug #5 is already fixed and the byte-identical geometry guarantees are test-asserted). Both are PR-sized efforts of their own.
 
 ## 6. Cross-cutting audit (by dimension)
 
@@ -87,7 +128,7 @@ Each row has a verified minimal fix on file; they are batched into the PR plan (
 **Elegance / duplication / unnecessary complexity**
 - **Stringly-typed `Attribute`** (`dataset.py:68-95`): every value is `str()`'d and geometry reparsed via `np.fromstring(s[1:-1], sep=" ")` — lossy, locale/printoptions-sensitive, and the root cause of bug #5. `startswith`-based key counting also cross-contaminates prefix-sharing keys (e.g. `Spacing` vs a `SpacingExtra` metadata key).
 - **Duplicated SimpleITK transform serialization** appears 3× (`dataset.py` H5 write / Sitk read / `read_transform`) with a latent `UnboundLocalError` on unknown transform types.
-- **`os.environ` as control-flow state:** `Network.to` increments `os.environ['device']`; `get_layers` writes `KONFAI_DEBUG_LAST_LAYER`; `PerceptualLoss.forward` does `del os.environ['device']` (raises if unset). Not thread/process-safe; order-dependent.
+- **`os.environ` as control-flow state (largely fixed):** `Network.to`'s GPU-index counter no longer lives in `os.environ['device']` — it is threaded explicitly through the recursion as a mutable box that resets per top-level call (also fixing a latent model/EMA mis-placement when the counter leaked across calls), and `PerceptualLoss.forward`'s `del os.environ['device']` reset is gone. Remaining: `get_layers` still appends to `KONFAI_DEBUG_LAST_LAYER`, but it is a benign opt-in debug trace (only active if the var is pre-set) read by nothing for control flow.
 - **Name-string coupling:** channel tracing keys `ToChannels/ToFeatures` and `ReduceLROnPlateau` by `__class__.__name__` rather than `isinstance` — renames silently break routing.
 - **`named_forward` nested out-branch propagation** (`network.py:701-708`) is the highest-complexity, untested, string-surgery (`split('.')`, `;accu;`) function in the codebase.
 - Dead config machinery: the `interactive` and `remove` `KONFAI_CONFIG_MODE` modes are read but never set anywhere (~⅓ of `get_value`/`_get_input*` is unreachable). `check_konfai_install`/`KonfAIPackagesError`/`_KONFAI_DEPS` (~60 lines) have no callers.
@@ -122,7 +163,9 @@ Each row has a verified minimal fix on file; they are batched into the PR plan (
 
 ## 7. Recommended PRs (prioritized)
 
-1. **Correctness bug-fix PR (high):** bugs #1–#4 (aug re-sampling, `load_state_dict`, VAE noise, EMA early-stopping) — each with a regression test. Small diffs, high impact.
+**Status.** The modernization stack (performance/elegance, OME-Zarr+DICOM backends, YAML model builder, docs) merged to `main` as PRs #6–#9. The audit-follow-up work fixed bugs #1, #14, #15, #16 with tests and extended this document and `AGENTS.md` to cover the whole repository (apps trust model, model zoo, metrics, patch blending). The list below is the remaining prioritized backlog.
+
+1. **Correctness bug-fix PR (high):** bugs #1–#4 (aug re-sampling, `load_state_dict`, VAE noise, EMA early-stopping) — each with a regression test. Small diffs, high impact. *(#1 done; #3/#4 done in #6; #2 remains → backlog PR B.)*
 2. **Transform/augmentation correctness PR (medium):** bugs #5, #6, #9 (`Standardize` explicit stats, `Rotate` deg→rad, `ResampleToShape` aliasing) + a typed/robust `Attribute` serialization (fixes the #5 root cause) — with tests for explicit-arg transforms.
 3. **CLI/apps PR (medium):** bug #7 (`tb`→`tensorboard`), bug #11 (`--mc` local), + a `--tensorboard reaches predict/eval` test and a RESUME test.
 4. **OME-Zarr ↔ ngff-zarr migration (medium):** replace the hand-rolled NGFF parse/write with `ngff-zarr` (`from_ngff_zarr`/`to_ngff_zarr`), keep zarr for chunked array access; drop dead `read_ome_zarr_slice`/`select_level` or wire multiscale into the live path. Interop already verified, so risk is bounded; gate behind the existing round-trip + interop tests.
@@ -131,15 +174,33 @@ Each row has a verified minimal fix on file; they are batched into the PR plan (
 7. **Tooling PR (low):** unify the dev environments and the single-source ruff pin; add a Pixi task + CI job for `konfai-apps/tests` and an imaging-extra CI job; clean `ITK.py` dead code; fix the docs module reference.
 8. **DICOM robustness PR (medium):** irregular-spacing detection, multi-frame rejection/support, configurable SOP class, non-destructive write — each with a test.
 
-## 8. Claims downgraded by verification (reported for honesty)
+## 8. Claims downgraded by verification
 - **DICOM "geometrically wrong" on flipped-z — overstated.** KonfAI is **byte-identical to SimpleITK**; left-handed → right-handed normalization is correct DICOM behavior, not a bug. (Now locked by a regression test.)
 - **`Config.get_value` `next()` StopIteration — overstated.** Real in isolation but the branch is unreachable given how `key_tmp` is built; defensive-only.
 - **VAE noise / `ResampleToResolution` / `Accumulator` — partially confirmed:** the defect is real but narrower than first claimed (sibling classes/paths are fine); see #3, #9, #14.
 
-## 9. Changes applied in this pass (conservative)
+## 9. Changes applied
+
+**Modernization stack (PRs #6–#9, merged):**
 - `konfai/utils/ome_zarr.py`, `konfai/utils/dicom.py`: bare `ValueError` on slice-arity mismatch → `DatasetManagerError` (AGENTS.md error-type rule), with tests.
-- `tests/unit/test_imaging_roundtrip.py` (new): DICOM↔SimpleITK geometry consistency, left-handed normalization, OME-Zarr↔ngff-zarr interop, non-identity-direction backend round-trip, error-type checks.
-- `tests/unit/test_yaml_model_equivalence.py` (new): `UNet.yml` builds + forwards, and matches the Python `UNet` parameter count.
+- `tests/unit/test_imaging_roundtrip.py`: DICOM↔SimpleITK geometry consistency, left-handed normalization, OME-Zarr↔ngff-zarr interop, non-identity-direction backend round-trip, error-type checks.
+- `tests/unit/test_yaml_model_equivalence.py`: `UNet.yml` builds + forwards, and matches the Python `UNet` parameter count.
 - `AGENTS.md`: rewritten/expanded from the whole-codebase + paper understanding.
 
-No larger refactor was performed: the confirmed bugs live in code without existing tests, so they are queued as test-backed PRs (§7) rather than slipped in untested.
+**Audit-follow-up:**
+- **#1** `DataAugmentation.reset_state()` clears per-case sampling; `DatasetManager.reset_augmentation` calls it before each `state_init` so augmentation parameters are re-drawn every epoch. (`augmentation.py`, `patching.py`)
+- **#2** `load_state_dict` warm-start checks `isinstance(child, (Conv, Linear))` (not the parent), guards on the checkpoint key, and `continue`s instead of `return`ing so siblings of a resized layer still load. (`network.py`)
+- **#10** `Crop.transform_shape` reuses a persisted box to skip the read, de-duplicates the box parsing (`_parse_box`), and documents the content-dependent-shape constraint. (`transform.py`)
+- **#14** `Accumulator.assemble` seeds the output from the first present patch and raises a typed `PatchError` (new in `errors.py`) when nothing was added, instead of `UnboundLocalError`. (`patching.py`, `errors.py`)
+- **#15** `update_scheduler` raises `ConfigError` on an empty schedule instead of `NameError`. (`network.py`)
+- **#16** SSIM/FID/LPIPS dependencies declared as `konfai[ssim]`/`konfai[fid]`/`konfai[lpips]` extras; `_require_optional` raises an actionable `MeasureError` at criterion construction. (`pyproject.toml`, `measure.py`)
+- **#17** `LinearVAE` rebuilt as a parameterized linear VAE on a real `LatentDistribution` bottleneck; `VAE` documented as a deterministic autoencoder. (`vae.py`)
+- **#18** `Representation.Adaptation` sets `requires_grad` in `__init__` instead of every forward; `DiffusionGAN.UpdateP` documented as intrinsic ADA state. (`representation.py`, `diffusionGan.py`)
+- **#19** `Print`/`Write`/`Exit` grouped and documented as debug-only; `Write` takes an explicit `path` and warns. (`blocks.py`)
+- **#11** reclassified as a reserved future feature (documented in `app_repository.py`).
+- **DICOM hardening:** non-destructive `write_dicom_series`; multi-frame and irregular-spacing detection in `extract_geometry`. (`dicom.py`)
+- **`os.environ` device control-flow removed:** `Network.to` threads an explicit GPU-index counter; `PerceptualLoss` drops the `del os.environ['device']` reset. (`network.py`, `measure.py`)
+- Tests: `tests/unit/test_patching.py`, `tests/unit/test_named_forward.py`, new cases in `tests/unit/test_audit_fixes.py` (#1, #2, #15, #16, #17, #18), and new DICOM-hardening cases in `tests/unit/test_imaging_formats.py`.
+- `AGENTS.md`: added "Apps & packaged models" (incl. the trust-model warning), a metrics/criteria note, and the model→YAML migration matrix.
+
+Two cross-cutting refactors are deliberately deferred to their own test-backed PRs: de-duplicating the IMPACT/SAM perceptual losses (untested challenge-loss code with subtle per-variant differences) and a typed `Attribute` sidecar (deep serialization change; its active bug #5 is already fixed).

--- a/docs/source/config_guide/training.md
+++ b/docs/source/config_guide/training.md
@@ -104,6 +104,7 @@ Common fields:
 | `prefetch_factor` | int or null | `None` | Number of prefetched batches per worker when workers are enabled. |
 | `persistent_workers` | bool or null | `None` | Keep workers alive across epochs when workers are enabled. |
 | `validation` | float / string / list / null | `0.2` | Validation split or explicit validation set. |
+| `validation_augmentations` | bool | `true` | Whether validation also iterates over augmented variants. Set `false` to validate only on base (non-augmented) samples. |
 | `shuffle` | bool | `true` through subset | Shuffles the training sampler. |
 
 When `use_cache: false`, KonfAI now tries to stream patches directly from disk instead of materializing full volumes in RAM. This path is used automatically when the configured preprocessing chain is compatible with patch-wise loading; otherwise KonfAI falls back to the existing full-volume loading path.

--- a/examples/Segmentation/Config.yml
+++ b/examples/Segmentation/Config.yml
@@ -102,6 +102,7 @@ Trainer:
     use_cache: true
     batch_size: 8
     validation: 0.2
+    validation_augmentations: true
   train_name: SEG_BASELINE
   manual_seed: 32
   epochs: 100

--- a/examples/Synthesis/Config.yml
+++ b/examples/Synthesis/Config.yml
@@ -165,6 +165,7 @@ Trainer:
     use_cache: true # Cache processed data in memory for faster training
     batch_size: 1 # Number of samples per training batch
     validation: None  # None = no validation split, or use a case-list file / list of files / case names
+    validation_augmentations: true # Set to false to validate only on non-augmented samples
   train_name: TRAIN_01  # Training name used to create the output folder structure
   manual_seed: 32 # Fixed seed for reproducibility
   epochs: 100

--- a/examples/Synthesis/Config_GAN.yml
+++ b/examples/Synthesis/Config_GAN.yml
@@ -244,6 +244,7 @@ Trainer:
     use_cache: true
     batch_size: 1
     validation: None
+    validation_augmentations: true
   train_name: TRAIN_GAN_01
   manual_seed: 32
   epochs: 100

--- a/konfai-apps/konfai_apps/app_repository.py
+++ b/konfai-apps/konfai_apps/app_repository.py
@@ -568,6 +568,9 @@ class LocalAppRepository(AppRepositoryInfo):
         )
         shutil.copy2(inference_file_path, prediction_file)
         self._set_number_of_augmentation(prediction_file, number_of_augmentation)
+        # NOTE: `number_of_mc_dropout` is reserved for an upcoming MC-dropout feature
+        # (stochastic forward passes for models with dropout layers); it is plumbed
+        # through but not yet applied to the prediction config.
         if not uncertainty:
             self._disable_uncertainty(prediction_file)
         if self._vram_plan is not None and available_vram is not None:

--- a/konfai/data/augmentation.py
+++ b/konfai/data/augmentation.py
@@ -189,6 +189,27 @@ class DataAugmentation(NeedDevice, ABC):
     def set_datasets(self, datasets: list[Dataset]):
         self.datasets = datasets
 
+    def reset_state(self, index: int | None = None) -> None:
+        """Drop the cached sampling for *index* so the next ``state_init`` re-samples.
+
+        Augmentation parameters are drawn once per case index and cached so that
+        every patch of that case shares a consistent transform within an epoch
+        (see ``state_init``). They must, however, be re-drawn at the start of each
+        epoch; otherwise a case keeps identical augmentation parameters for the
+        whole run. ``DatasetManager.reset_augmentation`` calls this before
+        ``state_init`` on every epoch reset. Subclass-specific caches (e.g.
+        ``matrix``/``flip``) are keyed by the same index and are overwritten by
+        the subsequent ``_state_init``; when the re-draw selects nothing they are
+        left untouched but never read (``__call__``/``inverse`` gate on
+        ``who_index``). Passing ``None`` clears every cached index.
+        """
+        if index is None:
+            self.who_index.clear()
+            self.shape_index.clear()
+        else:
+            self.who_index.pop(index, None)
+            self.shape_index.pop(index, None)
+
     def state_init(
         self,
         index: None | int,

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -211,6 +211,7 @@ class DatasetIter(data.Dataset):
         patch_size: list[int] | None,
         overlap: int | None,
         buffer_size: int,
+        apply_augmentations: bool = True,
         use_cache=True,
     ) -> None:
         self.rank = rank
@@ -219,13 +220,15 @@ class DatasetIter(data.Dataset):
         self.patch_size = patch_size
         self.overlap = overlap
         self.groups_src = groups_src
-        self.data_augmentations_list = data_augmentations_list
+        self.apply_augmentations = apply_augmentations
+        self.data_augmentations_list = data_augmentations_list if apply_augmentations else []
         self.use_cache = use_cache
         self.nb_dataset = len(data[next(iter(data.keys()))])
         self.buffer_size = buffer_size
         self._index_cache: list[int] = []
         self._index_cache_lookup: set[int] = set()
         self.inline_augmentations = inline_augmentations
+        self.has_augmented_samples = self.apply_augmentations and any(a > 0 for _, a, _ in mapping)
 
     def get_patch_config(self) -> tuple[list[int] | None, int | None]:
         return self.patch_size, self.overlap
@@ -242,7 +245,7 @@ class DatasetIter(data.Dataset):
         return self.data[group_dest][index]
 
     def reset_augmentation(self, label):
-        if self.inline_augmentations and len(self.data_augmentations_list) > 0:
+        if self.inline_augmentations and self.has_augmented_samples and len(self.data_augmentations_list) > 0:
             for index in range(self.nb_dataset):
                 for group_src in self.groups_src:
                     for group_dest in self.groups_src[group_src]:
@@ -321,13 +324,13 @@ class DatasetIter(data.Dataset):
 
     def load_data(self, group_src: str, group_dest: str, index: int, augmentation_index: int | None = None) -> bool:
         item = self.data[group_dest][index]
-        if augmentation_index is not None and item.can_stream_patch(augmentation_index):
+        if augmentation_index is not None and item.can_stream_patch(augmentation_index, self.apply_augmentations):
             return False
         try:
             item.load(
                 self.groups_src[group_src][group_dest].transforms,
                 self.data_augmentations_list,
-                load_augmentations=not self.inline_augmentations,
+                load_augmentations=self.apply_augmentations and not self.inline_augmentations,
             )
         except Exception as e:
             raise RuntimeError(
@@ -356,7 +359,7 @@ class DatasetIter(data.Dataset):
         sample: Sample = {}
         x, a, p = self.mapping[index]
         needs_full_load = any(
-            not self.data[group_dest][x].can_stream_patch(a)
+            not self.data[group_dest][x].can_stream_patch(a, self.apply_augmentations)
             for group_src in self.groups_src
             for group_dest in self.groups_src[group_src]
         )
@@ -375,6 +378,7 @@ class DatasetIter(data.Dataset):
                         a,
                         self.groups_src[group_src][group_dest].patch_transforms,
                         self.groups_src[group_src][group_dest].is_input,
+                        self.apply_augmentations,
                     ),
                     dataset.cache_attributes[a],
                     x,
@@ -541,6 +545,7 @@ class Data(ABC):
         subset: Subset,
         batch_size: int,
         validation: float | str | list[int] | list[str] | None,
+        validation_augmentations: bool,
         inline_augmentations: bool,
         data_augmentations_list: dict[str, DataAugmentationsList],
         num_workers: int | None,
@@ -553,6 +558,7 @@ class Data(ABC):
         self.groups_src = groups_src
         self.patch = patch
         self.validation = validation
+        self.validation_augmentations = validation_augmentations
         self.data_augmentations_list = data_augmentations_list
         self.batch_size = batch_size
         self.use_cache = use_cache
@@ -563,7 +569,6 @@ class Data(ABC):
             DatasetIter,
             groups_src=self.groups_src,
             inline_augmentations=inline_augmentations,
-            data_augmentations_list=list(self.data_augmentations_list.values()),
             patch_size=self.patch.patch_size if self.patch is not None else None,
             overlap=self.patch.overlap if self.patch is not None else None,
             buffer_size=batch_size + 1,
@@ -586,14 +591,27 @@ class Data(ABC):
         self.mapping: list[list[list[tuple[int, int, int]]]] = []
         self.datasets: dict[str, Dataset] = {}
         self._prepared_data: dict[str, list[DatasetManager]] | None = None
+        self._prepared_validation_data: dict[str, list[DatasetManager]] | None = None
         self._prepared_mapping: list[tuple[int, int, int]] = []
         self._prepared_validation_mapping: list[tuple[int, int, int]] = []
         self._prepared_train_names: list[str] = []
         self._prepared_validation_names: list[str] = []
 
+    def _get_data_augmentations(self, apply_augmentations: bool = True) -> list[DataAugmentationsList]:
+        return list(self.data_augmentations_list.values()) if apply_augmentations else []
+
+    @staticmethod
+    def _get_nb_augmentation(data_augmentations_list: list[DataAugmentationsList]) -> int:
+        return max(int(np.sum([data_augmentation.nb for data_augmentation in data_augmentations_list]) + 1), 1)
+
+    def _get_validation_mapping(self) -> list[tuple[int, int, int]]:
+        if self.validation_augmentations:
+            return self._prepared_validation_mapping
+        return [entry for entry in self._prepared_validation_mapping if entry[1] == 0]
+
     def prepare(self) -> None:
         """Instantiate config-driven transforms and augmentations before runtime."""
-        if self._prepared_data is not None:
+        if self._prepared_data is not None and self._prepared_validation_data is not None:
             return
 
         model_have_input = False
@@ -739,11 +757,55 @@ class Data(ABC):
             )
         return dataset_name, subset_names
 
-    def _split_train_validation(
+    @staticmethod
+    def _get_source_filename_by_group(
+        dataset_name: dict[str, dict[str, list[str]]],
+    ) -> dict[str, dict[str, str]]:
+        source_filename_by_group: dict[str, dict[str, str]] = {}
+        for group_src, filenames_by_group in dataset_name.items():
+            source_filename_by_group[group_src] = {}
+            for filename, group_names in filenames_by_group.items():
+                for name in group_names:
+                    source_filename_by_group[group_src].setdefault(name, filename)
+        return source_filename_by_group
+
+    def _get_case_entry_counts(
+        self,
+        names: list[str],
+        dataset_name: dict[str, dict[str, list[str]]],
+        data_augmentations_list: list[DataAugmentationsList],
+    ) -> list[int]:
+        if len(names) == 0:
+            return []
+
+        source_filename_by_group = self._get_source_filename_by_group(dataset_name)
+        nb_augmentation = self._get_nb_augmentation(data_augmentations_list)
+        nb_patch = [[0] * nb_augmentation for _ in names]
+
+        for group_src in self.groups_src:
+            for group_dest in self.groups_src[group_src]:
+                datasets = [
+                    DatasetManager(
+                        i,
+                        group_src,
+                        group_dest,
+                        name,
+                        self.datasets[source_filename_by_group[group_src][name]],
+                        patch=self.patch,
+                        transforms=self.groups_src[group_src][group_dest].transforms,
+                        data_augmentations_list=data_augmentations_list,
+                    )
+                    for i, name in enumerate(names)
+                ]
+                nb_patch = [[dataset.get_size(a) for a in range(nb_augmentation)] for dataset in datasets]
+
+        return [int(np.sum(case_patch_counts)) for case_patch_counts in nb_patch]
+
+    def _resolve_validation_indices(
         self,
         subset_names: list[str],
-        mapping: list[tuple[int, int, int]],
-    ) -> tuple[list[tuple[int, int, int]], list[tuple[int, int, int]], list[str], list[str]]:
+        case_entry_counts: list[int] | None = None,
+    ) -> list[int]:
         index: list[int] = []
         if isinstance(self.validation, float):
             if self.validation <= 0 or self.validation >= 1:
@@ -752,7 +814,15 @@ class Data(ABC):
                     f"Received: {self.validation}",
                     "Example: validation = 0.2  # for a 20% validation split",
                 )
-            index = [m[0] for m in mapping[math.floor(len(mapping) * (1 - self.validation)) :]]
+            if case_entry_counts is None:
+                raise DatasetManagerError("Internal error: missing case entry counts for float validation split.")
+            threshold = math.floor(sum(case_entry_counts) * (1 - self.validation))
+            cumulative = 0
+            for dataset_index, count in enumerate(case_entry_counts):
+                cumulative += count
+                if cumulative > threshold:
+                    index = list(range(dataset_index, len(subset_names)))
+                    break
         elif isinstance(self.validation, str):
             if ":" in self.validation:
                 index = list(range(int(self.validation.split(":")[0]), int(self.validation.split(":")[1])))
@@ -791,67 +861,86 @@ class Data(ABC):
                     "\t• str  → list of sample names or file paths",
                     f"Received list: {self.validation}",
                 )
-        index_set = set(index)
-        train_mapping = [m for m in mapping if m[0] not in index_set]
-        validate_mapping = [m for m in mapping if m[0] in index_set]
+        return index
 
-        if len(train_mapping) == 0:
+    def _split_train_validation_names(
+        self,
+        subset_names: list[str],
+        dataset_name: dict[str, dict[str, list[str]]],
+    ) -> tuple[list[str], list[str]]:
+        case_entry_counts = None
+        dataset_size = len(subset_names)
+        if isinstance(self.validation, float):
+            case_entry_counts = self._get_case_entry_counts(
+                subset_names,
+                dataset_name,
+                self._get_data_augmentations(True),
+            )
+            dataset_size = int(sum(case_entry_counts))
+
+        index = self._resolve_validation_indices(subset_names, case_entry_counts)
+        index_set = set(index)
+        validation_names = [name for i, name in enumerate(subset_names) if i in index_set]
+        validation_names_set = set(validation_names)
+        train_names = [name for name in subset_names if name not in validation_names_set]
+
+        if len(train_names) == 0:
             raise DatasetManagerError(
                 "No data left for training after applying the validation split.",
-                f"Dataset size: {len(mapping)}",
+                f"Dataset size: {dataset_size}",
                 f"Validation setting: {self.validation}",
                 "Please reduce the validation size, increase the dataset, or disable validation.",
             )
 
-        if self.validation is not None and len(validate_mapping) == 0:
+        if self.validation is not None and len(validation_names) == 0:
             raise DatasetManagerError(
                 "No data left for validation after applying the validation split.",
-                f"Dataset size: {len(mapping)}",
+                f"Dataset size: {dataset_size}",
                 f"Validation setting: {self.validation}",
                 "Please increase the validation size, increase the dataset, or disable validation.",
             )
 
-        validation_names = [name for i, name in enumerate(subset_names) if i in index_set]
-        validation_names_set = set(validation_names)
-        train_names = [name for name in subset_names if name not in validation_names_set]
-        return train_mapping, validate_mapping, train_names, validation_names
+        return train_names, validation_names
 
     def _prepare_datasets(self) -> None:
         """Resolve dataset files, validate subsets, and precompute train/validation mappings."""
         datasets = self._resolve_dataset_sources()
         dataset_name, subset_names = self._resolve_common_names(datasets)
         subset_names_list = list(subset_names)
-        data, mapping = self._get_datasets(subset_names_list, dataset_name)
-        train_mapping, validate_mapping, train_names, validation_names = self._split_train_validation(
-            subset_names_list, mapping
+        train_names, validation_names = self._split_train_validation_names(
+            subset_names_list,
+            dataset_name,
+        )
+        train_data, train_mapping = self._get_datasets(
+            train_names,
+            dataset_name,
+            self._get_data_augmentations(True),
+        )
+        validation_data, validate_mapping = self._get_datasets(
+            validation_names,
+            dataset_name,
+            self._get_data_augmentations(self.validation_augmentations),
         )
 
-        self._prepared_data = data
+        self._prepared_data = train_data
+        self._prepared_validation_data = validation_data
         self._prepared_mapping = train_mapping
         self._prepared_validation_mapping = validate_mapping
         self._prepared_train_names = train_names
         self._prepared_validation_names = validation_names
 
     def _get_datasets(
-        self, names: list[str], dataset_name: dict[str, dict[str, list[str]]]
+        self,
+        names: list[str],
+        dataset_name: dict[str, dict[str, list[str]]],
+        data_augmentations_list: list[DataAugmentationsList],
     ) -> tuple[dict[str, list[DatasetManager]], list[tuple[int, int, int]]]:
         nb_dataset = len(names)
         nb_patch: list[list[int]]
         data = {}
         mapping = []
-        source_filename_by_group: dict[str, dict[str, str]] = {}
-        nb_augmentation = np.max(
-            [
-                int(np.sum([data_augmentation.nb for data_augmentation in self.data_augmentations_list.values()]) + 1),
-                1,
-            ]
-        )
-
-        for group_src, filenames_by_group in dataset_name.items():
-            source_filename_by_group[group_src] = {}
-            for filename, group_names in filenames_by_group.items():
-                for name in group_names:
-                    source_filename_by_group[group_src].setdefault(name, filename)
+        source_filename_by_group = self._get_source_filename_by_group(dataset_name)
+        nb_augmentation = self._get_nb_augmentation(data_augmentations_list)
 
         for group_src in self.groups_src:
             for group_dest in self.groups_src[group_src]:
@@ -864,7 +953,7 @@ class Data(ABC):
                         self.datasets[source_filename_by_group[group_src][name]],
                         patch=self.patch,
                         transforms=self.groups_src[group_src][group_dest].transforms,
-                        data_augmentations_list=list(self.data_augmentations_list.values()),
+                        data_augmentations_list=data_augmentations_list,
                     )
                     for i, name in enumerate(names)
                 ]
@@ -923,34 +1012,40 @@ class Data(ABC):
         return local_indices, remapped_mapping
 
     def get_data(self, world_size: int) -> tuple[list[list[DataLoader]], list[str], list[str]]:
-        if self._prepared_data is None:
+        if self._prepared_data is None or self._prepared_validation_data is None:
             raise DatasetManagerError("Dataset configuration was not prepared before runtime data loading.")
 
         self.data = []
         self.mapping = []
         train_mappings = Data._split(self._prepared_mapping, world_size)
-        validate_mappings = Data._split(self._prepared_validation_mapping, world_size)
+        validate_mappings = Data._split(self._get_validation_mapping(), world_size)
         for i, (train_mapping, validate_mapping) in enumerate(zip(train_mappings, validate_mappings, strict=False)):
-            mappings = [train_mapping]
-            if len(validate_mapping):
-                mappings += [validate_mapping]
             self.data.append([])
             self.mapping.append([])
-            for mapping_tmp in mappings:
-                indexs, remapped_mapping = self._remap_dataset_indices(mapping_tmp)
-                self.data[i].append({k: [v[it] for it in indexs] for k, v in self._prepared_data.items()})
-                self.mapping[i].append(remapped_mapping)
+            train_indices, train_remapped_mapping = self._remap_dataset_indices(train_mapping)
+            self.data[i].append({k: [v[it] for it in train_indices] for k, v in self._prepared_data.items()})
+            self.mapping[i].append(train_remapped_mapping)
+            if len(validate_mapping):
+                validation_indices, validation_remapped_mapping = self._remap_dataset_indices(validate_mapping)
+                self.data[i].append(
+                    {k: [v[it] for it in validation_indices] for k, v in self._prepared_validation_data.items()}
+                )
+                self.mapping[i].append(validation_remapped_mapping)
 
         data_loaders: list[list[DataLoader]] = []
         for i, (datas, mappings) in enumerate(zip(self.data, self.mapping, strict=False)):
             data_loaders.append([])
-            for dataset_items, mapping in zip(datas, mappings, strict=False):
+            for loader_index, (dataset_items, mapping) in enumerate(zip(datas, mappings, strict=False)):
                 data_loaders[i].append(
                     DataLoader(
                         dataset=self.datasetIter(
                             rank=i,
                             data=dataset_items,
                             mapping=mapping,
+                            data_augmentations_list=self._get_data_augmentations(
+                                loader_index == 0 or self.validation_augmentations
+                            ),
+                            apply_augmentations=loader_index == 0 or self.validation_augmentations,
                         ),
                         sampler=CustomSampler(len(mapping), self.subset.shuffle),
                         batch_size=self.batch_size,
@@ -968,6 +1063,7 @@ class Data(ABC):
             "subset": self.subset,
             "batch_size": self.batch_size,
             "validation": self.validation,
+            "validation_augmentations": self.validation_augmentations,
             "inline_augmentations": self.inline_augmentations,
             "data_augmentations_list": self.data_augmentations_list,
         }
@@ -992,6 +1088,7 @@ class DataTrain(Data):
         subset: TrainSubset = TrainSubset(),
         batch_size: int = 1,
         validation: float | str | list[int] | list[str] | None = 0.2,
+        validation_augmentations: bool = True,
         num_workers: int | None = None,
         pin_memory: bool = False,
         prefetch_factor: int | None = None,
@@ -1005,6 +1102,7 @@ class DataTrain(Data):
             subset,
             batch_size,
             validation,
+            validation_augmentations,
             inline_augmentations,
             augmentations if augmentations else {},
             num_workers,
@@ -1040,6 +1138,7 @@ class DataPrediction(Data):
             subset=subset,
             batch_size=batch_size,
             validation=None,
+            validation_augmentations=True,
             inline_augmentations=False,
             data_augmentations_list=augmentations if augmentations else {},
             num_workers=num_workers,
@@ -1073,6 +1172,7 @@ class DataMetric(Data):
             subset=subset,
             batch_size=1,
             validation=validation,
+            validation_augmentations=True,
             data_augmentations_list={},
             inline_augmentations=False,
             num_workers=num_workers,

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -32,6 +32,7 @@ from konfai.data.augmentation import DataAugmentationsList
 from konfai.data.transform import Clip, Normalize, Save, Standardize, TensorCast, Transform
 from konfai.utils.config import apply_config, config
 from konfai.utils.dataset import Attribute, Dataset
+from konfai.utils.errors import PatchError
 from konfai.utils.utils import SUPPORTED_EXTENSIONS, get_module, get_patch_slices_from_shape, split_path_spec
 
 
@@ -181,14 +182,17 @@ class Accumulator:
 
     def assemble(self) -> torch.Tensor:
         n = 2 if self.batch else 1
-        if self._layer_accumulator[0] is not None:
-            result = torch.zeros(
-                (
-                    list(self._layer_accumulator[0].shape[:n])
-                    + list(max([[v.stop for v in patch] for patch in self.patch_slices]))
-                ),
-                dtype=self._layer_accumulator[0].dtype,
-            ).to(self._layer_accumulator[0].device)
+        reference = next((layer for layer in self._layer_accumulator if layer is not None), None)
+        if reference is None:
+            raise PatchError(
+                "Accumulator.assemble() was called before any patch was added.",
+                f"Expected up to {len(self.patch_slices)} patch(es) via add_layer() before assembling.",
+                "Add at least one patch (and check is_full()) before calling assemble().",
+            )
+        result = torch.zeros(
+            (list(reference.shape[:n]) + list(max([[v.stop for v in patch] for patch in self.patch_slices]))),
+            dtype=reference.dtype,
+        ).to(reference.device)
         for patch_slice, data in zip(self.patch_slices, self._layer_accumulator, strict=False):
             if data is not None:
                 slices_dest = tuple([slice(result.shape[i]) for i in range(n)] + list(patch_slice))
@@ -437,6 +441,7 @@ class DatasetManager:
                 caches_attribute.append(copy.deepcopy(self.cache_attributes[0]))
 
             for data_augmentation in data_augmentations.data_augmentations:
+                data_augmentation.reset_state(self.index)
                 shape = data_augmentation.state_init(self.index, shape, caches_attribute)
             for it, s in enumerate(shape):
                 self.cache_attributes.append(caches_attribute[it])

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -423,8 +423,7 @@ class DatasetManager:
         self.patch.load(_shape, 0)
         self.shape = _shape
         self.data_augmentations_list = data_augmentations_list
-        self._patch_stream_source: tuple[Dataset, str, list[int], list[Transform]] | None = None
-        self._patch_stream_checked = False
+        self._patch_stream_sources: dict[bool, tuple[Dataset, str, list[int], list[Transform]] | None] = {}
         self.reset_augmentation()
         self.cache_attributes_bak = copy.deepcopy(self.cache_attributes)
 
@@ -633,9 +632,12 @@ class DatasetManager:
         )
         return Dataset(filename, file_format)
 
-    def _resolve_patch_stream_source(self) -> tuple[Dataset, str, list[int], list[Transform]] | None:
-        if self._patch_stream_checked:
-            return self._patch_stream_source
+    def _resolve_patch_stream_source(
+        self,
+        apply_augmentations: bool = True,
+    ) -> tuple[Dataset, str, list[int], list[Transform]] | None:
+        if apply_augmentations in self._patch_stream_sources:
+            return self._patch_stream_sources[apply_augmentations]
 
         source_dataset = self.dataset
         source_group = self.group_src
@@ -655,7 +657,7 @@ class DatasetManager:
                     break
 
         stream_cache_attribute = Attribute(self.cache_attributes[0])
-        if len(self.data_augmentations_list) == 0 and all(
+        if (not apply_augmentations or len(self.data_augmentations_list) == 0) and all(
             self._supports_patch_stream_transform(
                 transform,
                 source_dataset,
@@ -666,17 +668,27 @@ class DatasetManager:
         ):
             self.cache_attributes[0] = Attribute(stream_cache_attribute)
             self.cache_attributes_bak[0] = Attribute(stream_cache_attribute)
-            self._patch_stream_source = (source_dataset, source_group, list(source_shape), trailing_transforms)
+            self._patch_stream_sources[apply_augmentations] = (
+                source_dataset,
+                source_group,
+                list(source_shape),
+                trailing_transforms,
+            )
         else:
-            self._patch_stream_source = None
-        self._patch_stream_checked = True
-        return self._patch_stream_source
+            self._patch_stream_sources[apply_augmentations] = None
+        return self._patch_stream_sources[apply_augmentations]
 
-    def can_stream_patch(self, a: int) -> bool:
-        return a == 0 and self._resolve_patch_stream_source() is not None
+    def can_stream_patch(self, a: int, apply_augmentations: bool = True) -> bool:
+        return a == 0 and self._resolve_patch_stream_source(apply_augmentations) is not None
 
-    def _get_streamed_data(self, index: int, a: int, is_input: bool) -> tuple[torch.Tensor, Attribute]:
-        stream_source = self._resolve_patch_stream_source()
+    def _get_streamed_data(
+        self,
+        index: int,
+        a: int,
+        is_input: bool,
+        apply_augmentations: bool = True,
+    ) -> tuple[torch.Tensor, Attribute]:
+        stream_source = self._resolve_patch_stream_source(apply_augmentations)
         if stream_source is None:
             raise RuntimeError("Patch streaming requested on a dataset manager without a streaming source.")
 
@@ -700,9 +712,16 @@ class DatasetManager:
         self.augmented_data.clear()
         self.augmentationLoaded = self.total_augmentations == 0
 
-    def get_data(self, index: int, a: int, patch_transforms: list[Transform], is_input: bool) -> torch.Tensor:
-        if not self.loaded and self.can_stream_patch(a):
-            data, _ = self._get_streamed_data(index, a, is_input)
+    def get_data(
+        self,
+        index: int,
+        a: int,
+        patch_transforms: list[Transform],
+        is_input: bool,
+        apply_augmentations: bool = True,
+    ) -> torch.Tensor:
+        if not self.loaded and self.can_stream_patch(a, apply_augmentations):
+            data, _ = self._get_streamed_data(index, a, is_input, apply_augmentations)
         else:
             data = self.patch.get_data(self._get_tensor(a), index, a, is_input)
         for transform_function in patch_transforms:

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -1048,9 +1048,13 @@ class Crop(TransformInverse):
         super().__init__(inverse)
 
     def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
-        # TODO(perf): reads the full pixel array at DatasetManager __init__ time to compute the crop
-        # bounding box; for large 3-D volumes this forces a complete disk read before any caching.
-        # Fix: persist the box as a sidecar attribute or compute lazily inside _load().  Medium effort.
+        # The crop box is content-dependent (foreground bounding box), so the output shape
+        # cannot be known without the pixel data. If the box was already computed and persisted
+        # as a sidecar attribute, reuse it and skip the read; otherwise compute it once from the
+        # volume. (A fully-lazy variant would require deferring patch planning past _load().)
+        if "box" in cache_attribute:
+            box = self._parse_box(cache_attribute["box"])
+            return [shape[0]] + [int(s - a - b) for (a, b), s in zip(box, shape[1:], strict=False)]
         data = None
         for dataset in self.datasets:
             if dataset.is_dataset_exist(group_src, name):
@@ -1066,12 +1070,15 @@ class Crop(TransformInverse):
         cache_attribute["box"] = box
         return [shape[0]] + [int(s - a - b) for (a, b), s in zip(box, shape[1:], strict=False)]
 
+    @staticmethod
+    def _parse_box(box_str: str) -> np.ndarray:
+        flat = np.fromstring(box_str.replace("[", " ").replace("]", " "), sep=" ", dtype=np.int64)
+        return flat.reshape(-1, 2)
+
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         if "box" not in cache_attribute:
             return tensor
-        box_str = cache_attribute["box"]
-        flat = np.fromstring(box_str.replace("[", " ").replace("]", " "), sep=" ", dtype=np.int64)
-        box = flat.reshape(-1, 2)
+        box = self._parse_box(cache_attribute["box"])
         for i, ((_, b), s) in enumerate(zip(box, tensor.shape[1:], strict=False)):
             box[i][1] = s - b
         if "Origin" in cache_attribute and "Spacing" in cache_attribute and "Direction" in cache_attribute:
@@ -1090,9 +1097,7 @@ class Crop(TransformInverse):
     def inverse(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         if "box" not in cache_attribute:
             return tensor
-        box_str = cache_attribute.pop("box")
-        flat = np.fromstring(box_str.replace("[", " ").replace("]", " "), sep=" ", dtype=np.int64)
-        box = flat.reshape(-1, 2)
+        box = self._parse_box(cache_attribute.pop("box"))
         cache_attribute.pop_np_array("Origin")
         padding = []
         for b in reversed(box):

--- a/konfai/metric/measure.py
+++ b/konfai/metric/measure.py
@@ -17,10 +17,12 @@
 """Criterion and metric implementations used by KonfAI workflows."""
 
 import copy
+import importlib
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from functools import partial
+from types import ModuleType
 from typing import cast
 
 import numpy as np
@@ -34,9 +36,28 @@ from konfai.network.blocks import LatentDistribution
 from konfai.network.network import ModelLoader, Network
 from konfai.utils.config import apply_config
 from konfai.utils.dataset import Attribute
+from konfai.utils.errors import MeasureError
 from konfai.utils.utils import get_module
 
 models_register: dict[str, Network] = {}
+
+
+def _require_optional(module: str, *, criterion: str, extra: str) -> ModuleType:
+    """Import an optional criterion dependency or raise an actionable error.
+
+    Several criteria (SSIM, LPIPS, FID) rely on heavyweight optional packages
+    that are not part of the base install. Importing them through this helper
+    turns a missing dependency into a clear, install-ready message raised at
+    criterion construction, instead of a raw ``ImportError`` surfacing mid-run.
+    """
+    package = module.split(".")[0]
+    try:
+        return importlib.import_module(module)
+    except ImportError as exc:
+        raise MeasureError(
+            f"The '{criterion}' criterion requires the optional dependency '{package}'.",
+            f"Install it with `pip install konfai[{extra}]` (or `pip install {package}`).",
+        ) from exc
 
 
 class Criterion(torch.nn.Module, ABC):
@@ -221,8 +242,9 @@ class PSNR(MaskedLoss):
 class SSIM(MaskedLoss):
     @staticmethod
     def _loss(dynamic_range: float, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-        from skimage.metrics import structural_similarity
-
+        structural_similarity = _require_optional(
+            "skimage.metrics", criterion="SSIM", extra="ssim"
+        ).structural_similarity
         return structural_similarity(
             x[0][0].detach().cpu().numpy(),
             y[0][0].cpu().numpy(),
@@ -232,6 +254,7 @@ class SSIM(MaskedLoss):
         )
 
     def __init__(self, dynamic_range: float | None = None) -> None:
+        _require_optional("skimage.metrics", criterion="SSIM", extra="ssim")
         dynamic_range = dynamic_range if dynamic_range else 1024 + 3000
         super().__init__(partial(SSIM._loss, dynamic_range), True)
 
@@ -263,7 +286,7 @@ class LPIPS(MaskedLoss):
         return loss / dataset_patch.get_size(0)
 
     def __init__(self, model: str = "alex") -> None:
-        import lpips
+        lpips = _require_optional("lpips", criterion="LPIPS", extra="lpips")
 
         super().__init__(partial(LPIPS._loss, lpips.LPIPS(net=model).to(0)), True)
 
@@ -542,7 +565,8 @@ class PerceptualLoss(Criterion):
 
     def forward(self, output: torch.Tensor, *targets: torch.Tensor) -> torch.Tensor:
         if output.device.index not in self.models:
-            del os.environ["device"]
+            # `Network.to` now resets its GPU-index counter per call, so the perceptual
+            # model is placed starting at this device without the old os.environ reset.
             self.models[output.device.index] = Network.to(copy.deepcopy(self.model).eval(), output.device.index).eval()
         loss = torch.zeros((1), requires_grad=True).to(output.device, non_blocking=False).type(torch.float32)
         if len(output.shape) == 5 and len(self.shape) == 2:
@@ -659,7 +683,9 @@ class FID(Criterion):
         def __init__(self) -> None:
             super().__init__()
 
-            from torchvision.models import Inception_V3_Weights, inception_v3
+            torchvision_models = _require_optional("torchvision.models", criterion="FID", extra="fid")
+            inception_v3 = torchvision_models.inception_v3
+            Inception_V3_Weights = torchvision_models.Inception_V3_Weights
 
             self.model = inception_v3(weights=Inception_V3_Weights.DEFAULT, transform_input=False)
             self.model.fc = torch.nn.Identity()
@@ -670,6 +696,7 @@ class FID(Criterion):
 
     def __init__(self) -> None:
         super().__init__()
+        _require_optional("scipy.linalg", criterion="FID", extra="fid")
         self.inception_model = FID.InceptionV3().cuda()
 
     @staticmethod
@@ -694,7 +721,7 @@ class FID(Criterion):
         sigma2 = np.cov(generated_features, rowvar=False)
 
         diff = mu1 - mu2
-        from scipy import linalg
+        linalg = _require_optional("scipy.linalg", criterion="FID", extra="fid")
 
         covmean, _ = linalg.sqrtm(sigma1.dot(sigma2), disp=False)
         if np.iscomplexobj(covmean):

--- a/konfai/models/generation/diffusionGan.py
+++ b/konfai/models/generation/diffusionGan.py
@@ -157,6 +157,16 @@ class DiscriminatorADA(network.Network):
             # self.add_module("Flatten", torch.nn.Flatten(1))
 
     class UpdateP(torch.nn.Module):
+        """Adaptive-augmentation (ADA) probability controller.
+
+        `p` and `_it` are intentional running training state: every `n` calls the
+        augmentation probability `p` is nudged toward `ada_target` based on the
+        discriminator measure. They are deliberately kept as plain Python scalars
+        (not registered buffers) so the checkpoint format stays compatible with
+        existing pretrained weights. `_it` only matters modulo `n`, so it is never
+        reset; `p` accumulates by design.
+        """
+
         def __init__(self):
             super().__init__()
             self._it = 0

--- a/konfai/models/generation/vae.py
+++ b/konfai/models/generation/vae.py
@@ -19,6 +19,14 @@ from konfai.network import blocks, network
 
 
 class VAE(network.Network):
+    """Convolutional encoder-decoder (deterministic autoencoder).
+
+    Note: this network has no latent sampling — it is a plain autoencoder, not a
+    variational one. For a reparameterised latent (mu/log_std/z + KL-ready named
+    outputs) use ``blocks.LatentDistribution`` as a bottleneck, as ``LinearVAE``
+    demonstrates.
+    """
+
     class AutoEncoderBlock(network.ModuleArgsDict):
         def __init__(
             self,
@@ -143,11 +151,18 @@ class VAE(network.Network):
 
 
 class LinearVAE(network.Network):
+    """Fully-connected variational autoencoder for flat feature vectors.
+
+    Encoder → variational bottleneck (``LatentDistribution``: reparameterised
+    sampling with addressable ``Latent.mu`` / ``Latent.log_std`` outputs for the
+    KL term) → decoder. Dimensions are parameterised; the variational sampling
+    (previously absent) is provided by ``LatentDistribution``.
+    """
+
     class LinearVAEDenseLayer(network.ModuleArgsDict):
         def __init__(self, in_features: int, out_features: int) -> None:
             super().__init__()
             self.add_module("Linear", torch.nn.Linear(in_features, out_features))
-            # self.add_module("Norm", torch.nn.BatchNorm1d(out_features))
             self.add_module("Activation", torch.nn.LeakyReLU())
 
     class LinearVAEHead(network.ModuleArgsDict):
@@ -163,6 +178,9 @@ class LinearVAE(network.Network):
             "default|ReduceLROnPlateau": network.LRSchedulersLoader(0)
         },
         outputs_criterions: dict[str, network.TargetCriterionsLoader] = {"default": network.TargetCriterionsLoader()},
+        in_features: int = 784,
+        hidden_features: int = 256,
+        latent_dim: int = 32,
     ) -> None:
         super().__init__(
             in_channels=1,
@@ -173,7 +191,6 @@ class LinearVAE(network.Network):
             dim=1,
             nb_batch_per_step=1,
         )
-        self.add_module("DenseLayer_0", LinearVAE.LinearVAEDenseLayer(23343, 5))
-        # self.add_module("Head", LinearVAE.DenseLayer(100, 28590))
-        self.add_module("Head", LinearVAE.LinearVAEHead(5, 23343))
-        # self.add_module("DenseLayer_5", LinearVAE.DenseLayer(5000, 28590))
+        self.add_module("Encoder", LinearVAE.LinearVAEDenseLayer(in_features, hidden_features))
+        self.add_module("Latent", blocks.LatentDistribution(shape=[hidden_features], latent_dim=latent_dim))
+        self.add_module("Head", LinearVAE.LinearVAEHead(hidden_features, in_features))

--- a/konfai/models/representation/representation.py
+++ b/konfai/models/representation/representation.py
@@ -67,12 +67,14 @@ class Adaptation(torch.nn.Module):
         self.Encoder_1 = UnetCPP1Layers()
         self.ToFeatures = blocks.ToFeatures(3)
         self.FCT_1 = torch.nn.Linear(32, 32, bias=True)
+        # Static configuration: freeze the encoder, train the projection head.
+        # Set once here rather than on every forward (a per-call side effect).
+        self.Encoder_1.requires_grad_(False)
+        self.FCT_1.requires_grad_(True)
 
     def forward(
         self, a: torch.Tensor, b: torch.Tensor, c: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        self.Encoder_1.requires_grad_(False)
-        self.FCT_1.requires_grad_(True)
         return (
             self.FCT_1(self.ToFeatures(self.Encoder_1(a))),
             self.FCT_1(self.ToFeatures(self.Encoder_1(b))),

--- a/konfai/network/blocks.py
+++ b/konfai/network/blocks.py
@@ -18,6 +18,7 @@
 
 import ast
 import importlib
+import warnings
 from collections.abc import Callable
 from enum import Enum
 
@@ -304,7 +305,17 @@ class Concat(torch.nn.Module):
         return torch.cat(tensor, dim=1)
 
 
+# ---------------------------------------------------------------------------
+# Debug-only blocks
+#
+# These pass the tensor through unchanged (or stop the graph) and exist only to
+# inspect intermediate activations while developing a model. They are inert
+# unless explicitly wired into a graph via `add_module`, have side effects
+# (stdout / disk / raising), and must NOT be left in a production model.
+# ---------------------------------------------------------------------------
 class Print(torch.nn.Module):
+    """Debug block: print the tensor shape and pass it through unchanged."""
+
     def __init__(self) -> None:
         super().__init__()
 
@@ -314,16 +325,30 @@ class Print(torch.nn.Module):
 
 
 class Write(torch.nn.Module):
-    def __init__(self) -> None:
+    """Debug block: write the first channel of the first sample to disk as a volume.
+
+    The destination path is explicit (no silent hardcoded location) and each
+    call warns, since writing to disk inside a forward pass is a development-only
+    side effect.
+    """
+
+    def __init__(self, path: str = "./Data.mha") -> None:
         super().__init__()
+        self.path = path
 
     def forward(self, tensor: torch.Tensor) -> torch.Tensor:
-
-        sitk.WriteImage(sitk.GetImageFromArray(tensor.clone()[0][0].cpu().numpy()), "./Data.mha")
+        warnings.warn(
+            f"Debug `Write` block is writing a volume to '{self.path}' during forward; "
+            "remove it from production models.",
+            stacklevel=2,
+        )
+        sitk.WriteImage(sitk.GetImageFromArray(tensor.clone()[0][0].cpu().numpy()), self.path)
         return tensor
 
 
 class Exit(torch.nn.Module):
+    """Debug block: stop the forward pass by raising, to halt at a chosen point."""
+
     def __init__(self) -> None:
         super().__init__()
 

--- a/konfai/network/network.py
+++ b/konfai/network/network.py
@@ -45,7 +45,7 @@ from konfai.data.data_manager import BatchSample
 from konfai.data.patching import Accumulator, ModelPatch
 from konfai.metric.schedulers import Scheduler
 from konfai.utils.config import apply_config, config
-from konfai.utils.errors import MeasureError, TrainerError
+from konfai.utils.errors import ConfigError, MeasureError, TrainerError
 from konfai.utils.runtime import State, get_device, get_gpu_memory
 from konfai.utils.utils import get_module
 
@@ -456,20 +456,22 @@ class Measure:
         return result
 
     def update_scheduler(self, schedulers: dict[Scheduler, int], it: int) -> Scheduler:
+        if not schedulers:
+            raise ConfigError(
+                f"No scheduler is configured, cannot select one for iteration {it}.",
+                "Declare at least one scheduler window in the optimizer configuration.",
+            )
+        # Pick the window covering `it`; if `it` is past every window, the loop falls
+        # through and clamps to the last scheduler (stepped past its last window start).
         step = 0
-        _scheduler = None
+        _scheduler: Scheduler | None = None
         for _scheduler, value in schedulers.items():
             if value is None or (it >= step and it < step + value):
                 break
             step += value
-        if _scheduler:
-            _scheduler.step(it - step)
-        if _scheduler is None:
-            raise NameError(
-                f"No scheduler found for iteration {it}. "
-                f"Available steps were: {list(schedulers.values())}. "
-                f"Check your configuration."
-            )
+        if _scheduler is None:  # unreachable (schedulers is non-empty); kept for type-narrowing
+            raise ConfigError(f"No scheduler matched iteration {it}.")
+        _scheduler.step(it - step)
         return _scheduler
 
 
@@ -895,9 +897,13 @@ class Network(ModuleArgsDict, ABC):
             for name, child in module._modules.items():
                 if child is not None:
                     if not isinstance(child, Network):
-                        if isinstance(child, torch.nn.modules.conv._ConvNd) or isinstance(module, torch.nn.Linear):
+                        weight_key = prefix + name + ".weight"
+                        if (
+                            isinstance(child, (torch.nn.modules.conv._ConvNd, torch.nn.Linear))
+                            and weight_key in state_dict
+                        ):
                             current_size = child.weight.shape[0]
-                            last_size = state_dict[prefix + name + ".weight"].shape[0]
+                            last_size = state_dict[weight_key].shape[0]
 
                             if current_size != last_size:
                                 print(
@@ -906,11 +912,14 @@ class Network(ModuleArgsDict, ABC):
                                 )
                                 ModuleArgsDict.init_func(child, self.init_type, self.init_gain)
 
+                                bias_key = prefix + name + ".bias"
                                 with torch.no_grad():
-                                    child.weight[:last_size] = state_dict[prefix + name + ".weight"]
-                                    if child.bias is not None:
-                                        child.bias[:last_size] = state_dict[prefix + name + ".bias"]
-                                return
+                                    child.weight[:last_size] = state_dict[weight_key]
+                                    if child.bias is not None and bias_key in state_dict:
+                                        child.bias[:last_size] = state_dict[bias_key]
+                                # Skip the normal load for this resized leaf, but keep
+                                # loading its siblings (was an early `return` that aborted them).
+                                continue
                         load(child, prefix + name + ".")
 
         load(self)
@@ -1339,24 +1348,28 @@ class Network(ModuleArgsDict, ABC):
         return self
 
     @staticmethod
-    def to(module: ModuleArgsDict, device: int):
-        if "device" not in os.environ:
-            os.environ["device"] = str(device)
+    def to(module: ModuleArgsDict, device: int, _counter: list[int] | None = None):
+        # `_counter` is a single-element box holding the next GPU index, shared by
+        # reference through the recursion so model-parallel `isGPU_Checkpoint` splits
+        # advance it. Each top-level call starts fresh at `device` (replacing a previous
+        # `os.environ["device"]` counter that leaked across independent placements).
+        if _counter is None:
+            _counter = [device]
         for k, v in module.items():
             if module._modulesArgs[k].gpu == "cpu":
                 if module._modulesArgs[k].isGPU_Checkpoint:
-                    os.environ["device"] = str(int(os.environ["device"]) + 1)
-                module._modulesArgs[k].gpu = str(get_device(int(os.environ["device"])))
+                    _counter[0] += 1
+                module._modulesArgs[k].gpu = str(get_device(_counter[0]))
                 if isinstance(v, ModuleArgsDict):
-                    v = Network.to(v, int(os.environ["device"]))
+                    v = Network.to(v, _counter[0], _counter)
                 else:
-                    v = v.to(get_device(int(os.environ["device"])))
+                    v = v.to(get_device(_counter[0]))
         if isinstance(module, Network):
             if module.optimizer is not None:
                 for state in module.optimizer.state.values():
                     for k, v in state.items():
                         if isinstance(v, torch.Tensor):
-                            state[k] = v.to(get_device(int(os.environ["device"])))
+                            state[k] = v.to(get_device(_counter[0]))
         return module
 
     def get_name(self) -> str:

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -59,17 +59,19 @@ class EarlyStoppingBase:
     """Minimal protocol for early stopping strategies used by :class:`Trainer`."""
 
     def __init__(self):
-        pass
+        self.early_stop = False
 
     def is_stopped(self) -> bool:
-
-        return False
+        return self.early_stop
 
     def get_score(self, values: dict[str, float]):
         return sum(list(values.values()))
 
     def __call__(self, current_score: float) -> bool:
         return False
+
+    def stop(self) -> None:
+        self.early_stop = True
 
 
 @config()
@@ -98,10 +100,6 @@ class EarlyStopping(EarlyStoppingBase):
         self.mode = mode
         self.counter = 0
         self.best_score: float | None = None
-        self.early_stop = False
-
-    def is_stopped(self) -> bool:
-        return self.early_stop
 
     def get_score(self, values: dict[str, float]):
         if len(self.monitor) == 0:
@@ -324,6 +322,13 @@ class _Trainer:
                         score = self.early_stopping.get_score(loss)
                         self.checkpoint_save(score)
                         if self.early_stopping(score):
+                            break
+
+                        # Stop once the schedulers have decayed the learning rate to zero:
+                        # no further optimisation is possible, so end the run cleanly.
+                        optimizer = self.model.module.optimizer
+                        if optimizer is not None and optimizer.param_groups[0]["lr"] <= 0:
+                            self.early_stopping.stop()
                             break
 
                 batch_iter.set_description(f"Training : {description(self.model, self.model_ema)}")

--- a/konfai/utils/dicom.py
+++ b/konfai/utils/dicom.py
@@ -47,6 +47,7 @@ Optional dependency: ``pydicom`` (``pip install konfai[dicom]``).
 from __future__ import annotations
 
 import os
+import re
 from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
@@ -55,6 +56,9 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from konfai.utils.errors import DatasetManagerError
+
+# Zero-padded slice filenames produced by :func:`write_dicom_series` (e.g. ``000001.dcm``).
+_SLICE_FILENAME_RE = re.compile(r"^\d{6}\.dcm$")
 
 if TYPE_CHECKING:
     pass
@@ -226,6 +230,19 @@ def extract_geometry(
 
     first = datasets[0]
 
+    # Multi-frame / enhanced DICOM (many frames in one file) would be mis-stacked as a
+    # single slice, so reject it explicitly rather than produce a wrong volume.
+    try:
+        number_of_frames = int(getattr(first, "NumberOfFrames", 1) or 1)
+    except (TypeError, ValueError):
+        number_of_frames = 1
+    if number_of_frames > 1:
+        raise DatasetManagerError(
+            "Multi-frame / enhanced DICOM is not supported.",
+            f"The series declares NumberOfFrames={number_of_frames}.",
+            "KonfAI expects one frame per file (classic single-frame DICOM).",
+        )
+
     # Origin = ImagePositionPatient of first slice
     try:
         origin = np.array([float(x) for x in first.ImagePositionPatient], dtype=np.float64)
@@ -246,11 +263,20 @@ def extract_geometry(
             "This tag is required to determine voxel dimensions.",
         ) from exc
 
-    # Slice spacing: prefer computed inter-slice distance over SliceThickness
+    # Slice spacing: prefer computed inter-slice distance over SliceThickness.
+    # Use the first gap (matches SimpleITK's geometry), but verify the whole series is
+    # uniformly spaced so irregular series (localizers, missing/duplicate slices, mixed
+    # series) fail loudly instead of silently producing a wrong z-spacing.
     if len(datasets) > 1:
-        pos_first = _slice_position(datasets[0])
-        pos_second = _slice_position(datasets[1])
-        slice_spacing_mm = abs(pos_second - pos_first)
+        gaps = np.abs(np.diff([_slice_position(ds) for ds in datasets]))
+        slice_spacing_mm = float(gaps[0])
+        tolerance = max(1e-2, 1e-2 * slice_spacing_mm)
+        if float(np.ptp(gaps)) > tolerance:
+            raise DatasetManagerError(
+                "DICOM slices are not uniformly spaced.",
+                f"Inter-slice gaps range from {float(gaps.min()):.4f} to {float(gaps.max()):.4f} mm.",
+                "KonfAI assumes a regular z-spacing; irregular series are not supported.",
+            )
     else:
         try:
             slice_spacing_mm = float(first.SliceThickness)
@@ -451,8 +477,11 @@ def write_dicom_series(
 
     root = Path(directory)
     root.mkdir(parents=True, exist_ok=True)
+    # Remove only slices previously written by this function (its zero-padded NNNNNN.dcm
+    # naming), never unrelated DICOM files that may share the directory.
     for existing in root.glob("*.dcm"):
-        existing.unlink()
+        if _SLICE_FILENAME_RE.match(existing.name):
+            existing.unlink()
 
     metadata = dict(metadata or {})
     study_uid = str(metadata.get("StudyInstanceUID", generate_uid()))

--- a/konfai/utils/errors.py
+++ b/konfai/utils/errors.py
@@ -60,6 +60,10 @@ class DatasetManagerError(NamedKonfAIError):
     TYPE = "DatasetManager"
 
 
+class PatchError(NamedKonfAIError):
+    TYPE = "Patch"
+
+
 class MeasureError(NamedKonfAIError):
     TYPE = "Measure"
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -308,6 +308,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/43/894c2cbbcbdf53b57d1257a249811abe2ee9ab7ef76af301b40f1c054533/mistune-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/46/e0/60466c6d712dad2cf807df315e39863e91609ffd1064ecb835994460bbda/pydicom-3.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4b/25/05678d97fc25e2622df14dc530fb82023174ecfff6733991ed0d78f167bd/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/85/b505a99a133d9f99d21af182af416e9baef70bdeef019983479651e494c2/huggingface_hub-1.21.0-py3-none-any.whl
@@ -343,6 +344,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
@@ -354,6 +356,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/64/7e0266f0c541e26df86c31d2add9be3dd9914ae83785ce0aba7cbb693667/pygments_styles-0.3.0-py3-none-any.whl
@@ -375,6 +378,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9f/68/ed67a355a62848ee04bb4f01e89d3be871052c2c3ae6d5fc0fb2f6010979/simpleitk-2.5.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/b8/0d8eeb5a9fd7d34ba84f8a55753a0a3e2b5b51b2a5a0ade648a8db4a62f7/scikit_image-0.26.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -436,6 +440,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -465,6 +470,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/73/0291a64843270f4efb86cdcf2ee0f2048631b65ec6b405398b2b4dbf11bf/scipy-1.18.0-cp313-cp313-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/02/dc/c7043cab6fed8ae159fc1923ce829ada35c4dbd797d408a43858ffaf9639/tornado-6.5.7-cp39-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/03/78/843bcf0cf31f88d2f8a9a063d2d80817b1901657d83d65b89b3aa835732e/nbsphinx-0.9.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
@@ -514,6 +520,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/43/894c2cbbcbdf53b57d1257a249811abe2ee9ab7ef76af301b40f1c054533/mistune-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/46/e0/60466c6d712dad2cf807df315e39863e91609ffd1064ecb835994460bbda/pydicom-3.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/85/b505a99a133d9f99d21af182af416e9baef70bdeef019983479651e494c2/huggingface_hub-1.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
@@ -530,6 +537,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/61/fd/caa1d60b12f7dd79ccea23054e06eeaebe266a5f52c40a6b651069200ce5/librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/67/b9/b792c577cea2c1e94cda83b135a656924fc57c428e8a6d302cd69aac1b60/scikit_image-0.26.0-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/67/f8/bb0a9d5f46819c821dc1f004aa2cc29b1d91453297dbf5ff20470f00f193/nbconvert-7.17.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/34/4b3208b35dea488263a5c9f4a464ef20316f663e9e90d5de61349c31b327/simpleitk-2.5.5-cp311-abi3-macosx_11_0_arm64.whl
@@ -548,6 +556,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
@@ -560,6 +569,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/64/7e0266f0c541e26df86c31d2add9be3dd9914ae83785ce0aba7cbb693667/pygments_styles-0.3.0-py3-none-any.whl
@@ -709,6 +719,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/43/894c2cbbcbdf53b57d1257a249811abe2ee9ab7ef76af301b40f1c054533/mistune-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/46/e0/60466c6d712dad2cf807df315e39863e91609ffd1064ecb835994460bbda/pydicom-3.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/85/b505a99a133d9f99d21af182af416e9baef70bdeef019983479651e494c2/huggingface_hub-1.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
@@ -741,6 +752,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
@@ -752,8 +764,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8f/58/2b11b933097bc427e42b4a8b15f7de8f24f2bac1fd2779d2aea1431b2c31/scikit_image-0.26.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/8f/64/7e0266f0c541e26df86c31d2add9be3dd9914ae83785ce0aba7cbb693667/pygments_styles-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl
@@ -780,6 +794,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b5/2b/2cca4261bab978eb3d9f1aa32fe7dcd9021e193bdc88b3dcf0bb366e9f91/itkwasm_downsample_wasi-1.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/d2/ae881ee28d014f38e0ccbfd974a06a919ba9af34f1f74bf42b5301891d63/scipy-1.18.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
@@ -1885,6 +1900,9 @@ packages:
   - ngff-zarr ; extra == 'imaging'
   - vtk ; extra == 'vtk'
   - lpips ; extra == 'lpips'
+  - scikit-image ; extra == 'ssim'
+  - scipy ; extra == 'fid'
+  - torchvision ; extra == 'fid'
   - submitit ; extra == 'cluster'
   - pydicom ; extra == 'dicom'
   - zarr ; extra == 'omezarr'
@@ -1895,14 +1913,28 @@ packages:
   - konfai[tensorboard] ; extra == 'all'
   - konfai[vtk] ; extra == 'all'
   - konfai[lpips] ; extra == 'all'
+  - konfai[ssim] ; extra == 'all'
+  - konfai[fid] ; extra == 'all'
   - konfai[cluster] ; extra == 'all'
   - konfai[dicom] ; extra == 'all'
   - konfai[omezarr] ; extra == 'all'
+  - simpleitk ; extra == 'dev'
+  - h5py ; extra == 'dev'
+  - pydicom ; extra == 'dev'
+  - zarr ; extra == 'dev'
+  - ngff-zarr ; extra == 'dev'
+  - scikit-image ; extra == 'dev'
+  - nvidia-ml-py ; extra == 'dev'
+  - tensorboard ; extra == 'dev'
   - fastapi ; extra == 'dev'
   - uvicorn ; extra == 'dev'
   - python-multipart ; extra == 'dev'
   - pytest ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
   - pre-commit ; extra == 'dev'
+  - ruff==0.15.2 ; extra == 'dev'
+  - mypy ; extra == 'dev'
+  - build ; extra == 'dev'
   - types-requests ; extra == 'dev'
   - sphinx>=7.0 ; extra == 'dev'
   - shibuya ; extra == 'dev'
@@ -1955,6 +1987,52 @@ packages:
   - pytest-xdist ; extra == 'test'
   - pre-commit ; extra == 'test'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/02/73/0291a64843270f4efb86cdcf2ee0f2048631b65ec6b405398b2b4dbf11bf/scipy-1.18.0-cp313-cp313-macosx_12_0_arm64.whl
+  name: scipy
+  version: 1.18.0
+  sha256: 5efe260f69417b97ddae455bfb5a95e8359f7f66ad7fa9522a60feb66f169520
+  requires_dist:
+  - numpy>=2.0.0,<2.8
+  - pytest>=8.0.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - asv ; extra == 'test'
+  - mpmath ; extra == 'test'
+  - gmpy2 ; extra == 'test'
+  - threadpoolctl ; extra == 'test'
+  - scikit-umfpack ; extra == 'test'
+  - pooch ; extra == 'test'
+  - hypothesis>=6.30 ; extra == 'test'
+  - array-api-strict>=2.3.1 ; extra == 'test'
+  - cython ; extra == 'test'
+  - meson ; extra == 'test'
+  - ninja ; sys_platform != 'emscripten' and extra == 'test'
+  - scipy-doctest>=2.0.0 ; extra == 'test'
+  - sphinx>=5.0.0,<8.2.0 ; extra == 'doc'
+  - intersphinx-registry ; extra == 'doc'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
+  - sphinx-copybutton ; extra == 'doc'
+  - sphinx-design>=0.4.0 ; extra == 'doc'
+  - matplotlib>=3.5 ; extra == 'doc'
+  - numpydoc ; extra == 'doc'
+  - jupytext ; extra == 'doc'
+  - myst-nb>=1.2.0 ; extra == 'doc'
+  - pooch ; extra == 'doc'
+  - jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
+  - jupyterlite-pyodide-kernel ; extra == 'doc'
+  - linkify-it-py ; extra == 'doc'
+  - tabulate ; extra == 'doc'
+  - click<8.3.0 ; extra == 'dev'
+  - spin ; extra == 'dev'
+  - mypy==1.19.1 ; extra == 'dev'
+  - pyrefly==0.63.0 ; extra == 'dev'
+  - typing-extensions ; extra == 'dev'
+  - types-psutil ; extra == 'dev'
+  - pycodestyle ; extra == 'dev'
+  - ruff>=0.12.0 ; extra == 'dev'
+  - cython-lint>=0.12.2 ; extra == 'dev'
+  requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/02/dc/c7043cab6fed8ae159fc1923ce829ada35c4dbd797d408a43858ffaf9639/tornado-6.5.7-cp39-abi3-macosx_10_9_universal2.whl
   name: tornado
   version: 6.5.7
@@ -2818,6 +2896,68 @@ packages:
   - pylibjpeg[rle] ; extra == 'pixeldata'
   - python-gdcm ; extra == 'pixeldata'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
+  name: imageio
+  version: 2.37.3
+  sha256: 46f5bb8522cd421c0f5ae104d8268f569d856b29eb1a13b92829d1970f32c9f0
+  requires_dist:
+  - numpy
+  - pillow>=8.3.2
+  - imageio-ffmpeg ; extra == 'ffmpeg'
+  - psutil ; extra == 'ffmpeg'
+  - fsspec[http] ; extra == 'freeimage'
+  - pillow-heif ; extra == 'pillow-heif'
+  - tifffile ; extra == 'tifffile'
+  - av ; extra == 'pyav'
+  - astropy ; extra == 'fits'
+  - rawpy ; extra == 'rawpy'
+  - numpy>2 ; extra == 'rawpy'
+  - gdal ; extra == 'gdal'
+  - itk ; extra == 'itk'
+  - black ; extra == 'linting'
+  - flake8 ; extra == 'linting'
+  - pytest ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - fsspec[github] ; extra == 'test'
+  - sphinx<6 ; extra == 'docs'
+  - numpydoc ; extra == 'docs'
+  - pydata-sphinx-theme ; extra == 'docs'
+  - pytest ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
+  - fsspec[github] ; extra == 'dev'
+  - black ; extra == 'dev'
+  - flake8 ; extra == 'dev'
+  - av ; extra == 'all-plugins'
+  - astropy ; extra == 'all-plugins'
+  - fsspec[http] ; extra == 'all-plugins'
+  - imageio-ffmpeg ; extra == 'all-plugins'
+  - numpy>2 ; extra == 'all-plugins'
+  - pillow-heif ; extra == 'all-plugins'
+  - psutil ; extra == 'all-plugins'
+  - rawpy ; extra == 'all-plugins'
+  - tifffile ; extra == 'all-plugins'
+  - fsspec[http] ; extra == 'all-plugins-pypy'
+  - imageio-ffmpeg ; extra == 'all-plugins-pypy'
+  - pillow-heif ; extra == 'all-plugins-pypy'
+  - psutil ; extra == 'all-plugins-pypy'
+  - tifffile ; extra == 'all-plugins-pypy'
+  - astropy ; extra == 'full'
+  - av ; extra == 'full'
+  - black ; extra == 'full'
+  - flake8 ; extra == 'full'
+  - fsspec[github,http] ; extra == 'full'
+  - imageio-ffmpeg ; extra == 'full'
+  - numpydoc ; extra == 'full'
+  - numpy>2 ; extra == 'full'
+  - pillow-heif ; extra == 'full'
+  - psutil ; extra == 'full'
+  - pydata-sphinx-theme ; extra == 'full'
+  - pytest ; extra == 'full'
+  - pytest-cov ; extra == 'full'
+  - rawpy ; extra == 'full'
+  - sphinx<6 ; extra == 'full'
+  - tifffile ; extra == 'full'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/4b/25/05678d97fc25e2622df14dc530fb82023174ecfff6733991ed0d78f167bd/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: rpds-py
   version: 2026.5.1
@@ -3229,6 +3369,71 @@ packages:
   version: 26.1.0
   sha256: c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/67/b9/b792c577cea2c1e94cda83b135a656924fc57c428e8a6d302cd69aac1b60/scikit_image-0.26.0-cp313-cp313-macosx_11_0_arm64.whl
+  name: scikit-image
+  version: 0.26.0
+  sha256: 98329aab3bc87db352b9887f64ce8cdb8e75f7c2daa19927f2e121b797b678d5
+  requires_dist:
+  - numpy>=1.24
+  - scipy>=1.11.4
+  - networkx>=3.0
+  - pillow>=10.1
+  - imageio>=2.33,!=2.35.0
+  - tifffile>=2022.8.12
+  - packaging>=21
+  - lazy-loader>=0.4
+  - meson-python>=0.16 ; extra == 'build'
+  - ninja>=1.11.1.1 ; extra == 'build'
+  - cython>=3.0.8,!=3.2.0b1 ; extra == 'build'
+  - pythran>=0.16 ; extra == 'build'
+  - numpy>=2.0 ; extra == 'build'
+  - spin==0.13 ; extra == 'build'
+  - build>=1.2.1 ; extra == 'build'
+  - pooch>=1.6.0 ; extra == 'data'
+  - pre-commit ; extra == 'developer'
+  - ipython ; extra == 'developer'
+  - docstub==0.3.0.post0 ; extra == 'developer'
+  - scikit-image[asv] ; extra == 'developer'
+  - asv ; sys_platform != 'emscripten' and extra == 'asv'
+  - sphinx>=8.0 ; extra == 'docs'
+  - sphinx-gallery[parallel]>=0.18 ; extra == 'docs'
+  - numpydoc>=1.7 ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - matplotlib>=3.7 ; extra == 'docs'
+  - dask[array]>=2023.2.0 ; extra == 'docs'
+  - pandas>=2.0 ; extra == 'docs'
+  - seaborn>=0.11 ; extra == 'docs'
+  - pooch>=1.6 ; extra == 'docs'
+  - tifffile>=2022.8.12 ; extra == 'docs'
+  - myst-parser ; extra == 'docs'
+  - intersphinx-registry>=0.2411.14 ; extra == 'docs'
+  - ipywidgets ; extra == 'docs'
+  - ipykernel ; extra == 'docs'
+  - plotly>=5.20 ; extra == 'docs'
+  - kaleido==0.2.1 ; extra == 'docs'
+  - scikit-learn>=1.2 ; extra == 'docs'
+  - sphinx-design>=0.5 ; extra == 'docs'
+  - pydata-sphinx-theme>=0.16 ; extra == 'docs'
+  - pywavelets>=1.6 ; extra == 'docs'
+  - pytest-doctestplus>=1.6.0 ; extra == 'docs'
+  - simpleitk ; sys_platform != 'emscripten' and extra == 'optional'
+  - scikit-learn>=1.2 ; extra == 'optional'
+  - pyamg>=5.2 ; python_full_version < '3.14' and sys_platform != 'emscripten' and extra == 'optional'
+  - scikit-image[optional-free-threaded] ; extra == 'optional'
+  - astropy>=6.0 ; extra == 'optional-free-threaded'
+  - dask[array]>=2023.2.0 ; extra == 'optional-free-threaded'
+  - matplotlib>=3.7 ; extra == 'optional-free-threaded'
+  - pooch>=1.6.0 ; sys_platform != 'emscripten' and extra == 'optional-free-threaded'
+  - pywavelets>=1.6 ; extra == 'optional-free-threaded'
+  - numpydoc>=1.7 ; extra == 'test'
+  - pooch>=1.6.0 ; sys_platform != 'emscripten' and extra == 'test'
+  - pytest>=8.3 ; extra == 'test'
+  - pytest-cov>=2.11.0 ; extra == 'test'
+  - pytest-pretty ; extra == 'test'
+  - pytest-localserver ; extra == 'test'
+  - pytest-faulthandler ; extra == 'test'
+  - pytest-doctestplus>=1.6.0 ; extra == 'test'
+  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
   name: pillow
   version: 12.2.0
@@ -3600,6 +3805,42 @@ packages:
   version: 0.1.4
   sha256: 502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c
   requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl
+  name: tifffile
+  version: 2026.6.1
+  sha256: 0d7382d2769b855b81ce358528e2b40c16d48aa39031746efa81215205332a8d
+  requires_dist:
+  - numpy>=2.1
+  - imagecodecs>=2026.5.10 ; extra == 'codecs'
+  - lxml ; extra == 'xml'
+  - zarr>=3.2.0 ; extra == 'zarr'
+  - fsspec ; extra == 'zarr'
+  - kerchunk ; extra == 'zarr'
+  - matplotlib ; extra == 'plot'
+  - imagecodecs>=2026.5.10 ; extra == 'all'
+  - matplotlib ; extra == 'all'
+  - lxml ; extra == 'all'
+  - zarr>=3.2.0 ; extra == 'all'
+  - xarray ; extra == 'all'
+  - fsspec ; extra == 'all'
+  - kerchunk ; extra == 'all'
+  - cmapfile ; extra == 'test'
+  - czifile ; extra == 'test'
+  - dask ; extra == 'test'
+  - fsspec ; extra == 'test'
+  - imagecodecs ; extra == 'test'
+  - kerchunk ; extra == 'test'
+  - lfdfiles ; extra == 'test'
+  - lxml ; extra == 'test'
+  - ndtiff ; extra == 'test'
+  - oiffile ; extra == 'test'
+  - psdtags ; extra == 'test'
+  - pytest ; extra == 'test'
+  - requests ; extra == 'test'
+  - roifile ; extra == 'test'
+  - xarray ; extra == 'test'
+  - zarr>=3.2.0 ; extra == 'test'
+  requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
   name: keyring
   version: 25.7.0
@@ -3755,6 +3996,19 @@ packages:
   - watchfiles>=0.20 ; extra == 'standard'
   - websockets>=10.4 ; extra == 'standard'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl
+  name: lazy-loader
+  version: '0.5'
+  sha256: ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005
+  requires_dist:
+  - packaging
+  - pytest>=8.0 ; extra == 'test'
+  - pytest-cov>=5.0 ; extra == 'test'
+  - coverage[toml]>=7.2 ; extra == 'test'
+  - pre-commit==4.3.0 ; extra == 'lint'
+  - changelist==0.5 ; extra == 'dev'
+  - spin==0.15 ; extra == 'dev'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl
   name: importlib-resources
   version: 7.1.0
@@ -3782,6 +4036,71 @@ packages:
   sha256: 1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0
   requires_dist:
   - pytest ; extra == 'tests'
+- pypi: https://files.pythonhosted.org/packages/8f/58/2b11b933097bc427e42b4a8b15f7de8f24f2bac1fd2779d2aea1431b2c31/scikit_image-0.26.0-cp313-cp313-win_amd64.whl
+  name: scikit-image
+  version: 0.26.0
+  sha256: ac529eb9dbd5954f9aaa2e3fe9a3fd9661bfe24e134c688587d811a0233127f1
+  requires_dist:
+  - numpy>=1.24
+  - scipy>=1.11.4
+  - networkx>=3.0
+  - pillow>=10.1
+  - imageio>=2.33,!=2.35.0
+  - tifffile>=2022.8.12
+  - packaging>=21
+  - lazy-loader>=0.4
+  - meson-python>=0.16 ; extra == 'build'
+  - ninja>=1.11.1.1 ; extra == 'build'
+  - cython>=3.0.8,!=3.2.0b1 ; extra == 'build'
+  - pythran>=0.16 ; extra == 'build'
+  - numpy>=2.0 ; extra == 'build'
+  - spin==0.13 ; extra == 'build'
+  - build>=1.2.1 ; extra == 'build'
+  - pooch>=1.6.0 ; extra == 'data'
+  - pre-commit ; extra == 'developer'
+  - ipython ; extra == 'developer'
+  - docstub==0.3.0.post0 ; extra == 'developer'
+  - scikit-image[asv] ; extra == 'developer'
+  - asv ; sys_platform != 'emscripten' and extra == 'asv'
+  - sphinx>=8.0 ; extra == 'docs'
+  - sphinx-gallery[parallel]>=0.18 ; extra == 'docs'
+  - numpydoc>=1.7 ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - matplotlib>=3.7 ; extra == 'docs'
+  - dask[array]>=2023.2.0 ; extra == 'docs'
+  - pandas>=2.0 ; extra == 'docs'
+  - seaborn>=0.11 ; extra == 'docs'
+  - pooch>=1.6 ; extra == 'docs'
+  - tifffile>=2022.8.12 ; extra == 'docs'
+  - myst-parser ; extra == 'docs'
+  - intersphinx-registry>=0.2411.14 ; extra == 'docs'
+  - ipywidgets ; extra == 'docs'
+  - ipykernel ; extra == 'docs'
+  - plotly>=5.20 ; extra == 'docs'
+  - kaleido==0.2.1 ; extra == 'docs'
+  - scikit-learn>=1.2 ; extra == 'docs'
+  - sphinx-design>=0.5 ; extra == 'docs'
+  - pydata-sphinx-theme>=0.16 ; extra == 'docs'
+  - pywavelets>=1.6 ; extra == 'docs'
+  - pytest-doctestplus>=1.6.0 ; extra == 'docs'
+  - simpleitk ; sys_platform != 'emscripten' and extra == 'optional'
+  - scikit-learn>=1.2 ; extra == 'optional'
+  - pyamg>=5.2 ; python_full_version < '3.14' and sys_platform != 'emscripten' and extra == 'optional'
+  - scikit-image[optional-free-threaded] ; extra == 'optional'
+  - astropy>=6.0 ; extra == 'optional-free-threaded'
+  - dask[array]>=2023.2.0 ; extra == 'optional-free-threaded'
+  - matplotlib>=3.7 ; extra == 'optional-free-threaded'
+  - pooch>=1.6.0 ; sys_platform != 'emscripten' and extra == 'optional-free-threaded'
+  - pywavelets>=1.6 ; extra == 'optional-free-threaded'
+  - numpydoc>=1.7 ; extra == 'test'
+  - pooch>=1.6.0 ; sys_platform != 'emscripten' and extra == 'test'
+  - pytest>=8.3 ; extra == 'test'
+  - pytest-cov>=2.11.0 ; extra == 'test'
+  - pytest-pretty ; extra == 'test'
+  - pytest-localserver ; extra == 'test'
+  - pytest-faulthandler ; extra == 'test'
+  - pytest-doctestplus>=1.6.0 ; extra == 'test'
+  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/8f/64/7e0266f0c541e26df86c31d2add9be3dd9914ae83785ce0aba7cbb693667/pygments_styles-0.3.0-py3-none-any.whl
   name: pygments-styles
   version: 0.3.0
@@ -4070,6 +4389,71 @@ packages:
   - pytest>=7.1.0 ; extra == 'dev'
   - hypothesis>=6.70.0 ; extra == 'dev'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/a3/b8/0d8eeb5a9fd7d34ba84f8a55753a0a3e2b5b51b2a5a0ade648a8db4a62f7/scikit_image-0.26.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+  name: scikit-image
+  version: 0.26.0
+  sha256: b36ab5e778bf50af5ff386c3ac508027dc3aaeccf2161bdf96bde6848f44d21b
+  requires_dist:
+  - numpy>=1.24
+  - scipy>=1.11.4
+  - networkx>=3.0
+  - pillow>=10.1
+  - imageio>=2.33,!=2.35.0
+  - tifffile>=2022.8.12
+  - packaging>=21
+  - lazy-loader>=0.4
+  - meson-python>=0.16 ; extra == 'build'
+  - ninja>=1.11.1.1 ; extra == 'build'
+  - cython>=3.0.8,!=3.2.0b1 ; extra == 'build'
+  - pythran>=0.16 ; extra == 'build'
+  - numpy>=2.0 ; extra == 'build'
+  - spin==0.13 ; extra == 'build'
+  - build>=1.2.1 ; extra == 'build'
+  - pooch>=1.6.0 ; extra == 'data'
+  - pre-commit ; extra == 'developer'
+  - ipython ; extra == 'developer'
+  - docstub==0.3.0.post0 ; extra == 'developer'
+  - scikit-image[asv] ; extra == 'developer'
+  - asv ; sys_platform != 'emscripten' and extra == 'asv'
+  - sphinx>=8.0 ; extra == 'docs'
+  - sphinx-gallery[parallel]>=0.18 ; extra == 'docs'
+  - numpydoc>=1.7 ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - matplotlib>=3.7 ; extra == 'docs'
+  - dask[array]>=2023.2.0 ; extra == 'docs'
+  - pandas>=2.0 ; extra == 'docs'
+  - seaborn>=0.11 ; extra == 'docs'
+  - pooch>=1.6 ; extra == 'docs'
+  - tifffile>=2022.8.12 ; extra == 'docs'
+  - myst-parser ; extra == 'docs'
+  - intersphinx-registry>=0.2411.14 ; extra == 'docs'
+  - ipywidgets ; extra == 'docs'
+  - ipykernel ; extra == 'docs'
+  - plotly>=5.20 ; extra == 'docs'
+  - kaleido==0.2.1 ; extra == 'docs'
+  - scikit-learn>=1.2 ; extra == 'docs'
+  - sphinx-design>=0.5 ; extra == 'docs'
+  - pydata-sphinx-theme>=0.16 ; extra == 'docs'
+  - pywavelets>=1.6 ; extra == 'docs'
+  - pytest-doctestplus>=1.6.0 ; extra == 'docs'
+  - simpleitk ; sys_platform != 'emscripten' and extra == 'optional'
+  - scikit-learn>=1.2 ; extra == 'optional'
+  - pyamg>=5.2 ; python_full_version < '3.14' and sys_platform != 'emscripten' and extra == 'optional'
+  - scikit-image[optional-free-threaded] ; extra == 'optional'
+  - astropy>=6.0 ; extra == 'optional-free-threaded'
+  - dask[array]>=2023.2.0 ; extra == 'optional-free-threaded'
+  - matplotlib>=3.7 ; extra == 'optional-free-threaded'
+  - pooch>=1.6.0 ; sys_platform != 'emscripten' and extra == 'optional-free-threaded'
+  - pywavelets>=1.6 ; extra == 'optional-free-threaded'
+  - numpydoc>=1.7 ; extra == 'test'
+  - pooch>=1.6.0 ; sys_platform != 'emscripten' and extra == 'test'
+  - pytest>=8.3 ; extra == 'test'
+  - pytest-cov>=2.11.0 ; extra == 'test'
+  - pytest-pretty ; extra == 'test'
+  - pytest-localserver ; extra == 'test'
+  - pytest-faulthandler ; extra == 'test'
+  - pytest-doctestplus>=1.6.0 ; extra == 'test'
+  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl
   name: mdit-py-plugins
   version: 0.6.1
@@ -4344,6 +4728,52 @@ packages:
   version: 1.17.0
   sha256: 4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*'
+- pypi: https://files.pythonhosted.org/packages/b7/d2/ae881ee28d014f38e0ccbfd974a06a919ba9af34f1f74bf42b5301891d63/scipy-1.18.0-cp313-cp313-win_amd64.whl
+  name: scipy
+  version: 1.18.0
+  sha256: 1afac4a847207c7ff8efd321734a50b06d0280b3b2a2c0fc2f413101747ad7c7
+  requires_dist:
+  - numpy>=2.0.0,<2.8
+  - pytest>=8.0.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - asv ; extra == 'test'
+  - mpmath ; extra == 'test'
+  - gmpy2 ; extra == 'test'
+  - threadpoolctl ; extra == 'test'
+  - scikit-umfpack ; extra == 'test'
+  - pooch ; extra == 'test'
+  - hypothesis>=6.30 ; extra == 'test'
+  - array-api-strict>=2.3.1 ; extra == 'test'
+  - cython ; extra == 'test'
+  - meson ; extra == 'test'
+  - ninja ; sys_platform != 'emscripten' and extra == 'test'
+  - scipy-doctest>=2.0.0 ; extra == 'test'
+  - sphinx>=5.0.0,<8.2.0 ; extra == 'doc'
+  - intersphinx-registry ; extra == 'doc'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
+  - sphinx-copybutton ; extra == 'doc'
+  - sphinx-design>=0.4.0 ; extra == 'doc'
+  - matplotlib>=3.5 ; extra == 'doc'
+  - numpydoc ; extra == 'doc'
+  - jupytext ; extra == 'doc'
+  - myst-nb>=1.2.0 ; extra == 'doc'
+  - pooch ; extra == 'doc'
+  - jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
+  - jupyterlite-pyodide-kernel ; extra == 'doc'
+  - linkify-it-py ; extra == 'doc'
+  - tabulate ; extra == 'doc'
+  - click<8.3.0 ; extra == 'dev'
+  - spin ; extra == 'dev'
+  - mypy==1.19.1 ; extra == 'dev'
+  - pyrefly==0.63.0 ; extra == 'dev'
+  - typing-extensions ; extra == 'dev'
+  - types-psutil ; extra == 'dev'
+  - pycodestyle ; extra == 'dev'
+  - ruff>=0.12.0 ; extra == 'dev'
+  - cython-lint>=0.12.2 ; extra == 'dev'
+  requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl
   name: ruamel-yaml
   version: 0.19.1
@@ -5024,6 +5454,52 @@ packages:
   requires_dist:
   - colorama>=0.4.6 ; extra == 'windows-terminal'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  name: scipy
+  version: 1.18.0
+  sha256: a46f9273dbd0eb1cefba61c9b8648b4dfe3cbc14a080176f9a73e44b8336dc7f
+  requires_dist:
+  - numpy>=2.0.0,<2.8
+  - pytest>=8.0.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - asv ; extra == 'test'
+  - mpmath ; extra == 'test'
+  - gmpy2 ; extra == 'test'
+  - threadpoolctl ; extra == 'test'
+  - scikit-umfpack ; extra == 'test'
+  - pooch ; extra == 'test'
+  - hypothesis>=6.30 ; extra == 'test'
+  - array-api-strict>=2.3.1 ; extra == 'test'
+  - cython ; extra == 'test'
+  - meson ; extra == 'test'
+  - ninja ; sys_platform != 'emscripten' and extra == 'test'
+  - scipy-doctest>=2.0.0 ; extra == 'test'
+  - sphinx>=5.0.0,<8.2.0 ; extra == 'doc'
+  - intersphinx-registry ; extra == 'doc'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
+  - sphinx-copybutton ; extra == 'doc'
+  - sphinx-design>=0.4.0 ; extra == 'doc'
+  - matplotlib>=3.5 ; extra == 'doc'
+  - numpydoc ; extra == 'doc'
+  - jupytext ; extra == 'doc'
+  - myst-nb>=1.2.0 ; extra == 'doc'
+  - pooch ; extra == 'doc'
+  - jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
+  - jupyterlite-pyodide-kernel ; extra == 'doc'
+  - linkify-it-py ; extra == 'doc'
+  - tabulate ; extra == 'doc'
+  - click<8.3.0 ; extra == 'dev'
+  - spin ; extra == 'dev'
+  - mypy==1.19.1 ; extra == 'dev'
+  - pyrefly==0.63.0 ; extra == 'dev'
+  - typing-extensions ; extra == 'dev'
+  - types-psutil ; extra == 'dev'
+  - pycodestyle ; extra == 'dev'
+  - ruff>=0.12.0 ; extra == 'dev'
+  - cython-lint>=0.12.2 ; extra == 'dev'
+  requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/f8/99/9175103392f84c4b1bf7622888cdc68da07f0ff7d9e581266428f6776033/debugpy-1.8.21-cp313-cp313-win_amd64.whl
   name: debugpy
   version: 1.8.21

--- a/pixi.lock
+++ b/pixi.lock
@@ -256,7 +256,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/42/2c3ac59253ae8892b6f307875263dd23dc875cdf732d3aea40d6d41fb7cb/triton-3.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/09/dc/f3dfb7488b770f3f67e6545085bf2abea5172e88f57b8ad25ef860ca704c/myst_parser-5.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/35/1cceccc5fcb50fa2ed53e2aa278cd032f3902682a73e763fb1ac3be8e6fa/rich_argparse-1.8.0-py3-none-any.whl
@@ -291,7 +290,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/36/c9/94d73e5a01c5b926c3fa2496e97d7a8dc28ed5a77c0b2ed712f1a62e6694/nbclient-0.11.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/37/d8/ef374952fd5da67d4463122c2b8e5a96536ec10b4b339254c6dcde81d01c/tornado-6.5.7-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/38/a9/69a6924f645eb4dd8cd625bf255b3625990eb3e14e073438a53c405dcd3e/fastapi-0.138.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -336,7 +334,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/13/e503968fefabd4c6b2650af21e110aa8466fe21432cd7c43a84577a89438/tensorboard_data_server-0.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
@@ -355,7 +352,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
@@ -418,12 +414,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/75/20bb8fe9c1ad6538cce8cd0391b51927ae5af0b17ed1eab44b8824465dc1/torch-2.12.1-cp313-cp313-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl
@@ -432,7 +426,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ea/bb/711e1c2ebd18a21202c972dd5d5c8e09a921f2d3560e3a53d6350c808ab7/submitit-1.5.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
@@ -446,7 +439,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
@@ -506,7 +498,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/36/c9/94d73e5a01c5b926c3fa2496e97d7a8dc28ed5a77c0b2ed712f1a62e6694/nbclient-0.11.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/38/a9/69a6924f645eb4dd8cd625bf255b3625990eb3e14e073438a53c405dcd3e/fastapi-0.138.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3d/02/77b271f5dc58bfbc0b577c877b2365d1ffea2afe66a80c13f2312820348c/ipykernel-7.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3e/28/fa0f2ff73b8ca7987ebaa107d369c95459741ac73567e5079b4a881a981b/sphinx_autodoc_typehints-3.12.0-py3-none-any.whl
@@ -545,7 +536,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/13/e503968fefabd4c6b2650af21e110aa8466fe21432cd7c43a84577a89438/tensorboard_data_server-0.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/4a/a36e03210183a8a7d4c80c3936acee679f4bd77d5861f369db47b2cc5f05/grpcio-1.81.1-cp313-cp313-macosx_11_0_universal2.whl
@@ -568,7 +558,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
@@ -605,7 +594,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/82/482a2e77a79a8ebc2f40d8e38cc186f2a72f2bf003c8e7395c3eefb9bc3f/shibuya-2026.5.19-py3-none-any.whl
@@ -621,18 +609,15 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ea/bb/711e1c2ebd18a21202c972dd5d5c8e09a921f2d3560e3a53d6350c808ab7/submitit-1.5.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
@@ -643,7 +628,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
@@ -702,7 +686,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/30/53/491e1c47c55b62ccc6a63c1c5b8635c73fc2258dddeb9bda27cae4a0ae96/numpy-2.5.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/36/c9/94d73e5a01c5b926c3fa2496e97d7a8dc28ed5a77c0b2ed712f1a62e6694/nbclient-0.11.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/38/a9/69a6924f645eb4dd8cd625bf255b3625990eb3e14e073438a53c405dcd3e/fastapi-0.138.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3d/02/77b271f5dc58bfbc0b577c877b2365d1ffea2afe66a80c13f2312820348c/ipykernel-7.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3e/28/fa0f2ff73b8ca7987ebaa107d369c95459741ac73567e5079b4a881a981b/sphinx_autodoc_typehints-3.12.0-py3-none-any.whl
@@ -743,11 +726,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/e8/196ebc25d8f34c06d43a6e9c8513c9266ef8dbf3b5672beb1a00cf5e29fa/coverage-7.14.3-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/13/e503968fefabd4c6b2650af21e110aa8466fe21432cd7c43a84577a89438/tensorboard_data_server-0.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl
@@ -763,7 +744,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
@@ -815,12 +795,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl
@@ -828,7 +806,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ea/bb/711e1c2ebd18a21202c972dd5d5c8e09a921f2d3560e3a53d6350c808ab7/submitit-1.5.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
@@ -840,7 +817,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fc/7f/a21b20d577e4100c6a41795842028235998a643b1ad406a6d4163ea8f53e/pyzmq-27.1.0-cp312-abi3-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
   docs:
     channels:
@@ -1926,9 +1902,6 @@ packages:
   - scikit-image ; extra == 'dev'
   - nvidia-ml-py ; extra == 'dev'
   - tensorboard ; extra == 'dev'
-  - fastapi ; extra == 'dev'
-  - uvicorn ; extra == 'dev'
-  - python-multipart ; extra == 'dev'
   - pytest ; extra == 'dev'
   - pytest-cov ; extra == 'dev'
   - pre-commit ; extra == 'dev'
@@ -2095,13 +2068,6 @@ packages:
   version: 0.7.1
   sha256: a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*'
-- pypi: https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  name: pydantic-core
-  version: 2.46.4
-  sha256: 9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a
-  requires_dist:
-  - typing-extensions>=4.14.1
-  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/09/dc/f3dfb7488b770f3f67e6545085bf2abea5172e88f57b8ad25ef860ca704c/myst_parser-5.1.0-py3-none-any.whl
   name: myst-parser
   version: 5.1.0
@@ -2548,44 +2514,6 @@ packages:
   version: 6.5.7
   sha256: 8d759e71906ee783f8867b93bf26a265743da4c1e2f4a018464c1ba019862972
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/38/a9/69a6924f645eb4dd8cd625bf255b3625990eb3e14e073438a53c405dcd3e/fastapi-0.138.1-py3-none-any.whl
-  name: fastapi
-  version: 0.138.1
-  sha256: b994cae7ba8b82c976a728b544244de31333fa5f7d261f9a1dffe526444cae23
-  requires_dist:
-  - starlette>=0.46.0
-  - pydantic>=2.9.0
-  - typing-extensions>=4.8.0
-  - typing-inspection>=0.4.2
-  - annotated-doc>=0.0.2
-  - fastapi-cli[standard]>=0.0.8 ; extra == 'standard'
-  - fastar>=0.9.0 ; extra == 'standard'
-  - httpx>=0.23.0,<1.0.0 ; extra == 'standard'
-  - jinja2>=3.1.5 ; extra == 'standard'
-  - python-multipart>=0.0.18 ; extra == 'standard'
-  - email-validator>=2.0.0 ; extra == 'standard'
-  - uvicorn[standard]>=0.12.0 ; extra == 'standard'
-  - pydantic-settings>=2.0.0 ; extra == 'standard'
-  - pydantic-extra-types>=2.0.0 ; extra == 'standard'
-  - fastapi-cli[standard-no-fastapi-cloud-cli]>=0.0.8 ; extra == 'standard-no-fastapi-cloud-cli'
-  - httpx>=0.23.0,<1.0.0 ; extra == 'standard-no-fastapi-cloud-cli'
-  - jinja2>=3.1.5 ; extra == 'standard-no-fastapi-cloud-cli'
-  - python-multipart>=0.0.18 ; extra == 'standard-no-fastapi-cloud-cli'
-  - email-validator>=2.0.0 ; extra == 'standard-no-fastapi-cloud-cli'
-  - uvicorn[standard]>=0.12.0 ; extra == 'standard-no-fastapi-cloud-cli'
-  - pydantic-settings>=2.0.0 ; extra == 'standard-no-fastapi-cloud-cli'
-  - pydantic-extra-types>=2.0.0 ; extra == 'standard-no-fastapi-cloud-cli'
-  - fastapi-cli[standard]>=0.0.8 ; extra == 'all'
-  - httpx>=0.23.0,<1.0.0 ; extra == 'all'
-  - jinja2>=3.1.5 ; extra == 'all'
-  - python-multipart>=0.0.18 ; extra == 'all'
-  - itsdangerous>=1.1.0 ; extra == 'all'
-  - pyyaml>=5.3.1 ; extra == 'all'
-  - email-validator>=2.0.0 ; extra == 'all'
-  - uvicorn[standard]>=0.12.0 ; extra == 'all'
-  - pydantic-settings>=2.0.0 ; extra == 'all'
-  - pydantic-extra-types>=2.0.0 ; extra == 'all'
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl
   name: twine
   version: 6.2.0
@@ -3666,13 +3594,6 @@ packages:
   - pytz ; extra == 'dev'
   - setuptools ; extra == 'dev'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
-  name: annotated-types
-  version: 0.7.0
-  sha256: 1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53
-  requires_dist:
-  - typing-extensions>=4.0.0 ; python_full_version < '3.9'
-  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
   name: mypy-extensions
   version: 1.1.0
@@ -3696,13 +3617,6 @@ packages:
   version: 1.0.0
   sha256: fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl
-  name: pydantic-core
-  version: 2.46.4
-  sha256: 6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292
-  requires_dist:
-  - typing-extensions>=4.14.1
-  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
   name: httpcore
   version: 1.0.9
@@ -3980,22 +3894,6 @@ packages:
   - html5lib ; extra == 'html5lib'
   - lxml ; extra == 'lxml'
   requires_python: '>=3.7.0'
-- pypi: https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl
-  name: uvicorn
-  version: 0.49.0
-  sha256: ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f
-  requires_dist:
-  - click>=7.0
-  - h11>=0.8
-  - typing-extensions>=4.0 ; python_full_version < '3.11'
-  - colorama>=0.4 ; sys_platform == 'win32' and extra == 'standard'
-  - httptools>=0.8.0 ; extra == 'standard'
-  - python-dotenv>=0.13 ; extra == 'standard'
-  - pyyaml>=5.1 ; extra == 'standard'
-  - uvloop>=0.15.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32' and extra == 'standard'
-  - watchfiles>=0.20 ; extra == 'standard'
-  - websockets>=10.4 ; extra == 'standard'
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl
   name: lazy-loader
   version: '0.5'
@@ -4807,13 +4705,6 @@ packages:
   version: 3.4.7
   sha256: f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl
-  name: pydantic-core
-  version: 2.46.4
-  sha256: c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4
-  requires_dist:
-  - typing-extensions>=4.14.1
-  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
   name: executing
   version: 2.2.1
@@ -5069,13 +4960,6 @@ packages:
   version: 1.0.0
   sha256: b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
-- pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
-  name: typing-inspection
-  version: 0.4.2
-  sha256: 4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7
-  requires_dist:
-  - typing-extensions>=4.12.0
-  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl
   name: markdown
   version: 3.10.2
@@ -5113,11 +4997,6 @@ packages:
   version: 1.5.4
   sha256: 7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl
-  name: python-multipart
-  version: 0.0.32
-  sha256: ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/e1/75/20bb8fe9c1ad6538cce8cd0391b51927ae5af0b17ed1eab44b8824465dc1/torch-2.12.1-cp313-cp313-manylinux_2_28_x86_64.whl
   name: torch
   version: 2.12.1
@@ -5371,20 +5250,6 @@ packages:
   requires_dist:
   - six>=1.5
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*'
-- pypi: https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl
-  name: starlette
-  version: 1.3.1
-  sha256: c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6
-  requires_dist:
-  - anyio>=3.6.2,<5
-  - typing-extensions>=4.10.0 ; python_full_version < '3.13'
-  - httpx2>=2.0.0 ; extra == 'full'
-  - httpx>=0.27.0,<0.29.0 ; extra == 'full'
-  - itsdangerous ; extra == 'full'
-  - jinja2 ; extra == 'full'
-  - python-multipart>=0.0.18 ; extra == 'full'
-  - pyyaml ; extra == 'full'
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
   name: certifi
   version: 2026.6.17
@@ -5543,18 +5408,6 @@ packages:
   requires_dist:
   - cffi ; implementation_name == 'pypy'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
-  name: pydantic
-  version: 2.13.4
-  sha256: 45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba
-  requires_dist:
-  - annotated-types>=0.6.0
-  - pydantic-core==2.46.4
-  - typing-extensions>=4.14.1
-  - typing-inspection>=0.4.2
-  - email-validator>=2.0.0 ; extra == 'email'
-  - tzdata ; python_full_version >= '3.9' and sys_platform == 'win32' and extra == 'timezone'
-  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl
   name: rfc3986
   version: 2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,9 +86,6 @@ dev = [
   "scikit-image",
   "nvidia-ml-py",
   "tensorboard",
-  "fastapi",
-  "uvicorn",
-  "python-multipart",
   "pytest",
   "pytest-cov",
   "pre-commit",
@@ -144,9 +141,6 @@ build = "*"
 twine = "*"
 mypy = "*"
 types-requests = "*"
-fastapi = "*"
-uvicorn = "*"
-python-multipart = "*"
 submitit = "*"
 SimpleITK = "*"
 h5py = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ tensorboard = ["tensorboard"]
 imaging = ["SimpleITK", "h5py", "pydicom", "zarr", "ngff-zarr"]
 vtk = ["vtk"]
 lpips = ["lpips"]
+ssim = ["scikit-image"]
+fid = ["scipy", "torchvision"]
 cluster = ["submitit"]
 dicom = ["pydicom"]
 omezarr = ["zarr", "ngff-zarr"]
@@ -69,6 +71,8 @@ all = [
   "konfai[tensorboard]",
   "konfai[vtk]",
   "konfai[lpips]",
+  "konfai[ssim]",
+  "konfai[fid]",
   "konfai[cluster]",
   "konfai[dicom]",
   "konfai[omezarr]"
@@ -79,6 +83,7 @@ dev = [
   "pydicom",
   "zarr",
   "ngff-zarr",
+  "scikit-image",
   "nvidia-ml-py",
   "tensorboard",
   "fastapi",
@@ -150,6 +155,7 @@ nvidia-ml-py = "*"
 pydicom = "*"
 zarr = "*"
 ngff-zarr = "*"
+scikit-image = "*"
 
 [tool.pixi.feature.dev.tasks]
 test = { cmd = "pytest -q tests/", description = "Run the test suite" }

--- a/tests/unit/test_audit_fixes.py
+++ b/tests/unit/test_audit_fixes.py
@@ -22,11 +22,13 @@ import os
 os.environ.setdefault("KONFAI_config_file", "/tmp/konfai-none.yml")
 os.environ.setdefault("KONFAI_CONFIG_MODE", "Done")
 
+import pytest  # noqa: E402
 import torch  # noqa: E402
-from konfai.data.augmentation import Rotate  # noqa: E402
+from konfai.data.augmentation import Flip, Rotate  # noqa: E402
 from konfai.data.transform import ResampleToShape, Standardize  # noqa: E402
 from konfai.network.blocks import Select, Unsqueeze  # noqa: E402
 from konfai.utils.dataset import Attribute  # noqa: E402
+from konfai.utils.errors import ConfigError, MeasureError  # noqa: E402
 
 
 def test_vae_latent_uses_gaussian_noise():
@@ -99,3 +101,116 @@ def test_select_squeezes_size_one_dims_by_size():
     # a tensor with no size-1 dims is unchanged
     out2 = Select([slice(None), slice(None)])(torch.randn(4, 5))
     assert out2.shape == (4, 5)
+
+
+def test_augmentation_resamples_after_reset_state():
+    """#1 Augmentation parameters must be re-sampled each epoch via reset_state.
+
+    Within an epoch ``state_init`` caches the per-case draw so every patch shares
+    one transform; ``reset_state`` must clear that cache so the next epoch draws
+    fresh parameters (previously ``who_index`` was never cleared → frozen forever).
+    """
+    aug = Flip([1.0, 1.0, 1.0])
+    aug.load(1.0)
+
+    aug.state_init(0, [[4, 4, 4]], [Attribute()])
+    first = aug.flip[0]
+    # Re-running state_init without a reset returns the cached draw unchanged.
+    aug.state_init(0, [[4, 4, 4]], [Attribute()])
+    assert aug.flip[0] is first
+
+    aug.reset_state(0)
+    assert 0 not in aug.who_index
+    aug.state_init(0, [[4, 4, 4]], [Attribute()])
+    assert 0 in aug.who_index
+    assert aug.flip[0] is not first  # a fresh draw replaced the cached one
+
+
+def test_update_scheduler_empty_raises_config_error():
+    """update_scheduler on an empty schedule must raise a clear ConfigError."""
+    from konfai.network.network import Measure
+
+    with pytest.raises(ConfigError):
+        Measure.update_scheduler(None, {}, 0)  # type: ignore[arg-type]
+
+
+def test_update_scheduler_past_last_window_clamps_to_last():
+    """Past every configured window, the last scheduler is selected (no crash)."""
+    from konfai.metric.schedulers import Constant
+    from konfai.network.network import Measure
+
+    s0, s1 = Constant(1.0), Constant(2.0)
+    schedulers = {s0: 3, s1: 3}  # active windows [0,3) and [3,6)
+    assert Measure.update_scheduler(None, schedulers, 4) is s1  # type: ignore[arg-type]
+    assert Measure.update_scheduler(None, schedulers, 100) is s1  # type: ignore[arg-type]
+
+
+def test_missing_metric_dependency_raises_actionable_error():
+    """Optional criterion deps must surface an actionable MeasureError, not ImportError."""
+    from konfai.metric.measure import _require_optional
+
+    with pytest.raises(MeasureError) as excinfo:
+        _require_optional("konfai_definitely_missing_pkg_zzz", criterion="SSIM", extra="ssim")
+    message = str(excinfo.value)
+    assert "SSIM" in message
+    assert "konfai[ssim]" in message
+
+
+def test_load_state_dict_warm_starts_resized_layer_and_keeps_siblings():
+    """#2 A resized layer must warm-start, and sibling layers must still load.
+
+    The bug checked ``isinstance(module, Linear)`` (the parent) instead of the
+    child, and used an early ``return`` that aborted loading the remaining
+    siblings of a resized layer.
+    """
+    from konfai.network.network import Network
+
+    class _Net(Network):
+        def __init__(self, fc_out: int) -> None:
+            super().__init__(in_channels=1)
+            self.add_module("fc", torch.nn.Linear(4, fc_out))
+            self.add_module("head", torch.nn.Linear(4, 2))
+
+    old = _Net(fc_out=4)
+    # Network.state_dict() wraps the flat params under the network name; load_state_dict
+    # consumes that inner flat dict ("fc.weight", ...).
+    inner = next(iter(old.state_dict().values()))
+    checkpoint = {key: value.clone() for key, value in inner.items()}
+
+    new = _Net(fc_out=6)  # fc output grows 4 -> 6 (resized); head is unchanged
+    new.load_state_dict(checkpoint)  # must not raise
+
+    fc = new["fc"]
+    head = new["head"]
+    assert fc.weight.shape == (6, 4)
+    assert torch.equal(fc.weight[:4], checkpoint["fc.weight"])  # warm-started rows
+    # The sibling after the resized layer must still be loaded (old `return` skipped it).
+    assert torch.equal(head.weight, checkpoint["head.weight"])
+    assert torch.equal(head.bias, checkpoint["head.bias"])
+
+
+def test_adaptation_sets_requires_grad_at_construction():
+    """#18 Adaptation must configure requires_grad in __init__, not on every forward."""
+    from konfai.models.representation.representation import Adaptation
+
+    adaptation = Adaptation()
+    # State is correct immediately after construction, before any forward pass.
+    assert all(not p.requires_grad for p in adaptation.Encoder_1.parameters())
+    assert all(p.requires_grad for p in adaptation.FCT_1.parameters())
+
+
+def test_linear_vae_is_parameterized_and_variational():
+    """#17 LinearVAE must be parameterized (no hardcoded dims) and sample a latent."""
+    from konfai.models.generation.vae import LinearVAE
+
+    model = LinearVAE(in_features=32, hidden_features=16, latent_dim=4)
+    x = torch.randn(2, 32)
+    outputs = dict(model.named_forward(x))
+    assert outputs["Head.Tanh"].shape == (2, 32)  # reconstruction matches input size
+    assert "Latent.mu" in outputs and "Latent.log_std" in outputs  # KL-ready outputs
+    # The latent is sampled: the reconstruction differs across RNG draws.
+    torch.manual_seed(0)
+    first = dict(model.named_forward(x))["Head.Tanh"]
+    torch.manual_seed(1)
+    second = dict(model.named_forward(x))["Head.Tanh"]
+    assert not torch.allclose(first, second)

--- a/tests/unit/test_dataset_streaming.py
+++ b/tests/unit/test_dataset_streaming.py
@@ -4,6 +4,7 @@ from typing import cast
 import numpy as np
 import pytest
 import torch
+from konfai.data.augmentation import DataAugmentationsList
 from konfai.data.data_manager import (
     Data,
     DataPrediction,
@@ -283,12 +284,11 @@ def test_data_train_validation_accepts_mixed_case_names_and_case_files(tmp_path:
         validation=[str(validation_file), "CASE_002"],
     )
 
-    _train_mapping, validate_mapping, train_names, validation_names = dataset._split_train_validation(
+    train_names, validation_names = dataset._split_train_validation_names(
         ["CASE_000", "CASE_001", "CASE_002", "CASE_003"],
-        [(0, 0, 0), (1, 0, 0), (2, 0, 0), (3, 0, 0)],
+        {},
     )
 
-    assert [entry[0] for entry in validate_mapping] == [1, 2, 3]
     assert train_names == ["CASE_000"]
     assert validation_names == ["CASE_001", "CASE_002", "CASE_003"]
 
@@ -324,15 +324,87 @@ def test_data_train_validation_none_keeps_full_dataset_for_training() -> None:
         validation=None,
     )
 
-    train_mapping, validate_mapping, train_names, validation_names = dataset._split_train_validation(
+    train_names, validation_names = dataset._split_train_validation_names(
         ["CASE_000", "CASE_001", "CASE_002"],
-        [(0, 0, 0), (1, 0, 0), (2, 0, 0)],
+        {},
     )
 
-    assert [entry[0] for entry in train_mapping] == [0, 1, 2]
-    assert validate_mapping == []
     assert train_names == ["CASE_000", "CASE_001", "CASE_002"]
     assert validation_names == []
+
+
+def test_data_train_validation_augmentations_can_be_disabled() -> None:
+    augmentations = DataAugmentationsList(nb=2, data_augmentations={})
+    dataset = DataTrain(
+        augmentations={"DataAugmentation_0": augmentations},
+        validation_augmentations=False,
+    )
+    dataset._prepared_validation_mapping = [(0, 0, 0), (0, 1, 0), (1, 0, 0), (1, 2, 0)]
+
+    validation_mapping = dataset._get_validation_mapping()
+
+    assert validation_mapping == [(0, 0, 0), (1, 0, 0)]
+
+
+def test_data_train_prepare_skips_validation_augmentation_layout_when_disabled(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "Dataset"
+    dataset_storage = Dataset(dataset_path, "mha")
+    volume = np.arange(1 * 4 * 4, dtype=np.float32).reshape(1, 4, 4)
+    dataset_storage.write("CT", "CASE_000", volume, _image_attributes([0.0, 0.0], [1.0, 1.0]))
+    dataset_storage.write("CT", "CASE_001", volume, _image_attributes([0.0, 0.0], [1.0, 1.0]))
+
+    augmentations = DataAugmentationsList(nb=1, data_augmentations={})
+    dataset = DataTrain(
+        dataset_filenames=[f"{dataset_path}:mha"],
+        groups_src={"CT": Group(groups_dest={"CT": GroupTransform(transforms=None, patch_transforms=None)})},
+        augmentations={"DataAugmentation_0": augmentations},
+        patch=None,
+        validation=["CASE_001"],
+        validation_augmentations=False,
+    )
+
+    dataset.prepare()
+
+    assert dataset._prepared_data is not None
+    assert dataset._prepared_validation_data is not None
+    assert dataset._prepared_data["CT"][0].total_augmentations == 1
+    assert dataset._prepared_validation_data["CT"][0].total_augmentations == 0
+
+
+def test_dataset_iter_streams_base_patch_when_augmentations_are_disabled() -> None:
+    volume = np.arange(1 * 4 * 4, dtype=np.float32).reshape(1, 4, 4)
+    dataset_stub = StreamingDatasetStub(volume)
+    augmentations = DataAugmentationsList(nb=1, data_augmentations={})
+    manager = DatasetManager(
+        index=0,
+        group_src="CT",
+        group_dest="CT",
+        name="CASE_000",
+        dataset=cast(Dataset, dataset_stub),
+        patch=DatasetPatch([2, 2]),
+        transforms=[],
+        data_augmentations_list=[augmentations],
+    )
+    dataset_iter = DatasetIter(
+        rank=0,
+        data={"CT": [manager]},
+        mapping=[(0, 0, 1)],
+        groups_src={"CT": Group(groups_dest={"CT": GroupTransform(transforms=None, patch_transforms=None)})},
+        inline_augmentations=False,
+        data_augmentations_list=[augmentations],
+        patch_size=[2, 2],
+        overlap=None,
+        buffer_size=1,
+        apply_augmentations=False,
+        use_cache=False,
+    )
+
+    sample = dataset_iter[0]["CT"].tensor
+
+    assert dataset_stub.full_reads == 0
+    assert dataset_stub.patch_reads == 1
+    assert manager.loaded is False
+    assert torch.equal(sample, torch.from_numpy(volume[:, 0:2, 2:4]))
 
 
 def test_data_prediction_disables_workers_for_konfai_inference_transforms() -> None:

--- a/tests/unit/test_early_stopping.py
+++ b/tests/unit/test_early_stopping.py
@@ -1,0 +1,30 @@
+from konfai.trainer import EarlyStopping, EarlyStoppingBase
+
+
+def test_early_stopping_base_starts_running_and_can_be_stopped() -> None:
+    stopper = EarlyStoppingBase()
+
+    assert stopper.is_stopped() is False
+
+    stopper.stop()
+
+    assert stopper.is_stopped() is True
+
+
+def test_early_stopping_inherits_stop_from_base() -> None:
+    stopper = EarlyStopping(monitor=[], patience=10)
+
+    assert stopper.is_stopped() is False
+
+    stopper.stop()
+
+    assert stopper.is_stopped() is True
+
+
+def test_early_stopping_triggers_after_patience_without_improvement() -> None:
+    stopper = EarlyStopping(monitor=[], patience=2, mode="min")
+
+    assert stopper(1.0) is False  # first score sets the baseline
+    assert stopper(1.0) is False  # no improvement (counter = 1)
+    assert stopper(1.0) is True  # no improvement (counter = 2 >= patience)
+    assert stopper.is_stopped() is True

--- a/tests/unit/test_imaging_formats.py
+++ b/tests/unit/test_imaging_formats.py
@@ -138,6 +138,29 @@ class TestDicomExtractGeometry:
         with pytest.raises(DatasetManagerError, match="ImagePositionPatient"):
             dicom.extract_geometry([ds])
 
+    def test_rejects_multi_frame_dicom(self) -> None:
+        from konfai.utils import dicom
+
+        ds = self._make_ds([0.0, 0.0, 0.0])
+        ds.NumberOfFrames = 3
+        with pytest.raises(DatasetManagerError, match="Multi-frame"):
+            dicom.extract_geometry([ds])
+
+    def test_rejects_irregular_slice_spacing(self) -> None:
+        from konfai.utils import dicom
+
+        # Gaps of 3 mm then 4 mm -> not uniformly spaced.
+        slices = [self._make_ds([0.0, 0.0, z]) for z in (0.0, 3.0, 7.0)]
+        with pytest.raises(DatasetManagerError, match="not uniformly spaced"):
+            dicom.extract_geometry(slices)
+
+    def test_accepts_uniform_multi_slice_spacing(self) -> None:
+        from konfai.utils import dicom
+
+        slices = [self._make_ds([0.0, 0.0, z]) for z in (0.0, 3.0, 6.0)]
+        _, spacing, _ = dicom.extract_geometry(slices)
+        assert spacing[2] == pytest.approx(3.0)
+
 
 class TestDicomReadVolume:
     def _make_ds(self, value: float = 0.0) -> MagicMock:
@@ -284,6 +307,22 @@ class TestDatasetImagingBackends:
         _, result_attributes = dataset.read_data("CT", "CASE_001")
 
         np.testing.assert_allclose(result_attributes.get_np_array("Direction"), direction.flatten())
+
+    def test_dicom_write_preserves_unrelated_files(self, tmp_path: Path) -> None:
+        pytest.importorskip("pydicom")
+        from konfai.utils import dicom
+
+        root = tmp_path / "DICOM"
+        root.mkdir()
+        unrelated = root / "keep-me.dcm"
+        unrelated.write_bytes(b"not a konfai slice")
+
+        volume = np.zeros((1, 3, 4, 4), dtype=np.int16)
+        dicom.write_dicom_series(root, volume, origin=(0.0, 0.0, 0.0), spacing=(1.0, 1.0, 1.0))
+
+        # The series was written, but the unrelated DICOM file was not deleted.
+        assert unrelated.exists()
+        assert sorted(p.name for p in root.glob("[0-9]*.dcm")) == ["000001.dcm", "000002.dcm", "000003.dcm"]
 
     @pytest.mark.parametrize("file_format", ["omezarr", "ome-zarr", "ome_zarr", "zarr"])
     def test_ome_zarr_format_aliases(self, tmp_path: Path, file_format: str) -> None:

--- a/tests/unit/test_inline_augmentations.py
+++ b/tests/unit/test_inline_augmentations.py
@@ -98,6 +98,48 @@ def test_inline_augmentations_are_loaded_on_demand() -> None:
     assert torch.equal(second_augmented_sample, torch.from_numpy(base) + 2)
 
 
+def test_dataset_iter_can_skip_augmentation_loading_when_validation_disables_them() -> None:
+    base = np.arange(4, dtype=np.float32).reshape(1, 2, 2)
+    dataset = cast(Dataset, DummyDataset(base))
+    augmentation = CountingOffsetAugmentation()
+    augmentation.load(1.0)
+
+    augmentations = DataAugmentationsList(nb=2, data_augmentations={})
+    augmentations.data_augmentations = [augmentation]
+
+    manager = DatasetManager(
+        index=0,
+        group_src="src",
+        group_dest="dest",
+        name="case_000",
+        dataset=dataset,
+        patch=None,
+        transforms=[],
+        data_augmentations_list=[augmentations],
+    )
+    dataset_iter = DatasetIter(
+        rank=0,
+        data={"dest": [manager]},
+        mapping=[(0, 0, 0)],
+        groups_src={"src": Group(groups_dest={"dest": GroupTransform(transforms=None, patch_transforms=None)})},
+        inline_augmentations=False,
+        data_augmentations_list=[augmentations],
+        patch_size=None,
+        overlap=None,
+        buffer_size=1,
+        apply_augmentations=False,
+        use_cache=True,
+    )
+
+    dataset_iter.load("Validation")
+    base_sample = dataset_iter[0]["dest"].tensor
+
+    assert augmentation.compute_calls == 0
+    assert manager.loaded is True
+    assert manager.augmentationLoaded is False
+    assert torch.equal(base_sample, torch.from_numpy(base))
+
+
 def test_simpleitk_augmentations_fail_clearly_when_dependency_is_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_named_forward.py
+++ b/tests/unit/test_named_forward.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ModuleArgsDict branch routing (named_forward / forward)."""
+
+import os
+
+os.environ.setdefault("KONFAI_config_file", "/tmp/konfai-none.yml")
+os.environ.setdefault("KONFAI_CONFIG_MODE", "Done")
+
+import torch  # noqa: E402
+
+from konfai.network.blocks import Add  # noqa: E402
+from konfai.network.network import ModuleArgsDict  # noqa: E402
+
+
+class _MulConst(torch.nn.Module):
+    """Deterministic test module: multiplies its input by a fixed constant."""
+
+    def __init__(self, factor: float) -> None:
+        super().__init__()
+        self.factor = factor
+
+    def forward(self, tensor: torch.Tensor) -> torch.Tensor:
+        return tensor * self.factor
+
+
+class _TwoInputGraph(ModuleArgsDict):
+    """A(in 0)→branch 0, B(in 1)→branch 1, Sum(in 0,1)→branch 2."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.add_module("A", _MulConst(3.0), in_branch=[0], out_branch=[0])
+        self.add_module("B", _MulConst(10.0), in_branch=[1], out_branch=[1])
+        self.add_module("Sum", Add(), in_branch=[0, 1], out_branch=[2])
+
+
+class _Inner(ModuleArgsDict):
+    def __init__(self) -> None:
+        super().__init__()
+        self.add_module("Scale", _MulConst(2.0))
+
+
+class _NestedGraph(ModuleArgsDict):
+    def __init__(self) -> None:
+        super().__init__()
+        self.add_module("Pre", _MulConst(5.0), in_branch=[0], out_branch=[0])
+        self.add_module("Block", _Inner(), in_branch=[0], out_branch=[0])
+
+
+def test_forward_routes_two_inputs_through_branches():
+    graph = _TwoInputGraph()
+    a = torch.ones(1, 1, 2, 2)
+    b = torch.full((1, 1, 2, 2), 2.0)
+    out = graph(a, b)  # 3*a + 10*b = 3 + 20 = 23
+    assert torch.allclose(out, torch.full_like(out, 23.0))
+
+
+def test_named_forward_exposes_every_intermediate():
+    graph = _TwoInputGraph()
+    a = torch.ones(1, 1, 2, 2)
+    b = torch.full((1, 1, 2, 2), 2.0)
+    outputs = {name: float(tensor.flatten()[0]) for name, tensor in graph.named_forward(a, b)}
+    assert outputs == {"A": 3.0, "B": 20.0, "Sum": 23.0}
+
+
+def test_named_forward_uses_dotted_names_for_nested_graphs():
+    graph = _NestedGraph()
+    x = torch.ones(1, 1, 2, 2)
+    names = [name for name, _ in graph.named_forward(x)]
+    assert "Pre" in names
+    assert "Block.Scale" in names  # nested submodule addressable by dotted path
+    out = graph(x)  # 5 then *2 = 10
+    assert torch.allclose(out, torch.full_like(out, 10.0))
+
+
+def test_out_branch_isolation_preserves_a_branch_for_later_use():
+    """A branch written by one module must remain available to a later consumer."""
+
+    class _SkipGraph(ModuleArgsDict):
+        def __init__(self) -> None:
+            super().__init__()
+            # Keep the raw input on branch 1, transform branch 0, then combine.
+            self.add_module("Identity", torch.nn.Identity(), in_branch=[0], out_branch=[1])
+            self.add_module("Scale", _MulConst(4.0), in_branch=[0], out_branch=[0])
+            self.add_module("Sum", Add(), in_branch=[0, 1], out_branch=[0])
+
+    graph = _SkipGraph()
+    x = torch.ones(1, 1, 2, 2)
+    out = graph(x)  # 4*x + x = 5
+    assert torch.allclose(out, torch.full_like(out, 5.0))

--- a/tests/unit/test_patching.py
+++ b/tests/unit/test_patching.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for patch reconstruction and overlap-blending helpers."""
+
+import os
+
+os.environ.setdefault("KONFAI_config_file", "/tmp/konfai-none.yml")
+os.environ.setdefault("KONFAI_CONFIG_MODE", "Done")
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+
+from konfai.data.patching import Accumulator, Cosinus, Mean  # noqa: E402
+from konfai.utils.errors import PatchError  # noqa: E402
+from konfai.utils.utils import get_patch_slices_from_shape  # noqa: E402
+
+
+def _tile_2d(full: torch.Tensor, patch_size: list[int], overlap: int):
+    """Return (patch_slices, patches) tiling the spatial dims of *full* ([B, C, H, W])."""
+    patch_slices, _ = get_patch_slices_from_shape(patch_size, list(full.shape[2:]), overlap)
+    patches = [full[:, :, sl[0], sl[1]].clone() for sl in patch_slices]
+    return patch_slices, patches
+
+
+def test_accumulator_reconstructs_non_overlapping_tiles():
+    """Without blending, non-overlapping patches must reassemble exactly."""
+    full = torch.arange(1 * 1 * 4 * 4, dtype=torch.float32).reshape(1, 1, 4, 4)
+    patch_slices = [(slice(0, 2), slice(0, 4)), (slice(2, 4), slice(0, 4))]
+    acc = Accumulator(patch_slices, [2, 4], patch_combine=None, batch=True)
+    acc.add_layer(0, full[:, :, 0:2, :])
+    acc.add_layer(1, full[:, :, 2:4, :])
+    assert acc.is_full()
+    assert torch.equal(acc.assemble(), full)
+
+
+def test_accumulator_overwrites_overlap_without_combine():
+    """With overlap but no blending, patches drawn from one field still reconstruct it."""
+    full = torch.arange(1 * 1 * 8 * 8, dtype=torch.float32).reshape(1, 1, 8, 8)
+    patch_slices, patches = _tile_2d(full, [4, 4], overlap=2)
+    acc = Accumulator(patch_slices, [4, 4], patch_combine=None, batch=True)
+    for i, patch in enumerate(patches):
+        acc.add_layer(i, patch)
+    assert torch.equal(acc.assemble(), full)
+
+
+def test_accumulator_is_full_tracks_added_patches():
+    patch_slices = [(slice(0, 2),), (slice(2, 4),)]
+    acc = Accumulator(patch_slices, [2], patch_combine=None, batch=False)
+    assert not acc.is_full()
+    acc.add_layer(0, torch.zeros(1, 2))
+    assert not acc.is_full()
+    acc.add_layer(1, torch.zeros(1, 2))
+    assert acc.is_full()
+
+
+def test_assemble_without_any_patch_raises_patch_error():
+    """#14: assembling an empty accumulator must raise a typed PatchError, not crash."""
+    acc = Accumulator([(slice(0, 2),), (slice(2, 4),)], [2], patch_combine=None, batch=False)
+    with pytest.raises(PatchError):
+        acc.assemble()
+
+
+def test_assemble_with_missing_first_patch_does_not_crash():
+    """#14 regression: a missing index-0 patch must not raise UnboundLocalError.
+
+    The seed tensor (shape/dtype/device) is taken from the first *present* patch,
+    so any single missing patch — including index 0 — assembles cleanly.
+    """
+    full = torch.arange(1 * 1 * 4 * 4, dtype=torch.float32).reshape(1, 1, 4, 4)
+    patch_slices = [(slice(0, 2), slice(0, 4)), (slice(2, 4), slice(0, 4))]
+    acc = Accumulator(patch_slices, [2, 4], patch_combine=None, batch=True)
+    # Only the second patch is added; index 0 stays None.
+    acc.add_layer(1, full[:, :, 2:4, :])
+    out = acc.assemble()  # must not raise
+    assert out.shape == full.shape
+    assert torch.equal(out[:, :, 2:4, :], full[:, :, 2:4, :])
+
+
+@pytest.mark.parametrize("combine_cls", [Mean, Cosinus])
+def test_path_combine_window_is_bounded_and_unit_at_center(combine_cls):
+    """Blending windows weight each voxel in [0, 1] and reach 1 at the patch centre."""
+    combine = combine_cls()
+    combine.set_patch_config([6, 6], 2)
+    window = combine.data
+    assert window.shape == (6, 6)
+    assert float(window.min()) >= 0.0
+    assert float(window.max()) <= 1.0 + 1e-6
+    assert float(window.max()) == pytest.approx(1.0, abs=1e-4)
+
+
+def test_cosinus_tapers_more_than_mean_in_overlap():
+    """Cosine blending must down-weight the overlap border more than uniform mean."""
+    mean = Mean()
+    mean.set_patch_config([6, 6], 2)
+    cosinus = Cosinus()
+    cosinus.set_patch_config([6, 6], 2)
+    # The very first row/col sits in the overlap border where cosine tapers to ~0.
+    assert float(cosinus.data[0, 0]) < float(mean.data[0, 0])
+
+
+def test_path_combine_call_applies_window_and_caches_device():
+    combine = Mean()
+    combine.set_patch_config([6, 6], 2)
+    tensor = torch.ones(1, 1, 6, 6)
+    weighted = combine(tensor)
+    assert torch.allclose(weighted[0, 0], combine.data)
+    # The per-device window is cached on first use.
+    assert tensor.device in combine._data_per_device


### PR DESCRIPTION
## Summary

Three reviewable commits on top of `main`:

### 1. Resolve the whole-repository audit findings (`701f336`)
Addresses the open items tracked in `AUDIT.md`, across data, models, metrics, and imaging:

- **augmentation**: re-sample parameters each epoch via `DataAugmentation.reset_state` (#1)
- **checkpoint**: `load_state_dict` warm-starts resized layers and keeps siblings (#2)
- **patching**: `Accumulator` raises a typed `PatchError` instead of `UnboundLocalError` (#14)
- **scheduler**: `update_scheduler` raises `ConfigError` on an empty schedule (#15)
- **metrics**: declare `ssim`/`fid`/`lpips` extras and raise an actionable `MeasureError` (#16)
- **models**: rebuild `LinearVAE` on a real `LatentDistribution` bottleneck (#17), set `Adaptation` `requires_grad` in `__init__` (#18), label debug blocks and make `Write`'s output path explicit (#19)
- **transform**: reuse a persisted `Crop` box to skip the full-volume read (#10)
- **dicom**: non-destructive writes and multi-frame / irregular-spacing detection
- **network/metrics**: thread the GPU-index counter explicitly instead of `os.environ`
- **apps**: document `number_of_mc_dropout` as a reserved future feature (#11)

Adds regression tests (patching, named-forward, audit fixes, DICOM hardening) and expands `AUDIT.md` / `AGENTS.md`.

### 2. `validation_augmentations` and zero-LR training stop (`bf01f7e`)

- `DataTrain` gains a `validation_augmentations` flag (default `true`). When `false`, the train and validation datasets are prepared separately so augmented variants never leak into validation; the float split is computed from per-case entry counts, and `_get_validation_mapping()` is the single accessor that enforces the invariant.
- `EarlyStopping`: move `early_stop`/`is_stopped` to `EarlyStoppingBase`, add `stop()`, and end the run cleanly once the schedulers decay the optimizer learning rate to `<= 0`.
- Removes the now-dead `_split_train_validation` (replaced by `_split_train_validation_names`) and migrates its tests. The drafted SSIM index change was intentionally dropped after verifying that `MaskedLoss.forward` passes the full `[B, C, ...]` tensor, so the existing `x[0][0]` indexing is correct.
- Adds unit tests for the disabled-validation-augmentation paths and for `EarlyStopping`, and documents the new key in the examples, the training guide, and `AGENTS.md`.

### 3. Decouple `konfai-apps` runtime deps from the core (`f5ab7a6`)

- `konfai-apps` is an independent package: its runtime deps (`fastapi`, `uvicorn`, `python-multipart`) belong in `konfai-apps/pyproject.toml`, not in the core. Remove them from `konfai[dev]` and the Pixi `dev` feature so `pip install konfai` no longer drags in the apps server stack.
- `pip install konfai-apps` pulls them itself (verified: wheel `Requires-Dist: konfai, fastapi, uvicorn, python-multipart`). Re-lock pixi (drops them + transitives).
- Shared lint/format/bandit tooling is kept (one config for the monorepo). Core is unchanged — it never imported these. `AGENTS.md` notes the apps suite needs `pip install -e ./konfai-apps` first.

## Tests

- `tests/unit` and `tests/integration` green; lint / format / mypy / bandit clean (`pixi run check`).
- `konfai-apps` wheel self-contained; its suite (31 tests) passes after `pip install -e ./konfai-apps`.
