### PR TITLE
fix(examples): use SAM_Perceptual loss in the Synthesis example

### DIFF
--- a/docs/source/reference/components/transforms.md
+++ b/docs/source/reference/components/transforms.md
@@ -84,7 +84,7 @@ Operate on a stacked `[N, …]` ensemble axis (prediction post-processing).
 
 | Name | Purpose |
 | --- | --- |
-| `Statistics` | Records ImageMin/Max/Mean/Std to the attribute cache and returns the tensor unchanged (feeds e.g. `IMPACTSynth`). Order in the transform list matters. |
+| `Statistics` | Records ImageMin/Max/Mean/Std to the attribute cache and returns the tensor unchanged (feeds the perceptual criteria `SAM_Perceptual`, `IMPACTSynth`, `IMPACTReg`). Order in the transform list matters. |
 | `Save` | Marker — a no-op passthrough (a checkpoint hint, not a saver). |
 | `KonfAIInference` | Run a nested KonfAI app inference in a spawned subprocess. Needs `konfai-apps` and `num_workers: 0`; defaults to a specific HF repo. |
 

--- a/examples/Synthesis/Config.yml
+++ b/examples/Synthesis/Config.yml
@@ -18,7 +18,7 @@ Trainer:
                   stop: None
                   accumulation: false
                   reduction: mean
-                IMPACTSynth:  # IMPACT-Synth perceptual loss based on SAM features
+                SAM_Perceptual:  # Perceptual loss based on SAM2.1 features
                   is_loss: true
                   schedulers:
                     Constant:
@@ -28,20 +28,12 @@ Trainer:
                   start: 0
                   stop: None
                   accumulation: false
-                  model_name: SAM2.1/SAM2.1_Small.pt # Pretrained model from HuggingFace repo VBoussot/impact-torchscript-models used to extract perceptual features
-                  shape: # Optional resize for the perceptual model (0,0 = keep original size)
-                  - 0
-                  - 0
-                  in_channels: 3 # Output is duplicated to 3 channels to match the perceptual model input
-                  losses: # Internal losses used inside IMPACTSynth
-                    torch:nn:L1Loss:  # L1 loss computed on perceptual feature layers
-                      weights: # One weight per feature layer (this model supports up to 4 layers)
-                      - 1
-                      - 1
-                      - 1
-                      size_average: None
-                      reduce: None
-                      reduction: mean
+                  train: true # Loss mode: use the raw SAM2.1 feature extractor (VBoussot/impact-torchscript-models)
+                  model_name: SAM2.1_Small.pt # SAM2.1 backbone; resolved under SAM2.1/ in VBoussot/impact-torchscript-models
+                  weights: # One weight per SAM feature layer (a weight of 0 skips that layer); the list length sets the number of layers
+                  - 1
+                  - 1
+                  - 1
                 torch:nn:L1Loss:
                   size_average: None
                   reduce: None
@@ -109,7 +101,7 @@ Trainer:
                 save_clip_min: true
                 save_clip_max: true
                 mask: None
-              Statistics: {} # Compute dataset statistics (min, max, mean, std) for IMPACT-Synth loss
+              Statistics: {} # Compute dataset statistics (min, max, mean, std) for the SAM_Perceptual loss
               Normalize:
                 lazy: false
                 channels: None
@@ -128,7 +120,7 @@ Trainer:
                 save_clip_min: false
                 save_clip_max: false
                 mask: MASK
-              Statistics: {} # Compute dataset statistics (min, max, mean, std) for IMPACT-Synth loss
+              Statistics: {} # Compute dataset statistics (min, max, mean, std) for the SAM_Perceptual loss
               Standardize: # Standardization using dataset mean and std
                 lazy: false
                 mean: None

--- a/examples/Synthesis/Config_GAN.yml
+++ b/examples/Synthesis/Config_GAN.yml
@@ -55,7 +55,7 @@ Trainer:
                     stop: None
                     accumulation: false
                     reduction: mean
-                  IMPACTSynth:
+                  SAM_Perceptual:
                     is_loss: true
                     schedulers:
                       Constant:
@@ -65,20 +65,12 @@ Trainer:
                     start: 0
                     stop: None
                     accumulation: false
-                    model_name: SAM2.1/SAM2.1_Small.pt
-                    shape:
-                    - 0
-                    - 0
-                    in_channels: 3
-                    losses:
-                      torch:nn:L1Loss:
-                        weights:
-                        - 1
-                        - 1
-                        - 1
-                        size_average: None
-                        reduce: None
-                        reduction: mean
+                    train: true
+                    model_name: SAM2.1_Small.pt
+                    weights:
+                    - 1
+                    - 1
+                    - 1
                   torch:nn:L1Loss:
                     size_average: None
                     reduce: None


### PR DESCRIPTION
The canonical **Synthesis example** silently trained without its perceptual loss on current `main`.

## Why
`IMPACTSynth` was refactored into a content+style criterion where `model_content_name` /
`model_style_name` are **required**. The example still used the old single-model block
(`model_name` / `shape` / `in_channels` / `losses`), so config binding resolved
`model_content_name` to `None` and the criterion hit its `if model_content_name is None: return`
early-exit — a **silent no-op**. Training ran with only the L1/MAE terms.

## What
- `examples/Synthesis/Config.yml` and `Config_GAN.yml`: `IMPACTSynth` → `SAM_Perceptual`
  (`train: true`, single `SAM2.1_Small.pt` backbone, number of feature layers set by the
  `weights` list). This is the intended replacement for the SAM-feature perceptual loss and
  matches the existing `Statistics: {}` transforms already present in the example.
- `docs/.../transforms.md`: the `Statistics` row now lists its real consumers
  (`SAM_Perceptual`, `IMPACTSynth`, `IMPACTReg`).

## Verification
Ran `konfai TRAIN` end to end on GPU with the migrated example: a full epoch completes and
`SAM_Perceptual` reports a real, non-zero, per-iteration loss (e.g. `SAM_Perceptual(1.00) : 0.081`),
confirming the perceptual term is now actually optimized (no `ImageMin/Mean/Max/Std` KeyError —
the `Statistics` transform feeds them).