### PR TITLE
refactor: dead-code removal and perf/elegance fixes across the core

### DIFF
--- a/konfai/__init__.py
+++ b/konfai/__init__.py
@@ -241,30 +241,6 @@ def _get_env(var: str) -> str:
     return value
 
 
-_KONFAI_DEPS: dict[str, str] = {
-    "torch": "torch",
-    "tqdm": "tqdm",
-    "numpy": "numpy",
-    "ruamel.yaml": "ruamel.yaml",
-    "psutil": "psutil",
-    "tensorboard": "tensorboard",
-    "SimpleITK": "SimpleITK",
-    "lxml": "lxml",  # often used as lxml.etree
-    "h5py": "h5py",
-    "nvidia-ml-py": "pynvml",  # IMPORTANT: pip != import
-    "requests": "requests",
-    "huggingface_hub": "huggingface_hub",
-}
-
-
-def _try_import(import_name: str) -> str | None:
-    try:
-        __import__(import_name)
-        return None
-    except Exception as e:
-        return f"{type(e).__name__}: {e}"
-
-
 def check_server(remote_server: RemoteServer, timeout_s: float = 2.0) -> tuple[bool, str]:
     """
     Check whether a remote KonfAI Apps server is reachable and healthy.
@@ -307,67 +283,3 @@ def check_server(remote_server: RemoteServer, timeout_s: float = 2.0) -> tuple[b
         return False, "Timeout"
     except Exception as e:
         return False, str(e)
-
-
-def check_konfai_install() -> tuple[bool, dict]:
-    """
-    Checks that KonfAI dependencies are importable.
-
-    Returns
-    -------
-    tuple[bool, dict]
-        A pair containing a global success flag and a report dictionary with the
-        keys ``missing``, ``errors``, and ``versions``.
-    """
-    missing: list[str] = []
-    errors: dict[str, str] = {}
-    versions: dict[str, str] = {}
-
-    deps = dict(_KONFAI_DEPS)
-    for pip_name, import_name in deps.items():
-        # best effort version lookup
-        try:
-            versions[pip_name] = metadata.version(pip_name)
-        except metadata.PackageNotFoundError:
-            versions[pip_name] = "not installed"
-        except Exception:
-            versions[pip_name] = "unknown"
-
-        err = _try_import(import_name)
-        if err is None:
-            continue
-
-        if versions[pip_name] == "not installed":
-            missing.append(pip_name)
-        else:
-            errors[pip_name] = err
-
-    return len(missing) == 0 and len(errors) == 0, {
-        "missing": missing,
-        "errors": errors,
-        "versions": versions,
-    }
-
-
-class KonfAIPackagesError(RuntimeError):
-    """Raised when required Python packages for KonfAI are missing/broken."""
-
-
-def assert_konfai_install() -> None:
-    """
-    Raise :class:`KonfAIPackagesError` if the KonfAI dependency check fails.
-    """
-    is_konfai_install, report = check_konfai_install()
-    if not is_konfai_install:
-        lines = ["KonfAI dependency check failed."]
-
-        if report["missing"]:
-            lines.append("\nMissing packages:")
-            lines.extend(f"  - {p}" for p in report["missing"])
-
-        if report["errors"]:
-            lines.append("\nImport/runtime errors:")
-            for p, e in report["errors"].items():
-                lines.append(f"  - {p}: {e}")
-
-        raise KonfAIPackagesError("\n".join(lines))

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -128,7 +128,7 @@ class Mean(PathCombine):
         super().__init__()
 
     def _set_function(self, data: torch.Tensor, overlap: int) -> torch.Tensor:
-        return torch.ones_like(self.data)
+        return torch.ones_like(data)
 
 
 class Cosinus(PathCombine):

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -420,12 +420,12 @@ class ResampleToResolution(Resample):
 
     def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
         if "Spacing" not in cache_attribute:
-            TransformError(
+            raise TransformError(
                 "Missing 'Spacing' in cache attributes, the data is likely not a valid image.",
                 "Make sure your input is a image (e.g., .nii, .mha) with proper metadata.",
             )
         if len(shape) != len(self.spacing):
-            TransformError("Shape and spacing dimensions do not match: shape={shape}, spacing={self.spacing}")
+            raise TransformError(f"Shape and spacing dimensions do not match: shape={shape}, spacing={self.spacing}")
         image_spacing = cache_attribute.get_tensor("Spacing")
         resize_factor = torch.tensor(
             [s / i_s if s > 0 else 1.0 for s, i_s in zip(self.spacing, image_spacing, strict=False)]
@@ -456,13 +456,8 @@ class ResampleToShape(Resample):
         self.shape = torch.tensor([0 if s < 0 else s for s in shape])
 
     def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
-        if "Spacing" not in cache_attribute:
-            TransformError(
-                "Missing 'Spacing' in cache attributes, the data is likely not a valid image.",
-                "Make sure your input is a image (e.g., .nii, .mha) with proper metadata.",
-            )
         if len(shape) != len(self.shape):
-            TransformError("Shape and spacing dimensions do not match: shape={shape}, spacing={self.spacing}")
+            raise TransformError(f"Shape and target-shape dimensions do not match: shape={shape}, target={self.shape}")
         new_shape = self.shape.clone()
         for i, s in enumerate(self.shape):
             if s == 0:

--- a/konfai/metric/measure.py
+++ b/konfai/metric/measure.py
@@ -211,11 +211,9 @@ class MAESaveMap(MAE):
     def forward(self, output: torch.Tensor, *targets: torch.Tensor):  # type: ignore[override]
         loss, true_loss = super().forward(output, *targets)
         if len(targets) == 2:
+            mask = torch.where(targets[1] == 1, 1, 0)
             error_map = (
-                torch.nn.L1Loss(reduction="none")(
-                    output.float() * torch.where(targets[1] == 1, 1, 0),
-                    targets[0].float() * torch.where(targets[1] == 1, 1, 0),
-                )
+                torch.nn.L1Loss(reduction="none")(output.float() * mask, targets[0].float() * mask)
                 .to(output.dtype)
                 .cpu()
             )
@@ -338,9 +336,10 @@ class Dice(Criterion):
     def forward(self, output: torch.Tensor, *targets: torch.Tensor) -> tuple[torch.Tensor, float]:
         mask = MaskedLoss.get_mask(list(targets[1:]))
         if mask is not None:
+            binary_mask = torch.where(targets[1] == 1, 1, 0)
             return self.loss(
-                (output * torch.where(targets[1] == 1, 1, 0)).to(torch.uint8),
-                (targets[0] * torch.where(targets[1] == 1, 1, 0)).to(torch.uint8),
+                (output * binary_mask).to(torch.uint8),
+                (targets[0] * binary_mask).to(torch.uint8),
             )
         else:
             return self.loss(output, targets[0])
@@ -355,12 +354,9 @@ class DiceSaveMap(Dice):
     def forward(self, output: torch.Tensor, *targets: torch.Tensor):  # type: ignore[override]
         loss, true_loss = super().forward(output, *targets)
         if len(targets) == 2:
+            binary_mask = torch.where(targets[1] == 1, 1, 0)
             error_map = (
-                torch.nn.L1Loss(reduction="none")(
-                    output * torch.where(targets[1] == 1, 1, 0), targets[0] * torch.where(targets[1] == 1, 1, 0)
-                )
-                .to(torch.uint8)
-                .cpu()
+                torch.nn.L1Loss(reduction="none")(output * binary_mask, targets[0] * binary_mask).to(torch.uint8).cpu()
             )
         else:
             error_map = torch.nn.L1Loss(reduction="none")(output, targets[0]).to(torch.uint8).cpu()
@@ -517,13 +513,7 @@ class PerceptualLoss(Criterion):
         self.models: dict[int, torch.nn.Module] = {}
 
     def preprocessing(self, tensor: torch.Tensor) -> torch.Tensor:
-        # if not all([tensor.shape[-i-1] == size for i, size in enumerate(reversed(self.shape[2:]))]):
-        #    tensor = F.interpolate(tensor, mode=self.mode,
-        # size=tuple(self.shape), align_corners=False).type(torch.float32)
-        # if tensor.shape[1] != self.model.in_channels:
-        #    tensor = tensor.repeat(tuple([1,self.model.in_channels] + [1 for _ in range(len(self.shape))]))
-        # tensor = (tensor - torch.min(tensor))/(torch.max(tensor)-torch.min(tensor))
-        # tensor = torchvision.transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])(tensor)
+        """Identity hook applied to output/targets before the perceptual feature passes."""
         return tensor
 
     def _compute(self, output: torch.Tensor, *targets: torch.Tensor) -> torch.Tensor:

--- a/konfai/models/classification/convNeXt.py
+++ b/konfai/models/classification/convNeXt.py
@@ -95,10 +95,10 @@ class DropPath(torch.nn.Module):
 
 
 class LayerScaler(torch.nn.Module):
-    def __init__(self, init_value: float, dimensions: int):
+    def __init__(self, init_value: float, dimensions: int, dim: int):
         super().__init__()
         self.init_value = init_value
-        self.gamma = torch.nn.Parameter(torch.ones(dimensions, 1, 1) * init_value)
+        self.gamma = torch.nn.Parameter(torch.ones(dimensions, *([1] * dim)) * init_value)
 
     def forward(self, tensor: torch.Tensor) -> torch.Tensor:
         return self.gamma * tensor
@@ -123,7 +123,7 @@ class BottleNeckBlock(network.ModuleArgsDict):
         self.add_module("ToChannels", blocks.ToChannels(dim))
         self.add_module(
             "LayerScaler",
-            LayerScaler(init_value=layer_scaler_init_value, dimensions=features),
+            LayerScaler(init_value=layer_scaler_init_value, dimensions=features, dim=dim),
             alias=[""],
         )
         self.add_module("StochasticDepth", DropPath(drop_p))

--- a/konfai/models/generation/cStyleGan.py
+++ b/konfai/models/generation/cStyleGan.py
@@ -14,10 +14,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import importlib
 import itertools
 
 import torch
+import torch.nn.functional as F
 from konfai.data.patching import ModelPatch
 from konfai.network import blocks, network
 
@@ -99,10 +99,7 @@ class ModulatedConv(torch.nn.Module):
 
             _, _, *ws = weights.shape
             if not self.isConv:
-                out = getattr(
-                    importlib.import_module("torch.nn.functional"),
-                    f"conv_transpose{self.dim}d",
-                )(
+                out = getattr(F, f"conv_transpose{self.dim}d")(
                     tensor,
                     weights.reshape(b * self.in_channels, *ws),
                     stride=self.stride,
@@ -110,10 +107,7 @@ class ModulatedConv(torch.nn.Module):
                     groups=b,
                 )
             else:
-                out = getattr(
-                    importlib.import_module("torch.nn.functional"),
-                    f"conv{self.dim}d",
-                )(
+                out = getattr(F, f"conv{self.dim}d")(
                     tensor,
                     weights.reshape(b * self.out_channels, *ws),
                     padding=self.padding,

--- a/konfai/models/registration/registration.py
+++ b/konfai/models/registration/registration.py
@@ -137,17 +137,6 @@ class Rigid(network.ModuleArgsDict):
         self["Head"].bias.data.copy_(torch.tensor([0, 0], dtype=torch.float))
 
 
-class MaskFlow(torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-
-    def forward(self, mask: torch.Tensor, *flows: torch.Tensor):
-        result = torch.zeros_like(flows[0])
-        for i, flow in enumerate(flows):
-            result = result + torch.where(mask == i + 1, flow, torch.tensor(0))
-        return result
-
-
 class SpatialTransformer(torch.nn.Module):
     def __init__(self, size: list[int], rigid: bool = False):
         super().__init__()

--- a/konfai/network/network.py
+++ b/konfai/network/network.py
@@ -1163,9 +1163,11 @@ class Network(ModuleArgsDict, ABC):
             name = name_tmp.replace(";accu;", "")
             if debug:
                 if "KONFAI_DEBUG_LAST_LAYER" in os.environ:
-                    os.environ["KONFAI_DEBUG_LAST_LAYER"] = f"{os.environ['KONFAI_DEBUG_LAST_LAYER']}|{name}:"
-                    f"{get_gpu_memory(output_layer.device)}:"
-                    f"{str(output_layer.device).replace('cuda:', '')}"
+                    os.environ["KONFAI_DEBUG_LAST_LAYER"] = (
+                        f"{os.environ['KONFAI_DEBUG_LAST_LAYER']}|{name}:"
+                        f"{get_gpu_memory(output_layer.device)}:"
+                        f"{str(output_layer.device).replace('cuda:', '')}"
+                    )
                 else:
                     os.environ["KONFAI_DEBUG_LAST_LAYER"] = (
                         f"{name}:{get_gpu_memory(output_layer.device)}:{str(output_layer.device).replace('cuda:', '')}"

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -245,7 +245,7 @@ class OutputDataset(Dataset, NeedDevice, ABC):
             "after_reduction_transforms": self.after_reduction_transforms,
             "final_transforms": self.final_transforms,
             "patch_combine": self.patch_combine,
-            "reduction": self.patch_combine,
+            "reduction": self.reduction_classpath,
         }
         return str(params)
 

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -600,9 +600,6 @@ class Trainer(DistributedObject):
         self.model_ema: torch.optim.swa_utils.AveragedModel | None = None
         self.data_log = data_log
 
-        modules = []
-        for i, _ in self.model.named_modules():
-            modules.append(i)
         self.gradient_checkpoints = gradient_checkpoints
         self.gpu_checkpoints = gpu_checkpoints
         self.save_checkpoint_mode = save_checkpoint_mode

--- a/konfai/utils/dicom.py
+++ b/konfai/utils/dicom.py
@@ -51,7 +51,7 @@ import re
 from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import numpy as np
 
@@ -59,9 +59,6 @@ from konfai.utils.errors import DatasetManagerError
 
 # Zero-padded slice filenames produced by :func:`write_dicom_series` (e.g. ``000001.dcm``).
 _SLICE_FILENAME_RE = re.compile(r"^\d{6}\.dcm$")
-
-if TYPE_CHECKING:
-    pass
 
 try:
     import pydicom

--- a/tests/unit/test_perf_elegance_fixes.py
+++ b/tests/unit/test_perf_elegance_fixes.py
@@ -1,0 +1,30 @@
+import pytest
+import torch
+
+from konfai.data.transform import ResampleToResolution, ResampleToShape
+from konfai.models.classification.convNeXt import LayerScaler
+from konfai.utils.dataset import Attribute
+from konfai.utils.errors import TransformError
+
+
+def test_resample_to_resolution_transform_shape_raises_without_spacing() -> None:
+    # The missing-Spacing guard used to build a TransformError and silently drop it.
+    transform = ResampleToResolution(spacing=[1.0, 1.0, 1.0])
+    with pytest.raises(TransformError, match="Spacing"):
+        transform.transform_shape("CT", "case", [10, 10, 10], Attribute())
+
+
+def test_resample_to_shape_transform_shape_needs_no_spacing_but_checks_dims() -> None:
+    # ResampleToShape.transform_shape does not use Spacing; it just resolves the target shape.
+    transform = ResampleToShape(shape=[10, 20, 30])
+    assert [int(x) for x in transform.transform_shape("CT", "case", [5, 6, 7], Attribute())] == [10, 20, 30]
+    with pytest.raises(TransformError, match="dimensions do not match"):
+        transform.transform_shape("CT", "case", [5, 6], Attribute())
+
+
+def test_layer_scaler_broadcasts_in_2d_and_3d() -> None:
+    # gamma was hardcoded [C, 1, 1] (2D); it now sizes to `dim` so 3D broadcasts.
+    scaler_3d = LayerScaler(init_value=1e-6, dimensions=4, dim=3)
+    assert scaler_3d(torch.randn(2, 4, 5, 6, 7)).shape == (2, 4, 5, 6, 7)
+    scaler_2d = LayerScaler(init_value=1e-6, dimensions=4, dim=2)
+    assert scaler_2d(torch.randn(2, 4, 6, 7)).shape == (2, 4, 6, 7)


### PR DESCRIPTION
## Summary

A fresh whole-repo **performance & elegance** pass (four subsystem audits: data pipeline, network/models, metrics/workflows, utils/imaging). This PR lands the **clean, low-risk** fixes only — net **−94 lines** (mostly dead code). Full unit + integration suite green; lint/format/mypy clean.

### Dead code removed
- `konfai/__init__.py`: unused install-check machinery (`_KONFAI_DEPS`, `_try_import`, `check_konfai_install`, `KonfAIPackagesError`, `assert_konfai_install`) — zero callers.
- `registration.py`: unused `MaskFlow`. · `dicom.py`: empty `if TYPE_CHECKING: pass`. · `trainer.py`: dead `modules` loop. · `measure.py`: commented-out `PerceptualLoss.preprocessing` body.

### Bug / correctness fixes
- **`ResampleToResolution.transform_shape`** now *raises* the missing-`Spacing` `TransformError` (it was constructed and silently discarded) with a real f-string; the **spurious** `Spacing` check is removed from `ResampleToShape.transform_shape`, which doesn't use `Spacing`.
- **`ConvNeXt.LayerScaler`** sizes `gamma` to `dim` instead of a hardcoded `[C,1,1]` — ConvNeXt was a broadcast failure at its **default `dim=3`**; 2D unchanged.
- **`OutputDataset.__str__`** reported `reduction` as `patch_combine`.
- **`network.py`** `KONFAI_DEBUG_LAST_LAYER` debug string dropped two of three f-string fragments (bare statements) — now concatenated.

### Perf / elegance
- **`cStyleGan`**: replace per-forward `importlib.import_module("torch.nn.functional")` with a module-level `import torch.nn.functional as F`.
- **`measure.py`**: compute the binary mask once in `Dice`/`DiceSaveMap`/`MAESaveMap`.
- **`patching.py`**: `Mean._set_function` uses its `data` argument.

Tests added for the `transform_shape` raise and the ConvNeXt 3D broadcast.

## Deferred — a follow-up bug-fix PR (risky / larger, each needs a focused test)

- **`Attribute` prefix collision** (real correctness bug): `_count_key`/`__contains__` use `startswith`, so e.g. `Image` collides with `ImageMax`/`ImageMin` and the value becomes silently unreadable (`NameError`). Fix is an exact-match key regex — but it changes serialization-matching semantics widely.
- **Imaging perf**: DICOM re-parses the whole series' headers ~4× per patch read (O(Z²) for statistics); OME-Zarr re-opens the store + re-parses NGFF on every slice/info access. Both want round-trip-tested caching.
- **Duplication** (checkpoint/numerical risk): GAN `Generator`/`Discriminator` between `gan.py` and `diffusionGan.py`; the IMPACT/SAM perceptual losses; SimpleITK transform serialization (×3, with a latent non-`elif` `UnboundLocalError`).
- **Dim-correctness** (numerical risk): 3D `SpatialTransformer`/`VecInt`, `Rigid.Head` hardcoded 512×512, `representation.py` re-implementing `ConvBlock`.
- **Not touched on purpose:** mutable default args — load-bearing for the config-reflection engine (`apply_config` introspects the literal defaults), confirmed by the audit.
