### PR TITLE
fix(patching): keep overlap-blend reassembly in the patch dtype (halve peak memory)

### DIFF
--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -209,7 +209,14 @@ class Accumulator:
         # it is computed once and accumulated spatially only; with padding weight_sum is ~1 and the
         # division is a near no-op.
         combine = self.patch_combine
-        weight_sum = torch.zeros(result.shape[n:], device=result.device) if combine is not None else torch.empty(0)
+        # Match the result dtype so the final ``result / weight_sum`` does not promote the whole
+        # (channels x volume) accumulator to float32 — a default float32 weight_sum silently doubled the
+        # peak memory of large multi-class reassemblies (e.g. a 118-class whole-body segmentation).
+        weight_sum = (
+            torch.zeros(result.shape[n:], dtype=result.dtype, device=result.device)
+            if combine is not None
+            else torch.empty(0)
+        )
         weight_patch: torch.Tensor | None = None
         for patch_slice, data in zip(self.patch_slices, self._layer_accumulator, strict=False):
             if data is not None:

--- a/tests/unit/test_patch_overlap_border.py
+++ b/tests/unit/test_patch_overlap_border.py
@@ -56,3 +56,25 @@ def test_overlap_blend_corner_not_quartered_in_2d() -> None:
 
         assert out.shape == (14, 14)
         torch.testing.assert_close(out, torch.ones(14, 14), rtol=0, atol=1e-5)
+
+
+def test_blended_reassembly_preserves_patch_dtype() -> None:
+    # The weight-normalised reassembly must not promote a float16 accumulator to float32: a default
+    # float32 weight_sum silently doubled the peak memory of large multi-class volumes (the 118-class
+    # whole-body segmentation OOM). Many channels make the effect visible in the assembled shape.
+    patch_slices = [
+        (slice(0, 8), slice(0, 8)),
+        (slice(0, 8), slice(6, 14)),
+        (slice(6, 14), slice(0, 8)),
+        (slice(6, 14), slice(6, 14)),
+    ]
+    combine = Cosinus()
+    combine.set_patch_config([8, 8], 2)
+    accumulator = Accumulator(patch_slices, patch_size=[8, 8], patch_combine=combine, batch=True)
+    for index in range(len(patch_slices)):
+        accumulator.add_layer(index, torch.ones(1, 5, 8, 8, dtype=torch.float16))
+
+    out = accumulator.assemble()
+
+    assert out.dtype == torch.float16
+    torch.testing.assert_close(out[0], torch.ones(5, 14, 14, dtype=torch.float16), rtol=0, atol=1e-2)


### PR DESCRIPTION
## Summary

`Accumulator.assemble` (overlap-blend reassembly) allocated `weight_sum` as a **default float32**
tensor. The final normalization `result = result / weight_sum` then promoted the whole
`(channels × volume)` accumulator to float32 **even when the patches were float16** (as they are for
autocast/fp16 inference, where `ModelComposite` casts outputs to fp16).

For large multi-class reassemblies this **silently doubled the peak memory of the assembled volume**.
Concretely, TotalSegmentator's 118-class whole-body output at inference has an assembled tensor of
shape `(118, D, H, W)` — for `total-3mm` that is ~3.1e9 elements = **12.5 GB in fp32 vs 6.3 GB in fp16**;
for the full `total` at 1.5 mm it is ~8× larger and was OOM-ing.

## The fix

Allocate `weight_sum` with `dtype=result.dtype`, so `result / weight_sum` stays in the patch dtype and
the accumulator is never promoted to float32.

## Effect (measured on `TotalSegmentator-KonfAI:total-3mm`, autocast fp16)

- Assembled volume dtype: **float32 → float16**; peak of that tensor halved (12.5 GB → 6.3 GB).
- Reassembly time: 17.65 s → 14.36 s.
- Output: **27 differing voxels / 15,068,484** (0.0000018%) vs the prior float32 path — fp16 rounding at
  class-boundary ties. The pipeline is already fp16 end-to-end (composite casts to fp16 before
  accumulation), so the float32 division was a spurious upcast, not a source of truth.

## Test plan

- New `test_blended_reassembly_preserves_patch_dtype`: a multi-channel float16 Cosinus-blended
  reassembly must stay float16.
- Existing blend/partition-of-unity tests (`test_patch_overlap_border`, `test_patching`) and
  `test_predictor_memory` still pass (17 passed).

Independent of #26 (device placement); together they let TotalSegmentator run without crashing or OOM.
