### PR TITLE
feat(core): registration primitives + app patch/batch & asset plumbing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,7 @@ examples/Synthesis/Task_1
 .pytest_cache
 .vscode
 .mypy_cache
-apps/impact_reg
-apps/impact_seg
 docs/build/
 .codex
 docs/_build/
+build/

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Install and run your first workflow:
 ```bash
 git clone https://github.com/vboussot/KonfAI.git
 cd KonfAI
-python -m pip install -e .
+python -m pip install -e ".[imaging]"   # [imaging] pulls SimpleITK/h5py, required to read the .mha demo data
 cd examples/Segmentation
 
 python -m pip install -U "huggingface_hub[cli]"

--- a/apps/impact_seg/.gitignore
+++ b/apps/impact_seg/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+build/
+*.egg-info/

--- a/apps/impact_seg/LICENSE
+++ b/apps/impact_seg/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/impact_seg/README.md
+++ b/apps/impact_seg/README.md
@@ -1,0 +1,159 @@
+[![License](https://img.shields.io/badge/license-Apache%202.0-green.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+[![PyPI version](https://img.shields.io/pypi/v/impact_seg_konfai.svg?color=blue)](https://pypi.org/project/impact_seg_konfai/)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
+[![CI](https://github.com/vboussot/KonfAI/actions/workflows/konfai_ci.yml/badge.svg)](https://github.com/vboussot/KonfAI/actions/workflows/konfai_ci.yml)
+[![Paper](https://img.shields.io/badge/📌%20Paper-KonfAI-blue)](https://www.arxiv.org/abs/2508.09823)
+
+# IMPACT-Seg-KonfAI
+
+**Fast and lightweight CLI for multimodal anatomical segmentation using IMPACT-Seg models within the KonfAI framework.**
+
+---
+
+## 🧩 Overview
+
+**IMPACT-Seg-KonfAI** is a lightweight **command-line interface (CLI)** for running **IMPACT-Seg** models through the
+[KonfAI](https://github.com/vboussot/KonfAI) deep learning framework.
+
+It provides a simple way to perform **anatomical segmentation inference**, **evaluation**, **ensembling**, and
+**uncertainty estimation** on medical image volumes.
+
+The underlying **IMPACT-Seg** models are **multimodal anatomical segmentation** networks built around a **2.5D U-Net
+with a residual encoder**. A single model segments **CBCT, MR, and CT** scans into a **consistent label space**,
+enabling cross-modality workflows without per-modality retraining.
+
+Pretrained models are automatically downloaded from
+[Hugging Face Hub](https://huggingface.co/VBoussot/ImpactSeg).
+
+---
+
+## 🧠 Features
+
+- ⚡ **Fast inference** powered by [KonfAI](https://github.com/vboussot/KonfAI)
+- 🤗 **Automatic model download** from Hugging Face
+- 🧩 **Multi-model ensembling** and **test-time augmentation (TTA)**
+- 🧠 **Supports evaluation workflows with reference data, and uncertainty estimation without reference**
+- 🧾 **Multi-format compatibility:** supports all major medical image formats handled by ITK
+
+---
+
+## 🗂️ Available models
+
+Model identifiers are resolved dynamically from the [`VBoussot/ImpactSeg`](https://huggingface.co/VBoussot/ImpactSeg)
+repository and passed as the first positional argument.
+
+| Model | Modalities | Labels | Training cohort |
+|-------|------------|--------|-----------------|
+| `body` | CBCT · MR · CT | 11 | 232 CBCT + 282 MR + 955 CT |
+
+The **`body`** model predicts **11 anatomical labels** spanning soft tissues, cavities, bones, and central structures:
+
+| # | Label | # | Label |
+|---|-------|---|-------|
+| 1 | subcutaneous_tissue | 7 | pericardium |
+| 2 | muscle | 8 | prosthetic_breast_implant |
+| 3 | abdominal_cavity | 9 | mediastinum |
+| 4 | thoracic_cavity | 10 | spinal_cord |
+| 5 | bones | 11 | brain |
+| 6 | gland_structure | | |
+
+---
+
+## 🚀 Installation
+
+From PyPI:
+
+```bash
+python -m pip install impact-seg-konfai
+```
+
+From source:
+
+```bash
+git clone https://github.com/vboussot/KonfAI.git
+python -m pip install -e apps/impact_seg
+```
+
+---
+
+## ⚙️ Usage
+
+The CLI is organised into sub-commands, mirroring the KonfAI Apps operations:
+
+| Sub-command | Purpose |
+|---|---|
+| `segment` | Run the segmentation (inference). |
+| `eval` | Evaluate a segmentation against a reference. |
+| `uncertainty` | Estimate uncertainty (TTA / MC-dropout / ensemble spread). |
+| `pipeline` | Segment, then evaluate and estimate uncertainty in one command. |
+
+Run anatomical segmentation on an input volume:
+
+```bash
+impact-seg-konfai segment body -i path/to/image.nii.gz -o ./Output/
+```
+
+Evaluate against a reference, or run everything at once:
+
+```bash
+impact-seg-konfai eval body -i image.nii.gz --gt reference_mask.nii.gz -o ./Output/
+impact-seg-konfai pipeline body -i image.nii.gz --gt reference_mask.nii.gz --mask eval_mask.nii.gz --gpu 0 --tta 2 -uncertainty
+```
+
+### Arguments
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `MODEL` | Model name on `VBoussot/ImpactSeg` (e.g. `body`) — determines what is predicted | *required* |
+| `-i`, `--inputs` | Input file(s) or a dataset directory | *required* |
+| `-o`, `--output` | Output directory | `./Output/` |
+| `--ensemble` | Number of models to ensemble (`segment` / `pipeline`) | `0` |
+| `--tta` | Number of test-time augmentations (`segment` / `pipeline`) | `0` |
+| `--mc` | Monte Carlo dropout samples (`segment` / `pipeline`) | `0` |
+| `-uncertainty` | Also write the inference stack (`segment` / `pipeline`) | `False` |
+| `--gt` | Reference labels — required by `eval`, optional in `pipeline` | *unset* |
+| `--mask` | Evaluation mask(s) (`eval` / `pipeline`) | *unset* |
+| `--gpu` | GPU id(s), e.g. `0` or `0 1` | CPU if unset |
+| `--cpu` | Number of CPU worker processes | *unset* |
+| `-q`, `--quiet` | Suppress console output | `False` |
+
+> When `--ensemble`, `--tta`, and `--mc` are left at `0`, the values declared in the app bundle (`app.json`) are used.
+
+See the full help of any sub-command with:
+
+```bash
+impact-seg-konfai segment --help
+```
+
+---
+
+## 📚 References
+
+If you use **IMPACT-Seg-KonfAI** in your work, please cite KonfAI along with the IMPACT-Seg materials associated with
+the model release you use.
+
+- Boussot, V., & Dillenseger, J.-L. (2025).
+  **KonfAI: A Modular and Fully Configurable Framework for Deep Learning in Medical Imaging.**
+  arXiv preprint [arXiv:2508.09823](https://arxiv.org/abs/2508.09823)
+
+---
+
+## ⚡ Performance & VRAM
+
+Benchmarked on an **NVIDIA RTX PRO 5000 (24 GB)**, synthetic data, patch `[1, 192, 192]`, single model (`Mean`). The app **auto-selects the batch size from your free GPU VRAM** (`vram_plan`); override it in SlicerKonfAI (⚙ **Advanced**) or on the CLI with `--patch-size` / `--batch-size`.
+
+| Free VRAM | Batch (auto) | Peak VRAM |
+|:--|:--|:--|
+| 8 GB  | 160 | ~7 GB |
+| 16 GB | 320 | ~14 GB |
+| 24 GB | 512 | ~22 GB |
+
+Measured peak VRAM: batch 64 → 3.1 GB · 128 → 5.8 GB · 256 → 8.5 GB · 512 → 22.4 GB. Inference ≈ **16 s / case** on the benchmark volume (scales with the case size).
+
+---
+
+## 🔗 Links
+
+- 🤗 **Model Hub:** [huggingface.co/VBoussot/ImpactSeg](https://huggingface.co/VBoussot/ImpactSeg)
+- 📦 **PyPI Package:** [pypi.org/project/impact_seg_konfai](https://pypi.org/project/impact_seg_konfai)
+- 🧠 **KonfAI Repository:** [github.com/vboussot/KonfAI](https://github.com/vboussot/KonfAI)

--- a/apps/impact_seg/impact_seg_konfai/__init__.py
+++ b/apps/impact_seg/impact_seg_konfai/__init__.py
@@ -1,0 +1,1 @@
+"""Python package for the IMPACT-Seg KonfAI app wrapper."""

--- a/apps/impact_seg/impact_seg_konfai/cli.py
+++ b/apps/impact_seg/impact_seg_konfai/cli.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Command-line wrapper for running IMPACT-Seg through KonfAI Apps.
+
+Exposes the app operations with segmentation vocabulary: ``segment`` / ``eval`` / ``uncertainty`` / ``pipeline``.
+"""
+
+import argparse
+
+from konfai_apps.cli import build_app_cli
+
+IMPACT_SEG_KONFAI_REPO = "VBoussot/ImpactSeg"
+
+
+def _add_selection(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "model",
+        help="Which published IMPACT-Seg model to use. An unknown name is reported when the app is resolved.",
+    )
+
+
+def _add_infer_knobs(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--ensemble", type=int, default=0, help="Size of model ensemble.")
+    parser.add_argument("--tta", type=int, default=0, help="Number of Test-Time Augmentations.")
+    parser.add_argument("--mc", type=int, default=0, help="Monte Carlo dropout samples.")
+
+
+main = build_app_cli(
+    "impact-seg-konfai",
+    "IMPACT-Seg (KonfAI app wrapper): multimodal segmentation.",
+    resolve_app=lambda args: f"{IMPACT_SEG_KONFAI_REPO}:{args.model}",
+    add_selection=_add_selection,
+    add_infer_knobs=_add_infer_knobs,
+    resolve_infer=lambda args: {"ensemble": args.ensemble, "ensemble_models": [], "tta": args.tta, "mc": args.mc},
+    infer_command="segment",
+)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/impact_seg/pyproject.toml
+++ b/apps/impact_seg/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=68", "wheel", "setuptools-scm>=8"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "impact-seg-konfai"
+dynamic = ["version", "dependencies"]
+description = "Fast and lightweight CLI for anatomical segmentation with 2.5D U-Net models using a residual encoder within the KonfAI framework."
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.10"
+
+authors = [
+  { name = "Valentin Boussot", email = "boussot.v@gmail.com" }
+]
+
+[project.urls]
+Homepage = "https://github.com/vboussot/KonfAI"
+Repository = "https://github.com/vboussot/KonfAI"
+Issues = "https://github.com/vboussot/KonfAI/issues"
+License = "https://www.apache.org/licenses/LICENSE-2.0"
+
+[project.scripts]
+impact-seg-konfai = "impact_seg_konfai.cli:main"
+
+[tool.setuptools_scm]
+root = "../.."
+tag_regex = "^v(?P<version>.*)$"
+local_scheme = "no-local-version"

--- a/apps/impact_seg/setup.py
+++ b/apps/impact_seg/setup.py
@@ -1,0 +1,20 @@
+from email import message_from_string
+from pathlib import Path
+
+from setuptools import setup
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _release_version() -> str:
+    pkg_info = Path(__file__).with_name("PKG-INFO")
+    if pkg_info.exists():
+        return message_from_string(pkg_info.read_text())["Version"]
+    from setuptools_scm import get_version
+
+    return get_version(root=str(_ROOT), tag_regex=r"^v(?P<version>.*)$", local_scheme="no-local-version")
+
+
+_version = _release_version()
+
+setup(install_requires=[f"konfai=={_version}", f"konfai-apps=={_version}"])

--- a/apps/impact_synth/README.md
+++ b/apps/impact_synth/README.md
@@ -43,34 +43,44 @@ python -m pip install -e apps/impact_synth
 
 ## ⚙️ Usage
 
-Perform image-to-sCT synthesis:
+The CLI is organised into sub-commands, mirroring the KonfAI Apps operations:
+
+| Sub-command | Purpose |
+|---|---|
+| `synthesize` | Generate the synthetic CT (inference). |
+| `eval` | Evaluate a synthetic CT against a reference CT. |
+| `uncertainty` | Estimate uncertainty (TTA / MC-dropout / ensemble spread). |
+| `pipeline` | Run synthesis, then evaluation and uncertainty in one command. |
+
+Generate a synthetic CT:
 
 ```bash
