### PR TITLE
feat(apps): multi-checkpoint fine-tune and core fixes for released apps

### DIFF
--- a/docs/source/reference/cli.md
+++ b/docs/source/reference/cli.md
@@ -119,8 +119,10 @@ This command is provided by the standalone `konfai-apps` package.
 
 - positional `name`
 - `-d`, `--dataset`
+- `--models` — checkpoint name(s) to fine-tune, e.g. `CV_0 CV_1` (default: first available)
 - `--epochs`
 - `--it-validation`
+- `--config` (aliases: `--config-file`, `--config_file`)
 
 ## `konfai-apps-server`
 

--- a/docs/source/usage/apps.md
+++ b/docs/source/usage/apps.md
@@ -75,9 +75,13 @@ Fine-tuning is available through:
 .. code-block:: bash
 
    konfai-apps fine-tune <app> <name> -d ./Dataset --epochs 10 --gpu 0
+   konfai-apps fine-tune <app> <name> -d ./Dataset --models CV_0 CV_1 --epochs 10 --gpu 0
 
-Under the hood, the app installs training assets, links the dataset, then calls
-the low-level training flow in resume mode.
+Under the hood, the app installs training assets, links the dataset, then, for each selected
+checkpoint, restarts training from its pretrained weights (fresh optimizer, learning-rate schedule
+and epoch counter) so that `--epochs` fine-tuning epochs actually run. Use `--models` to choose which
+checkpoint(s) to fine-tune (default: the first available); each is fine-tuned independently and
+written back into the output app, which is left as a ready-to-use app bundle.
 
 ## Local vs remote
 

--- a/konfai-apps/konfai_apps/app.py
+++ b/konfai-apps/konfai_apps/app.py
@@ -34,9 +34,10 @@ import requests
 import SimpleITK as sitk
 from konfai import RemoteServer, check_server, cuda_visible_devices, get_vram
 from konfai.utils.dataset import Dataset
-from konfai.utils.errors import KonfAIAppClientError
+from konfai.utils.errors import AppRepositoryError, KonfAIAppClientError
 from konfai.utils.runtime import MinimalLog, State
 from konfai.utils.utils import SUPPORTED_EXTENSIONS
+from ruamel.yaml import YAML
 
 from .app_repository import LocalAppRepository, get_app_repository_info
 
@@ -493,6 +494,11 @@ class KonfAIAppClient(AbstractKonfAIApp):
                             data["ensemble_models"] = ",".join(data["ensemble_models"])
                         else:
                             del data["ensemble_models"]
+                    if "models" in data:
+                        if len(data["models"]) > 0:
+                            data["models"] = ",".join(data["models"])
+                        else:
+                            del data["models"]
                     connect_timeout = 60
                     read_timeout: int = 600
 
@@ -604,6 +610,7 @@ class KonfAIAppClient(AbstractKonfAIApp):
         output: Path = Path("./Output/"),
         epochs: int = 10,
         it_validation: int = 1000,
+        models: list[str] = [],
         gpu: list[int] = [],
         cpu: int | None = None,
         quiet: bool = False,
@@ -1034,6 +1041,24 @@ class KonfAIApp(AbstractKonfAIApp):
         if uncertainty:
             self.uncertainty([inference_stacks], output / "Uncertainties", uncertainty_file, gpu, cpu, quiet, tmp_dir)
 
+    @staticmethod
+    def _weights_only_checkpoint(checkpoint_path: Path) -> dict[str, Any]:
+        """
+        Load a checkpoint and keep only its model weights.
+
+        Fine-tuning must start from the pretrained weights but with fresh training counters,
+        optimizer and LR schedule. Returning only the ``Model`` key (dropping ``epoch``/``it``/
+        ``loss``, ``Model_EMA`` and the optimizer/scheduler state) makes a subsequent RESUME leave
+        ``epoch``/``it`` at 0, so ``range(0, epochs)`` runs all fine-tuning epochs with a fresh LR
+        schedule.
+        """
+        import torch
+
+        state_dict = torch.load(str(checkpoint_path), map_location="cpu", weights_only=False)  # nosec B614
+        if "Model" not in state_dict:
+            raise AppRepositoryError(f"Checkpoint '{checkpoint_path}' has no 'Model' weights to fine-tune from.")
+        return {"Model": state_dict["Model"]}
+
     @run_distributed_app
     def fine_tune(
         self,
@@ -1042,6 +1067,7 @@ class KonfAIApp(AbstractKonfAIApp):
         output: Path = Path("./Output/"),
         epochs: int = 10,
         it_validation: int = 1000,
+        models: list[str] = [],
         gpu: list[int] = cuda_visible_devices(),
         cpu: int | None = None,
         quiet: bool = False,
@@ -1049,23 +1075,80 @@ class KonfAIApp(AbstractKonfAIApp):
         tmp_dir: Path | None = None,
     ) -> None:
         """
-        Run fine-tuning (training) locally.
+        Fine-tune one or several checkpoints of the app locally.
 
         Steps:
-        1. Install training assets/config via `self.app_repository.install_fine_tune`
-        2. Link the user dataset into ./Dataset
-        3. Call `konfai.trainer.train(...)` in resume mode
+        1. Install training assets/config and resolve the selected checkpoint(s) via
+           `self.app_repository.install_fine_tune`.
+        2. Link the user dataset into ./Dataset.
+        3. For each selected checkpoint: sanitize it to weights-only, write a per-model config with a
+           distinct ``train_name``, run `konfai.trainer.train(...)` in resume mode, then copy the
+           produced checkpoint back into the output app.
+
+        The output directory is left as a clean, resolvable app bundle (app.json + config + code +
+        fine-tuned checkpoint(s)); training artifacts (Checkpoints/Statistics) are kept out of it.
 
         Notes
         -----
-        - Runs inside an isolated workspace (run_distributed_app).
-        - GPU defaults to `cuda_visible_devices()`.
+        - Runs inside an isolated workspace (run_distributed_app); the workspace is the output dir.
+        - Fine-tuning requires a CUDA GPU when the loss relies on GPU-only components.
+        - `models` selects which checkpoint(s) to fine-tune (default: the first available).
         """
