### PR TITLE
feat(apps): add impact-seg-konfai segmentation CLI wrapper

### DIFF
--- a/apps/impact_seg/.gitignore
+++ b/apps/impact_seg/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+build/
+*.egg-info/

--- a/apps/impact_seg/LICENSE
+++ b/apps/impact_seg/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/impact_seg/README.md
+++ b/apps/impact_seg/README.md
@@ -1,0 +1,159 @@
+[![License](https://img.shields.io/badge/license-Apache%202.0-green.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+[![PyPI version](https://img.shields.io/pypi/v/impact_seg_konfai.svg?color=blue)](https://pypi.org/project/impact_seg_konfai/)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
+[![CI](https://github.com/vboussot/KonfAI/actions/workflows/konfai_ci.yml/badge.svg)](https://github.com/vboussot/KonfAI/actions/workflows/konfai_ci.yml)
+[![Paper](https://img.shields.io/badge/📌%20Paper-KonfAI-blue)](https://www.arxiv.org/abs/2508.09823)
+
+# IMPACT-Seg-KonfAI
+
+**Fast and lightweight CLI for multimodal anatomical segmentation using IMPACT-Seg models within the KonfAI framework.**
+
+---
+
+## 🧩 Overview
+
+**IMPACT-Seg-KonfAI** is a lightweight **command-line interface (CLI)** for running **IMPACT-Seg** models through the
+[KonfAI](https://github.com/vboussot/KonfAI) deep learning framework.
+
+It provides a simple way to perform **anatomical segmentation inference**, **evaluation**, **ensembling**, and
+**uncertainty estimation** on medical image volumes.
+
+The underlying **IMPACT-Seg** models are **multimodal anatomical segmentation** networks built around a **2.5D U-Net
+with a residual encoder**. A single model segments **CBCT, MR, and CT** scans into a **consistent label space**,
+enabling cross-modality workflows without per-modality retraining.
+
+Pretrained models are automatically downloaded from
+[Hugging Face Hub](https://huggingface.co/VBoussot/ImpactSeg).
+
+---
+
+## 🧠 Features
+
+- ⚡ **Fast inference** powered by [KonfAI](https://github.com/vboussot/KonfAI)
+- 🤗 **Automatic model download** from Hugging Face
+- 🧩 **Multi-model ensembling** and **test-time augmentation (TTA)**
+- 🧠 **Supports evaluation workflows with reference data, and uncertainty estimation without reference**
+- 🧾 **Multi-format compatibility:** supports all major medical image formats handled by ITK
+
+---
+
+## 🗂️ Available models
+
+Model identifiers are resolved dynamically from the [`VBoussot/ImpactSeg`](https://huggingface.co/VBoussot/ImpactSeg)
+repository and passed as the first positional argument.
+
+| Model | Modalities | Labels | Training cohort |
+|-------|------------|--------|-----------------|
+| `body` | CBCT · MR · CT | 11 | 232 CBCT + 282 MR + 955 CT |
+
+The **`body`** model predicts **11 anatomical labels** spanning soft tissues, cavities, bones, and central structures:
+
+| # | Label | # | Label |
+|---|-------|---|-------|
+| 1 | subcutaneous_tissue | 7 | pericardium |
+| 2 | muscle | 8 | prosthetic_breast_implant |
+| 3 | abdominal_cavity | 9 | mediastinum |
+| 4 | thoracic_cavity | 10 | spinal_cord |
+| 5 | bones | 11 | brain |
+| 6 | gland_structure | | |
+
+---
+
+## 🚀 Installation
+
+From PyPI:
+
+```bash
+python -m pip install impact-seg-konfai
+```
+
+From source:
+
+```bash
+git clone https://github.com/vboussot/KonfAI.git
+python -m pip install -e apps/impact_seg
+```
+
+---
+
+## ⚙️ Usage
+
+The CLI is organised into sub-commands, mirroring the KonfAI Apps operations:
+
+| Sub-command | Purpose |
+|---|---|
+| `segment` | Run the segmentation (inference). |
+| `eval` | Evaluate a segmentation against a reference. |
+| `uncertainty` | Estimate uncertainty (TTA / MC-dropout / ensemble spread). |
+| `pipeline` | Segment, then evaluate and estimate uncertainty in one command. |
+
+Run anatomical segmentation on an input volume:
+
+```bash
+impact-seg-konfai segment body -i path/to/image.nii.gz -o ./Output/
+```
+
+Evaluate against a reference, or run everything at once:
+
+```bash
+impact-seg-konfai eval body -i image.nii.gz --gt reference_mask.nii.gz -o ./Output/
+impact-seg-konfai pipeline body -i image.nii.gz --gt reference_mask.nii.gz --mask eval_mask.nii.gz --gpu 0 --tta 2 -uncertainty
+```
+
+### Arguments
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `MODEL` | Model name on `VBoussot/ImpactSeg` (e.g. `body`) — determines what is predicted | *required* |
+| `-i`, `--inputs` | Input file(s) or a dataset directory | *required* |
+| `-o`, `--output` | Output directory | `./Output/` |
+| `--ensemble` | Number of models to ensemble (`segment` / `pipeline`) | `0` |
+| `--tta` | Number of test-time augmentations (`segment` / `pipeline`) | `0` |
+| `--mc` | Monte Carlo dropout samples (`segment` / `pipeline`) | `0` |
+| `-uncertainty` | Also write the inference stack (`segment` / `pipeline`) | `False` |
+| `--gt` | Reference labels — required by `eval`, optional in `pipeline` | *unset* |
+| `--mask` | Evaluation mask(s) (`eval` / `pipeline`) | *unset* |
+| `--gpu` | GPU id(s), e.g. `0` or `0 1` | CPU if unset |
+| `--cpu` | Number of CPU worker processes | *unset* |
+| `-q`, `--quiet` | Suppress console output | `False` |
+
+> When `--ensemble`, `--tta`, and `--mc` are left at `0`, the values declared in the app bundle (`app.json`) are used.
+
+See the full help of any sub-command with:
+
+```bash
+impact-seg-konfai segment --help
+```
+
+---
+
+## 📚 References
+
+If you use **IMPACT-Seg-KonfAI** in your work, please cite KonfAI along with the IMPACT-Seg materials associated with
+the model release you use.
+
+- Boussot, V., & Dillenseger, J.-L. (2025).
+  **KonfAI: A Modular and Fully Configurable Framework for Deep Learning in Medical Imaging.**
+  arXiv preprint [arXiv:2508.09823](https://arxiv.org/abs/2508.09823)
+
+---
+
+## ⚡ Performance & VRAM
+
+Benchmarked on an **NVIDIA RTX PRO 5000 (24 GB)**, synthetic data, patch `[1, 192, 192]`, single model (`Mean`). The app **auto-selects the batch size from your free GPU VRAM** (`vram_plan`); override it in SlicerKonfAI (⚙ **Advanced**) or on the CLI with `--patch-size` / `--batch-size`.
+
+| Free VRAM | Batch (auto) | Peak VRAM |
+|:--|:--|:--|
+| 8 GB  | 160 | ~7 GB |
+| 16 GB | 320 | ~14 GB |
+| 24 GB | 512 | ~22 GB |
+
+Measured peak VRAM: batch 64 → 3.1 GB · 128 → 5.8 GB · 256 → 8.5 GB · 512 → 22.4 GB. Inference ≈ **16 s / case** on the benchmark volume (scales with the case size).
+
+---
+
+## 🔗 Links
+
+- 🤗 **Model Hub:** [huggingface.co/VBoussot/ImpactSeg](https://huggingface.co/VBoussot/ImpactSeg)
+- 📦 **PyPI Package:** [pypi.org/project/impact_seg_konfai](https://pypi.org/project/impact_seg_konfai)
+- 🧠 **KonfAI Repository:** [github.com/vboussot/KonfAI](https://github.com/vboussot/KonfAI)

--- a/apps/impact_seg/impact_seg_konfai/__init__.py
+++ b/apps/impact_seg/impact_seg_konfai/__init__.py
@@ -1,0 +1,1 @@
+"""Python package for the IMPACT-Seg KonfAI app wrapper."""

--- a/apps/impact_seg/impact_seg_konfai/cli.py
+++ b/apps/impact_seg/impact_seg_konfai/cli.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Command-line wrapper for running IMPACT-Seg through KonfAI Apps.
+
+Exposes the app operations with segmentation vocabulary: ``segment`` / ``eval`` / ``uncertainty`` / ``pipeline``.
+"""
+
+import argparse
+
+from konfai_apps.cli import build_app_cli
+
+IMPACT_SEG_KONFAI_REPO = "VBoussot/ImpactSeg"
+
+
+def _add_selection(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "model",
+        help="Which published IMPACT-Seg model to use. An unknown name is reported when the app is resolved.",
+    )
+
+
+def _add_infer_knobs(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--ensemble", type=int, default=0, help="Size of model ensemble.")
+    parser.add_argument("--tta", type=int, default=0, help="Number of Test-Time Augmentations.")
+    parser.add_argument("--mc", type=int, default=0, help="Monte Carlo dropout samples.")
+
+
+main = build_app_cli(
+    "impact-seg-konfai",
+    "IMPACT-Seg (KonfAI app wrapper): multimodal segmentation.",
+    resolve_app=lambda args: f"{IMPACT_SEG_KONFAI_REPO}:{args.model}",
+    add_selection=_add_selection,
+    add_infer_knobs=_add_infer_knobs,
+    resolve_infer=lambda args: {"ensemble": args.ensemble, "ensemble_models": [], "tta": args.tta, "mc": args.mc},
+    infer_command="segment",
+)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/impact_seg/pyproject.toml
+++ b/apps/impact_seg/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=68", "wheel", "setuptools-scm>=8"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "impact-seg-konfai"
+dynamic = ["version", "dependencies"]
+description = "Fast and lightweight CLI for anatomical segmentation with 2.5D U-Net models using a residual encoder within the KonfAI framework."
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.10"
+
+authors = [
+  { name = "Valentin Boussot", email = "boussot.v@gmail.com" }
+]
+
+[project.urls]
+Homepage = "https://github.com/vboussot/KonfAI"
+Repository = "https://github.com/vboussot/KonfAI"
+Issues = "https://github.com/vboussot/KonfAI/issues"
+License = "https://www.apache.org/licenses/LICENSE-2.0"
+
+[project.scripts]
+impact-seg-konfai = "impact_seg_konfai.cli:main"
+
+[tool.setuptools_scm]
+root = "../.."
+tag_regex = "^v(?P<version>.*)$"
+local_scheme = "no-local-version"

--- a/apps/impact_seg/setup.py
+++ b/apps/impact_seg/setup.py
@@ -1,0 +1,20 @@
+from email import message_from_string
+from pathlib import Path
+
+from setuptools import setup
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _release_version() -> str:
+    pkg_info = Path(__file__).with_name("PKG-INFO")
+    if pkg_info.exists():
+        return message_from_string(pkg_info.read_text())["Version"]
+    from setuptools_scm import get_version
+
+    return get_version(root=str(_ROOT), tag_regex=r"^v(?P<version>.*)$", local_scheme="no-local-version")
+
+
+_version = _release_version()
+
+setup(install_requires=[f"konfai=={_version}", f"konfai-apps=={_version}"])


### PR DESCRIPTION
> 📚 **Stacked on #17** (`pr/modif-core`). The diff is against `pr/modif-core`.

## Summary

Adds `impact-seg-konfai`, a thin, pip-installable CLI wrapper that runs the published **IMPACT-Seg** models through KonfAI Apps. These are 2.5D residual-encoder U-Nets that segment CBCT, MR, and CT into a single consistent label space; the bundle gives them a `segment` / `eval` / `uncertainty` / `pipeline` command surface without users hand-writing configs or resolving Hugging Face repos manually. Purely additive: a new `apps/impact_seg/` bundle built on the `konfai_apps` public API introduced earlier in the stack — no core or `konfai-apps` changes.

## What changed

**New app bundle — `apps/impact_seg/`** (excluded from the `konfai` wheel, like the other `apps/*` wrappers).

- **CLI (`impact_seg_konfai/cli.py`)** — builds `main` via `konfai_apps.cli.build_app_cli`:
  - `resolve_app` pins the app id to `VBoussot/ImpactSeg:<model>` (`IMPACT_SEG_KONFAI_REPO = "VBoussot/ImpactSeg"`), so the model is chosen by a single positional `model` argument (`_add_selection`); an unknown name is reported at app-resolution time.
  - `_add_infer_knobs` adds `--ensemble`, `--tta`, and `--mc` (all `int`, default `0`); `resolve_infer` returns the `infer` kwargs `{"ensemble", "ensemble_models": [], "tta", "mc"}`.
  - `infer_command="segment"` renames the inference operation, giving sub-commands `segment` / `eval` / `uncertainty` / `pipeline`.
- **Packaging (`pyproject.toml`)** — distribution `impact-seg-konfai` with `dynamic = ["version", "dependencies"]`; `setuptools_scm` rooted at the repo root (`root = "../.."`, `tag_regex = "^v(?P<version>.*)$"`, `local_scheme = "no-local-version"`); registers the `impact-seg-konfai = impact_seg_konfai.cli:main` console script.
- **Version/deps resolution (`setup.py`)** — `_release_version()` reads `Version` from `PKG-INFO` when building from an sdist, otherwise falls back to `setuptools_scm.get_version`, then pins `install_requires=["konfai==<v>", "konfai-apps==<v>"]` to lock the wrapper to matching core and apps releases.
- **Housekeeping** — `impact_seg_konfai/__init__.py` (package docstring), `.gitignore`, and Apache-2.0 `LICENSE` (SPDX header on `cli.py`).
- **`README.md`** — documents the `body` model (11 anatomical labels across CBCT/MR/CT), the four sub-commands and all flags, PyPI/source installation, automatic model download from `VBoussot/ImpactSeg`, and a Performance & VRAM section (auto batch-size selection via `vram_plan`, overridable with `--patch-size` / `--batch-size`).

## Testing

No tests are added or modified — `git diff --name-only pr/modif-core..pr/seg` touches only `apps/impact_seg/*` (7 files, +468). The CLI is a declarative wrapper over `konfai_apps.cli.build_app_cli`, which already exists on the base branch and is covered by the `konfai-apps/tests` suite; the new surface is limited to the callbacks and packaging metadata above.

## Review notes

- **Stacked PR** — base is `pr/modif-core` (#17); review only the `apps/impact_seg/` diff.
- **Risk** — additive only; no `konfai` or `konfai-apps` sources change, so there is no regression surface for existing workflows.
- **Points to verify** — the `==<v>` pinning in `install_requires` ties each wrapper release strictly to matching `konfai` / `konfai-apps` versions (intended; worth a sanity check against the tag scheme), and `resolve_infer` passes an empty `ensemble_models: []`, deferring to the bundle's `app.json` defaults when `--ensemble` / `--tta` / `--mc` are left at `0`.