-impact-synth-konfai MR -i path/to/input.nii.gz -o ./Output/
+impact-synth-konfai synthesize MR -i path/to/input.nii.gz -o ./Output/
 ```
 
-### Optional arguments
+Evaluate against a reference CT, or run everything at once:
+
+```bash
+impact-synth-konfai eval MR -i input.nii.gz --gt reference_ct.nii.gz -o ./Output/
+impact-synth-konfai pipeline CBCT -i patient01.nii.gz --gt ct.nii.gz -o patient01 --gpu 0 --tta 2 --ensemble 5 -uncertainty
+```
+
+### Arguments
 
 | Flag | Description | Default |
 |------|--------------|----------|
-| `MODEL` | Input modality / model name on Hugging Face | `MR` or  `CBCT`|
-| `-i`, `--input` | Path to the input file | *required* |
-| `-o`, `--output` | Path to save the synthetic CT | `./Output/` |
-| `--gt` | Path to reference CT (ground truth), if available (enables evaluation workflows) | *unset* |
-| `--mask` | Path to region-of-interest mask used for evaluation and uncertainty analysis | *unset* |
-| `--tta` | Number of test-time augmentations (TTA) | `2` |
-| `--ensemble` | Number of models to ensemble | `5` |
-| `--mc` | Monte Carlo dropout samples for uncertainty | `1` |
-| `-uncertainty` | Save uncertainty maps | `False` |
-| `--gpu` | GPU list (e.g. `0` or `0,1`) | CPU if unset |
-| `--cpu` | Number of CPU cores (if no GPU) | `1` |
+| `MODEL` | Model name on Hugging Face (`MR` or `CBCT`) — determines what is predicted | *required* |
+| `-i`, `--inputs` | Input file(s) or a dataset directory | *required* |
+| `-o`, `--output` | Output directory | `./Output/` |
+| `--ensemble` | Number of models to ensemble (`synthesize` / `pipeline`) | `0` |
+| `--tta` | Number of test-time augmentations (`synthesize` / `pipeline`) | `0` |
+| `--mc` | Monte Carlo dropout samples (`synthesize` / `pipeline`) | `0` |
+| `-uncertainty` | Also write the inference stack (`synthesize` / `pipeline`) | `False` |
+| `--gt` | Reference CT(s) — required by `eval`, optional in `pipeline` | *unset* |
+| `--mask` | Evaluation mask(s) (`eval` / `pipeline`) | *unset* |
+| `--gpu` | GPU id(s), e.g. `0` or `0 1` | CPU if unset |
+| `--cpu` | Number of CPU worker processes | *unset* |
 | `-q`, `--quiet` | Suppress console output | `False` |
-
-### Example
-
-```bash
-impact-synth-konfai CBCT -i patient01.nii.gz -o patient01 --gpu 0 --tta 2 --ensemble 5 -uncertainty
-```
 
 ---
 
@@ -98,9 +108,23 @@ If you use **IMPACT-Synth-KonfAI** in your work, please cite:
 
 ---
 
+## ⚡ Performance & VRAM
+
+Benchmarked on an **NVIDIA RTX PRO 5000 (24 GB)**, synthetic data, patch `[1, 512, 512]`, 5-model ensemble (`Concat`). The app **auto-selects the batch size from your free GPU VRAM** (`vram_plan`); override it in SlicerKonfAI (⚙ **Advanced**) or on the CLI with `--patch-size` / `--batch-size`.
+
+| Free VRAM | Batch (auto) | Peak VRAM |
+|:--|:--|:--|
+| 8 GB  | 16 | ~7.6 GB |
+| 16 GB | 28 | ~15 GB |
+| 24 GB | 48 | ~21.7 GB |
+
+Measured peak VRAM: batch 8 → 4.0 GB · 16 → 7.6 GB · 24 → 12.8 GB · 32 → 17.5 GB · 48 → 21.7 GB. Inference ≈ **25 s / case** on the benchmark volume (scales with the case size).
+
+---
+
 ## 🔗 Links
 
-- 🤗 **Model Hub:** [huggingface.co/VBoussot/IMPACT-Synth](https://huggingface.co/VBoussot/ImpactSynth)  
+- 🤗 **Model Hub:** [huggingface.co/VBoussot/ImpactSynth](https://huggingface.co/VBoussot/ImpactSynth)  
 - 📦 **PyPI Package:** [pypi.org/project/impact_synth_konfai](https://pypi.org/project/impact_synth_konfai)  
 
 ---

--- a/apps/impact_synth/impact_synth_konfai/cli.py
+++ b/apps/impact_synth/impact_synth_konfai/cli.py
@@ -14,36 +14,42 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Command-line wrapper for running IMPACT-Synth through KonfAI Apps."""
+"""Command-line wrapper for running IMPACT-Synth through KonfAI Apps.
+
+Exposes the app operations with synthesis vocabulary: ``synthesize`` / ``eval`` / ``uncertainty`` / ``pipeline``.
+"""
 
 import argparse
 
-from konfai_apps import KonfAIApp
-from konfai_apps.app_repository import get_available_apps_on_hf_repo
-from konfai_apps.cli import add_common_konfai_apps
+from konfai_apps.cli import build_app_cli
 
 IMPACT_SYNTH_KONFAI_REPO = "VBoussot/ImpactSynth"
 
 
-def main():
-    """Parse CLI arguments and run the selected IMPACT-Synth app pipeline."""
-    parser = argparse.ArgumentParser(
-        prog="impact-synth-konfai",
-        description="ImpactSynth (KonfAI app wrapper)",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
+def _add_selection(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "model",
-        choices=list(get_available_apps_on_hf_repo(IMPACT_SYNTH_KONFAI_REPO, False)),
-        help="Select which model to use. This determines what is predicted.",
+        help="Which synthesis model to use (determines what is predicted). "
+        "An unknown name is reported when the app is resolved.",
     )
-    parser.add_argument("--ensemble", type=int, default=0, help="Size of model ensemble")
-    parser.add_argument("--tta", type=int, default=0, help="Number of Test-Time Augmentations")
-    parser.add_argument("--mc", type=int, default=0, help="Monte Carlo dropout samples")
 
-    kwargs = add_common_konfai_apps(parser)
 
-    model = kwargs.pop("model")
+def _add_infer_knobs(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--ensemble", type=int, default=0, help="Size of model ensemble.")
+    parser.add_argument("--tta", type=int, default=0, help="Number of Test-Time Augmentations.")
+    parser.add_argument("--mc", type=int, default=0, help="Monte Carlo dropout samples.")
 
-    konfai_app = KonfAIApp(f"{IMPACT_SYNTH_KONFAI_REPO}:{model}", kwargs.pop("download"), kwargs.pop("force_update"))
-    konfai_app.pipeline(**kwargs)
+
+main = build_app_cli(
+    "impact-synth-konfai",
+    "ImpactSynth (KonfAI app wrapper): whole-body synthetic CT from MR/CBCT.",
+    resolve_app=lambda args: f"{IMPACT_SYNTH_KONFAI_REPO}:{args.model}",
+    add_selection=_add_selection,
+    add_infer_knobs=_add_infer_knobs,
+    resolve_infer=lambda args: {"ensemble": args.ensemble, "ensemble_models": [], "tta": args.tta, "mc": args.mc},
+    infer_command="synthesize",
+)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/mrsegmentator/README.md
+++ b/apps/mrsegmentator/README.md
@@ -94,30 +94,39 @@ python -m pip install -e apps/mrsegmentator
 
 ## ⚙️ Usage
 
-Run inference on an MRI scan:
+The CLI is organised into sub-commands, mirroring the KonfAI Apps operations:
+
+| Sub-command | Purpose |
+|---|---|
+| `segment` | Run the segmentation (inference). |
+| `eval` | Evaluate a segmentation against a reference. |
+| `uncertainty` | Estimate uncertainty (fold-ensemble spread). |
+| `pipeline` | Segment, then evaluate and estimate uncertainty in one command. |
+
+Run segmentation on an MRI scan:
 ```bash
-mrsegmentator-konfai -i path/to/input.nii.gz -o ./Output/
+mrsegmentator-konfai segment -i path/to/input.nii.gz -o ./Output/
 ```
 
-### Optional arguments
+Evaluate against a reference, or run everything at once:
+```bash
+mrsegmentator-konfai eval -i input.nii.gz --gt reference.nii.gz -o ./Output/
+mrsegmentator-konfai pipeline -i input.nii.gz --gt reference.nii.gz --gpu 0 -f 3 -uncertainty
+```
+
+### Arguments
 
 | Flag | Description | Default |
 |------|--------------|----------|
-| `-i`, `--input` | Path to the input MRI volume | *required* |
-| `-o`, `--output` | Path to save the segmentation | `./Output/` |
-| `--gt` | Path to reference segmentation (ground truth), if available (enables evaluation workflows) | *unset* |
-| `--mask` | Path to region-of-interest mask used for evaluation and uncertainty analysis | *unset* |
-| `-f`, `--folds` | Number of model folds to ensemble (1–5) | `2` |
-| `-uncertainty` | Save uncertainty maps | `False` |
-| `--gpu` | GPU list (e.g. `0` or `0,1`) | CPU if unset |
-| `--cpu` | Number of CPU cores (if no GPU) | `1` |
+| `-i`, `--inputs` | Input MRI volume(s) or a dataset directory | *required* |
+| `-o`, `--output` | Output directory | `./Output/` |
+| `-f`, `--folds` | Number of model folds to ensemble, 1–5 (`segment` / `pipeline`) | `2` |
+| `-uncertainty` | Also write the inference stack (`segment` / `pipeline`) | `False` |
+| `--gt` | Reference segmentation(s) — required by `eval`, optional in `pipeline` | *unset* |
+| `--mask` | Evaluation mask(s) (`eval` / `pipeline`) | *unset* |
+| `--gpu` | GPU id(s), e.g. `0` or `0 1` | CPU if unset |
+| `--cpu` | Number of CPU worker processes | *unset* |
 | `-q`, `--quiet` | Suppress console output | `False` |
-
-### Example
-
-```bash
-mrsegmentator-konfai -i path/to/input.nii.gz -o ./Output/ --gt path/to/reference.nii.gz --mask path/to/mask.nii.gz --gpu 0 -f 3 -uncertainty
-```
 
 ---
 
@@ -132,6 +141,20 @@ If you use **MRSegmentator-KonfAI** in your work, please cite the original MRSeg
 - Boussot, V., & Dillenseger, J.-L. (2025).  
   **KonfAI: A Modular and Fully Configurable Framework for Deep Learning in Medical Imaging**.  
   arXiv preprint [arXiv:2508.09823](https://arxiv.org/abs/2508.09823)
+
+---
+
+## ⚡ Performance & VRAM
+
+Benchmarked on an **NVIDIA RTX PRO 5000 (24 GB)**, synthetic data, patch `[96, 128, 160]`, 5-model ensemble (`Concat`), half precision (autocast). The app **auto-selects the batch size from your free GPU VRAM** (`vram_plan`); override it in SlicerKonfAI (⚙ **Advanced**) or on the CLI with `--patch-size` / `--batch-size`.
+
+| Free VRAM | Batch (auto) | Peak VRAM |
+|:--|:--|:--|
+| 8 GB  | 4  | ~8 GB |
+| 16 GB | 8  | ~15 GB |
+| 24 GB | 12 | ~23 GB |
+
+Measured peak VRAM (single model, half): batch 4 → 6.9 GB · 8 → 13.3 GB · 12 → 19.7 GB — the full 5-model ensemble adds ~15 %. Inference ≈ 25 s/model → **~125 s / case** for the full ensemble (scales with the case size).
 
 ---
 

--- a/apps/mrsegmentator/mrsegmentator_konfai/cli.py
+++ b/apps/mrsegmentator/mrsegmentator_konfai/cli.py
@@ -14,29 +14,38 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Command-line wrapper for running MRSegmentator through KonfAI Apps."""
+"""Command-line wrapper for running MRSegmentator through KonfAI Apps.
+
+Exposes the app operations with segmentation vocabulary: ``segment`` / ``eval`` / ``uncertainty`` / ``pipeline``.
+"""
 
 import argparse
 
-from konfai_apps import KonfAIApp
-from konfai_apps.cli import add_common_konfai_apps
+from konfai_apps.cli import build_app_cli
 
 MR_SEGMENTATOR_KONFAI_REPO = "VBoussot/MRSegmentator-KonfAI"
 
 
-def main():
-    """Parse CLI arguments and run the MRSegmentator app pipeline."""
-    parser = argparse.ArgumentParser(
-        prog="mrsegmentator-konfai",
-        description="MRSegmentator (KonfAI app wrapper)",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
+def _add_infer_knobs(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
-        "-f", "--folds", choices=[1, 2, 3, 4, 5], help="Number of folds to ensemble.", default=2, type=int
+        "-f",
+        "--folds",
+        choices=[1, 2, 3, 4, 5],
+        default=2,
+        type=int,
+        help="Number of cross-validation folds to ensemble.",
     )
-    kwargs = add_common_konfai_apps(parser)
-    kwargs["ensemble"] = kwargs.pop("folds")
-    konfai_app = KonfAIApp(
-        f"{MR_SEGMENTATOR_KONFAI_REPO}:MRSegmentator", kwargs.pop("download"), kwargs.pop("force_update")
-    )
-    konfai_app.pipeline(**kwargs)
+
+
+main = build_app_cli(
+    "mrsegmentator-konfai",
+    "MRSegmentator (KonfAI app wrapper): multi-organ MR segmentation.",
+    resolve_app=lambda args: f"{MR_SEGMENTATOR_KONFAI_REPO}:MRSegmentator",
+    add_infer_knobs=_add_infer_knobs,
+    resolve_infer=lambda args: {"ensemble": args.folds, "ensemble_models": [], "tta": 0, "mc": 0},
+    infer_command="segment",
+)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/totalsegmentator/README.md
+++ b/apps/totalsegmentator/README.md
@@ -1,5 +1,5 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-green.svg)](https://www.apache.org/licenses/LICENSE-2.0)
-[![PyPI version](https://img.shields.io/pypi/v/mrsegmentator-konfai.svg?color=blue)](https://pypi.org/project/mrsegmentator-konfai/)
+[![PyPI version](https://img.shields.io/pypi/v/totalsegmentator-konfai.svg?color=blue)](https://pypi.org/project/totalsegmentator-konfai/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
 [![CI](https://github.com/vboussot/KonfAI/actions/workflows/konfai_ci.yml/badge.svg)](https://github.com/vboussot/KonfAI/actions/workflows/konfai_ci.yml)
 [![CI](https://github.com/vboussot/KonfAI/actions/workflows/konfai_apps_ci.yml/badge.svg)](https://github.com/vboussot/KonfAI/actions/workflows/konfai_apps_ci.yml)
@@ -92,31 +92,42 @@ python -m pip install -e apps/totalsegmentator
 
 ## ⚙️ Usage
 
+The CLI is organised into sub-commands, mirroring the KonfAI Apps operations:
+
+| Sub-command | Purpose |
+|---|---|
+| `segment` | Run the segmentation (inference). |
+| `eval` | Evaluate a segmentation against a reference. |
+| `pipeline` | Segment, then evaluate in one command. |
+
 Perform segmentation on an input volume:
 
 ```bash