-        models_path = self.app_repository.install_fine_tune(config_file, Path("./"), name, epochs, it_validation)
+        import torch
+
+        selected_models = self.app_repository.install_fine_tune(
+            config_file, Path("./"), name, epochs, it_validation, models
+        )
         KonfAIApp.symlink(dataset, Path("./Dataset").absolute())
+
         from konfai.trainer import train
 
-        train(State.RESUME, True, models_path[0], gpu, cpu, quiet, False, config_file)
+        # Keep training artifacts (Checkpoints/Statistics) outside the output so it stays a clean app.
+        work_dir = Path(tempfile.mkdtemp(prefix="konfai_finetune_")).resolve()
+        config_path = Path(config_file)
+        try:
+            for checkpoint_name, checkpoint_src in selected_models:
+                stem = Path(checkpoint_name).stem
+                train_name = f"{name}_{stem}"
+
+                sanitized_ckpt = work_dir / f"{stem}_init.pt"
+                torch.save(KonfAIApp._weights_only_checkpoint(checkpoint_src), sanitized_ckpt)  # nosec B614
+
+                model_config = work_dir / f"{config_path.stem}_{stem}{config_path.suffix}"
+                yaml = YAML()
+                with open(config_path) as file:
+                    data = yaml.load(file)
+                data["Trainer"]["train_name"] = train_name
+                with open(model_config, "w") as file:
+                    yaml.dump(data, file)
+
+                train(
+                    State.RESUME,
+                    True,
+                    sanitized_ckpt,
+                    gpu,
+                    cpu,
+                    quiet,
+                    False,
+                    model_config,
+                    work_dir / "Checkpoints",
+                    work_dir / "Statistics",
+                )
+
+                produced_dir = work_dir / "Checkpoints" / train_name
+                produced = sorted(produced_dir.glob("*.pt"), key=lambda p: p.stat().st_mtime)
+                if not produced:
+                    raise AppRepositoryError(
+                        f"Fine-tuning of '{checkpoint_name}' produced no checkpoint in '{produced_dir}'."
+                    )
+                shutil.copy2(produced[-1], Path(checkpoint_name).name)
+        finally:
+            shutil.rmtree(work_dir, ignore_errors=True)
+            dataset_link = Path("./Dataset")
+            if dataset_link.is_symlink() or dataset_link.is_file():
+                dataset_link.unlink()
+            elif dataset_link.is_dir():
+                shutil.rmtree(dataset_link, ignore_errors=True)
 
     def __str__(self) -> str:
         return str(self.app_repository)

--- a/konfai-apps/konfai_apps/app_repository.py
+++ b/konfai-apps/konfai_apps/app_repository.py
@@ -496,33 +496,38 @@ class LocalAppRepository(AppRepositoryInfo):
             if filename.endswith(".py"):
                 codes_path.append((filename, self._download(filename)))
 
-        requirements_filename = self._find_repo_filename("requirements.txt", filenames)
-        if requirements_filename is not None:
-            with open(self._download(requirements_filename), encoding="utf-8") as file:
-                required_lines = [line.strip() for line in file if line.strip() and not line.startswith("#")]
-                installed = {
-                    dist.metadata["Name"].lower(): dist.version
-                    for dist in importlib.metadata.distributions()
-                    if dist.metadata.get("Name")
-                }
-                missing_or_outdated = []
-                for line in required_lines:
-                    req = Requirement(line)
-                    name = req.name.lower()
-                    installed_version_str = installed.get(name)
-                    if installed_version_str is None:
-                        missing_or_outdated.append(line)
-                        continue
-                    if req.specifier and not req.specifier.contains(installed_version_str, prereleases=True):
-                        missing_or_outdated.append(line)
-
-                if missing_or_outdated:
-                    try:
-                        subprocess.check_call([sys.executable, "-m", "pip", "install", *missing_or_outdated])  # nosec B603
-                    except subprocess.CalledProcessError as exc:
-                        raise AppRepositoryError(f"Failed to install packages: {exc}") from exc
+        self._install_requirements(filenames)
 
         return models_path, inference_file_path, codes_path
+
+    def _install_requirements(self, filenames: list[str]) -> None:
+        """Install any missing/outdated packages listed in the app's requirements.txt."""
+        requirements_filename = self._find_repo_filename("requirements.txt", filenames)
+        if requirements_filename is None:
+            return
+        with open(self._download(requirements_filename), encoding="utf-8") as file:
+            required_lines = [line.strip() for line in file if line.strip() and not line.startswith("#")]
+        installed = {
+            dist.metadata["Name"].lower(): dist.version
+            for dist in importlib.metadata.distributions()
+            if dist.metadata.get("Name")
+        }
+        missing_or_outdated = []
+        for line in required_lines:
+            req = Requirement(line)
+            name = req.name.lower()
+            installed_version_str = installed.get(name)
+            if installed_version_str is None:
+                missing_or_outdated.append(line)
+                continue
+            if req.specifier and not req.specifier.contains(installed_version_str, prereleases=True):
+                missing_or_outdated.append(line)
+
+        if missing_or_outdated:
+            try:
+                subprocess.check_call([sys.executable, "-m", "pip", "install", *missing_or_outdated])  # nosec B603
+            except subprocess.CalledProcessError as exc:
+                raise AppRepositoryError(f"Failed to install packages: {exc}") from exc
 
     def download_app(self) -> list[tuple[str, Path]]:
         filenames = self._get_filenames()
