### PR TITLE
feat: add app bundle command

### DIFF
--- a/konfai-apps/konfai_apps/bundle.py
+++ b/konfai-apps/konfai_apps/bundle.py
@@ -1,0 +1,285 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Assemble a KonfAI app bundle (the HuggingFace layout) from trained artifacts.
+
+App bundles were previously assembled by hand. :func:`assemble_bundle` builds the
+standard bundle folder (``app.json`` + configs + checkpoints + optional ``Model.py`` /
+``requirements.txt``) and validates the metadata. With ``--onnx``,
+:func:`export_onnx_into_bundle` also emits the portable contract (``model.onnx`` +
+``manifest.json``) so the same bundle drives both the PyTorch runtime and the
+portable konfai-rs / ONNX-Runtime-Web runtimes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+from konfai.utils.errors import AppMetadataError
+
+REQUIRED_APP_JSON_KEYS = ["display_name", "description", "short_description", "tta", "mc_dropout"]
+
+# import name -> PyPI package name, for best-effort requirements derivation.
+_IMPORT_TO_PYPI = {
+    "segmentation_models_pytorch": "segmentation-models-pytorch",
+    "cv2": "opencv-python",
+    "PIL": "Pillow",
+    "skimage": "scikit-image",
+    "sklearn": "scikit-learn",
+}
+# Already provided by konfai / konfai-apps (and their deps): never emitted as a requirement.
+_PROVIDED_MODULES = {"torch", "torchvision", "numpy", "scipy", "yaml", "konfai", "konfai_apps"}
+
+
+def derive_requirements(py_files: list[str | Path]) -> list[str]:
+    """Best-effort: infer the *extra* PyPI requirements from imports in custom ``.py`` files.
+
+    Returns third-party packages imported beyond the standard library and what konfai
+    already provides (so ``segmentation_models_pytorch`` is kept, ``torch``/``numpy`` are
+    not). Heuristic — a draft the author should review; the import→package mapping is
+    approximate.
+    """
+    import ast
+    import sys
+
+    stdlib = set(sys.stdlib_module_names)
+    found: set[str] = set()
+    for py_file in py_files:
+        for node in ast.walk(ast.parse(Path(py_file).read_text())):
+            if isinstance(node, ast.Import):
+                modules = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                modules = [node.module]
+            else:
+                continue
+            for module in modules:
+                top = module.split(".")[0]
+                if top in stdlib or top in _PROVIDED_MODULES or top.startswith("konfai"):
+                    continue
+                found.add(_IMPORT_TO_PYPI.get(top, top.replace("_", "-")))
+    return sorted(found)
+
+
+def _derive_onnx_params(config: dict[str, Any], root: str) -> tuple[list[int] | None, int | None, int]:
+    """Best-effort ``(patch_size, in_channels, extend_slice)`` read from a prediction config.
+
+    ``patch_size`` is the inference ``Patch`` spatial size (dropping a singleton slice
+    dimension for 2.5D); ``in_channels`` comes from the model's ``nb_channel`` /
+    ``in_channels`` / first of ``channels``; ``extend_slice`` from the inference ``Patch``.
+    Returns ``None`` for values that cannot be derived (the caller may use explicit flags).
+    """
+
+    def find_inference_patch(node: Any) -> dict[str, Any] | None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key == "ModelPatch":
+                    continue
+                if key == "Patch" and isinstance(value, dict) and "patch_size" in value:
+                    return value
+                found = find_inference_patch(value)
+                if found is not None:
+                    return found
+        return None
+
+    patch_size: list[int] | None = None
+    extend_slice = 0
+    patch = find_inference_patch(config)
+    if patch is not None:
+        raw = patch.get("patch_size")
+        if isinstance(raw, list):
+            dims = [int(d) for d in raw]
+            patch_size = [d for d in dims if d > 1] or dims
+        raw_extend = patch.get("extend_slice", 0)
+        if isinstance(raw_extend, int):
+            extend_slice = raw_extend
+        elif isinstance(raw_extend, str) and raw_extend.lstrip("-").isdigit():
+            extend_slice = int(raw_extend)
+
+    in_channels: int | None = None
+    model_cfg = config.get(root, {}).get("Model", {}) if isinstance(config.get(root), dict) else {}
+    for value in model_cfg.values() if isinstance(model_cfg, dict) else []:
+        if not isinstance(value, dict):
+            continue
+        if isinstance(value.get("nb_channel"), int):
+            in_channels = value["nb_channel"]
+            break
+        if isinstance(value.get("in_channels"), int):
+            in_channels = value["in_channels"]
+            break
+        channels = value.get("channels")
+        if isinstance(channels, list) and channels and isinstance(channels[0], int):
+            in_channels = channels[0]
+            break
+    return patch_size, in_channels, extend_slice
+
+
+def assemble_bundle(
+    name: str,
+    out_dir: str | Path,
+    app_json: str | Path,
+    configs: list[str],
+    checkpoints: list[str],
+    model_py: str | None = None,
+    requirements: str | None = None,
+) -> Path:
+    """Assemble ``<out_dir>/<name>/`` in the standard app-bundle layout.
+
+    Validates that ``app.json`` has the required keys and that its ``models`` list (if
+    present) matches the provided checkpoints; fills ``models`` from the checkpoints
+    otherwise. Returns the bundle directory.
+    """
+    metadata: dict[str, Any] = json.loads(Path(app_json).read_text())
+    missing = [key for key in REQUIRED_APP_JSON_KEYS if key not in metadata]
+    if missing:
+        raise AppMetadataError(f"app.json is missing required keys: {', '.join(missing)}")
+
+    checkpoint_names = [Path(c).name for c in checkpoints]
+    declared = [str(m) for m in metadata.get("models", [])]
+    if declared and sorted(declared) != sorted(checkpoint_names):
+        raise AppMetadataError(
+            f"app.json 'models' {declared} does not match the provided checkpoints {checkpoint_names}",
+        )
+
+    bundle = Path(out_dir) / name
+    bundle.mkdir(parents=True, exist_ok=True)
+
+    if not declared:
+        metadata["models"] = checkpoint_names
+    (bundle / "app.json").write_text(json.dumps(metadata, indent=2))
+
+    for config in configs:
+        shutil.copy(config, bundle / Path(config).name)
+    for checkpoint in checkpoints:
+        shutil.copy(checkpoint, bundle / Path(checkpoint).name)
+    if model_py is not None:
+        shutil.copy(model_py, bundle / "Model.py")
+    if requirements is not None:
+        shutil.copy(requirements, bundle / "requirements.txt")
+    return bundle
+
+
+def export_onnx_into_bundle(
+    bundle: str | Path,
+    *,
+    patch_size: list[int] | None = None,
+    in_channels: int | None = None,
+    prediction_config: str = "Prediction.yml",
+    checkpoint: str | None = None,
+    output_module: str | None = None,
+    root: str = "Predictor",
+) -> Path:
+    """Add ``model.onnx`` + ``manifest.json`` to an assembled bundle.
+
+    Loads the model declared in the bundle's prediction config (its ``Model.classpath``)
+    with the given checkpoint — mirroring how ``konfai.predictor`` loads it — and exports
+    it via :func:`konfai.export.export_to_onnx`. ``patch_size`` / ``in_channels`` are read
+    from the config (the app already declares them) when not given explicitly. The bundle's
+    custom ``Model.py`` is made importable for the duration of the call. The config file is
+    restored afterwards so the defaults-materialising config reader does not mutate the bundle.
+    """
+    import torch
+    import yaml
+    from konfai.export import export_to_onnx, list_output_modules
+    from konfai.network.network import ModelLoader
+
+    bundle = Path(bundle)
+    config_path = bundle / prediction_config
+    if not config_path.exists():
+        raise AppMetadataError(f"prediction config '{prediction_config}' not found in bundle {bundle}")
+
+    config = yaml.safe_load(config_path.read_text())
+    try:
+        classpath = config[root]["Model"]["classpath"]
+    except (KeyError, TypeError) as exc:
+        raise AppMetadataError(f"could not read {root}.Model.classpath from {config_path}") from exc
+
+    derived_patch, derived_channels, extend_slice = _derive_onnx_params(config, root)
+    patch_size = patch_size or derived_patch
+    in_channels = in_channels if in_channels is not None else derived_channels
+    if not patch_size or not in_channels:
+        raise AppMetadataError(
+            "could not derive patch_size/in_channels from the config; pass --patch-size and --in-channels",
+        )
+
+    config_snapshot = config_path.read_text()
+    env_keys = ("KONFAI_config_file", "KONFAI_CONFIG_MODE", "KONFAI_ROOT", "KONFAI_STATE")
+    env_backup = {key: os.environ.get(key) for key in env_keys}
+    sys.path.insert(0, str(bundle))
+    try:
+        os.environ["KONFAI_config_file"] = str(config_path)
+        os.environ["KONFAI_CONFIG_MODE"] = "Done"
+        os.environ["KONFAI_ROOT"] = root
+        os.environ["KONFAI_STATE"] = "PREDICTION"
+
+        model = ModelLoader(classpath).get_model(train=False)
+        # Disable the model's internal patch-based forward: we export the per-patch
+        # network and let the portable runtime do the sliding-window tiling.
+        model.patch = None
+        model.eval()
+        if checkpoint is not None:
+            ckpt_path = Path(checkpoint)
+            if not ckpt_path.is_absolute():
+                ckpt_path = bundle / ckpt_path.name
+            state = torch.load(str(ckpt_path), map_location="cpu", weights_only=False)  # nosec B614
+            model.load(state, init=False)
+
+        example = torch.randn(1, in_channels, *patch_size)
+        head = output_module or list_output_modules(model, example)[-1][0]
+        return export_to_onnx(model, bundle, example, head, extend_slice=extend_slice)
+    finally:
+        sys.path.remove(str(bundle))
+        config_path.write_text(config_snapshot)
+        for key, value in env_backup.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def run_bundle_cli(args: dict[str, Any]) -> None:
+    """Entry point for the ``konfai-apps bundle`` subcommand."""
+    bundle = assemble_bundle(
+        name=args["name"],
+        out_dir=args["out"],
+        app_json=args["app_json"],
+        configs=args["config"],
+        checkpoints=args["checkpoint"],
+        model_py=args.get("model_py"),
+        requirements=args.get("requirements"),
+    )
+    print(f"Bundle assembled at {bundle}")
+
+    # If no requirements.txt was provided, draft one from the custom Model.py imports.
+    if not args.get("requirements") and (bundle / "Model.py").exists():
+        drafted = derive_requirements([bundle / "Model.py"])
+        if drafted:
+            (bundle / "requirements.txt").write_text("\n".join(drafted) + "\n")
+            print(f"Drafted requirements.txt (review!): {', '.join(drafted)}")
+
+    if args.get("onnx"):
+        onnx_path = export_onnx_into_bundle(
+            bundle,
+            patch_size=args.get("patch_size"),
+            in_channels=args.get("in_channels"),
+            checkpoint=Path(args["checkpoint"][0]).name if args.get("checkpoint") else None,
+            output_module=args.get("output_module"),
+        )
+        print(f"Portable model exported: {onnx_path} (+ manifest.json)")