-totalsegmentator-konfai total -i path/to/image.nii.gz -o ./Output/
+totalsegmentator-konfai segment total -i path/to/image.nii.gz -o ./Output/
 ```
 
-### Optional arguments
+Evaluate against a reference, or run both at once:
+
+```bash
+totalsegmentator-konfai eval total -i image.nii.gz --gt reference.nii.gz -o ./Output/
+totalsegmentator-konfai pipeline total -i image.nii.gz --gt reference.nii.gz --gpu 0
+```
+
+### Arguments
 
 | Flag | Description | Default |
 |------|--------------|----------|
-| `TASK` | Input modality / model name on Hugging Face | `total`, `total_mr`, `total_3mm`, `total_mr_3mm`|
-| `-i`, `--input` | Path to the input medical image | *required* |
-| `-o`, `--output` | Path to save the segmentation | `./Output/` |
-| `--gt` | Path to reference segmentation (ground truth), if available (enables evaluation workflows) | *unset* |
-| `--mask` | Path to region-of-interest mask used for evaluation and uncertainty analysis | *unset* |
-| `--gpu` | GPU list (e.g. `0` or `0,1`) | CPU if unset |
-| `--cpu` | Number of CPU cores (if no GPU) | `1` |
+| `TASK` | Model on Hugging Face (`total`, `total_mr`, `total_3mm`, `total_mr_3mm`) — determines what is predicted | *required* |
+| `-i`, `--inputs` | Input medical image(s) or a dataset directory | *required* |
+| `-o`, `--output` | Output directory | `./Output/` |
+| `--models` | Explicit model identifiers/paths to ensemble (`segment` / `pipeline`) | *unset* |
+| `--gt` | Reference segmentation(s) — required by `eval`, optional in `pipeline` | *unset* |
+| `--mask` | Evaluation mask(s) (`eval` / `pipeline`) | *unset* |
+| `--gpu` | GPU id(s), e.g. `0` or `0 1` | CPU if unset |
+| `--cpu` | Number of CPU worker processes | *unset* |
 | `-q`, `--quiet` | Suppress console output | `False` |
 
-### Example
-
-```bash
-totalsegmentator-konfai total -i path/to/input.nii.gz -o ./Output/ --gt path/to/reference.nii.gz --mask path/to/mask.nii.gz --gpu 0 -uncertainty
-
-```
+> **Note:** TotalSegmentator models do not expose an uncertainty workflow, so there is no `uncertainty` sub-command.
 
 ---
 
@@ -135,6 +146,20 @@ If you use **TotalSegmentator-KonfAI** in your work, please cite the original To
 - Boussot, V., & Dillenseger, J.-L. (2025).  
   **KonfAI: A Modular and Fully Configurable Framework for Deep Learning in Medical Imaging**.  
   arXiv preprint [arXiv:2508.09823](https://arxiv.org/abs/2508.09823)
+
+---
+
+## ⚡ Performance & VRAM
+
+Benchmarked on an **NVIDIA RTX PRO 5000 (24 GB)**, synthetic data, patch `[96, 128, 160]`, 5-model ensemble (`Concat`), half precision (autocast). The app **auto-selects the batch size from your free GPU VRAM** (`vram_plan`); override it in SlicerKonfAI (⚙ **Advanced**) or on the CLI with `--patch-size` / `--batch-size`.
+
+| Free VRAM | Batch (auto) | Peak VRAM |
+|:--|:--|:--|
+| 8 GB  | 4  | ~8 GB |
+| 16 GB | 8  | ~15 GB |
+| 24 GB | 12 | ~23 GB |
+
+Measured peak VRAM (single model, half): batch 4 → 5.6 GB · 8 → 10.6 GB · 12 → 15.6 GB — the full 5-model ensemble adds ~15 %. Inference ≈ 20 s/model → **~110 s / case** for the full ensemble (scales with the case size).
 
 ---
 

--- a/apps/totalsegmentator/totalsegmentator_konfai/cli.py
+++ b/apps/totalsegmentator/totalsegmentator_konfai/cli.py
@@ -14,34 +14,42 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Command-line wrapper for running TotalSegmentator through KonfAI Apps."""
+"""Command-line wrapper for running TotalSegmentator through KonfAI Apps.
+
+Exposes the app operations with segmentation vocabulary: ``segment`` / ``eval`` / ``pipeline``
+(TotalSegmentator models do not provide an uncertainty workflow).
+"""
 
 import argparse
 
-from konfai_apps import KonfAIApp
-from konfai_apps.app_repository import get_available_apps_on_hf_repo
-from konfai_apps.cli import add_common_konfai_apps
+from konfai_apps.cli import build_app_cli
 
 TOTAL_SEGMENTATOR_KONFAI_REPO = "VBoussot/TotalSegmentator-KonfAI"
 
 
-def main():
-    """Parse CLI arguments and run the selected TotalSegmentator app pipeline."""
-    parser = argparse.ArgumentParser(
-        prog="totalsegmentator-konfai",
-        description="TotalSegmentator (KonfAI app wrapper)",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
+def _add_selection(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "task",
-        choices=list(get_available_apps_on_hf_repo(TOTAL_SEGMENTATOR_KONFAI_REPO, False)),
-        help="Select which model to use. This determines what is predicted.",
+        help="Which anatomical task/model to use (determines what is predicted). "
+        "An unknown name is reported when the app is resolved.",
     )
-    parser.add_argument("--models", nargs="+", default=[], help="Explicit list of model identifiers/paths to use.")
-    kwargs = add_common_konfai_apps(parser, False)
-    task = kwargs.pop("task")
-    konfai_app = KonfAIApp(
-        f"{TOTAL_SEGMENTATOR_KONFAI_REPO}:{task}", kwargs.pop("download"), kwargs.pop("force_update")
-    )
-    kwargs["ensemble_models"] = kwargs.pop("models")
-    konfai_app.pipeline(**kwargs)
+
+
+def _add_infer_knobs(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--models", nargs="+", default=[], help="Explicit list of model identifiers/paths to ensemble.")
+
+
+main = build_app_cli(
+    "totalsegmentator-konfai",
+    "TotalSegmentator (KonfAI app wrapper): whole-body CT segmentation.",
+    resolve_app=lambda args: f"{TOTAL_SEGMENTATOR_KONFAI_REPO}:{args.task}",
+    add_selection=_add_selection,
+    add_infer_knobs=_add_infer_knobs,
+    resolve_infer=lambda args: {"ensemble": 0, "ensemble_models": args.models, "tta": 0, "mc": 0},
+    infer_command="segment",
+    with_uncertainty=False,
+)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,7 +19,7 @@ Medical image synthesis example based on:
 - `Config.yml` for training
 - `Prediction.yml` for inference
 - `Evaluation.yml` for evaluation
-- `UNetpp.py` and `UnNormalize.py` for local custom Python modules
+- `Model.py` and `UnNormalize.py` for local custom Python modules
 
 Use this example if you want to understand how KonfAI combines:
 

--- a/konfai-apps/konfai_apps/app.py
+++ b/konfai-apps/konfai_apps/app.py
@@ -580,6 +580,8 @@ class KonfAIAppClient(AbstractKonfAIApp):
         ensemble_models: list[str] = [],
         tta: int = 0,
         mc: int = 0,
+        patch_size: list[int] | None = None,
+        batch_size: int | None = None,
         uncertainty: bool = False,
         prediction_file: str = "Prediction.yml",
         gpu: list[int] = [],
@@ -627,6 +629,8 @@ class KonfAIAppClient(AbstractKonfAIApp):
         ensemble_models: list[str] = [],
         tta: int = 0,
         mc: int = 0,
+        patch_size: list[int] | None = None,
+        batch_size: int | None = None,
         prediction_file: str = "Prediction.yml",
         mask: list[list[Path]] | None = None,
         evaluation_file: str = "Evaluation.yml",
@@ -931,6 +935,8 @@ class KonfAIApp(AbstractKonfAIApp):
         ensemble_models: list[str] = [],
         tta: int = 0,
         mc: int = 0,
+        patch_size: list[int] | None = None,
+        batch_size: int | None = None,
         uncertainty: bool = False,
         prediction_file: str = "Prediction.yml",
         gpu: list[int] = cuda_visible_devices(),
@@ -962,7 +968,15 @@ class KonfAIApp(AbstractKonfAIApp):
 
             available_vram = min(available_vram_per_device)
         models_path = self.app_repository.install_inference(
-            tta, ensemble, ensemble_models, mc, uncertainty, prediction_file, available_vram
+            tta,
+            ensemble,
+            ensemble_models,
+            mc,
+            uncertainty,
+            prediction_file,
+            available_vram,
+            forced_patch_size=patch_size,
+            forced_batch_size=batch_size,
         )
         from konfai.predictor import predict
 
@@ -1050,6 +1064,8 @@ class KonfAIApp(AbstractKonfAIApp):
         ensemble_models: list[str] = [],
         tta: int = 0,
         mc: int = 0,
+        patch_size: list[int] | None = None,
+        batch_size: int | None = None,
         prediction_file: str = "Prediction.yml",
         mask: list[list[Path]] | None = None,
         evaluation_file: str = "Evaluation.yml",
@@ -1077,18 +1093,20 @@ class KonfAIApp(AbstractKonfAIApp):
         - runs uncertainty only if ``uncertainty=True``
         """
         self.infer(
-            inputs,
-            output / "Predictions",
-            ensemble,
-            ensemble_models,
-            tta,
-            mc,
-            uncertainty,
-            prediction_file,
-            gpu,
-            cpu,
-            quiet,
-            tmp_dir,
+            inputs=inputs,
+            output=output / "Predictions",
+            ensemble=ensemble,
+            ensemble_models=ensemble_models,
+            tta=tta,
+            mc=mc,
+            patch_size=patch_size,
+            batch_size=batch_size,
+            uncertainty=uncertainty,
+            prediction_file=prediction_file,
+            gpu=gpu,
+            cpu=cpu,
+            quiet=quiet,
+            tmp_dir=tmp_dir,
         )
         outputs = []
         inference_stacks = []

--- a/konfai-apps/konfai_apps/app_repository.py
+++ b/konfai-apps/konfai_apps/app_repository.py
@@ -37,7 +37,7 @@ from huggingface_hub.hf_api import RepoFolder
 from konfai import RemoteServer
 from konfai.utils.errors import AppMetadataError, AppRepositoryError, ConfigError
 from konfai.utils.utils import is_windows_absolute_path
-from packaging.requirements import Requirement
+from packaging.requirements import InvalidRequirement, Requirement
 from ruamel.yaml import YAML
 
 
@@ -157,6 +157,7 @@ class AppRepositoryInfo(ABC):
         inputs_evaluations: dict[EvaluationKey, dict[str, DataEntry]],
         terminology: dict[int, TerminologyEntry] | None = None,
         vram_plan: dict[int, VRAMPlanEntry] | None = None,
+        patch_size: list[int] | None = None,
     ) -> None:
         super().__init__()
         self._app_name = app_name
@@ -172,6 +173,7 @@ class AppRepositoryInfo(ABC):
         self._inputs_evaluations = inputs_evaluations
         self._terminology = terminology
         self._vram_plan = vram_plan
+        self._patch_size = patch_size
 
     def __str__(self) -> str:
         return (
@@ -208,6 +210,10 @@ class AppRepositoryInfo(ABC):
 
     def get_maximum_tta(self) -> int:
         return self._maximum_tta
+
+    def get_patch_size(self) -> list[int] | None:
+        """The app's default inference patch size (per-dim), for UI patch controls; None if undeclared."""
+        return self._patch_size
 
     def get_mc_dropout(self) -> int:
         return self._mc_dropout
@@ -321,6 +327,9 @@ class LocalAppRepository(AppRepositoryInfo):
                 for key, value in app_repository_metadata["vram_plan"].items()
             }
 
+        patch_size = app_repository_metadata.get("patch_size")
+        patch_size = [int(x) for x in patch_size] if isinstance(patch_size, list) else None
+
         checkpoints_name: list[str] = app_repository_metadata.get("models", [])
         checkpoints_name_available = self._get_available_checkpoint_names(checkpoints_name, filenames)
 
@@ -338,6 +347,7 @@ class LocalAppRepository(AppRepositoryInfo):
             inputs_evaluations=inputs_evaluations,
             terminology=terminology,
             vram_plan=vram_plan,
+            patch_size=patch_size,
         )
 
     def _get_available_checkpoint_names(self, checkpoints_name: list[str], filenames: list[str]) -> list[str]:
@@ -423,16 +433,29 @@ class LocalAppRepository(AppRepositoryInfo):
     def _set_patch_size_and_batch_size(
         self,
         inference_file_path: str,
-        patch_size: list[int],
-        batch_size: int,
+        patch_size: list[int] | None = None,
+        batch_size: int | None = None,
     ) -> None:
+        """Write the inference ``Patch.patch_size`` / ``batch_size``, overriding only the values given.
+
+        A single-element ``patch_size`` is broadcast to the config's spatial dimensionality (an isotropic
+        cube), so ``--patch-size 192`` works regardless of 2D/3D; a full list is written verbatim.
+        """
+        if patch_size is None and batch_size is None:
+            return
         yaml = YAML()
         with open(inference_file_path) as file:
             data = yaml.load(file)
 
         tmp = data["Predictor"]["Dataset"]
-        tmp["Patch"]["patch_size"] = patch_size
-        tmp["batch_size"] = batch_size
+        if patch_size is not None:
+            if len(patch_size) == 1:
+                existing = tmp.get("Patch", {}).get("patch_size")
+                dim = len(existing) if isinstance(existing, list) and len(existing) > 1 else 3
+                patch_size = patch_size * dim
+            tmp["Patch"]["patch_size"] = patch_size
+        if batch_size is not None:
+            tmp["batch_size"] = batch_size
 
         with open(inference_file_path, "w") as file:
             yaml.dump(data, file)
@@ -444,6 +467,23 @@ class LocalAppRepository(AppRepositoryInfo):
     @abstractmethod
     def _download(self, filename: str) -> Path:
         raise NotImplementedError()
+
+    def _all_repo_filenames(self) -> list[str]:
+        """The complete app file list.
+
+        For a Hugging Face repo the local snapshot is populated lazily (one file per ``hf_hub_download``),
+        so a snapshot-derived listing can omit bundle assets not pulled yet (e.g. elastix parameter maps).
+        Refresh it from the Hub tree once — a lightweight metadata call, no file transfer — so every asset
+        is known; the per-file downloads still hit the local cache, and it falls back to the local snapshot
+        when offline.
+        """
+        filenames = self._get_filenames()
+        if isinstance(self, LocalAppRepositoryFromHF):
+            try:
+                filenames = LocalAppRepositoryFromHF.get_filenames(self._repo_id, self._app_name, True)
+            except AppRepositoryError:
+                pass
+        return filenames
 
     def has_capabilities(self) -> tuple[bool, bool, bool]:
         filenames = self._get_filenames()
@@ -461,9 +501,13 @@ class LocalAppRepository(AppRepositoryInfo):
         return files_path
 
     def download_inference(
-        self, number_of_model: int, name_of_models: list[str], prediction_file: str
+        self,
+        number_of_model: int,
+        name_of_models: list[str],
+        prediction_file: str,
+        install_requirements: bool = False,
     ) -> tuple[list[Path], Path, list[tuple[str, Path]]]:
-        filenames = self._get_filenames()
+        filenames = self._all_repo_filenames()
         models_path: list[Path] = []
         codes_path: list[tuple[str, Path]] = []
 
@@ -492,19 +536,30 @@ class LocalAppRepository(AppRepositoryInfo):
             for name in models_to_download[:number_of_model]:
                 models_path.append(self._download(name))
 
+        # Make every bundle asset (custom .py, elastix parameter maps, lookup tables, …) available in
+        # the run workspace, as documented ("files can live in the app directory and will be available
+        # at runtime"). Model checkpoints (.pt) are handled separately via ``models_path``.
         for filename in filenames:
-            if filename.endswith(".py"):
+            if not filename.endswith(".pt"):
                 codes_path.append((filename, self._download(filename)))
 
-        self._install_requirements(filenames)
+        self._install_requirements(filenames, install_requirements)
 
         return models_path, inference_file_path, codes_path
 
-    def _install_requirements(self, filenames: list[str]) -> None:
-        """Install any missing/outdated packages listed in the app's requirements.txt."""
+    def _install_requirements(self, filenames: list[str], install_requirements: bool = False) -> None:
+        """Install missing/outdated packages listed in the app's requirements.txt.
+
+        Installation is opt-in (``install_requirements=True``) and defaults to a no-op. Core
+        packages (torch, konfai, …) are never installed or altered, and lines that are not
+        PEP 508 requirements (``-r``, ``--extra-index-url``, ``git+https``…) are skipped.
+        """
+        if not install_requirements:
+            return
         requirements_filename = self._find_repo_filename("requirements.txt", filenames)
         if requirements_filename is None:
             return
+        protected = {"torch", "torchvision", "torchaudio", "konfai", "konfai-apps"}
         with open(self._download(requirements_filename), encoding="utf-8") as file:
             required_lines = [line.strip() for line in file if line.strip() and not line.startswith("#")]
         installed = {
@@ -514,8 +569,14 @@ class LocalAppRepository(AppRepositoryInfo):
         }
         missing_or_outdated = []
         for line in required_lines:
-            req = Requirement(line)
+            try:
+                req = Requirement(line)
+            except InvalidRequirement:
+                continue
             name = req.name.lower()
+            if name in protected:
+                print(f"[KonfAI-Apps] Skipping protected requirement '{line}'.")
+                continue
             installed_version_str = installed.get(name)
             if installed_version_str is None:
                 missing_or_outdated.append(line)
@@ -538,20 +599,22 @@ class LocalAppRepository(AppRepositoryInfo):
         return files_path
 
     def download_evaluation(self, evaluation_file: str) -> tuple[Path, list[tuple[str, Path]]]:
-        filenames = self._get_filenames()
+        filenames = self._all_repo_filenames()
         codes_path: list[tuple[str, Path]] = []
-        evaluation_file_path = self._download(self._require_repo_filename(evaluation_file, filenames))
+        config_filename = self._require_repo_filename(evaluation_file, filenames)
+        evaluation_file_path = self._download(config_filename)
         for filename in filenames:
-            if filename.endswith(".py"):
+            if filename != config_filename and not filename.endswith(".pt"):
                 codes_path.append((filename, self._download(filename)))
         return evaluation_file_path, codes_path
 
     def download_uncertainty(self, uncertainty_file: str) -> tuple[Path, list[tuple[str, Path]]]:
-        filenames = self._get_filenames()
+        filenames = self._all_repo_filenames()
         codes_path: list[tuple[str, Path]] = []
-        uncertainty_file_path = self._download(self._require_repo_filename(uncertainty_file, filenames))
+        config_filename = self._require_repo_filename(uncertainty_file, filenames)
+        uncertainty_file_path = self._download(config_filename)
         for filename in filenames:
-            if filename.endswith(".py"):
+            if filename != config_filename and not filename.endswith(".pt"):
                 codes_path.append((filename, self._download(filename)))
         return uncertainty_file_path, codes_path
 
@@ -564,13 +627,23 @@ class LocalAppRepository(AppRepositoryInfo):
         uncertainty: bool,
         prediction_file: str,
         available_vram: float | None,
+        install_requirements: bool = False,
+        forced_patch_size: list[int] | None = None,
+        forced_batch_size: int | None = None,
     ) -> list[Path]:
         if len(name_of_models) == 0 and number_of_model == 0:
             number_of_model = len(self._checkpoints_name)
 
         models_path, inference_file_path, codes_path = self.download_inference(
-            number_of_model, name_of_models, prediction_file
+            number_of_model, name_of_models, prediction_file, install_requirements
         )
+        # Copy every bundle asset into the workspace first, then write (and tweak) the prediction config
+        # last so its modifications are never clobbered by a raw copy of the same file.
+        for repo_filename, code_path in codes_path:
+            dest = Path(repo_filename)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(code_path, dest)
+
         shutil.copy2(inference_file_path, prediction_file)
         self._set_number_of_augmentation(prediction_file, number_of_augmentation)
         # NOTE: `number_of_mc_dropout` is reserved for an upcoming MC-dropout feature
@@ -578,6 +651,10 @@ class LocalAppRepository(AppRepositoryInfo):
         # through but not yet applied to the prediction config.
         if not uncertainty:
             self._disable_uncertainty(prediction_file)
+        # Patch/batch precedence: an explicit override wins; otherwise the app's VRAM plan (largest
+        # threshold that fits the detected free VRAM); otherwise the config's own defaults are left as-is.
+        plan_patch_size: list[int] | None = None
+        plan_batch_size: int | None = None
         if self._vram_plan is not None and available_vram is not None:
             thresholds = sorted(self._vram_plan.keys())
             selected_t = thresholds[0]
@@ -586,33 +663,31 @@ class LocalAppRepository(AppRepositoryInfo):
                     selected_t = threshold
                 else:
                     break
-            vram_plan = self._vram_plan[selected_t]
-            self._set_patch_size_and_batch_size(prediction_file, vram_plan.patch_size, vram_plan.batch_size)
-        for repo_filename, code_path in codes_path:
-            if code_path.suffix == ".py":
-                dest = Path(repo_filename)
-                dest.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(code_path, dest)
+            plan_patch_size = self._vram_plan[selected_t].patch_size
+            plan_batch_size = self._vram_plan[selected_t].batch_size
+        self._set_patch_size_and_batch_size(
+            prediction_file,
+            forced_patch_size if forced_patch_size is not None else plan_patch_size,
+            forced_batch_size if forced_batch_size is not None else plan_batch_size,
+        )
 
         return models_path
 
     def install_evaluation(self, evaluation_file: str) -> None:
         evaluation_file_path, codes_path = self.download_evaluation(evaluation_file)
-        shutil.copy2(evaluation_file_path, evaluation_file)
         for repo_filename, code_path in codes_path:
-            if code_path.suffix == ".py":
-                dest = Path(repo_filename)
-                dest.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(code_path, dest)
+            dest = Path(repo_filename)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(code_path, dest)
+        shutil.copy2(evaluation_file_path, evaluation_file)
 
     def install_uncertainty(self, uncertainty_file: str) -> None:
         uncertainty_file_path, codes_path = self.download_uncertainty(uncertainty_file)
-        shutil.copy2(uncertainty_file_path, uncertainty_file)
         for repo_filename, code_path in codes_path:
-            if code_path.suffix == ".py":
-                dest = Path(repo_filename)
-                dest.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(code_path, dest)
+            dest = Path(repo_filename)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(code_path, dest)
+        shutil.copy2(uncertainty_file_path, uncertainty_file)
 
     def _resolve_fine_tune_models(self, filenames: list[str], name_of_models: list[str]) -> list[tuple[str, Path]]:
         """
@@ -658,6 +733,7 @@ class LocalAppRepository(AppRepositoryInfo):
         epochs: int,
         it_validation: int | None,
         name_of_models: list[str],
+        install_requirements: bool = False,
     ) -> list[tuple[str, Path]]:
         """
         Install the app assets needed for fine-tuning and resolve the selected checkpoint(s).
@@ -678,7 +754,7 @@ class LocalAppRepository(AppRepositoryInfo):
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(self._download(filename), dest)
 
-        self._install_requirements(filenames)
+        self._install_requirements(filenames, install_requirements)
 
         metadata_file = path / "app.json"
         config_file_path = path / config_file
@@ -845,9 +921,6 @@ class LocalAppRepositoryFromHF(LocalAppRepository):
         base_repo_id, revision = LocalAppRepositoryFromHF._split_repo_reference(repo_id)
         if force_update:
             try:
-                from huggingface_hub.constants import HF_HUB_CACHE
-                from huggingface_hub.file_download import repo_folder_name
-
                 filename_path = PurePosixPath(filename)
                 if len(filename_path.parts) < 2:
                     raise AppRepositoryError(
@@ -855,17 +928,6 @@ class LocalAppRepositoryFromHF(LocalAppRepository):
                     )
                 app_name = filename_path.parts[0]
                 allow_patterns = LocalAppRepositoryFromHF._get_sync_patterns(repo_id, app_name, filename)
-
-                lock_path = (
-                    Path(HF_HUB_CACHE)
-                    / ".locks"
-                    / repo_folder_name(
-                        repo_id=base_repo_id,
-                        repo_type="model",
-                    )
-                )
-                if lock_path.is_dir():
-                    shutil.rmtree(lock_path)
 
                 snapshot_dir = snapshot_download(
                     repo_id=base_repo_id,

--- a/konfai-apps/konfai_apps/app_server.py
+++ b/konfai-apps/konfai_apps/app_server.py
@@ -568,6 +568,7 @@ def get_app_info(app_id: str):
         "checkpoints_name_available": app.get_checkpoints_name_available(),
         "maximum_tta": app.get_maximum_tta(),
         "mc_dropout": app.get_mc_dropout(),
+        "patch_size": app.get_patch_size(),
         "has_capabilities": app.has_capabilities(),
     }
     terminology = app.get_terminology()

--- a/konfai-apps/konfai_apps/cli.py
+++ b/konfai-apps/konfai_apps/cli.py
@@ -6,6 +6,7 @@ import argparse
 import importlib.metadata
 import json
 import os
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -99,6 +100,262 @@ def add_common_konfai_apps(parser: argparse.ArgumentParser, with_uncertainty: bo
     if not with_uncertainty:
         kwargs["uncertainty"] = False
     return kwargs
+
+
+def _resolved_path(value: str) -> Path:
+    return Path(value).resolve()
+
+
+def _positive_int(value: str) -> int:
+    ivalue = int(value)
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError("CPU value must be > 0")
+    return ivalue
+
+
+def _add_app_io(parser: argparse.ArgumentParser) -> None:
+    """Add the input/output/device options shared by every app operation."""
+    parser.add_argument(
+        "-i",
+        "--inputs",
+        type=_resolved_path,
+        nargs="+",
+        action="append",
+        required=True,
+        help="Input path(s): one or multiple volume files, or a dataset directory.",
+    )
+    parser.add_argument(
+        "-o", "--output", type=_resolved_path, default=Path("./Output").resolve(), help="Output directory / file."
+    )
+    parser.add_argument(
+        "--tmp-dir",
+        "--tmp_dir",
+        dest="tmp_dir",
+        type=_resolved_path,
+        default=None,
+        help="Temporary directory (optional).",
+    )
+    device = parser.add_mutually_exclusive_group()
+    device.add_argument(
+        "--gpu", type=int, nargs="+", default=[], help="GPU device ids, e.g. '0' or '0 1'. CPU if omitted."
+    )
+    device.add_argument("--cpu", type=_positive_int, default=None, help="Run on CPU using N worker processes.")
+    parser.add_argument("-q", "--quiet", action="store_true", help="Suppress console output.")
+    parser.add_argument("--download", action="store_true", help="Download the full KonfAI app upfront.")
+    parser.add_argument("--force_update", action="store_true", help="Refresh required app files before running.")
+
+
+def _add_gt(parser: argparse.ArgumentParser, required: bool) -> None:
+    parser.add_argument(
+        "--gt",
+        type=_resolved_path,
+        nargs="+",
+        action="append",
+        required=required,
+        help="Ground-truth path(s): one or multiple data files, or a dataset directory.",
+    )
+
+
+def _add_mask(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--mask", type=_resolved_path, nargs="+", action="append", help="Optional evaluation mask path(s)."
+    )
+
+
+def _add_patch_overrides(parser: argparse.ArgumentParser) -> None:
+    """Add the optional patch/batch overrides (``--patch-size`` / ``--batch-size``).
+
+    When omitted the app follows its VRAM plan (or the config default); when given they force the
+    inference ``Patch.patch_size`` / ``batch_size``. A single ``--patch-size`` value is an isotropic cube.
+    """
+    parser.add_argument(
+        "--patch-size",
+        "--patch_size",
+        dest="patch_size",
+        type=int,
+        nargs="+",
+        default=None,
+        help="Override the inference patch size, e.g. '192' (cube) or '192 192 192'. Default: VRAM plan / config.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        "--batch_size",
+        dest="batch_size",
+        type=int,
+        default=None,
+        help="Override the inference batch size. Default: VRAM plan / config.",
+    )
+
+
+def build_app_cli(
+    prog: str,
+    description: str,
+    *,
+    resolve_app: Callable[[argparse.Namespace], str],
+    add_selection: Callable[[argparse.ArgumentParser], None] | None = None,
+    add_infer_knobs: Callable[[argparse.ArgumentParser], None] | None = None,
+    resolve_infer: Callable[[argparse.Namespace], dict[str, Any]] | None = None,
+    infer_command: str = "infer",
+    with_uncertainty: bool = True,
+) -> Callable[[], None]:
+    """Build a ``main()`` for a repo-pinned app CLI exposing ``<infer_command>``/eval/uncertainty/pipeline.
+
+    The set of *operations* is uniform across apps, but the *arguments* stay domain-specific through hooks:
+
+    - ``resolve_app(args) -> "repo:app"``          resolves the pinned app id from the parsed selection;
+    - ``add_selection(subparser)``                 adds the model/task selection args (shared by every command);
+    - ``add_infer_knobs(subparser)``               adds the inference knobs (ensemble/folds/models/tta/mc …);
+    - ``resolve_infer(args) -> dict``              maps those knobs to ``KonfAIApp.infer`` kwargs.
+
+    ``infer_command`` names the inference operation with the app's own vocabulary (e.g. ``segment``,
+    ``synthesize``); ``with_uncertainty=False`` drops the uncertainty command for models that do not support it.
+    """
+    select = add_selection or (lambda parser: None)
+    knobs = add_infer_knobs or (lambda parser: None)
+    infer_kwargs = resolve_infer or (lambda args: {})
+
+    def main() -> None:
+        parser = argparse.ArgumentParser(
+            prog=prog,
+            description=description,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+            allow_abbrev=False,
+        )
+        subparsers = parser.add_subparsers(dest="command", required=True)
+
+        run_p = subparsers.add_parser(infer_command, help=f"Run {infer_command} (model inference).")
+        select(run_p)
+        _add_app_io(run_p)
+        knobs(run_p)
+        _add_patch_overrides(run_p)
+        if with_uncertainty:
+            run_p.add_argument("-uncertainty", action="store_true", help="Also write the inference stack.")
+        run_p.add_argument(
+            "--prediction-file",
+            "--prediction_file",
+            dest="prediction_file",
+            default="Prediction.yml",
+            help="Prediction config filename inside the app.",
+        )
+
+        eval_p = subparsers.add_parser("eval", help="Evaluate the model against ground-truth labels.")
+        select(eval_p)
+        _add_app_io(eval_p)
+        _add_gt(eval_p, required=True)
+        _add_mask(eval_p)
+        eval_p.add_argument(
+            "--evaluation-file",
+            "--evaluation_file",
+            dest="evaluation_file",
+            default="Evaluation.yml",
+            help="Evaluation config filename inside the app.",
+        )
+
+        if with_uncertainty:
+            unc_p = subparsers.add_parser("uncertainty", help="Compute model uncertainty.")
+            select(unc_p)
+            _add_app_io(unc_p)
+            unc_p.add_argument(
+                "--uncertainty-file",
+                "--uncertainty_file",
+                dest="uncertainty_file",
+                default="Uncertainty.yml",
+                help="Uncertainty config filename inside the app.",
+            )
+
+        pipe_p = subparsers.add_parser(
+            "pipeline", help=f"Run {infer_command}, then evaluation and uncertainty in a single command."
+        )
+        select(pipe_p)
+        _add_app_io(pipe_p)
+        knobs(pipe_p)
+        _add_patch_overrides(pipe_p)
+        _add_gt(pipe_p, required=False)
+        _add_mask(pipe_p)
+        pipe_p.add_argument(
+            "--prediction-file",
+            "--prediction_file",
+            dest="prediction_file",
+            default="Prediction.yml",
+            help="Prediction config filename inside the app.",
+        )
+        pipe_p.add_argument(
+            "--evaluation-file",
+            "--evaluation_file",
+            dest="evaluation_file",
+            default="Evaluation.yml",
+            help="Evaluation config filename inside the app.",
+        )
+        if with_uncertainty:
+            pipe_p.add_argument(
+                "--uncertainty-file",
+                "--uncertainty_file",
+                dest="uncertainty_file",
+                default="Uncertainty.yml",
+                help="Uncertainty config filename inside the app.",
+            )
+            pipe_p.add_argument("-uncertainty", action="store_true", help="Also run the uncertainty workflow.")
+
+        args = parser.parse_args()
+        gpu = [] if args.cpu is not None else args.gpu
+        konfai_app = app_module.KonfAIApp(resolve_app(args), args.download, args.force_update)
+
+        if args.command == infer_command:
+            konfai_app.infer(
+                inputs=args.inputs,
+                output=args.output,
+                tmp_dir=args.tmp_dir,
+                gpu=gpu,
+                cpu=args.cpu,
+                quiet=args.quiet,
+                uncertainty=getattr(args, "uncertainty", False),
+                prediction_file=args.prediction_file,
+                patch_size=args.patch_size,
+                batch_size=args.batch_size,
+                **infer_kwargs(args),
+            )
+        elif args.command == "eval":
+            konfai_app.evaluate(
+                inputs=args.inputs,
+                gt=args.gt,
+                mask=args.mask,
+                output=args.output,
+                tmp_dir=args.tmp_dir,
+                evaluation_file=args.evaluation_file,
+                gpu=gpu,
+                cpu=args.cpu,
+                quiet=args.quiet,
+            )
+        elif args.command == "uncertainty":
+            konfai_app.uncertainty(
+                inputs=args.inputs,
+                output=args.output,
+                tmp_dir=args.tmp_dir,
+                uncertainty_file=args.uncertainty_file,
+                gpu=gpu,
+                cpu=args.cpu,
+                quiet=args.quiet,
+            )
+        elif args.command == "pipeline":
+            konfai_app.pipeline(
+                inputs=args.inputs,
+                gt=args.gt,
+                mask=args.mask,
+                output=args.output,
+                tmp_dir=args.tmp_dir,
+                prediction_file=args.prediction_file,
+                evaluation_file=args.evaluation_file,
+                uncertainty=getattr(args, "uncertainty", False),
+                uncertainty_file=getattr(args, "uncertainty_file", "Uncertainty.yml"),
+                gpu=gpu,
+                cpu=args.cpu,
+                quiet=args.quiet,
+                patch_size=args.patch_size,
+                batch_size=args.batch_size,
+                **infer_kwargs(args),
+            )
+
+    return main
 
 
 def run_download_cli(kwargs: dict[str, Any]) -> None:
@@ -217,6 +474,7 @@ def main_apps() -> None:
     )
     infer_p.add_argument("--tta", type=int, default=0, help="Number of Test-Time Augmentations")
     infer_p.add_argument("--mc", type=int, default=0, help="Monte Carlo dropout samples")
+    _add_patch_overrides(infer_p)
     infer_p.add_argument("-uncertainty", action="store_true", help="If enabled, inference write the inference stack")
     infer_p.add_argument(
         "--prediction-file",
@@ -276,6 +534,7 @@ def main_apps() -> None:
     )
     pipe_p.add_argument("--tta", type=int, default=0, help="Number of Test-Time Augmentations.")
     pipe_p.add_argument("--mc", type=int, default=0, help="Number of Monte Carlo dropout samples.")
+    _add_patch_overrides(pipe_p)
     pipe_p.add_argument(
         "--prediction-file",
         "--prediction_file",
@@ -340,6 +599,13 @@ def main_apps() -> None:
         type=str,
         default="Config.yml",
         help="Training configuration filename inside the app.",
+    )
+    ft_p.add_argument(
+        "--lr",
+        type=float,
+        default=None,
+        help="Override the learning rate. If omitted, the checkpoint learning rate is resumed and the "
+        "scheduler continues; if set, the learning rate restarts from this value.",
     )
 
     bundle_p = subparsers.add_parser(

--- a/konfai-apps/tests/unit/test_app_repository.py
+++ b/konfai-apps/tests/unit/test_app_repository.py
@@ -1,12 +1,10 @@
 import json
+import sys
 from pathlib import Path
 
 import pytest
-from huggingface_hub import constants as hf_constants
-from huggingface_hub import file_download as hf_file_download
-from konfai_apps import app_repository as app_repository_module
-
 from konfai.utils.errors import AppMetadataError
+from konfai_apps import app_repository as app_repository_module
 
 
 def test_get_app_repository_info_rejects_missing_required_metadata_keys(tmp_path: Path) -> None:
@@ -139,17 +137,12 @@ def test_local_hf_download_syncs_non_model_files_for_current_revision(
         def __init__(self, path: str) -> None:
             self.path = path
 
-    cache_dir = tmp_path / "hf-cache"
-    lock_dir = cache_dir / ".locks" / "repo-lock"
-    lock_dir.mkdir(parents=True)
     snapshot_dir = tmp_path / "snapshot"
     (snapshot_dir / "demo_app").mkdir(parents=True)
 
     calls: dict[str, object] = {}
 
     monkeypatch.setattr(app_repository_module, "RepoFolder", DummyFolder)
-    monkeypatch.setattr(hf_constants, "HF_HUB_CACHE", str(cache_dir))
-    monkeypatch.setattr(hf_file_download, "repo_folder_name", lambda repo_id, repo_type: "repo-lock")
     monkeypatch.setattr(app_repository_module.shutil, "rmtree", lambda path: calls.setdefault("removed", str(path)))
     monkeypatch.setattr(
         app_repository_module.LocalAppRepositoryFromHF,
@@ -178,7 +171,7 @@ def test_local_hf_download_syncs_non_model_files_for_current_revision(
     )
 
     assert result == snapshot_dir / "demo_app" / "Inference.yml"
-    assert calls["removed"] == str(lock_dir)
+    assert "removed" not in calls
     assert calls["snapshot"] == {
         "repo_id": "org/demo",
         "repo_type": "model",
@@ -341,7 +334,9 @@ def test_local_hf_download_inference_refreshes_selected_remote_model(
 
     assert models_path == [tmp_path / "CV_0.pt"]
     assert prediction_path == inference_yml
-    assert codes_path == []
+    # download_inference now stages every non-model bundle file (so assets like elastix parameter maps
+    # are available in the run workspace, as the apps docs promise).
+    assert codes_path == [("Inference.yml", inference_yml), ("app.json", app_json)]
     assert get_filenames_calls == [False, False, True]
 
 
@@ -411,6 +406,70 @@ def test_local_directory_nested_uncertainty_file_is_detected(tmp_path: Path) -> 
     repo = app_repository_module.LocalAppRepositoryFromDirectory(app_root.parent, app_root.name)
 
     assert repo.has_capabilities() == (False, False, True)
+
+
+def test_install_evaluation_stages_non_python_assets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    app_root = tmp_path / "repo" / "demo_app"
+    app_root.mkdir(parents=True)
+    (app_root / "app.json").write_text(
+        json.dumps(
+            {
+                "display_name": "Demo App",
+                "description": "Local eval app",
+                "short_description": "Demo",
+                "tta": 0,
+                "mc_dropout": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (app_root / "Evaluation.yml").write_text("Evaluator: {}\n", encoding="utf-8")
+    (app_root / "labels.csv").write_text("id,name\n1,liver\n", encoding="utf-8")
+    (app_root / "helper.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (app_root / "model.pt").write_text("weights", encoding="utf-8")
+
+    repo = app_repository_module.LocalAppRepositoryFromDirectory(app_root.parent, app_root.name)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+
+    repo.install_evaluation("Evaluation.yml")
+
+    assert (workspace / "Evaluation.yml").exists()
+    assert (workspace / "labels.csv").exists()
+    assert (workspace / "helper.py").exists()
+    assert not (workspace / "model.pt").exists()
+
+
+def test_install_uncertainty_stages_non_python_assets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    app_root = tmp_path / "repo" / "demo_app"
+    app_root.mkdir(parents=True)
+    (app_root / "app.json").write_text(
+        json.dumps(
+            {
+                "display_name": "Demo App",
+                "description": "Local uncertainty app",
+                "short_description": "Demo",
+                "tta": 0,
+                "mc_dropout": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (app_root / "Uncertainty.yml").write_text("Predictor: {}\n", encoding="utf-8")
+    (app_root / "lookup.json").write_text("{}\n", encoding="utf-8")
+    (app_root / "model.pt").write_text("weights", encoding="utf-8")
+
+    repo = app_repository_module.LocalAppRepositoryFromDirectory(app_root.parent, app_root.name)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+
+    repo.install_uncertainty("Uncertainty.yml")
+
+    assert (workspace / "Uncertainty.yml").exists()
+    assert (workspace / "lookup.json").exists()
+    assert not (workspace / "model.pt").exists()
 
 
 def _write_two_checkpoint_app(app_root: Path) -> None:
@@ -506,3 +565,69 @@ def test_install_fine_tune_rejects_unknown_checkpoint(tmp_path: Path) -> None:
 
     with pytest.raises(app_repository_module.AppRepositoryError):
         _install_fine_tune(app_root, workspace, ["CV_9"])
+
+
+def _write_app_with_requirements(app_root: Path, requirements: str) -> None:
+    app_root.mkdir(parents=True, exist_ok=True)
+    (app_root / "app.json").write_text(
+        json.dumps(
+            {
+                "display_name": "Demo App",
+                "description": "Local app with requirements",
+                "short_description": "Demo",
+                "tta": 0,
+                "mc_dropout": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (app_root / "requirements.txt").write_text(requirements, encoding="utf-8")
+
+
+def test_install_requirements_is_a_noop_by_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    app_root = tmp_path / "repo" / "demo_app"
+    _write_app_with_requirements(app_root, "konfai-nonexistent-xyz==1.2.3\n")
+    repo = app_repository_module.LocalAppRepositoryFromDirectory(app_root.parent, app_root.name)
+
+    calls: list[object] = []
+    monkeypatch.setattr(app_repository_module.subprocess, "check_call", lambda *args, **kwargs: calls.append(args))
+
+    repo._install_requirements(repo._get_filenames())
+
+    assert calls == []
+
+
+def test_install_requirements_skips_protected_and_non_pep508_lines(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app_root = tmp_path / "repo" / "demo_app"
+    _write_app_with_requirements(
+        app_root,
+        "\n".join(
+            [
+                "# comment line",
+                "-r other-requirements.txt",
+                "--extra-index-url https://example.com/simple",
+                "git+https://github.com/foo/bar.git#egg=bar",
+                "torch==1.0.0",
+                "konfai==0.0.1",
+                "konfai-nonexistent-xyz==1.2.3",
+            ]
+        )
+        + "\n",
+    )
+    repo = app_repository_module.LocalAppRepositoryFromDirectory(app_root.parent, app_root.name)
+
+    captured: list[list[str]] = []
+    monkeypatch.setattr(
+        app_repository_module.subprocess, "check_call", lambda cmd, *args, **kwargs: captured.append(cmd)
+    )
+
+    repo._install_requirements(repo._get_filenames(), install_requirements=True)
+
+    assert len(captured) == 1
+    cmd = captured[0]
+    assert cmd[:5] == [sys.executable, "-m", "pip", "install", "konfai-nonexistent-xyz==1.2.3"]
+    assert "torch==1.0.0" not in cmd
+    assert "konfai==0.0.1" not in cmd
+    assert not any(part.startswith(("-r", "--extra-index-url", "git+")) for part in cmd[4:])

--- a/konfai/data/augmentation.py
+++ b/konfai/data/augmentation.py
@@ -382,16 +382,30 @@ class Scale(EulerTransform):
 
 
 class Flip(DataAugmentation):
-    def __init__(self, f_prob: list[float] = [0.33, 0.33, 0.33]) -> None:
+    def __init__(self, f_prob: list[float] = [0.33, 0.33, 0.33], vector_field: bool = False) -> None:
         super().__init__()
         self.f_prob = f_prob
-        self.flip: dict[int, list[int]] = {}
+        self.vector_field = vector_field
+        self.flip: dict[int, list[list[int]]] = {}
 
     def _state_init(self, index: int, shapes: list[list[int]], caches_attribute: list[Attribute]) -> list[list[int]]:
         prob = torch.rand((len(shapes), len(self.f_prob))) < torch.tensor(self.f_prob)
         dims = torch.tensor([1, 2, 3][: len(self.f_prob)])
         self.flip[index] = [dims[mask].tolist() for mask in prob]
         return shapes
+
+    def _flip(self, tensor: torch.Tensor, dims: list[int]) -> torch.Tensor:
+        result = torch.flip(tensor, dims=dims)
+        # A displacement/vector field (one channel per spatial axis, channel-first [C=(dx,dy,dz),(D),H,W])
+        # is not mirror-invariant: flipping a spatial axis must also negate its component channel
+        # (channel = tensor.dim() - 1 - dim, as channels are in (x,y,z) order and axes are reversed).
+        # Enable ``vector_field`` only in configs whose augmented tensors are single-channel (scalars/masks,
+        # left untouched) or genuine vector fields: any OTHER multi-channel tensor whose channel count
+        # equals the spatial rank (e.g. a 3-contrast volume in 3D) would be wrongly negated by this guard.
+        if self.vector_field and tensor.shape[0] == tensor.dim() - 1:
+            for dim in dims:
+                result[tensor.dim() - 1 - dim] = -result[tensor.dim() - 1 - dim]
+        return result
 
     def _compute(
         self,
@@ -401,11 +415,11 @@ class Flip(DataAugmentation):
     ) -> list[torch.Tensor]:
         results = []
         for tensor, flip in zip(tensors, self.flip[index], strict=False):
-            results.append(torch.flip(tensor, dims=flip))
+            results.append(self._flip(tensor, flip))
         return results
 
     def _inverse(self, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
-        return torch.flip(tensor, dims=self.flip[index][a])
+        return self._flip(tensor, self.flip[index][a])
 
 
 class ColorTransform(DataAugmentation):

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -988,6 +988,33 @@ class InferenceStack(Transform):
         )
 
 
+class Norm(Transform):
+    """Vector magnitude over the trailing component axis.
+
+    Reduces a stacked vector field (e.g. a displacement-field ensemble ``[N, (D), H, W, C]``) to
+    per-sample magnitudes ``[N, (D), H, W]``, typically before ``Variance``/``StandardDeviation``.
+    The trailing tensor axis is the first geometry axis (numpy order is reversed), so that axis is
+    dropped from ``Origin``/``Spacing``/``Direction``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def __call__(self, name: str, tensors: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
+        if "Origin" in cache_attribute:
+            origin = cache_attribute.pop_np_array("Origin")
+            spacing = cache_attribute.pop_np_array("Spacing")
+            direction = cache_attribute.pop_np_array("Direction")
+            rank = len(origin)
+            cache_attribute["Origin"] = origin[1:]
+            cache_attribute["Spacing"] = spacing[1:]
+            cache_attribute["Direction"] = direction.reshape(rank, rank)[1:, 1:].flatten()
+        return torch.linalg.norm(tensors.float(), dim=-1)
+
+    def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
+        return shape[:-1]
+
+
 class Variance(Transform):
     def __init__(self) -> None:
         super().__init__()

--- a/konfai/network/network.py
+++ b/konfai/network/network.py
@@ -677,11 +677,16 @@ class ModuleArgsDict(torch.nn.Module, ABC):
         for module in self._modules.values():
             ModuleArgsDict.init_func(module, init_type, init_gain)
 
-    def named_forward(self, *inputs: torch.Tensor) -> Iterator[tuple[str, torch.Tensor]]:
+    def named_forward(
+        self, *inputs: torch.Tensor, attributes: list[list[Attribute]] | None = None
+    ) -> Iterator[tuple[str, torch.Tensor]]:
         if len(inputs) > 0:
             branchs: dict[str, torch.Tensor] = {}
+            attribute_branchs: dict[str, list[Attribute]] = {}
             for i, sinput in enumerate(inputs):
                 branchs[str(i)] = sinput
+                if attributes is not None and i < len(attributes) and attributes[i] is not None:
+                    attribute_branchs[str(i)] = attributes[i]
 
             out = inputs[0]
             tmp: list[int | str] = []
@@ -719,7 +724,12 @@ class ModuleArgsDict(torch.nn.Module, ABC):
                     else:
                         if isinstance(module, ModuleArgsDict):
                             for k, out in module.named_forward(
-                                *[branchs[i] for i in self._modulesArgs[name].in_branch]
+                                *[branchs[i] for i in self._modulesArgs[name].in_branch],
+                                attributes=(
+                                    [attribute_branchs.get(i, [Attribute()]) for i in self._modulesArgs[name].in_branch]
+                                    if attribute_branchs
+                                    else None
+                                ),
                             ):
                                 for ob in self._modulesArgs[name].out_branch:
                                     if ob in module._modulesArgs[k.split(".")[0].replace(";accu;", "")].out_branch:
@@ -730,7 +740,16 @@ class ModuleArgsDict(torch.nn.Module, ABC):
                                 if ob not in tmp:
                                     branchs[ob] = out
                         elif isinstance(module, torch.nn.Module):
-                            out = module(*[branchs[i] for i in self._modulesArgs[name].in_branch])
+                            if getattr(module, "accepts_attributes", False):
+                                out = module(
+                                    *[branchs[i] for i in self._modulesArgs[name].in_branch],
+                                    attributes=[
+                                        attribute_branchs.get(i, [Attribute()])
+                                        for i in self._modulesArgs[name].in_branch
+                                    ],
+                                )
+                            else:
+                                out = module(*[branchs[i] for i in self._modulesArgs[name].in_branch])
                             for ob in self._modulesArgs[name].out_branch:
                                 branchs[ob] = out
                             yield name, out
@@ -1151,7 +1170,9 @@ class Network(ModuleArgsDict, ABC):
     def initialized(self):
         pass
 
-    def named_forward(self, *inputs: torch.Tensor) -> Iterator[tuple[str, torch.Tensor]]:
+    def named_forward(
+        self, *inputs: torch.Tensor, attributes: list[list[Attribute]] | None = None
+    ) -> Iterator[tuple[str, torch.Tensor]]:
         if self.patch:
             self.patch.load(inputs[0].shape[2:])
             accumulators: dict[str, Accumulator] = {}
@@ -1159,7 +1180,7 @@ class Network(ModuleArgsDict, ABC):
             patch_iterator = self.patch.disassemble(*inputs)
             buffer = []
             for i, patch_input in enumerate(patch_iterator):
-                for name, output_layer in super().named_forward(*patch_input):
+                for name, output_layer in super().named_forward(*patch_input, attributes=attributes):
                     yield f";accu;{name}", output_layer
                     buffer.append((name.split(".")[0], output_layer))
                     if len(buffer) == 2:
@@ -1184,18 +1205,21 @@ class Network(ModuleArgsDict, ABC):
             for name, accumulator in accumulators.items():
                 yield name, accumulator.assemble()
         else:
-            for name, output_layer in super().named_forward(*inputs):
+            for name, output_layer in super().named_forward(*inputs, attributes=attributes):
                 yield name, output_layer
 
     def get_layers(
-        self, inputs: list[torch.Tensor], layers_name: list[str]
+        self,
+        inputs: list[torch.Tensor],
+        layers_name: list[str],
+        attributes: list[list[Attribute]] | None = None,
     ) -> Iterator[tuple[str, torch.Tensor, PatchIndexed | None]]:
         layers_name = layers_name.copy()
         output_layer_accumulator: dict[str, Accumulator] = {}
         output_layer_patch_indexed: dict[str, PatchIndexed] = {}
         it = 0
         debug = "KONFAI_DEBUG" in os.environ
-        for name_tmp, output_layer in self.named_forward(*inputs):
+        for name_tmp, output_layer in self.named_forward(*inputs, attributes=attributes):
             name = name_tmp.replace(";accu;", "")
             if debug:
                 if "KONFAI_DEBUG_LAST_LAYER" in os.environ:
@@ -1294,6 +1318,9 @@ class Network(ModuleArgsDict, ABC):
         for name, layer, patch_indexed in self.get_layers(
             [batch_data_item.tensor for batch_data_item in batch_sample.values() if batch_data_item.is_input],
             list(set(list(measure_output_layers) + output_layers)),
+            attributes=[
+                batch_data_item.attribute for batch_data_item in batch_sample.values() if batch_data_item.is_input
+            ],
         ):
             outputs_group = [outputs_group for outputs_group in self.outputsGroup if name in outputs_group]
 

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -52,6 +52,7 @@ from konfai.utils.runtime import (
     confirm_overwrite_or_raise,
     description,
     run_distributed_app,
+    safe_torch_load,
 )
 from konfai.utils.utils import get_module, split_path_spec
 
@@ -726,7 +727,7 @@ class ModelComposite(Network):
             return source
         if isinstance(source, str) and source.startswith("https://"):
             return torch.hub.load_state_dict_from_url(url=source, map_location="cpu", check_hash=True)
-        return torch.load(str(source), map_location=torch.device("cpu"), weights_only=False)  # nosec B614
+        return safe_torch_load(source, torch.device("cpu"))
 
     def _ensure_model_loaded(self, index: int) -> Network:
         model = self._get_model()
@@ -936,6 +937,13 @@ class Predictor(DistributedObject):
         shutil.copyfile(config_file(), self.predict_path / "Prediction.yml")
 
         self.model_composite = ModelComposite(self.model, self.combine)
+        if not self.path_to_models:
+            raise PredictorError(
+                "No model checkpoint available for prediction.",
+                "At least one '.pt' checkpoint must be provided (for KonfAI Apps, declare it via the "
+                "'models' field in app.json).",
+                "Without a checkpoint the model is never executed and prediction would silently produce no output.",
+            )
         self.model_composite.load(self._load())
 
         self.size = len(self.gpu_checkpoints) + 1 if self.gpu_checkpoints else 1

--- a/tests/unit/test_augmentation_flip.py
+++ b/tests/unit/test_augmentation_flip.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from konfai.data.augmentation import Flip
+from konfai.utils.dataset import Attribute
+
+
+def _flip_all_axes(vector_field: bool) -> Flip:
+    flip = Flip(f_prob=[1.0, 1.0, 1.0], vector_field=vector_field)
+    flip._state_init(0, [[4, 5, 6]], [Attribute()])
+    return flip
+
+
+def test_flip_vector_field_round_trip_is_identity() -> None:
+    # TTA un-flips the model output with ``_inverse``: on a displacement field the compose of
+    # ``_compute`` and ``_inverse`` must be the identity, component signs included.
+    flip = _flip_all_axes(vector_field=True)
+    dvf = torch.randn(3, 4, 5, 6)
+
+    augmented = flip._compute("case", 0, [dvf.clone()])[0]
+
+    assert torch.equal(flip._inverse(0, 0, augmented), dvf)
+
+
+def test_flip_vector_field_negates_flipped_components() -> None:
+    # Mirroring a spatial axis reverses the voxel layout AND the sign of that axis' component channel
+    # (channels are (dx, dy, dz) while tensor axes are reversed: dim 3 = x -> channel 0, ...).
+    flip = _flip_all_axes(vector_field=True)
+    dvf = torch.randn(3, 4, 5, 6)
+
+    augmented = flip._compute("case", 0, [dvf.clone()])[0]
+
+    layout_only = torch.flip(dvf, dims=[1, 2, 3])
+    assert torch.equal(augmented, -layout_only)
+
+
+def test_flip_scalar_data_is_layout_only() -> None:
+    # Single-channel data (images, masks) is mirror-invariant: even with ``vector_field`` enabled the
+    # shared Flip instance must not negate intensities.
+    flip = _flip_all_axes(vector_field=True)
+    volume = torch.randn(1, 4, 5, 6)
+
+    augmented = flip._compute("case", 0, [volume.clone()])[0]
+
+    assert torch.equal(augmented, torch.flip(volume, dims=[1, 2, 3]))
+    assert torch.equal(flip._inverse(0, 0, augmented), volume)
+
+
+def test_flip_default_stays_layout_only_on_vector_data() -> None:
+    # ``vector_field`` is opt-in: existing intensity-TTA bundles keep the historical behaviour.
+    flip = _flip_all_axes(vector_field=False)
+    dvf = torch.randn(3, 4, 5, 6)
+
+    augmented = flip._compute("case", 0, [dvf.clone()])[0]
+
+    assert torch.equal(augmented, torch.flip(dvf, dims=[1, 2, 3]))

--- a/tests/unit/test_resume_lr_override.py
+++ b/tests/unit/test_resume_lr_override.py
@@ -1,0 +1,100 @@
+"""Resume/fine-tune learning-rate override semantics for ``Network.load``.
+
+Without ``override_lr`` a resume must keep the checkpoint (decayed) learning rate and
+let the scheduler continue from ``_nb_lr_update``. With ``override_lr`` the learning
+rate must restart from the requested value and the scheduler must decay from there.
+"""
+
+import torch
+from konfai.metric.schedulers import PolyLRScheduler
+from konfai.network.network import Network
+
+_CONFIG_LR = 0.1
+_GAMMA = 0.5
+_NB_LR_UPDATE = 3
+
+
+class _LeafNet(Network):
+    """Minimal concrete network with no sub-networks, driving ``Network.load`` directly."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+
+def _fresh_optimizer() -> torch.optim.Optimizer:
+    param = torch.nn.Parameter(torch.zeros(1))
+    return torch.optim.SGD([param], lr=_CONFIG_LR)
+
+
+def _decayed_optimizer_state() -> tuple[dict, float]:
+    """Optimizer state as saved by a checkpoint after ``_NB_LR_UPDATE`` StepLR decays."""
+    optimizer = _fresh_optimizer()
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=_GAMMA)
+    for _ in range(_NB_LR_UPDATE):
+        scheduler.step()
+    return optimizer.state_dict(), optimizer.param_groups[0]["lr"]
+
+
+def _make_net(scheduler_factory) -> tuple[_LeafNet, torch.optim.lr_scheduler.LRScheduler, dict]:
+    net = _LeafNet()
+    optimizer = _fresh_optimizer()
+    scheduler = scheduler_factory(optimizer)
+    net.optimizer = optimizer
+    net.schedulers = {scheduler: 0}
+    net._it = 0
+    net._nb_lr_update = 0
+    optimizer_state, decayed_lr = _decayed_optimizer_state()
+    state_dict = {
+        f"{net.get_name()}_optimizer_state_dict": optimizer_state,
+        f"{net.get_name()}_nb_lr_update": _NB_LR_UPDATE,
+    }
+    return net, scheduler, {"state_dict": state_dict, "decayed_lr": decayed_lr}
+
+
+def test_resume_without_override_keeps_decayed_lr_and_restores_scheduler() -> None:
+    net, scheduler, ctx = _make_net(lambda opt: torch.optim.lr_scheduler.StepLR(opt, step_size=1, gamma=_GAMMA))
+
+    net.load(ctx["state_dict"], init=False, ema=False)
+
+    # The decayed learning rate from the checkpoint is preserved (not reset to the config LR).
+    assert net.optimizer.param_groups[0]["lr"] == ctx["decayed_lr"]
+    assert net.optimizer.param_groups[0]["lr"] != _CONFIG_LR
+    # The scheduler continues from where it left off instead of restarting at 0.
+    assert scheduler.last_epoch == _NB_LR_UPDATE
+
+
+def test_resume_with_override_restarts_lr_and_scheduler() -> None:
+    override = 0.02
+    net, scheduler, ctx = _make_net(lambda opt: torch.optim.lr_scheduler.StepLR(opt, step_size=1, gamma=_GAMMA))
+
+    net.load(ctx["state_dict"], init=False, ema=False, override_lr=override)
+
+    # The learning rate is forced to the override, and the schedule restarts from it.
+    assert net.optimizer.param_groups[0]["lr"] == override
+    assert net.optimizer.param_groups[0]["initial_lr"] == override
+    assert scheduler.base_lrs == [override]
+    assert scheduler.last_epoch == 0
+
+    # Decaying from the override reproduces a fresh schedule anchored at ``override``.
+    scheduler.step()
+    assert net.optimizer.param_groups[0]["lr"] == override * _GAMMA
+
+
+def test_resume_with_override_restarts_polylr_from_value() -> None:
+    override = 0.05
+    max_steps = 100
+    exponent = 0.9
+    net, scheduler, ctx = _make_net(
+        lambda opt: PolyLRScheduler(opt, initial_lr=_CONFIG_LR, max_steps=max_steps, exponent=exponent)
+    )
+
+    net.load(ctx["state_dict"], init=False, ema=False, override_lr=override)
+
+    assert net.optimizer.param_groups[0]["lr"] == override
+    assert scheduler.initial_lr == override
+    assert scheduler.last_epoch == 0
+
+    scheduler.step()
+    assert net.optimizer.param_groups[0]["lr"] == override * (1 - 0 / max_steps) ** exponent
+    scheduler.step()
+    assert net.optimizer.param_groups[0]["lr"] == override * (1 - 1 / max_steps) ** exponent

--- a/tests/unit/test_transform_norm.py
+++ b/tests/unit/test_transform_norm.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import torch
+from konfai.data.transform import Norm
+from konfai.utils.dataset import Attribute
+
+
+def _stack_attribute() -> Attribute:
+    # Geometry of a displacement-field stack: the leading image axis holds the vector components
+    # (origin 0 / spacing 1 / identity direction row), the remaining axes carry the fixed grid.
+    attribute = Attribute()
+    attribute["Origin"] = np.asarray([0.0, 1.0, 2.0, 3.0])
+    attribute["Spacing"] = np.asarray([1.0, 2.0, 2.0, 2.0])
+    direction = np.eye(4)
+    direction[1:, 1:] = np.diag([1.0, -1.0, 1.0])
+    attribute["Direction"] = direction.flatten()
+    return attribute
+
+
+def test_norm_reduces_trailing_component_axis_and_geometry() -> None:
+    # A stack of 2 displacement fields [N=2, D, H, W, C=3] -> per-sample magnitudes [2, D, H, W].
+    tensors = torch.randn(2, 4, 5, 6, 3)
+    attribute = _stack_attribute()
+
+    out = Norm()("case", tensors, attribute)
+
+    assert list(out.shape) == [2, 4, 5, 6]
+    assert torch.allclose(out, torch.linalg.norm(tensors, dim=-1))
+    # The reduced trailing tensor axis is the first geometry axis: it must be dropped.
+    assert attribute.get_np_array("Origin").tolist() == [1.0, 2.0, 3.0]
+    assert attribute.get_np_array("Spacing").tolist() == [2.0, 2.0, 2.0]
+    assert attribute.get_np_array("Direction").tolist() == np.diag([1.0, -1.0, 1.0]).flatten().tolist()
+
+
+def test_norm_transform_shape_drops_trailing_axis() -> None:
+    assert Norm().transform_shape("group", "case", [4, 5, 6, 3], Attribute()) == [4, 5, 6]


### PR DESCRIPTION
> 📚 **Stacked on #16** (`pr/audit`). The diff is against `pr/audit` — review #16 first.

## Summary

Adds the core building blocks the registration apps need and hardens the KonfAI Apps inference path.

Core: a vector-field-aware `Flip` augmentation, a `Norm` magnitude transform, an optional geometry (`Attribute`) channel threaded through the network forward, and a fail-fast guard when no checkpoint is supplied.

Apps: the per-app CLIs are refactored onto a single `build_app_cli` factory, `--patch-size`/`--batch-size` inference overrides are plumbed end-to-end, *all* non-checkpoint bundle assets are staged into the workspace (not just `.py`), and app-requirement installation becomes opt-in and hardened.

These are the primitives the stacked seg/reg apps (`#18`/`#19`) build on.