@@ -609,6 +614,42 @@ class LocalAppRepository(AppRepositoryInfo):
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(code_path, dest)
 
+    def _resolve_fine_tune_models(self, filenames: list[str], name_of_models: list[str]) -> list[tuple[str, Path]]:
+        """
+        Resolve the checkpoint(s) to fine-tune into ``(basename, source_path)`` pairs.
+
+        If ``name_of_models`` is provided, each requested name is resolved to a ``.pt`` file.
+        Otherwise the first checkpoint advertised in ``app.json`` (falling back to the first
+        available ``.pt``) is selected. Missing files trigger a Hugging Face refresh, mirroring
+        :meth:`download_inference`.
+        """
+        selected: list[str] = []
+        if name_of_models:
+            if isinstance(self, LocalAppRepositoryFromHF):
+                for name in name_of_models:
+                    if self._find_repo_filename(name, filenames, suffix=".pt") is None:
+                        filenames = LocalAppRepositoryFromHF.get_filenames(self._repo_id, self._app_name, True)
+                        break
+            selected = [self._require_repo_filename(name, filenames, suffix=".pt") for name in name_of_models]
+        else:
+            default_name: str | None = None
+            for candidate in self._checkpoints_name:
+                resolved = self._find_repo_filename(candidate, filenames, suffix=".pt")
+                if resolved is not None:
+                    default_name = resolved
+                    break
+            if default_name is None:
+                available = sorted(name for name in filenames if name.endswith(".pt"))
+                if not available and isinstance(self, LocalAppRepositoryFromHF):
+                    filenames = LocalAppRepositoryFromHF.get_filenames(self._repo_id, self._app_name, True)
+                    available = sorted(name for name in filenames if name.endswith(".pt"))
+                if not available:
+                    raise AppRepositoryError(f"No checkpoint (.pt) found to fine-tune in app '{self._app_name}'.")
+                default_name = available[0]
+            selected = [default_name]
+
+        return [(PurePosixPath(repo_name).name, self._download(repo_name)) for repo_name in selected]
+
     def install_fine_tune(
         self,
         config_file: str,
@@ -616,40 +657,28 @@ class LocalAppRepository(AppRepositoryInfo):
         display_name: str,
         epochs: int,
         it_validation: int | None,
-    ) -> list[Path]:
-        src_paths = self.download_app()
-        models_path = []
+        name_of_models: list[str],
+    ) -> list[tuple[str, Path]]:
+        """
+        Install the app assets needed for fine-tuning and resolve the selected checkpoint(s).
 
-        overwrite_all = None
+        Shared assets (config, code, ``app.json``, ``requirements.txt``) are installed into
+        ``path``; ``app.json`` is rewritten with the new ``display_name`` and a ``models`` list
+        limited to the selected checkpoints, and the training config's ``epochs``/``it_validation``
+        are updated. Only the selected ``.pt`` checkpoints are downloaded. Returns ``(basename,
+        source_path)`` pairs for the checkpoints to fine-tune.
+        """
+        filenames = self._get_filenames()
+        models = self._resolve_fine_tune_models(filenames, name_of_models)
 
-        def ask_overwrite_cli(dest_path: Path) -> bool:
-            nonlocal overwrite_all
-            if overwrite_all is not None:
-                return overwrite_all
-
-            while True:
-                print(f"KonfAI-Apps] File already exists: {dest_path}")
-                choice = input("Overwrite? [y]es / [n]o / [a]ll / [s]kip_all: ").strip().lower()
-                if choice == "y":
-                    return True
-                if choice == "n":
-                    return False
-                if choice == "a":
-                    overwrite_all = True
-                    return True
-                if choice == "s":
-                    overwrite_all = False
-                    return False
-                print("[KonfAI-Apps] Invalid input. Please choose y / n / a / s.")
-
-        for repo_filename, src in src_paths:
-            dest = path / repo_filename
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            if str(src).endswith(".pt"):
-                models_path.append(src)
-            if dest.exists() and not ask_overwrite_cli(dest):
+        for filename in filenames:
+            if filename.endswith(".pt"):
                 continue
-            shutil.copy2(src, dest)
+            dest = path / filename
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(self._download(filename), dest)
+
+        self._install_requirements(filenames)
 
         metadata_file = path / "app.json"
         config_file_path = path / config_file
@@ -663,6 +692,7 @@ class LocalAppRepository(AppRepositoryInfo):
             app_repository_metadata = json.load(file)
 
         app_repository_metadata["display_name"] = display_name
+        app_repository_metadata["models"] = [basename for basename, _ in models]
 
         with open(metadata_file, "w", encoding="utf-8") as file:
             json.dump(app_repository_metadata, file, indent=2, ensure_ascii=False)
@@ -682,7 +712,7 @@ class LocalAppRepository(AppRepositoryInfo):
         with open(config_file_path, "w") as file:
             yaml.dump(data, file)
 
-        return models_path
+        return models
 
 
 class LocalAppRepositoryFromDirectory(LocalAppRepository):

