### PR TITLE
docs: add konfai-cli skill and fix AGENTS.md workspace/trust drifts

### DIFF
--- a/.claude/skills/konfai-cli/SKILL.md
+++ b/.claude/skills/konfai-cli/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: konfai-cli
+description: >-
+  Run KonfAI deep-learning workflows for medical imaging (segmentation, synthesis,
+  registration) from the command line: author or adapt a YAML config, then train, resume,
+  predict, and evaluate with the `konfai` CLI, or run a packaged model with the `konfai-apps`
+  CLI. Use when the user wants to train / fine-tune / run inference / evaluate a KonfAI model
+  from the terminal, adapt an example (Segmentation / Synthesis) config, understand the
+  workspace outputs (Checkpoints / Predictions / Evaluations), reference a custom model or
+  loss by classpath, or run and serve a published app (impact-synth, impact-seg, konfai-apps,
+  konfai-apps-server). Triggers: "train a KonfAI model", "konfai TRAIN / PREDICTION /
+  EVALUATION", "run konfai on the CLI", "konfai-apps infer", "run the segmentation example",
+  "evaluate my predictions", "fine-tune this app".
+---
+
+# Running KonfAI from the command line
+
+KonfAI is **config-driven**: a model, its data pipeline, losses/metrics, optimizer, and the
+whole train/predict/evaluate workflow are described in **YAML** and mapped onto Python objects
+by a reflection engine — no experiment-specific code for standard tasks. **The config is the
+experiment**, and every run leaves a fully-resolved config on disk.
+
+There are two command-line surfaces:
+
+- **`konfai`** — the low-level engine: author a config and `TRAIN` / `RESUME` / `PREDICTION` /
+  `EVALUATION`. This is the main path for building and training a workflow.
+- **`konfai-apps`** — the packaged-app runtime: run inference/evaluation with an already-trained
+  model bundled as an *app* (local, HuggingFace, or a remote server). Use this to *run* a
+  stable model, not to build one. See [references/apps-layer.md](references/apps-layer.md).
+
+## The canonical loop (`konfai`)
+
+Three workflows map to three files, each with one mandatory root key:
+
+| Command | File | Root key |
+|---|---|---|
+| `TRAIN` / `RESUME` | `Config.yml` | `Trainer:` |
+| `PREDICTION` | `Prediction.yml` | `Predictor:` |
+| `EVALUATION` | `Evaluation.yml` | `Evaluator:` |
+
+**Don't write configs from scratch — copy a runnable template from `examples/`** (Segmentation
+or Synthesis) and adapt it. Then:
+
+```bash
+cd examples/Segmentation                 # always run from the dir holding the configs + Dataset/
+
+konfai TRAIN      -y --gpu 0 --config Config.yml
+konfai PREDICTION -y --gpu 0 --config Prediction.yml --models Checkpoints/<train_name>/<checkpoint>.pt
+konfai EVALUATION -y          --config Evaluation.yml
+```
+
+Outputs are namespaced by the `train_name` in the config: `Checkpoints/<train_name>/`,
+`Statistics/<train_name>/`, `Predictions/<train_name>/`, `Evaluations/<train_name>/`. To
+iterate: edit the YAML (or bump `train_name`), re-run. See
+[references/examples-and-recipes.md](references/examples-and-recipes.md) for the verified
+Segmentation and Synthesis recipes, and
+[references/cli-reference.md](references/cli-reference.md) for every flag.
+
+## Rules that keep runs correct
+
+- **Run from the directory that holds the configs** (and `Dataset/`). KonfAI resolves relative
+  paths — configs, `Dataset/`, output dirs, and local `File:Class` classpaths — against the
+  current working directory (it prepends CWD to `sys.path`).
+- **Reading a config rewrites it on disk.** A run materialises resolved defaults back into the
+  YAML (`None` becomes the literal `"None"`). Expect a post-run git diff; keep configs under
+  version control. There is no read-only path. (Details:
+  [references/workspace-and-runtime.md](references/workspace-and-runtime.md).)
+- **`train_name` is the join key.** `Prediction.yml` and `Evaluation.yml` must use the *same*
+  `train_name` as the training run whose checkpoints/predictions they consume — the most common
+  failure is "evaluation can't find predictions" from a mismatched `train_name`.
+- **`--gpu` and `--cpu` are mutually exclusive**; with neither, it runs on CPU. `--gpu` ids are
+  validated against the visible CUDA devices. `--cpu N` needs `N > 0`.
+- **Install the imaging extra** to read `.mha` / medical formats: `pip install "konfai[imaging]"`
+  (a bare install fails on the first data read).
+- **`-y/--overwrite` overwrites existing outputs without prompting** — a destructive flag;
+  don't add it blindly when a prior run's outputs matter. `RESUME` needs `--model`; `PREDICTION`
+  needs `--models`.
+- **Custom models/losses/transforms** live in a `.py` beside the config and are referenced by
+  classpath `File:Class` (e.g. `Model:UNetpp5`). Write the `.py` before running.
+
+## Running a packaged app (`konfai-apps`)
+
+When a workflow is stable, it can be shipped as an **app** and run without touching YAML:
+
+```bash
+konfai-apps infer VBoussot/ImpactSynth:sCT -i patient/mr.nii.gz -o ./Output --gpu 0
+```
+
+`konfai-apps` also does `eval`, `uncertainty`, `pipeline`, `fine-tune`, `bundle`, and
+`download`; `konfai-apps-server` serves apps over HTTP (bearer auth by default). The published
+bundles under `apps/` (e.g. `impact-synth-konfai synthesize ...`, `impact-seg-konfai segment ...`)
+are thin task-named wrappers.
+
+> ⚠️ **Trust model.** Resolving/running an app **copies and imports the app's `.py` files**
+> (runs arbitrary code) and can pip-install its `requirements.txt`. **Only run apps from sources
+> you trust.** See [references/apps-layer.md](references/apps-layer.md).
+
+## Reference material (load on demand)
+
+- [references/cli-reference.md](references/cli-reference.md) — the `konfai` / `konfai-cluster` commands and every flag.
+- [references/config-authoring.md](references/config-authoring.md) — writing KonfAI YAML: files, root keys, classpaths, conventions, the mutation invariant.
+- [references/examples-and-recipes.md](references/examples-and-recipes.md) — verified Segmentation + Synthesis train→predict→evaluate recipes.
+- [references/workspace-and-runtime.md](references/workspace-and-runtime.md) — outputs keyed by `train_name`, env vars, DDP, SLURM, config modes.
+- [references/apps-layer.md](references/apps-layer.md) — `konfai-apps` / `konfai-apps-server`, app resolution, trust model, published bundles.
+
+The authoritative user-facing catalogue lives in `docs/source/config_guide/` (`training.md`,
+`prediction.md`, `evaluation.md`) and `docs/source/reference/cli.md`; `AGENTS.md` is the source
+of truth for framework internals and conventions.