## What changed

### Core — registration primitives (`konfai/`)
- **`data/augmentation.py`: `Flip` gains a `vector_field: bool` flag.** A new `_flip()` helper (shared by `_compute` and `_inverse`) negates the component channel matching each flipped spatial axis (`channel = tensor.dim() - 1 - dim`) only when the tensor is a genuine displacement/vector field (`tensor.shape[0] == tensor.dim() - 1`). The default (`vector_field=False`) path and scalars/masks are unchanged; an inline comment flags the multi-contrast edge case the channel-count guard cannot distinguish.
- **`data/transform.py`: new `Norm` transform.** Reduces a stacked vector field over its trailing component axis via `torch.linalg.norm(dim=-1)` (e.g. a displacement-field ensemble `[N,(D),H,W,C]` → per-sample magnitudes `[N,(D),H,W]`), drops that axis from `Origin`/`Spacing`/`Direction`, and reports the reduced shape in `transform_shape()` (`shape[:-1]`) so patch planning stays correct. Intended to precede `Variance`/`StandardDeviation`.
- **`network/network.py`: optional `attributes` channel through the forward.** `ModuleArgsDict.named_forward`, `Network.named_forward`, and `Network.get_layers` now accept `attributes: list[list[Attribute]] | None`, thread a parallel `attribute_branchs` register alongside the tensor branches, recurse into nested `ModuleArgsDict`, and pass `attributes=` to leaf modules that declare `accepts_attributes = True` (all others keep the old call signature). The measure path sources them from each input `batch_data_item.attribute`, letting geometry-aware registration modules read `Origin`/`Spacing`/`Direction` during forward.
- **`predictor.py`: safer load + fail-fast on missing weights.** `ModelComposite` loads local checkpoints via `safe_torch_load(...)` instead of raw `torch.load(..., weights_only=False)`, and `Predictor` now raises `PredictorError` when `path_to_models` is empty instead of silently running no model and producing no output.