--- a/konfai-apps/konfai_apps/app_server.py
+++ b/konfai-apps/konfai_apps/app_server.py
@@ -1015,6 +1015,7 @@ async def fine_tune(
     name: Annotated[str, Form()] = "Finetune",
     epochs: Annotated[int, Form()] = 10,
     it_validation: Annotated[int, Form()] = 1000,
+    models: Annotated[str, Form()] = "",  # CSV
     config_file: Annotated[str, Form()] = "Config.yml",
     gpu: Annotated[str | None, Form()] = "",
     cpu: Annotated[int, Form()] = 1,
@@ -1038,6 +1039,8 @@ async def fine_tune(
         Number of training epochs.
     it_validation : int
         Validation interval.
+    models : str
+        Comma-separated checkpoint name(s) to fine-tune (empty = first available).
     config_file : str
         Training configuration file.
     gpu : str | None
@@ -1064,6 +1067,9 @@ async def fine_tune(
         "--it_validation",
         str(it_validation),
     ]
+    models_list = [x.strip() for x in models.split(",") if x.strip()]
+    if models_list:
+        cmd += ["--models", *models_list]
     return cmd
 
 

--- a/konfai-apps/konfai_apps/cli.py
+++ b/konfai-apps/konfai_apps/cli.py
@@ -299,6 +299,13 @@ def main_apps() -> None:
     ft_p = subparsers.add_parser("fine-tune", help="Fine-tune a KonfAI App on a dataset.")
     add_common_args(ft_p, True)
     ft_p.add_argument("name", type=str, help="New KonfAI App display name")
+    ft_p.add_argument(
+        "--models",
+        nargs="+",
+        default=[],
+        help="Checkpoint name(s) to fine-tune, e.g. 'CV_0 CV_1'. If omitted, the first available "
+        "checkpoint is fine-tuned. Each selected checkpoint is fine-tuned independently.",
+    )
     ft_p.add_argument("--epochs", type=int, default=10, help="Number of fine-tuning epochs")
     ft_p.add_argument(
         "--it-validation",
@@ -306,6 +313,15 @@ def main_apps() -> None:
         type=int,
         default=1000,
         help="Number of training iterations between validation runs.",
+    )
+    ft_p.add_argument(
+        "--config",
+        "--config-file",
+        "--config_file",
+        dest="config_file",
+        type=str,
+        default="Config.yml",
+        help="Training configuration filename inside the app.",
     )
 
     bundle_p = subparsers.add_parser(

--- a/konfai-apps/tests/integration/test_konfai_apps.py
+++ b/konfai-apps/tests/integration/test_konfai_apps.py
@@ -304,3 +304,167 @@ def test_konfai_apps_pipeline_is_local_and_deterministic(tmp_path: Path) -> None
 
     assert _single_case_metric(evaluation_path, expected_metric_suffix="MAE") == pytest.approx(0.0, abs=3e-4)
     assert _single_case_metric(uncertainty_path, expected_metric_suffix="Uncertainty") == pytest.approx(0.0, abs=1e-6)
+
+
+# Counters baked into the fixture checkpoints. They mimic a released model whose `epoch` already
+# reaches the fine-tuning target: without the weights-only sanitize step, `range(epoch, epochs)` is
+# empty and fine-tuning silently trains for zero steps.
+_PRETRAINED_EPOCH = 10
+_PRETRAINED_IT = 125134
+
+
+def _write_local_finetune_app(app_dir: Path) -> None:
+    app_dir.mkdir(parents=True, exist_ok=True)
+    (app_dir / "app.json").write_text(
+        json.dumps(
+            {
+                "display_name": "Tiny Synth",
+                "description": "Tiny local synthesis app for fine-tuning integration testing",
+                "short_description": "Tiny synth",
+                "tta": 0,
+                "mc_dropout": 0,
+                "models": ["tiny_0.pt", "tiny_1.pt"],
+                "inputs": {"Volume_0": {"display_name": "MR", "volume_type": "VOLUME", "required": True}},
+                "outputs": {"sCT": {"display_name": "sCT", "volume_type": "VOLUME", "required": True}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    # Reuse the core training-config template (TinySynthNet + MR/CT/MASK groups). The dataset is linked
+    # into ./Dataset by fine_tune, and train_name is overridden per-model, so only the placeholders
+    # need substituting here.
+    config = (WORKFLOW_ASSETS_DIR / "Config.yml").read_text(encoding="utf-8")
+    config = config.replace("__DATASET_DIR__", "./Dataset").replace("__TRAIN_NAME__", "FT")
+    (app_dir / "Config.yml").write_text(config, encoding="utf-8")
+    (app_dir / "TinySynth.py").write_text(
+        (WORKFLOW_ASSETS_DIR / "TinySynth.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    spec = importlib.util.spec_from_file_location("TinySynth", app_dir / "TinySynth.py")
+    if spec is None or spec.loader is None:
+        raise AssertionError("Failed to load TinySynth test module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    model = module.TinySynthNet()
+    checkpoint = {
+        "epoch": _PRETRAINED_EPOCH,
+        "it": _PRETRAINED_IT,
+        "loss": 0.0,
+        "Model": model.state_dict(),
+    }
+    torch.save(checkpoint, app_dir / "tiny_0.pt")
+    torch.save(checkpoint, app_dir / "tiny_1.pt")
+
+
+def _build_finetune_dataset(dataset_dir: Path) -> None:
+    dataset_dir.mkdir(parents=True, exist_ok=True)
+    for idx in range(4):
+        case_dir = dataset_dir / f"CASE_{idx:03d}"
+        case_dir.mkdir(parents=True, exist_ok=True)
+        zz, yy, xx = np.meshgrid(
+            np.linspace(-0.2, 0.2, 3, dtype=np.float32),
+            np.linspace(-1.0, 1.0, 16, dtype=np.float32),
+            np.linspace(-1.0, 1.0, 16, dtype=np.float32),
+            indexing="ij",
+        )
+        mr = np.clip(0.45 * yy + 0.35 * xx + zz + (idx - 1.5) * 0.05, -0.9, 0.9).astype(np.float32)
+        ct = np.tanh(1.25 * mr - 0.15).astype(np.float32)
+        mask = np.ones_like(mr, dtype=np.uint8)
+        _write_image(case_dir / "MR.mha", mr, SimpleITK.sitkFloat32)
+        _write_image(case_dir / "CT.mha", ct, SimpleITK.sitkFloat32)
+        _write_image(case_dir / "MASK.mha", mask, SimpleITK.sitkUInt8)
+
+
+def _run_finetune(
+    app_dir: Path,
+    dataset_dir: Path,
+    output_dir: Path,
+    *,
+    models: list[str] | None = None,
+    epochs: int = 2,
+) -> subprocess.CompletedProcess[str]:
+    cmd = [
+        sys.executable,
+        "-c",
+        (
+            f"import sys; sys.path.insert(0, {str(REPO_ROOT)!r}); "
+            f"sys.path.insert(0, {str(KONFAI_APPS_ROOT)!r}); "
+            "from konfai_apps.cli import main_apps; main_apps()"
+        ),
+        "fine-tune",
+        str(app_dir),
+        "FT",
+        "-d",
+        str(dataset_dir),
+        "--epochs",
+        str(epochs),
+        "--cpu",
+        "1",
+        "-o",
+        str(output_dir),
+    ]
+    if models:
+        cmd += ["--models", *models]
+    return run(cmd)
+
+
+def _assert_finetuned_from_checkpoint(checkpoint_path: Path) -> None:
+    """A fine-tuned checkpoint must start fresh (counters reset) yet have actually trained."""
+    assert checkpoint_path.exists(), checkpoint_path
+    state = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    assert state["epoch"] < _PRETRAINED_EPOCH, f"epoch not reset: {state['epoch']}"
+    assert 0 < state["it"] < _PRETRAINED_IT, f"training did not run from a fresh counter: it={state['it']}"
+
+
+def test_finetune_single_model_resumes_from_checkpoint_and_trains(tmp_path: Path) -> None:
+    app_dir = tmp_path / "TinySynthApp"
+    dataset_dir = tmp_path / "Dataset"
+    output_dir = tmp_path / "Output"
+    _write_local_finetune_app(app_dir)
+    _build_finetune_dataset(dataset_dir)
+
+    result = _run_finetune(app_dir, dataset_dir, output_dir, models=["tiny_0"])
+    assert result.returncode == 0, f"CMD failed.\nSTDOUT:\n{result.stdout}\n\nSTDERR:\n{result.stderr}"
+
+    meta = _read_json(output_dir / "app.json")
+    assert meta["display_name"] == "FT"
+    assert meta["models"] == ["tiny_0.pt"]
+
+    _assert_finetuned_from_checkpoint(output_dir / "tiny_0.pt")
+    # Only the selected checkpoint is packaged, and the bundle is clean (no training artifacts).
+    assert not (output_dir / "tiny_1.pt").exists()
+    for artifact in ("Checkpoints", "Statistics", "Dataset"):
+        assert not (output_dir / artifact).exists(), artifact
+
+
+def test_finetune_defaults_to_first_checkpoint(tmp_path: Path) -> None:
+    app_dir = tmp_path / "TinySynthApp"
+    dataset_dir = tmp_path / "Dataset"
+    output_dir = tmp_path / "Output"
+    _write_local_finetune_app(app_dir)
+    _build_finetune_dataset(dataset_dir)
+
+    result = _run_finetune(app_dir, dataset_dir, output_dir)  # no --models
+    assert result.returncode == 0, f"CMD failed.\nSTDOUT:\n{result.stdout}\n\nSTDERR:\n{result.stderr}"
+
+    meta = _read_json(output_dir / "app.json")
+    assert meta["models"] == ["tiny_0.pt"]
+    assert (output_dir / "tiny_0.pt").exists()
+    assert not (output_dir / "tiny_1.pt").exists()
+
+
+def test_finetune_multiple_models_produces_one_checkpoint_each(tmp_path: Path) -> None:
+    app_dir = tmp_path / "TinySynthApp"
+    dataset_dir = tmp_path / "Dataset"
+    output_dir = tmp_path / "Output"
+    _write_local_finetune_app(app_dir)
+    _build_finetune_dataset(dataset_dir)
+
+    result = _run_finetune(app_dir, dataset_dir, output_dir, models=["tiny_0", "tiny_1"])
+    assert result.returncode == 0, f"CMD failed.\nSTDOUT:\n{result.stdout}\n\nSTDERR:\n{result.stderr}"
+
+    meta = _read_json(output_dir / "app.json")
+    assert meta["models"] == ["tiny_0.pt", "tiny_1.pt"]
+    _assert_finetuned_from_checkpoint(output_dir / "tiny_0.pt")
+    _assert_finetuned_from_checkpoint(output_dir / "tiny_1.pt")

--- a/konfai-apps/tests/unit/test_app_repository.py
+++ b/konfai-apps/tests/unit/test_app_repository.py
@@ -411,3 +411,98 @@ def test_local_directory_nested_uncertainty_file_is_detected(tmp_path: Path) -> 
     repo = app_repository_module.LocalAppRepositoryFromDirectory(app_root.parent, app_root.name)
 
     assert repo.has_capabilities() == (False, False, True)
+
+
+def _write_two_checkpoint_app(app_root: Path) -> None:
+    app_root.mkdir(parents=True, exist_ok=True)
+    (app_root / "app.json").write_text(
+        json.dumps(
+            {
+                "display_name": "Demo App",
+                "description": "Local app with two checkpoints",
+                "short_description": "Demo",
+                "tta": 0,
+                "mc_dropout": 0,
+                "models": ["CV_0.pt", "CV_1.pt"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (app_root / "Config.yml").write_text(
+        "Trainer:\n  epochs: 100\n  it_validation: 2500\n  train_name: FT_0\n",
+        encoding="utf-8",
+    )
+    (app_root / "CV_0.pt").write_text("weights-0", encoding="utf-8")
+    (app_root / "CV_1.pt").write_text("weights-1", encoding="utf-8")
+
+
+def _install_fine_tune(app_root: Path, workspace: Path, name_of_models: list[str]) -> list[tuple[str, Path]]:
+    workspace.mkdir(parents=True, exist_ok=True)
+    repo = app_repository_module.LocalAppRepositoryFromDirectory(app_root.parent, app_root.name)
+    return repo.install_fine_tune(
+        config_file="Config.yml",
+        path=workspace,
+        display_name="Fine Tuned",
+        epochs=3,
+        it_validation=5,
+        name_of_models=name_of_models,
+    )
+
+
+def test_install_fine_tune_defaults_to_first_checkpoint(tmp_path: Path) -> None:
+    from ruamel.yaml import YAML
+
+    app_root = tmp_path / "repo" / "demo_app"
+    _write_two_checkpoint_app(app_root)
+    workspace = tmp_path / "workspace"
+
+    models = _install_fine_tune(app_root, workspace, [])
+
+    assert [name for name, _ in models] == ["CV_0.pt"]
+    assert models[0][1] == app_root / "CV_0.pt"
+    # Shared assets are installed but checkpoints are not copied into the workspace by install.
+    assert (workspace / "app.json").exists()
+    assert (workspace / "Config.yml").exists()
+    assert not (workspace / "CV_0.pt").exists()
+
+    metadata = json.loads((workspace / "app.json").read_text(encoding="utf-8"))
+    assert metadata["display_name"] == "Fine Tuned"
+    assert metadata["models"] == ["CV_0.pt"]
+
+    with open(workspace / "Config.yml") as file:
+        config = YAML().load(file)
+    assert config["Trainer"]["epochs"] == 3
+    assert config["Trainer"]["it_validation"] == 5
+
+
+def test_install_fine_tune_selects_requested_checkpoint(tmp_path: Path) -> None:
+    app_root = tmp_path / "repo" / "demo_app"
+    _write_two_checkpoint_app(app_root)
+    workspace = tmp_path / "workspace"
+
+    models = _install_fine_tune(app_root, workspace, ["CV_1"])
+
+    assert [name for name, _ in models] == ["CV_1.pt"]
+    metadata = json.loads((workspace / "app.json").read_text(encoding="utf-8"))
+    assert metadata["models"] == ["CV_1.pt"]
+
+
+def test_install_fine_tune_selects_multiple_checkpoints(tmp_path: Path) -> None:
+    app_root = tmp_path / "repo" / "demo_app"
+    _write_two_checkpoint_app(app_root)
+    workspace = tmp_path / "workspace"
+
+    models = _install_fine_tune(app_root, workspace, ["CV_0", "CV_1"])
+
+    assert [name for name, _ in models] == ["CV_0.pt", "CV_1.pt"]
+    metadata = json.loads((workspace / "app.json").read_text(encoding="utf-8"))
+    assert metadata["models"] == ["CV_0.pt", "CV_1.pt"]
+
+
+def test_install_fine_tune_rejects_unknown_checkpoint(tmp_path: Path) -> None:
+    app_root = tmp_path / "repo" / "demo_app"
+    _write_two_checkpoint_app(app_root)
+    workspace = tmp_path / "workspace"
+
+    with pytest.raises(app_repository_module.AppRepositoryError):
+        _install_fine_tune(app_root, workspace, ["CV_9"])

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -157,6 +157,12 @@ class Clip(Transform):
         else:
             max_value = self.max_value
 
+        # Resolved bounds may be a torch 0-d tensor ("min"/"max") or a numpy scalar
+        # ("percentile:<p>"); coerce to a Python float so the in-place assignments below are valid
+        # for a torch tensor across numpy/torch versions.
+        min_value = float(min_value)
+        max_value = float(max_value)
+
         tensor[torch.where(tensor.float() < min_value)] = min_value
         tensor[torch.where(tensor.float() > max_value)] = max_value
         if self.save_clip_min:

--- a/konfai/metric/measure.py
+++ b/konfai/metric/measure.py
@@ -1275,19 +1275,36 @@ class IMPACTSynth(CriterionWithAttribute):
 
 
 class SAM_Perceptual(CriterionWithAttribute):
-    def __init__(self) -> None:
+    """SAM-feature perceptual criterion usable both as a metric and as a training loss.
+
+    With ``train=False`` (a **metric**) it uses the metric-tuned model
+    ``VBoussot/ImpactSynth/<model_name>`` over all feature layers. With ``train=True`` (a **loss**) it
+    uses the raw feature extractor ``VBoussot/impact-torchscript-models`` / ``SAM2.1/<model_name>`` and
+    applies per-layer ``weights`` (e.g. ``[0, 1, 1, 0]``); a weight of ``0`` skips that layer.
+    """
+
+    def __init__(
+        self,
+        train: bool = False,
+        model_name: str = "SAM2.1_Small.pt",
+        weights: list[float] | None = None,
+    ) -> None:
         super().__init__()
         self.model: torch.nn.Module | None = None
         self.loss = torch.nn.L1Loss()
-        self.model_path = hf_hub_download(
-            repo_id="VBoussot/ImpactSynth", filename="SAM2.1_Small.pt", repo_type="model", revision=None
-        )  # nosec B615
+        self.weights = weights
+        self.nb_layer = len(weights) if weights is not None else 4
+        if train:
+            repo_id, filename = "VBoussot/impact-torchscript-models", f"SAM2.1/{model_name}"
+        else:
+            repo_id, filename = "VBoussot/ImpactSynth", model_name
+        self.model_path = hf_hub_download(repo_id=repo_id, filename=filename, repo_type="model", revision=None)  # nosec B615
 
     def preprocessing(self, tensor: torch.Tensor, attribute: list[Attribute]) -> list[torch.Tensor]:
         tensor = tensor.repeat(1, 3, 1, 1)
         return [
             tensor,
-            torch.tensor([4]),
+            torch.tensor([self.nb_layer]),
             torch.tensor(
                 [
                     [
@@ -1318,11 +1335,16 @@ class SAM_Perceptual(CriterionWithAttribute):
             mask_patch = model_patch.get_data(mask, index, 0, True) if mask is not None else None
 
             if mask is None or (mask_patch is not None and torch.any(mask_patch == 1)):
-                for zipped_output in zip(
-                    model(model_patch.get_data(output[0], index, 0, True), output[1], output[2]),
-                    model(model_patch.get_data(target[0], index, 0, True), target[1], target[2]),
-                    strict=False,
+                for i, zipped_output in enumerate(
+                    zip(
+                        model(model_patch.get_data(output[0], index, 0, True), output[1], output[2]),
+                        model(model_patch.get_data(target[0], index, 0, True), target[1], target[2]),
+                        strict=False,
+                    )
                 ):
+                    weight = self.weights[i] if self.weights is not None else 1.0
+                    if weight == 0:
+                        continue
                     output_feature = zipped_output[0]
                     target_feature = zipped_output[1]
                     if mask_patch is not None:
@@ -1334,14 +1356,14 @@ class SAM_Perceptual(CriterionWithAttribute):
                             == 1
                         )
                         if torch.any(mask_index_resampled):
-                            loss += self.loss(
+                            loss += weight * self.loss(
                                 torch.masked_select(output_feature, mask_index_resampled).float(),
                                 torch.masked_select(target_feature, mask_index_resampled).float(),
                             )
                         else:
                             continue
                     else:
-                        loss += self.loss(output_feature.float(), target_feature.float())
+                        loss += weight * self.loss(output_feature.float(), target_feature.float())
                 true_nb += 1
         return loss, true_nb
 
@@ -1349,6 +1371,9 @@ class SAM_Perceptual(CriterionWithAttribute):
         self, output: torch.Tensor, *targets: torch.Tensor, attributes: list[list[Attribute]]
     ) -> tuple[torch.Tensor, float]:
         mask = targets[-1] if targets[-1].dtype == torch.uint8 else None
+        # ``targets[0]`` is the reference (e.g. CT), normalized with its own stats; the same stats
+        # normalize the prediction since both live in the same intensity space.
+        target_attributes = attributes[0]
 
         if self.model is None:
             self.model = torch.jit.load(self.model_path, map_location=torch.device("cpu"))  # nosec B614
@@ -1365,13 +1390,13 @@ class SAM_Perceptual(CriterionWithAttribute):
                 loss_tmp, true_nb_tmp = self._compute(
                     output[:, :, i, ...],
                     targets[0][:, :, i, ...],
-                    attributes[1],
+                    target_attributes,
                     mask[:, :, i, ...] if mask is not None else None,
                 )
                 loss += loss_tmp
                 true_nb += true_nb_tmp
         else:
-            loss, true_nb = self._compute(output, targets[0], attributes[1], mask)
+            loss, true_nb = self._compute(output, targets[0], target_attributes, mask)
         return loss / true_nb, np.nan if true_nb == 0 else loss.item() / true_nb
 
 

--- a/konfai/metric/measure.py
+++ b/konfai/metric/measure.py
@@ -958,6 +958,12 @@ class IMPACTReg(CriterionWithAttribute):
     ) -> tuple[torch.Tensor, float]:
         mask = targets[-1] if targets[-1].dtype == torch.uint8 else None
 
+        # The prediction and the target share the same intensity space, so a single target attribute
+        # (single-group target such as ``CT``) is reused to normalize both output and target; a second
+        # attribute set is honored when the target is multi-group.
+        output_attributes = attributes[0]
+        target_attributes = attributes[1] if len(attributes) > 1 else attributes[0]
+
         if self.model is None:
             self.model = torch.jit.load(self.model_path)  # nosec B614
         self.model.to(output.device)
@@ -969,15 +975,15 @@ class IMPACTReg(CriterionWithAttribute):
             for i in range(output.shape[2]):
                 loss_tmp, true_nb_tmp = self._compute(
                     output[:, :, i, ...],
-                    attributes[0],
+                    output_attributes,
                     targets[0][:, :, i, ...],
-                    attributes[1],
+                    target_attributes,
                     mask[:, :, i, ...] if mask is not None else None,
                 )
                 loss += loss_tmp
                 true_nb += true_nb_tmp
         else:
-            loss, true_nb = self._compute(output, attributes[0], targets[0], attributes[1], mask)
+            loss, true_nb = self._compute(output, output_attributes, targets[0], target_attributes, mask)
         return loss / true_nb, np.nan if true_nb == 0 else loss.item() / true_nb
 
 

--- a/konfai/utils/config.py
+++ b/konfai/utils/config.py
@@ -311,8 +311,8 @@ def _unwrap_optional(annotation):
     args = [arg for arg in get_args(annotation) if arg not in {type(None), types.NoneType}]
     if len(args) == 1:
         return args[0]
-    if len(args) > 1:
-        return args[0]
+    # Genuine unions (e.g. ``float | str``) are kept intact so the binding can try each
+    # member type; only ``Optional[X]`` (``X | None``) collapses to ``X``.
     return annotation
 
 
@@ -412,6 +412,16 @@ def apply_config(konfai_args: str | None = None):
                                     kwargs[param.name] = config.get_value(
                                         param.name,
                                         param.default,
+                                    )
+                                continue
+
+                            if get_origin(annotation) in {Union, types.UnionType}:
+                                value = config.get_value(param.name, param.default)
+                                if value is None:
+                                    kwargs[param.name] = None
+                                else:
+                                    kwargs[param.name] = _convert_union_sequence_value(
+                                        value, get_args(annotation), param.name
                                     )
                                 continue
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -181,6 +181,37 @@ def test_apply_config_converts_sequence_of_union_scalars(
     assert all(isinstance(value, int) for value in root.values)
 
 
+def test_apply_config_binds_scalar_float_or_str_union(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Mirrors the Clip transform (``min_value``/``max_value: float | str``) which accepts numeric
+    # bounds as well as string sentinels such as ``min`` / ``percentile:99.5``.
+    _configure_env(
+        tmp_path,
+        monkeypatch,
+        "Root:\n  low: min\n  high: 'percentile:99.5'\n  fixed: 1024\n",
+    )
+
+    class Root:
+        def __init__(
+            self,
+            low: float | str = 0.0,
+            high: float | str = 0.0,
+            fixed: float | str = 0.0,
+        ) -> None:
+            self.low = low
+            self.high = high
+            self.fixed = fixed
+
+    root = apply_config("Root")(Root)()
+
+    assert root.low == "min"
+    assert root.high == "percentile:99.5"
+    assert root.fixed == 1024.0
+    assert isinstance(root.fixed, float)
+
+
 def test_apply_config_honors_konfai_without_for_skipped_parameters(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_transform_clip.py
+++ b/tests/unit/test_transform_clip.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from konfai.data.transform import Clip
+from konfai.utils.dataset import Attribute
+
+
+def test_clip_resolves_min_and_percentile_bounds() -> None:
+    # ``min`` (torch scalar) and ``percentile:<p>`` (numpy scalar) bounds must be coerced to float
+    # so the in-place clip assignments are valid for a torch tensor.
+    tensor = torch.arange(0, 100, dtype=torch.float32)
+    clip = Clip(min_value="min", max_value="percentile:90")
+
+    out = clip("case", tensor.clone(), Attribute())
+
+    assert out.min().item() == pytest.approx(0.0)
+    assert out.max().item() == pytest.approx(89.1)
+    assert out.dtype == torch.float32
+
+
+def test_clip_fixed_numeric_bounds() -> None:
+    tensor = torch.arange(-50, 50, dtype=torch.float32)
+    clip = Clip(min_value=-10.0, max_value=10.0)
+
+    out = clip("case", tensor.clone(), Attribute())
+
+    assert out.min().item() == pytest.approx(-10.0)
+    assert out.max().item() == pytest.approx(10.0)


### PR DESCRIPTION
## Summary

Adds multi-checkpoint fine-tuning to `konfai-apps`, plus the core fixes needed to fine-tune the
released ImpactSynth apps end-to-end.

## konfai-apps

- `fine-tune` gains `--models` to select one or several checkpoints (default: the first available);
  each selected checkpoint is fine-tuned independently from its pretrained weights.
- Before resuming, the checkpoint is reduced to weights only, so counters, optimizer and LR schedule
  restart and the requested `--epochs` actually run. Previously a released checkpoint sitting at
  `epoch == epochs` trained for zero steps.
- Each result is written back into a clean, directly resolvable app bundle (training artifacts are
  kept out of the output directory).
- Adds a `--config` option and `--models` parity for the remote client and the FastAPI server.

## Core konfai fixes (surfaced by the released MR config)

- **config**: bind scalar `float | str` unions instead of collapsing them to `float`, so sentinels
  such as `Clip.min_value: min` / `max_value: percentile:99.5` bind again (this also unblocks
  inference of the released app).
- **transform**: coerce resolved `Clip` percentile / min-max bounds to Python `float` (numpy 2.x
  rejects assigning a `numpy.float32` into a torch tensor).
- **metric**: `SAM_Perceptual` can now serve both as a metric (`train=False`, default, metric-tuned
  model) and as a training loss (`train=True`, raw feature extractor with per-layer `weights`); it
  reuses the single target attribute for single-group targets.
- **metric**: `IMPACTReg` reuses the target attribute for single-group targets instead of indexing a
  missing `attributes[1]`.

## Tests

- konfai-apps: fine-tune integration tests (single / default / multi-model; assert that training
  actually runs from the checkpoint) and `install_fine_tune` unit tests.
- core: scalar-union config binding and `Clip` bound resolution.

## Notes

- Validated end-to-end on the real UNet++/ResNet34 MR model with the MAE + `SAM_Perceptual` loss.
- The published `VBoussot/ImpactSynth` train and eval configs now use `SAM_Perceptual`, so they
  depend on this release.
