### PR TITLE
perf: transparent Dilate/startup speedups (~54s → ~34s, byte-identical output)

### DIFF
--- a/konfai/__init__.py
+++ b/konfai/__init__.py
@@ -22,7 +22,6 @@ from importlib import metadata
 from pathlib import Path
 
 import psutil
-import requests
 
 try:
     import pynvml
@@ -30,8 +29,10 @@ try:
     _PYNVML_AVAILABLE = True
 except ImportError:
     _PYNVML_AVAILABLE = False
-from torch.cuda import get_device_name
 
+# ``requests`` (remote-server helpers only) and ``torch`` (device-name lookup only) are imported lazily
+# at their point of use so that ``import konfai`` stays light — in particular it no longer forces the
+# ~1s torch import for CLI paths that never touch a GPU (``--help``/``--version``, light apps helpers).
 from konfai.utils.errors import KonfAIError
 
 try:
@@ -137,6 +138,8 @@ def get_available_devices(
         Available device indices and the corresponding device names.
     """
     if remote_server is not None:
+        import requests
+
         r = requests.get(
             f"{remote_server.get_url()}/available_devices", headers=remote_server.get_headers(), timeout=timeout_s
         )
@@ -144,6 +147,8 @@ def get_available_devices(
         data = r.json()
         return data["devices_index"], data["devices_name"]
     else:
+        from torch.cuda import get_device_name
+
         devices_index = cuda_visible_devices()
         # Torch reindexes devices after CUDA_VISIBLE_DEVICES masking, so the
         # visible names must be resolved through local ordinals (0..N-1) while
@@ -168,6 +173,8 @@ def get_ram(remote_server: RemoteServer | None = None, timeout_s: float = 2.0) -
         Used RAM and total RAM in gigabytes.
     """
     if remote_server is not None:
+        import requests
+
         r = requests.get(
             f"{remote_server.get_url()}/ram",
             headers=remote_server.get_headers(),
@@ -204,6 +211,8 @@ def get_vram(
         Used VRAM and total VRAM in gigabytes.
     """
     if remote_server is not None:
+        import requests
+
         r = requests.get(
             f"{remote_server.get_url()}/vram",
             params=[("devices", device_index) for device_index in devices],
@@ -281,6 +290,8 @@ def check_server(remote_server: RemoteServer, timeout_s: float = 2.0) -> tuple[b
     tuple[bool, str]
         A boolean success flag and a human-readable status message.
     """
+    import requests
+
     try:
         r = requests.get(
             f"{remote_server.get_url()}/health",

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -604,12 +604,20 @@ class Dilate(Transform):
 
         data = (tensor > 0).to(torch.float32)
         spatial_dims = data.dim() - 1
-        kernel_size = 2 * self.dilate + 1
+        d = self.dilate
+        k = 2 * d + 1
 
+        # A cubic (box) structuring element is separable: dilating by a k**n box equals n successive
+        # 1-D max-pools, one per spatial axis. This is bit-identical to a single k**n max-pool (max is
+        # associative and the box is the Minkowski sum of 1-D segments) for ~k**(n-1)x fewer comparisons
+        # — the k**3 dense pool is the dominant cost of the whole-volume mask load.
         if spatial_dims == 2:
-            data = F.max_pool2d(data, kernel_size=kernel_size, stride=1, padding=self.dilate)
+            data = F.max_pool2d(data, kernel_size=(k, 1), stride=1, padding=(d, 0))
+            data = F.max_pool2d(data, kernel_size=(1, k), stride=1, padding=(0, d))
         elif spatial_dims == 3:
-            data = F.max_pool3d(data, kernel_size=kernel_size, stride=1, padding=self.dilate)
+            data = F.max_pool3d(data, kernel_size=(k, 1, 1), stride=1, padding=(d, 0, 0))
+            data = F.max_pool3d(data, kernel_size=(1, k, 1), stride=1, padding=(0, d, 0))
+            data = F.max_pool3d(data, kernel_size=(1, 1, k), stride=1, padding=(0, 0, d))
         else:
             raise ValueError(
                 "[Dilate] Unsupported tensor shape for "

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -111,7 +111,10 @@ def description(model, model_ema=None, show_memory: bool = True, train: bool = T
 
 def get_cpu_info() -> str:
     """Return current CPU utilization as a short status string."""
-    return f"CPU ({psutil.cpu_percent(interval=0.5):.2f} %)"
+    # interval=None is non-blocking (utilization since the previous call). The blocking interval=0.5
+    # form stalled the caching progress-bar refresh by half a second each call, on the data-load
+    # critical path, purely to render a telemetry label.
+    return f"CPU ({psutil.cpu_percent(interval=None):.2f} %)"
 
 
 def get_memory_info() -> str:

--- a/tests/unit/test_runtime_guards.py
+++ b/tests/unit/test_runtime_guards.py
@@ -202,7 +202,8 @@ def test_get_available_devices_maps_visible_env_ids_to_local_torch_indices(
         queried_indices.append(index)
         return f"GPU{index}"
 
-    monkeypatch.setattr(konfai_module, "get_device_name", fake_get_device_name)
+    # get_available_devices imports get_device_name lazily from torch.cuda, so patch it at the source.
+    monkeypatch.setattr("torch.cuda.get_device_name", fake_get_device_name)
 
     devices_index, devices_name = konfai_module.get_available_devices()
 

--- a/tests/unit/test_transform_dilate.py
+++ b/tests/unit/test_transform_dilate.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import torch.nn.functional as F
+from konfai.data.transform import Dilate
+from konfai.utils.dataset import Attribute
+
+
+def _dense_cube_dilation(tensor: torch.Tensor, dilate: int) -> torch.Tensor:
+    """Reference: dilation via a single dense k**n max-pool (the pre-separable implementation)."""
+    data = (tensor > 0).to(torch.float32)
+    k = 2 * dilate + 1
+    if data.dim() - 1 == 2:
+        data = F.max_pool2d(data, kernel_size=k, stride=1, padding=dilate)
+    else:
+        data = F.max_pool3d(data, kernel_size=k, stride=1, padding=dilate)
+    return data.to(tensor.dtype)
+
+
+@pytest.mark.parametrize("dilate", [1, 2, 5])
+@pytest.mark.parametrize("shape", [(1, 24, 30), (2, 12, 20, 18)])
+def test_dilate_separable_matches_dense_cube(shape: tuple[int, ...], dilate: int) -> None:
+    # The separable 1-D max-pool implementation must be bit-identical to the dense k**n cube it replaces,
+    # for both [C,H,W] and [C,D,H,W] inputs and several radii — this is the correctness guarantee that
+    # lets the ~14x speedup ship as a transparent optimization.
+    torch.manual_seed(0)
+    mask = (torch.rand(shape) > 0.7).to(torch.uint8)
+
+    out = Dilate(dilate)("case", mask.clone(), Attribute())
+    ref = _dense_cube_dilation(mask, dilate)
+
+    assert torch.equal(out, ref)
+    assert out.dtype == mask.dtype
+    assert out.shape == mask.shape
+
+
+def test_dilate_single_voxel_fills_neighbourhood() -> None:
+    # A single active voxel dilated by 1 must fill its full 3x3x3 neighbourhood.
+    mask = torch.zeros(1, 5, 5, 5, dtype=torch.uint8)
+    mask[0, 2, 2, 2] = 1
+
+    out = Dilate(1)("case", mask.clone(), Attribute())
+
+    assert out[0, 1:4, 1:4, 1:4].sum().item() == 27
+    assert out.sum().item() == 27
+
+
+def test_dilate_zero_is_identity() -> None:
+    mask = (torch.rand(1, 8, 8, 8) > 0.5).to(torch.uint8)
+    out = Dilate(0)("case", mask.clone(), Attribute())
+    assert torch.equal(out, mask)


### PR DESCRIPTION
## Summary

Three transparent speedups on the prediction chain, found by profiling a real ensemble inference
(ImpactSynth:MR, 5 models) on a full CT. Each change is a faster way to compute the exact same result —
**the output is byte-for-byte identical**, verified end-to-end on a real case (0 / 15,068,484 voxels differ)
and locked by unit tests. No config, no numerics, and no dataloader genericity is affected.

Measured wall-clock on that case: **~54 s → ~34 s (−37 %)**, essentially all of it from the `Dilate` fix.

## Motivation

Transform-by-transform profiling of the whole-volume data load showed a single morphological op,
`Dilate(5)` on the body mask, taking **23.2 s — 43 % of the entire run** — while the actual GPU compute is
only ~2.4 s. The cost was a dense `k**3` max-pool over the whole volume.

## Changes

| Change | Saving | Why it is transparent |
|---|---:|---|
| `Dilate` computed as 3 separable 1-D max-pools instead of one dense `k**n` cube | ~21.5 s | a box structuring element is separable (max is associative; the box is the Minkowski sum of 1-D segments) → `torch.equal`-identical, ~14× fewer comparisons |
| `get_cpu_info` uses `psutil.cpu_percent(interval=None)` (non-blocking) instead of `interval=0.5` | ~1.0 s | telemetry label only; the blocking sample stalled the caching progress bar on the load critical path |
| `konfai/__init__` imports `requests` and `torch.cuda.get_device_name` lazily at point of use | ~0.2 s | `import konfai` no longer forces the ~1 s torch import for GPU-less CLI paths; behaviour unchanged |

## Proof of transparency

- End-to-end: the produced `sCT.mha` is `np.array_equal` to the pre-change output on a real full CT
  (max |diff| = 0, 0 differing voxels).
- Unit test: `Dilate` separable output is asserted `torch.equal` to the dense cube across 2-D/3-D inputs and
  radii 1/2/5.

## Not included (on purpose)

- A `Clip` in-place fast path was initially part of this PR but **removed**: it duplicates — and is less safe
  than — the existing `perf(data): device-side accumulator alloc + float32 clamp fast path` on `perf/hot-paths`,
  which correctly restricts the fused `clamp_` to `float32` and guards against NaN bounds. That work should land
  via the `perf/hot-paths` re-land instead.
- Skipping the config write-back in `Done` mode was evaluated and deferred (touches the documented
  "reading a config rewrites it on disk" invariant for a negligible saving).

## Test plan

- `pixi run check` (lint + format + full test suite) — green.
- New test: `tests/unit/test_transform_dilate.py`.