### Apps — CLI factory (`konfai-apps/konfai_apps/cli.py` + `apps/*`)
- **New `build_app_cli(...)` factory** produces a subcommand `main()` exposing a uniform operation set (`<infer_command>`/`eval`/`uncertainty`/`pipeline`) while keeping arguments domain-specific through hooks (`resolve_app`, `add_selection`, `add_infer_knobs`, `resolve_infer`). `infer_command` renames the inference verb per domain and `with_uncertainty=False` drops the uncertainty command. Shared arg builders: `_add_app_io`, `_add_gt`, `_add_mask`, `_add_patch_overrides`.
- **Per-app CLIs migrated** onto the factory: `impact_synth` (`synthesize`; ensemble/tta/mc knobs), `mrsegmentator` (`segment`; `--folds`), `totalsegmentator` (`segment`; `--models`, `with_uncertainty=False`).

### Apps — inference overrides & metadata
- **`--patch-size` / `--batch-size` overrides** plumbed end-to-end: CLI (`_add_patch_overrides`, also wired into `main_apps` infer/pipeline) → `KonfAIApp.infer`/`pipeline` → `install_inference(forced_patch_size=, forced_batch_size=)` → `_set_patch_size_and_batch_size`. Precedence is explicit override → VRAM plan → config default; a single `--patch-size` value is broadcast to the config's spatial dimensionality (isotropic cube), and `_set_patch_size_and_batch_size` writes only the values supplied (no-op when both are `None`).
- **`patch_size` surfaced as app metadata**: parsed from `app.json`, exposed via `AppRepositoryInfo.get_patch_size()`, and returned in `app_server.get_app_info` for UI patch controls.
- **Fine-tune `--lr` flag** added to the `fine-tune` subparser, forwarded through `fine_tune(...)` to the existing `Network.load(override_lr=...)` resume-override path.