--- a/konfai-apps/konfai_apps/cli.py
+++ b/konfai-apps/konfai_apps/cli.py
@@ -308,9 +308,42 @@ def main_apps() -> None:
         help="Number of training iterations between validation runs.",
     )
 
+    bundle_p = subparsers.add_parser(
+        "bundle", help="Assemble an app bundle (HF layout), optionally with a portable ONNX model."
+    )
+    bundle_p.add_argument("name", type=str, help="Bundle/app variant name (the folder name).")
+    bundle_p.add_argument("--out", required=True, help="Output directory; the bundle is written to <out>/<name>/.")
+    bundle_p.add_argument("--app-json", required=True, help="Path to the app.json metadata file.")
+    bundle_p.add_argument(
+        "--config",
+        nargs="+",
+        required=True,
+        help="Config file(s), space-separated: Prediction.yml Evaluation.yml …",
+    )
+    bundle_p.add_argument("--checkpoint", nargs="+", required=True, help="Checkpoint .pt file(s): CV_0.pt CV_1.pt …")
+    bundle_p.add_argument("--model-py", help="Optional custom Model.py to include.")
+    bundle_p.add_argument(
+        "--requirements", help="Optional requirements.txt; if omitted, a draft is derived from Model.py imports."
+    )
+    bundle_p.add_argument(
+        "--onnx", action="store_true", help="Also export model.onnx + manifest.json (portable runtime)."
+    )
+    bundle_p.add_argument(
+        "--patch-size", type=int, nargs="+", help="Override --onnx patch size (else read from config)."
+    )
+    bundle_p.add_argument("--in-channels", type=int, help="Override --onnx input channels (else read from config).")
+    bundle_p.add_argument("--output-module", help="Named head to export for --onnx (default: last graph output).")
+
     parser.add_argument("--version", action="version", version=_package_version())
 
     kwargs = vars(parser.parse_args())