--- a/.claude/skills/konfai-cli/references/apps-layer.md
+++ b/.claude/skills/konfai-cli/references/apps-layer.md
@@ -1,0 +1,92 @@
+# The apps layer (`konfai-apps`)
+
+Once a KonfAI workflow is stable, package it as an **app** for a clean inference interface.
+`konfai-apps` is a separate package (own `pyproject.toml`, tests, CI) that layers on KonfAI's
+public API. Use it when you want inference/evaluation/packaging rather than authoring raw YAML.
+
+Two console scripts: `konfai-apps` (local or remote execution) and `konfai-apps-server`
+(host apps behind an HTTP API). There is also a Python API under `konfai_apps`.
+
+## What an app is, and where it resolves from
+
+An **app bundle** contains a KonfAI config + custom `.py` module(s) + model weights
+(+ an optional `requirements.txt`). The app id (and `--host`) decides the source:
+
+| How you name the app | Source |
+|---|---|
+| a filesystem path or bare local name | **Local directory** |
+| `repo_id:app_name` (one `:`, e.g. `VBoussot/ImpactSynth:sCT`) | **HuggingFace repo** (weights/config pulled via `huggingface_hub`) |
+| any app id **with `--host`/`--port`/`--token`** | **Remote server** (`konfai-apps-server`) |
+
+## ⚠️ Trust model — read before resolving an app
+
+Resolving or running an app is **not** a pure data download. It:
+
+- **copies the app's `.py` files into a run workspace and imports them** (the workspace is put
+  on `sys.path`, and KonfAI imports the custom modules) — i.e. it **runs arbitrary code**;
+- can **pip-install `requirements.txt`** — this mechanism is **opt-in and off by default**
+  (`install_requirements=True`); when enabled it installs the app's declared dependencies;
+- for HuggingFace apps, **downloads weights/config over the network**;
+- in remote mode, **uploads your inputs and config** to the server.
+
+**Only resolve/run apps from sources you trust.** This is the same trust boundary as any
+"download and execute" tool.
+
+## `konfai-apps` subcommands
+
+Inputs use `-i/--inputs` (repeatable; a file or a dataset dir), output goes to `-o/--output`
+(default `./Output`), device is `--gpu` XOR `--cpu`.
+
+| Command | Purpose | Example |
+|---|---|---|
+| `infer` | Run inference with an app | `konfai-apps infer VBoussot/ImpactSynth:sCT -i mr.nii.gz -o ./Output --gpu 0 --tta 4 --ensemble 3` |
+| `eval` | Inference + evaluation vs ground truth | `konfai-apps eval my_app -i ./inputs --gt ./gt --mask ./masks -o ./Eval` |
+| `uncertainty` | Uncertainty estimation | `konfai-apps uncertainty my_app -i mr.nii.gz -o ./Output` |
+| `pipeline` | Infer, then eval and optionally uncertainty in one run | `konfai-apps pipeline my_app -i ./in --gt ./gt -o ./Out --ensemble 3 -uncertainty` |
+| `fine-tune` | Fine-tune an app's checkpoint(s) into a new named app | `konfai-apps fine-tune my_app MyFT -d ./Dataset --models CV_0 CV_1 --epochs 20 --lr 1e-4` |
+| `bundle` | Assemble a bundle (config + checkpoints + optional `Model.py`), optionally export ONNX | `konfai-apps bundle sCT --out ./bundles --app-json app.json --config Prediction.yml --checkpoint CV_0.pt --onnx` |
+| `download` | Fetch a HuggingFace app's files into the local cache | `konfai-apps download VBoussot/ImpactSynth:sCT Prediction.yml` |
+
+Inference knobs on `infer`/`pipeline`: `--tta N` (test-time augmentations), `--ensemble N` /
+`--ensemble-models ...` (checkpoint ensembling), `--mc N` (Monte-Carlo dropout),
+`--patch-size` / `--batch-size` (override inference patch/batch), `-uncertainty` (also write
+the inference stack).
+
+### Serving apps over HTTP
+
+`konfai-apps-server` hosts a FastAPI app (uvicorn `konfai_apps.app_server:app`) and, unlike
+the internal MCP server, **defaults to bearer auth** (`--auth bearer`, token from
+`KONFAI_API_TOKEN`):
+
+```bash
+KONFAI_API_TOKEN=secret konfai-apps-server --apps ./apps.json --host 0.0.0.0 --port 8000
+# clients then run konfai-apps with --host/--port/--token to execute remotely
+konfai-apps infer my_app -i mr.nii.gz -o ./Out --host 127.0.0.1 --port 8000 --token secret
+```
+
+`--apps` is a required JSON file listing the app ids to serve; `--check` validates them
+(no download) and `--download` pre-fetches them. Relevant env vars: `KONFAI_API_TOKEN`
+(bearer token, client and server) and `KONFAI_IMPACTREG_REPO` (used by the IMPACT-Reg app).
+
+## Published app bundles (`apps/`)
+
+The `apps/` directory holds ready-to-use bundles — each an **independent pip package** that
+layers on `konfai` + `konfai-apps` (excluded from the `konfai` wheel):
+
+| Bundle | Task | Entry / usage |
+|---|---|---|
+| `impact_synth` | Synthesis (e.g. MR→CT) | `pip install impact-synth-konfai` → `impact-synth-konfai synthesize MR -i input.nii.gz -o ./Output/` |
+| `impact_seg` | Segmentation | `pip install impact-seg-konfai` → `impact-seg-konfai segment body -i image.nii.gz -o ./Output/` |
+| `impact_reg` | Registration | IMPACT-Reg orchestrator (`KONFAI_IMPACTREG_REPO`) |
+| `mrsegmentator` | MR segmentation | thin wrapper over `konfai-apps` |
+| `totalsegmentator` | CT segmentation | thin wrapper over `konfai-apps` |
+
+The thin wrappers (`impact_synth`, `impact_seg`, `mrsegmentator`, `totalsegmentator`) just
+call `konfai-apps` with a fixed app id, giving a task-named command
+(`impact-synth-konfai synthesize ...`) instead of `konfai-apps infer <id> ...`.
+
+## Where this fits
+
+- Author + train a workflow → raw `konfai` CLI (this skill's main path).
+- Ship a stable workflow for others to run inference → package as a `konfai-apps` app.
+- Integrate into an external tool (e.g. 3D Slicer) or a lightweight client → `konfai-apps-server`.

--- a/.claude/skills/konfai-cli/references/cli-reference.md
+++ b/.claude/skills/konfai-cli/references/cli-reference.md
@@ -1,0 +1,98 @@
+# The `konfai` command-line reference
+
+KonfAI installs two console scripts (`konfai` and `konfai-cluster`, entry points
+`konfai.main:main` / `konfai.main:cluster`). Everything runs through four subcommands.
+
+```
+konfai <TRAIN|RESUME|PREDICTION|EVALUATION> [options]
+konfai --version
+```
+
+The subcommand (`dest="command"`) is **required** and maps to the KonfAI `State`. TRAIN and
+RESUME dispatch to `konfai.trainer.train`, PREDICTION to `konfai.predictor.predict`,
+EVALUATION to `konfai.evaluator.evaluate`.
+
+## Common options (every subcommand)
+
+| Option | Meaning |
+|---|---|
+| `-c`, `--config PATH` | Path to the workflow YAML. If omitted, a command-specific default filename is used — **always pass it explicitly** to avoid ambiguity. |
+| `-y`, `--overwrite` | Overwrite existing outputs (checkpoints, logs, predictions) without prompting. |
+| `--gpu ID [ID ...]` | GPU device ids, constrained to the visible devices, e.g. `--gpu 0` or `--gpu 0 1 2`. Omit to run on CPU. |
+| `--cpu N` | Run on CPU with `N` (>0) worker processes. **Mutually exclusive with `--gpu`.** |
+| `-q`, `--quiet` | Suppress console output. |
+| `-tb`, `--tensorboard` | Launch TensorBoard. |
+
+`--gpu` and `--cpu` are a mutually-exclusive group. With neither, execution falls back to CPU.
+
+## `TRAIN` — train from scratch
+
+Reads a `Trainer:` config and runs the full training loop.
+
+| Extra option | Default | Meaning |
+|---|---|---|
+| `--checkpoints-dir DIR` | `./Checkpoints/` | Where checkpoints are saved. |
+| `--statistics-dir DIR` | `./Statistics/` | Where training statistics / TensorBoard logs are saved. |
+
+```bash
+konfai TRAIN -y --gpu 0 --config Config.yml
+```
+
+## `RESUME` — continue an existing run
+
+Same as TRAIN plus checkpoint reload.
+
+| Extra option | Default | Meaning |
+|---|---|---|
+| `--model PATH` | *(required)* | Checkpoint to resume from. |
+| `-checkpoints-dir DIR` | `./Checkpoints/` | Checkpoints directory. |
+| `-statistics-dir DIR` | `./Statistics/` | Statistics directory. |
+| `--lr FLOAT` | *(unset)* | Override the learning rate. If omitted, the checkpoint LR resumes and the scheduler continues; if set, LR restarts from this value. |
+
+```bash
+konfai RESUME -y --gpu 0 --config Config.yml --model Checkpoints/TRAIN_01/last.pt
+```
+
+## `PREDICTION` — inference with a trained model
+
+Reads a `Predictor:` config. The `--config` value is passed as `prediction_file`.
+
+| Extra option | Default | Meaning |
+|---|---|---|
+| `--models PATH [PATH ...]` | *(required)* | One or more checkpoints. Passing several enables **ensembling**. |
+| `--predictions-dir DIR` | `./Predictions/` | Where predictions are written. |
+
+```bash
+konfai PREDICTION -y --gpu 0 --config Prediction.yml --models Checkpoints/TRAIN_01/best.pt
+```
+
+## `EVALUATION` — score predictions against ground truth
+
+Reads an `Evaluator:` config. The `--config` value is passed as `evaluations_file`.
+
+| Extra option | Default | Meaning |
+|---|---|---|
+| `--evaluations-dir DIR` | `./Evaluations/` | Where per-case + aggregate metric JSON is written. |
+
+```bash
+konfai EVALUATION -y --config Evaluation.yml
+```
+
+## `konfai-cluster` — SLURM submission
+
+Same four subcommands, plus a "Cluster manager arguments" group that submits via `submitit`
+instead of running locally:
+
+| Option | Default | Meaning |
+|---|---|---|
+| `--name NAME` | *(required)* | Job name. |
+| `--num-nodes N` | `1` | Number of nodes. |
+| `--memory GB` | `16` | Memory per node. |
+| `--time-limit MIN` | `1440` | Job time limit (minutes). |
+| `--resubmit` | off | Auto-resubmit just before timeout. |
+
+```bash
+konfai-cluster TRAIN --name seg_run --num-nodes 1 --gpu 0 --config Config.yml
+```
+
+Requires the `cluster` extra (`pip install konfai[cluster]`).

--- a/.claude/skills/konfai-cli/references/config-authoring.md
+++ b/.claude/skills/konfai-cli/references/config-authoring.md
@@ -1,0 +1,88 @@
+# Authoring KonfAI YAML configs
+
+A KonfAI experiment is **fully described in YAML** and mapped onto Python objects by a
+reflection engine — no experiment-specific Python for standard tasks. **The config is the
+experiment**, and a finished run leaves a fully-resolved config on disk.
+
+The fastest way to author a config is to **copy a runnable template from `examples/`**
+(Segmentation or Synthesis) and adapt it, rather than writing from a blank file.
+
+## The three files and their root keys
+
+| Command | File (by convention) | Root key | Holds |
+|---|---|---|---|
+| `TRAIN` / `RESUME` | `Config.yml` | `Trainer:` | model + dataset + losses + augmentations + optimizer/schedulers + patch + training params |
+| `PREDICTION` | `Prediction.yml` | `Predictor:` | model load(s), patch/TTA/ensemble inference, output post-processing |
+| `EVALUATION` | `Evaluation.yml` | `Evaluator:` | predictions vs ground truth → per-case + aggregate metric JSON |
+
+The root key is mandatory and load-bearing: a `Prediction.yml` must open with `Predictor:`.
+
+## Reading a config rewrites it — the mutation invariant
+
+`apply_config` reads a callable's signature and fills its arguments from the YAML subtree it
+owns (`@config("Key")`), recursing into nested `@config` objects. **Resolved defaults are
+written back to the file**, so every `konfai` run rewrites its config in place, materialising
+defaults. Consequences for a CLI user:
+
+- After a run, the on-disk YAML is the fully-resolved snapshot — commit it as the record of
+  the experiment; a re-run is reproducible from it.
+- Keep a pristine copy (or use version control) if you want to preserve exactly what you
+  hand-wrote before defaults were expanded.
+- Workflows run with `KONFAI_CONFIG_MODE='Done'` (forced), which is what triggers the
+  write-back at the end of the run.
+
+## Non-negotiable conventions
+
+- **Arrays are channel-first**: `[C, (Z), Y, X]`.
+- **Geometry/spacing is `(x, y, z)`** (SimpleITK order), keys `Origin` / `Spacing` / `Direction`.
+- **Datasets are lazy and patch-based** — patch size, overlap, and streaming are config, not
+  code. Never assume a whole volume is in RAM.
+
+## Classpath resolution (how to name any object in YAML)
+
+- A **bare name** resolves inside that kind's package: `Dice` (a criterion), `Flip`
+  (an augmentation), `CosineAnnealing` (a scheduler). **Models are the exception** — a model
+  is referenced by its **dotted classpath under `konfai.models`**, e.g. `segmentation.UNet.UNet`,
+  not a bare name.
+- `module:Class` imports **anything** — a **local file beside the config** (`Model:UNetpp5`,
+  `UnNormalize:UnNormalize`) or an installed library (`monai.losses:DiceLoss`, `torch:nn:L1Loss`).
+  KonfAI prepends the current working directory to `sys.path`, so a `.py` next to the config
+  resolves. This is the pattern the Synthesis example uses.
+
+Component kinds: `loss`/`metric` (both → a `Criterion`), `transform`, `augmentation`,
+`scheduler`, `model`, `block`. To discover what exists, read the runnable `examples/`, the
+authoritative config catalogue under `docs/source/config_guide/`
+(`training.md` = `Trainer:`, `prediction.md` = `Predictor:`, `evaluation.md` = `Evaluator:`,
+`patterns.md` = `dataset_filenames`/`groups_src`/`subset`/`validation` conventions), and the
+base classes in `konfai/` (e.g. `konfai/metric/measure.py` for criteria,
+`konfai/data/augmentation.py` for augmentations). The CLI is documented at
+`docs/source/reference/cli.md`.
+
+## The shape of each file (top-level keys)
+
+- **`Trainer:`** → `Model` (`classpath` + selected-class args + `optimizer` + `outputs_criterions`
+  + `schedulers`), `Dataset` (`dataset_filenames`, `groups_src`, `augmentations`, `Patch`),
+  plus training params (epochs, `train_name`, etc.).
+- **`Predictor:`** → `Model` (same `classpath` convention, inference-simplified),
+  `Dataset` (`dataset_filenames`, `groups_src`, TTA `augmentations`, `Patch`), and
+  `outputs_dataset` (which model output → which on-disk group).
+- **`Evaluator:`** → `metrics` (predicted group → target group(s), optionally composed with
+  `;` like `CT;MASK` → criteria) and `Dataset` (`DataMetric`: `dataset_filenames`, `groups_src`,
+  `subset`, `validation`).
+
+## Losses, metrics, and named module outputs
+
+- Losses and metrics are both `Criterion` subclasses, attached under `outputs_criterions` /
+  `metrics` to a **named module output**.
+- **An `outputs_criterions` key equals a module's dotted path** — e.g. `UNetBlock_0:Head:Softmax`,
+  or with the patch-accumulation marker `Generator_A_to_B:;accu;Head:Tanh`. The `:` / `.` /
+  `;accu;` separators are **load-bearing**; do not rewrite them.
+- `;accu;` refers to the patch-wise output **before overlap-blended re-assembly** — used when a
+  downstream module (e.g. a 3D discriminator) must see the reassembled chunk.
+- A `forward` returns a `Tensor` for a loss or a `(value, dict)` tuple for a metric.
+
+## What to adapt first for a new project
+
+From either example: `dataset_filenames`, `train_name` (keys every output folder), patch size,
+batch size, model class + hyperparameters, losses/monitored metrics, preprocessing transforms,
+and (segmentation) `nb_class` + `Dice.labels` in `Evaluation.yml`.

--- a/.claude/skills/konfai-cli/references/examples-and-recipes.md
+++ b/.claude/skills/konfai-cli/references/examples-and-recipes.md
@@ -1,0 +1,94 @@
+# Verified end-to-end recipes
+
+These are the exact command sequences from the runnable examples in `examples/`. Run every
+command **from inside the example directory** — KonfAI resolves relative paths (`Dataset/`,
+`Checkpoints/`, config files) against the current working directory.
+
+The `train_name` set inside each `Config.yml` is what keys every output folder — the
+examples below use `SEG_BASELINE` and `TRAIN_01`.
+
+## Segmentation (`examples/Segmentation`)
+
+2D slice-wise multiclass segmentation baseline; model graph declared in `UNet.yml`,
+`CrossEntropyLoss` for training, Dice for evaluation.
+
+Dataset layout (one input image + one label map per case):
+
+```text
+Dataset/
+├── CASE_000/
+│   ├── CT.mha      # CT: input image
+│   └── SEG.mha     # SEG: label map (0 = background, 1..40 = classes)
+└── ...
+```
+
+```bash
+cd examples/Segmentation
+
+# 1. Train  ->  Checkpoints/SEG_BASELINE/ , Statistics/SEG_BASELINE/
+konfai TRAIN -y --gpu 0 --config Config.yml
+
+# 2. Predict  ->  Predictions/SEG_BASELINE/    (pick a checkpoint written by step 1)
+konfai PREDICTION -y --gpu 0 --config Prediction.yml --models Checkpoints/SEG_BASELINE/<checkpoint>.pt
+
+# 3. Evaluate  ->  Evaluations/SEG_BASELINE/
+konfai EVALUATION -y --config Evaluation.yml
+```
+
+First things to adapt for a real project: `dataset_filenames`, `train_name`, patch size,
+batch size, `nb_class`, preprocessing transforms, and `Dice.labels` in `Evaluation.yml`.
+
+## Synthesis (`examples/Synthesis`)
+
+MR→CT synthesis with a **local custom model** (`Model.py` defines `UNetpp5`, `Discriminator`,
+`Gan`) and a custom post-processing transform (`UnNormalize.py`), referenced from YAML via
+`classpath: Model:UNetpp5`. Dataset groups: `MR` (input), `CT` (target), `MASK` (masked
+evaluation).
+
+```bash
+cd examples/Synthesis
+
+# 1. Train  ->  Checkpoints/TRAIN_01/ , Statistics/TRAIN_01/   (use --cpu 1 if no GPU)
+konfai TRAIN -y --gpu 0 --config Config.yml
+
+# 2. Predict  ->  Predictions/TRAIN_01/
+konfai PREDICTION -y --gpu 0 --config Prediction.yml --models Checkpoints/TRAIN_01/<checkpoint>.pt
+
+# 3. Evaluate  ->  Evaluations/TRAIN_01/
+konfai EVALUATION -y --config Evaluation.yml
+```
+
+### GAN variant
+
+`Config_GAN.yml` trains `Model:Gan` (a 2.5D generator + 3D discriminator sharing the same
+`UNetpp5`). Because the generator class name is unchanged, the same `Prediction.yml` reloads
+either a baseline or a GAN checkpoint.
+
+```bash
+konfai TRAIN -y --gpu 0 --config Config_GAN.yml     # -> Checkpoints/TRAIN_GAN_01/
+```
+
+**Important:** before predicting/evaluating a *different* checkpoint source, set `train_name`
+(and the prediction folder in `Evaluation.yml`) to match — e.g. `TRAIN_GAN_01` — so outputs
+land in the right folder and evaluation reads the right predictions.
+
+## The local-custom-code pattern
+
+The Synthesis example is the template for custom architectures/transforms:
+
+1. Put a `.py` next to the configs (e.g. `Model.py`, `UnNormalize.py`).
+2. Reference it from YAML by classpath — a local file uses `File:Class` (e.g. `Model:UNetpp5`,
+   `UnNormalize:UnNormalize`). KonfAI prepends the CWD to `sys.path`, so a module beside the
+   config resolves.
+3. Run the normal `konfai TRAIN/PREDICTION/EVALUATION` commands unchanged.
+
+## Demo data
+
+Both examples pull a public subset from `huggingface.co/datasets/VBoussot/konfai-demo`
+(`hf download VBoussot/konfai-demo --repo-type dataset --include "Segmentation/**" --local-dir Dataset`).
+The `*_demo.ipynb` notebooks automate clone + install + download for a fresh machine or Colab.
+
+## When to stop using raw YAML
+
+Once a workflow is mature, the next step is to package it as a **KonfAI App** (see
+`apps/impact_synth`) for a simpler user-facing interface — that is beyond this skill's scope.

--- a/.claude/skills/konfai-cli/references/workspace-and-runtime.md
+++ b/.claude/skills/konfai-cli/references/workspace-and-runtime.md
@@ -1,0 +1,74 @@
+# Workspace, outputs, and the runtime
+
+## You don't set `KONFAI_*` yourself
+
+The `konfai` CLI is a thin front-end. When you run a subcommand, the runtime
+(`run_distributed_app` / `execute_distributed_object`) sets every `KONFAI_*` environment
+variable, **forces `KONFAI_CONFIG_MODE='Done'`**, and spawns the workflow. You configure
+runs through the **YAML + CLI flags**, not env vars. The variables below matter only for
+debugging or advanced setups.
+
+| Variable | Set by runtime to | Notes |
+|---|---|---|
+| `KONFAI_config_file` | resolved absolute path of the active config | read by every `Config()`; the file is rewritten on exit |
+| `KONFAI_CONFIG_MODE` | `Done` | Trainer/Predictor/Evaluator raise `ConfigError` unless it is `Done` |
+| `KONFAI_ROOT` | `Trainer` / `Predictor` / `Evaluator` | anchors reflection paths |
+| `KONFAI_STATE` | `TRAIN` / `RESUME` / `PREDICTION` / `EVALUATION` | the subcommand token |
+| `KONFAI_CHECKPOINTS_DIRECTORY` | `./Checkpoints/` (or `--checkpoints-dir`) | |
+| `KONFAI_STATISTICS_DIRECTORY` | `./Statistics/` (or `--statistics-dir`) | |
+| `KONFAI_PREDICTIONS_DIRECTORY` | `./Predictions/` (or `--predictions-dir`) | |
+| `KONFAI_EVALUATIONS_DIRECTORY` | `./Evaluations/` (or `--evaluations-dir`) | |
+| `KONFAI_OVERWRITE` | `True` when `-y/--overwrite` | skips the overwrite prompt |
+| `CUDA_VISIBLE_DEVICES` | frozen at startup | valid `--gpu` ids are validated against it |
+| `KONFAI_MASTER_PORT` / `KONFAI_TENSORBOARD_PORT` | DDP rendezvous / TensorBoard port | |
+| `KONFAI_VERBOSE` / `KONFAI_CLUSTER` | from `--quiet` / SLURM submission | verbosity and per-rank logging |
+
+## Workspace layout — keyed by `train_name`
+
+Every output directory is namespaced by the `train_name` set in the config (default
+`TRAIN_01`; the Segmentation example uses `SEG_BASELINE`). A full train→predict→evaluate
+loop produces:
+
+```text
+Checkpoints/<train_name>/    # timestamped <YYYY_MM_DD_HH_MM_SS>.pt (each holds epoch, it, loss, Model state)
+Statistics/<train_name>/     # tb/ TensorBoard logdir + the resolved-config snapshot of the training run
+Predictions/<train_name>/    # the Prediction.yml snapshot + one output-dataset subfolder per exported output
+Evaluations/<train_name>/    # the Evaluation.yml snapshot + Metric_<split>.json (e.g. Metric_TRAIN.json)
+```
+
+The **resolved-config snapshot** written next to each run is the reproducible record — it is
+the config after defaults were materialised. (Prediction and evaluation write their snapshot
+into `Predictions/` and `Evaluations/`; there is no separate top-level snapshot directory.)
+
+`train_name` is the single most important handle: **`Prediction.yml` and `Evaluation.yml`
+must use the same `train_name`** as the training run whose checkpoints/predictions they
+consume, or evaluation won't find its inputs.
+
+## Config modes (mostly invisible, occasionally sharp)
+
+Workflows always run in `KONFAI_CONFIG_MODE='Done'` (resolve + write back, no prompts). Other
+modes exist in the engine and are worth knowing so you don't trip on them:
+
+- `default` — materialise defaults non-interactively; may create a missing config file.
+- `interactive` — prompt for every `default`-marked field.
+- `remove` — **deletes** the config file on context exit (destructive).
+- `Import` — suppresses config reading (used internally around imports).
+
+Practical consequence: **there is no read-only path** — entering and exiting any `Config`
+context rewrites the file (materialising defaults; `None` round-trips as the literal string
+`"None"`). Keep configs under version control and expect a post-run diff.
+
+## Parallelism and clusters
+
+- **DDP — one process per GPU.** The runtime computes `world_size = len(gpu_ids)` (or the CPU
+  worker count when no GPU) and `mp.spawn`s that many processes; each runs one rank.
+  Disk/log side effects are gated on `global_rank == 0`.
+- **SLURM.** `konfai-cluster` submits the same subcommands to a scheduler via `submitit`
+  (adds `--name`, `--num-nodes`, `--memory`, `--time-limit`, `--resubmit`). Needs the
+  `cluster` extra.
+
+## Install note
+
+Reading the `.mha` demo data needs SimpleITK — install the imaging extra:
+`pip install "konfai[imaging]"` (a bare `pip install konfai` fails on first read). Other
+extras: `itk`, `hdf5`, `dicom`, `omezarr`, `tensorboard`, `lpips`, `ssim`, `fid`, `cluster`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Three pillars run through the codebase:
 | `PREDICTION` | `Prediction.yml` | `Predictor:` | Load model(s), patch/TTA/ensemble inference, output post-processing |
 | `EVALUATION` | `Evaluation.yml` | `Evaluator:` | Predictions vs ground truth → per-case + aggregate metric JSON |
 
-Each run writes a **workspace** keyed by `train_name`: `Checkpoints/`, `Setups/` (resolved config snapshot), `Statistics/` (TensorBoard), `Predictions/`, `Evaluations/` (metric JSON), `Dataset/`.
+Each run writes a **workspace** keyed by `train_name`: `Checkpoints/`, `Statistics/` (TensorBoard + the resolved-config snapshot), `Predictions/`, `Evaluations/` (metric JSON). `Dataset/` is the *input* data directory, not a run output.
 
 **Conventions.** Arrays are **channel-first** `[C,(Z),Y,X]`; geometry/spacing is **`(x,y,z)`** (SimpleITK). `Attribute` geometry keys are `Origin`/`Spacing`/`Direction`.
 
@@ -62,7 +62,7 @@ Every extension point is **"subclass a base, reference it by classpath in YAML"*
 
 A separate package layered on KonfAI's **public** API (core never imports it). An "app" bundles a config + custom `.py` + `.pt` weights, resolved from a Local dir, a HuggingFace repo, or a Remote server; the `apps/*` bundles are thin CLI wrappers.
 
-> ⚠️ **Trust model.** Resolving an app **copies and imports its `.py` files** and **pip-installs its `requirements.txt`** → it runs arbitrary code and dependency installs. **Only resolve apps from sources you trust.**
+> ⚠️ **Trust model.** Resolving an app **copies and imports its `.py` files** → it **runs arbitrary code**. It can also **pip-install its `requirements.txt`**, but that is **opt-in** (`install_requirements=True`; off by default). **Only resolve apps from sources you trust.**
 
 ## 6. Running things
 


### PR DESCRIPTION
## Summary

Adds a KonfAI command-line usage skill and corrects two factual drifts in `AGENTS.md`. Docs-only — no runtime code changes.

## `.claude/skills/konfai-cli/`

A usage guide for driving KonfAI from the terminal, covering both public command-line surfaces:

- **`konfai`** — author a YAML config, then `TRAIN` / `RESUME` / `PREDICTION` / `EVALUATION`.
- **`konfai-apps`** — run a packaged model (`infer` / `eval` / `uncertainty` / `pipeline` / `fine-tune` / `bundle` / `download`) and serve it with `konfai-apps-server`.

`SKILL.md` (playbook) plus references:

- `cli-reference.md` — every `konfai` / `konfai-cluster` subcommand and flag
- `config-authoring.md` — the three files, root keys, classpath resolution, the reading-a-config-rewrites-it invariant
- `examples-and-recipes.md` — the verified Segmentation and Synthesis train → predict → evaluate recipes
- `workspace-and-runtime.md` — outputs keyed by `train_name`, env vars, DDP, SLURM, config modes
- `apps-layer.md` — `konfai-apps` resolution (Local / HuggingFace / Remote), the trust model, and the published `apps/*` bundles

Every command, flag, default, env var, and the workspace layout were checked against `konfai/main.py`, `konfai/utils/config.py`, `konfai/utils/runtime.py`, the `konfai-apps` package, and the example READMEs.

## `AGENTS.md` fixes

- The runtime writes no `Setups/` directory (`grep -rn Setups konfai/` returns nothing); the resolved-config snapshot lives in `Statistics/<train_name>/`. `Dataset/` is the **input** data directory, not a run output.
- Resolving an app copies and imports its `.py` files (arbitrary code) **unconditionally**, but the `requirements.txt` pip-install is **opt-in** (`install_requirements=False` by default) — not automatic.