### Apps — asset staging & requirement safety (`app_repository.py`)
- **Stage all non-checkpoint assets.** `download_inference`/`download_evaluation`/`download_uncertainty` now copy every bundle file except `.pt` (custom `.py`, elastix parameter maps, lookup tables, …) into the workspace, and the config file is written *last* so its patch/batch tweaks are never clobbered by a raw copy. New `_all_repo_filenames()` refreshes the file list from the HF tree (metadata-only, cache-backed) so lazily-populated snapshots don't miss assets, falling back to the local snapshot when offline.
- **Opt-in, hardened requirement install.** `_install_requirements(..., install_requirements=False)` defaults to a no-op, skips protected core packages (`torch`, `torchvision`, `torchaudio`, `konfai`, `konfai-apps`), and skips non-PEP 508 lines (`-r`, `--extra-index-url`, `git+https`, …) via an `InvalidRequirement` guard.
- **HF force-update simplification.** Dropped the manual deletion of the HF cache `.locks` directory (and its `HF_HUB_CACHE`/`repo_folder_name` imports) in `LocalAppRepositoryFromHF`, relying on `snapshot_download`.

### Docs & misc
- App READMEs gain VRAM / performance sections; root `README.md` install hint uses `.[imaging]`; `examples/README.md` corrects the custom-module filename (`UNetpp.py` → `Model.py`).
- `.gitignore` stops ignoring `apps/impact_reg` / `apps/impact_seg` and adds `build/`.