+
+    if kwargs.get("command") == "bundle":
+        from konfai_apps.bundle import run_bundle_cli
+
+        run_bundle_cli(kwargs)
+        return
+
     host = kwargs.pop("host")
     port = kwargs.pop("port")
     token = kwargs.pop("token")

--- a/konfai-apps/tests/unit/test_bundle.py
+++ b/konfai-apps/tests/unit/test_bundle.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the app-bundle assembler."""
+
+import json
+
+import pytest
+
+from konfai.utils.errors import AppMetadataError
+from konfai_apps.bundle import assemble_bundle
+
+VALID_META = {
+    "display_name": "Synthesis: MR",
+    "description": "d",
+    "short_description": "s",
+    "tta": 0,
+    "mc_dropout": 0,
+}
+
+
+def _write(path, obj):
+    path.write_text(json.dumps(obj))
+    return path
+
+
+def test_assemble_bundle_layout(tmp_path):
+    app_json = _write(tmp_path / "app.json", VALID_META)
+    config = tmp_path / "Prediction.yml"
+    config.write_text("Predictor: {}\n")
+    checkpoint = tmp_path / "CV_0.pt"
+    checkpoint.write_bytes(b"weights")
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("torch\n")
+    model_py = tmp_path / "Model.py"
+    model_py.write_text("# custom\n")
+
+    bundle = assemble_bundle(
+        "MR", tmp_path / "out", app_json, [str(config)], [str(checkpoint)],
+        model_py=str(model_py), requirements=str(requirements),
+    )
+
+    assert bundle == tmp_path / "out" / "MR"
+    for expected in ("app.json", "Prediction.yml", "CV_0.pt", "Model.py", "requirements.txt"):
+        assert (bundle / expected).exists(), expected
+    # `models` auto-filled from the provided checkpoints
+    assert json.loads((bundle / "app.json").read_text())["models"] == ["CV_0.pt"]
+
+
+def test_missing_required_keys_raises(tmp_path):
+    app_json = _write(tmp_path / "app.json", {"display_name": "x"})
+    with pytest.raises(AppMetadataError):
+        assemble_bundle("MR", tmp_path / "out", app_json, [], [])
+
+
+def test_models_mismatch_raises(tmp_path):
+    app_json = _write(tmp_path / "app.json", {**VALID_META, "models": ["CV_0.pt", "CV_1.pt"]})
+    checkpoint = tmp_path / "CV_0.pt"
+    checkpoint.write_bytes(b"w")
+    with pytest.raises(AppMetadataError):
+        assemble_bundle("MR", tmp_path / "out", app_json, [], [str(checkpoint)])
+
+
+def test_derive_requirements_keeps_only_extra(tmp_path):
+    from konfai_apps.bundle import derive_requirements
+
+    model_py = tmp_path / "Model.py"
+    model_py.write_text(
+        "import os\n"
+        "import torch\n"
+        "import numpy as np\n"
+        "import segmentation_models_pytorch as smp\n"
+        "from konfai.network import network\n"
+        "import skimage\n"
+    )
+    # stdlib (os), konfai-provided (torch/numpy), and konfai itself are excluded.
+    assert derive_requirements([model_py]) == ["scikit-image", "segmentation-models-pytorch"]
+
+
+def test_derive_onnx_params_from_config():
+    from konfai_apps.bundle import _derive_onnx_params
+
+    config = {
+        "Predictor": {
+            "Model": {"classpath": "Model:UNetpp", "UNetpp": {"nb_channel": 5}},
+            "Dataset": {"Patch": {"patch_size": [1, 256, 256], "extend_slice": 2}},
+            "Model_unused_patch": {"ModelPatch": {"patch_size": [128, 128, 128]}},
+        }
+    }
+    patch_size, in_channels, extend_slice = _derive_onnx_params(config, "Predictor")
+    assert patch_size == [256, 256]  # singleton slice dim dropped (2.5D)
+    assert in_channels == 5
+    assert extend_slice == 2

--- a/konfai/export.py
+++ b/konfai/export.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Export a frozen KonfAI ``Network`` to a self-contained ONNX graph + manifest.
+
+This is the producer side of the ``konfai-rs`` portable-inference contract: a
+trained KonfAI model becomes ``model.onnx`` (graph + weights, single file) plus
+``manifest.json`` (patch geometry, input/output spec) that a no-Python runtime
+consumes. The chain ``torch -> ONNX -> burn-onnx`` was validated end-to-end; the
+non-obvious steps it requires are encoded here:
+
+* KonfAI ``Network`` overrides ``state_dict()`` with a custom signature that breaks
+  the legacy TorchScript exporter, so the **dynamo** exporter is used.
+* ``Network.forward`` returns per-output-group results (empty without ``init()``),
+  so the graph is reached via ``named_forward`` and a named head is selected.
+* The dynamo exporter writes weights as external data; they are inlined so the
+  ``.onnx`` is a single self-contained file (required by ``burn-onnx``).
+"""
+
+from __future__ import annotations
+
+import json
+from importlib import import_module
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import torch
+
+from konfai.utils.errors import PredictorError
+
+MANIFEST_VERSION = 1
+
+
+def _require(module: str) -> ModuleType:
+    """Import an optional export dependency or raise an actionable error."""
+    try:
+        return import_module(module)
+    except ImportError as exc:  # pragma: no cover - exercised only without the extra
+        raise PredictorError(
+            f"ONNX export needs the optional dependency '{module}'. Install it with `pip install konfai[export]`.",
+        ) from exc
+
+
+class _NamedHead(torch.nn.Module):
+    """Wrap a routed KonfAI graph to return a single named output tensor.
+
+    ``Network.forward`` yields per-output-group results (deep-supervision aware);
+    for export we want one specific head. ``named_forward`` exposes every module
+    output as ``(dotted_name, tensor)``; this returns the tensor of ``output_module``.
+    """
+
+    def __init__(self, net: torch.nn.Module, output_module: str) -> None:
+        super().__init__()
+        self.net = net
+        self.output_module = output_module
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = x
+        for name, tensor in self.net.named_forward(x):
+            if name == self.output_module:
+                out = tensor
+        return out
+
+
+def list_output_modules(model: torch.nn.Module, example_input: torch.Tensor) -> list[tuple[str, tuple[int, ...]]]:
+    """Return ``(dotted_name, shape)`` for every output of the routed graph.
+
+    Use this to discover the inference head to export (e.g. ``UNetBlock_0.Head.Softmax``
+    or ``Head.Tanh``), skipping deep-supervision heads and integer ``Argmax`` outputs.
+    """
+    if not hasattr(model, "named_forward"):
+        raise PredictorError("export expects a KonfAI Network exposing `named_forward`.")
+    model.eval()
+    outputs: list[tuple[str, tuple[int, ...]]] = []
+    with torch.no_grad():
+        for name, tensor in model.named_forward(example_input):
+            outputs.append((name, tuple(tensor.shape)))
+    return outputs
+
+
+def export_to_onnx(
+    model: torch.nn.Module,
+    output_dir: str | Path,
+    example_input: torch.Tensor,
+    output_module: str,
+    *,
+    opset: int = 18,
+    input_name: str = "input",
+    output_name: str = "output",
+    input_group: str = "Volume_0",
+    output_group: str = "output",
+    patch_overlap: list[int] | None = None,
+    extend_slice: int = 0,
+    extra_manifest: dict[str, Any] | None = None,
+) -> Path:
+    """Export ``model`` to ``output_dir/model.onnx`` (+ ``manifest.json``).
+
+    Parameters
+    ----------
+    model:
+        A frozen KonfAI ``Network`` (or any module exposing ``named_forward``).
+    output_dir:
+        Directory to write ``model.onnx`` and ``manifest.json`` into.
+    example_input:
+        A fixed-shape example patch ``[N, C, (Z), Y, X]``; the ONNX is exported at
+        this exact shape (burn-onnx dislikes dynamic shapes).
+    output_module:
+        Dotted name of the inference head to export (see :func:`list_output_modules`).
+    opset:
+        ONNX opset (>= 18 recommended; the dynamo exporter implements 18).
+
+    Returns
+    -------
+    Path to the written ``model.onnx``.
+    """
+    onnx = _require("onnx")
+    _require("onnxscript")  # required by the torch dynamo ONNX exporter
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    onnx_path = out_dir / "model.onnx"
+
+    model.eval()
+    available = list_output_modules(model, example_input)
+    matches = [shape for name, shape in available if name == output_module]
+    if not matches:
+        names = [name for name, _ in available]
+        raise PredictorError(
+            f"output_module '{output_module}' not found in the graph. Available outputs (last few): {names[-8:]}",
+        )
+    output_shape = matches[-1]
+
+    wrapper = _NamedHead(model, output_module).eval()
+    with torch.no_grad():
+        torch.onnx.export(
+            wrapper,
+            example_input,
+            str(onnx_path),
+            opset_version=opset,
+            input_names=[input_name],
+            output_names=[output_name],
+            dynamo=True,
+        )
+
+    # The dynamo exporter writes weights as external data; inline them so the
+    # .onnx is a single self-contained file (required by burn-onnx's ModelGen and
+    # simpler to serve to ONNX-Runtime-Web). Remove the now-orphan sidecar.
+    onnx.save(onnx.load(str(onnx_path)), str(onnx_path), save_as_external_data=False)
+    sidecar = onnx_path.with_name(onnx_path.name + ".data")
+    if sidecar.exists():
+        sidecar.unlink()
+
+    input_shape = tuple(int(s) for s in example_input.shape)
+    spatial = list(input_shape[2:])
+    dim = len(spatial)
+    manifest: dict[str, Any] = {
+        "konfai_rs_manifest": MANIFEST_VERSION,
+        "model": onnx_path.name,
+        "opset": opset,
+        "output_module": output_module,
+        "input": {"name": input_name, "group": input_group, "channels": input_shape[1], "dtype": "f32"},
+        "output": {"name": output_name, "group": output_group, "channels": int(output_shape[1]), "dtype": "f32"},
+        "patch": {
+            "size": spatial,
+            "overlap": patch_overlap if patch_overlap is not None else [0] * dim,
+            "dim": dim,
+            "extend_slice": extend_slice,
+        },
+        "geometry": "preserve_from_input",
+    }
+    if extra_manifest:
+        manifest.update(extra_manifest)
+    (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    return onnx_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ fid = ["scipy", "torchvision"]
 cluster = ["submitit"]
 dicom = ["pydicom"]
 omezarr = ["zarr", "ngff-zarr"]
+export = ["onnx", "onnxruntime", "onnxscript"]
 all = [
   "konfai[itk]",
   "konfai[hdf5]",
@@ -75,7 +76,8 @@ all = [
   "konfai[fid]",
   "konfai[cluster]",
   "konfai[dicom]",
-  "konfai[omezarr]"
+  "konfai[omezarr]",
+  "konfai[export]"
 ]
 dev = [
   "SimpleITK",
@@ -84,6 +86,9 @@ dev = [
   "zarr",
   "ngff-zarr",
   "scikit-image",
+  "onnx",
+  "onnxruntime",
+  "onnxscript",
   "nvidia-ml-py",
   "tensorboard",
   "pytest",

--- a/tests/unit/test_onnx_export.py
+++ b/tests/unit/test_onnx_export.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""ONNX export parity test (onnxruntime vs torch) on the example UNet."""
+
+import json
+
+import numpy as np
+import pytest
+import torch
+
+
+def test_export_to_onnx_parity(tmp_path, monkeypatch):
+    monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
+    monkeypatch.setenv("KONFAI_config_file", str(tmp_path / "config.yml"))
+
+    pytest.importorskip("onnx")
+    pytest.importorskip("onnxscript")
+    ort = pytest.importorskip("onnxruntime")
+
+    from konfai.export import _NamedHead, export_to_onnx, list_output_modules
+    from konfai.models.segmentation.UNet import UNet
+
+    model = UNet(dim=2, channels=[1, 8, 16], nb_class=2).eval()
+    example = torch.randn(1, 1, 64, 64)
+
+    heads = [name for name, _ in list_output_modules(model, example)]
+    head = "UNetBlock_0.Head.Softmax"
+    assert head in heads, f"expected full-res head among {heads[-5:]}"
+
+    onnx_path = export_to_onnx(model, tmp_path, example, head, opset=18)
+    assert onnx_path.exists()
+
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    assert manifest["konfai_rs_manifest"] == 1
+    assert manifest["patch"]["size"] == [64, 64]
+    assert manifest["patch"]["dim"] == 2
+    assert manifest["input"]["channels"] == 1
+    assert manifest["output"]["channels"] == 2
+    assert manifest["output_module"] == head
+
+    with torch.no_grad():
+        reference = _NamedHead(model, head)(example).numpy()
+
+    session = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    produced = session.run(None, {"input": example.numpy().astype(np.float32)})[0]
+
+    assert produced.shape == reference.shape
+    assert float(np.mean(np.abs(produced - reference))) < 1e-4
+
+
+def test_export_unknown_head_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
+    monkeypatch.setenv("KONFAI_config_file", str(tmp_path / "config.yml"))
+    pytest.importorskip("onnx")
+    pytest.importorskip("onnxscript")
+
+    from konfai.export import export_to_onnx
+    from konfai.models.segmentation.UNet import UNet
+    from konfai.utils.errors import PredictorError
+
+    model = UNet(dim=2, channels=[1, 8, 16], nb_class=2).eval()
+    with pytest.raises(PredictorError):
+        export_to_onnx(model, tmp_path, torch.randn(1, 1, 64, 64), "Does.Not.Exist")


### PR DESCRIPTION
Adds `konfai-apps bundle`: assemble an app bundle (standard HF layout — app.json + configs + checkpoints + optional Model.py/requirements) with metadata validation, and `--onnx` to also emit the portable `model.onnx` + `manifest.json` via `konfai.export`.

- `assemble_bundle()` + `export_onnx_into_bundle()` (loads the model from the bundle's Prediction.yml + checkpoint like the predictor, disables internal patching for export, snapshots/restores the config so it is not mutated).
- Requirements auto-derived from `Model.py` imports; patch size / channels read from the config; space-separated list args.
- Tests: assembler + config-derivation.

⚠️ Stacked on #13 (imports `konfai.export`). Base is `feat/export-onnx`; retarget to `main` after #13 merges.