## Testing

New regression tests:
- `tests/unit/test_augmentation_flip.py` — vector-field round-trip identity, component-channel negation on flip, scalar data stays layout-only, and the default (`vector_field=False`) stays layout-only on vector data.
- `tests/unit/test_transform_norm.py` — trailing-axis reduction with geometry update, and `transform_shape()` dropping the trailing axis.
- `tests/unit/test_resume_lr_override.py` — resume without override keeps the decayed LR and restores the scheduler; with override the LR/scheduler restart from the requested value (incl. `PolyLRScheduler`).
- `konfai-apps/tests/unit/test_app_repository.py` — `install_evaluation`/`install_uncertainty` stage non-Python assets; `_install_requirements` is a no-op by default and skips protected / non-PEP 508 lines.

## Review notes

- **Stacked PR** — base is `pr/audit` (`#16`); review only the `pr/audit..pr/modif-core` range.
- **Backward compatible.** `Flip.vector_field` defaults to `False`, `Norm` is new, and the network `attributes` argument is optional with leaf modules opted in via `accepts_attributes` — existing configs and models behave exactly as before.
- **Behaviour changes to note:** app requirement installation is now opt-in (previously ran during install); inference stages every non-`.pt` asset rather than only `.py` files (intentional, so registration bundles reach the workspace); and an empty checkpoint set is now a hard `PredictorError` instead of a silent no-op.
- **Watch area:** the `Flip` component-negation guard keys on channel-count == spatial-rank, so `vector_field=True` should only be set on configs whose augmented tensors are scalars/masks or true vector fields (see the inline comment on the multi-contrast case).
