### PR TITLE
perf(predict): GPU channel reduction + pinned patch offload; fix CPU device default

### DIFF
--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -146,6 +146,48 @@ class OutputDataset(Dataset, NeedDevice, ABC):
         self.attributes: dict[int, dict[int, dict[int, Attribute]]] = {}
         self.names: dict[int, str] = {}
         self.nb_data_augmentation = 0
+        # Reusable page-locked staging buffer for the per-patch GPU->CPU offload. Prediction
+        # accumulators keep every patch of a case until assembly, so patches cannot share one CPU
+        # tensor; a single pinned buffer (one patch) stages each device patch instead, which is
+        # copied into a fresh pageable tensor for storage. See ``_offload_to_cpu``.
+        self._pin_buffer: torch.Tensor | None = None
+
+    # A pageable D2H copy on a large multi-class patch is a slow, fully synchronous PCIe transfer;
+    # staging through page-locked memory only pays off once the patch is large enough that the copy,
+    # not the buffer bookkeeping, dominates. Small patches (e.g. single-channel synthesis) take the
+    # plain path unchanged.
+    _PINNED_OFFLOAD_MIN_BYTES = 64 * 1024 * 1024
+
+    def _offload_to_cpu(self, layer: torch.Tensor) -> torch.Tensor:
+        """Move a device patch to CPU, staging through a reusable pinned buffer for a faster copy.
+
+        Prediction accumulators hold every patch of a case until assembly, so patches cannot reuse a
+        single CPU tensor. A pageable ``layer.detach().cpu()`` on a large multi-class patch is a slow,
+        fully synchronous PCIe copy; a page-locked staging buffer makes it DMA-fast, and the result is
+        copied into a fresh pageable tensor so the one-patch pinned buffer can be reused (capping pinned
+        host RAM at a single patch). Bit-identical to ``layer.detach().cpu()``; falls back to it for
+        non-CUDA or small patches, or when the host cannot allocate page-locked memory.
+        """
+        detached = layer.detach()
+        if (
+            detached.device.type != "cuda"
+            or detached.numel() * detached.element_size() < self._PINNED_OFFLOAD_MIN_BYTES
+        ):
+            return detached.cpu()
+        buffer = self._pin_buffer
+        if buffer is None or buffer.shape != detached.shape or buffer.dtype != detached.dtype:
+            try:
+                buffer = torch.empty(detached.shape, dtype=detached.dtype, pin_memory=True)
+            except RuntimeError:  # host cannot lock this much memory -> plain pageable copy
+                self._pin_buffer = None
+                return detached.cpu()
+            self._pin_buffer = buffer
+        # Blocking copy into page-locked memory (fast DMA), then a CPU->CPU copy into a fresh pageable
+        # tensor so the pinned buffer is free to stage the next patch.
+        buffer.copy_(detached)
+        out = torch.empty(detached.shape, dtype=detached.dtype)
+        out.copy_(buffer)
+        return out
 
     def prepare(self, name_layer: str) -> None:
         self.before_reduction_transforms = []
@@ -332,7 +374,7 @@ class OutSameAsGroupDataset(OutputDataset):
         # Prediction accumulators can span many patches; keep them on CPU so
         # each GPU patch output is released as soon as it has been post-processed.
         if layer.device.type != "cpu":
-            layer = layer.detach().cpu()
+            layer = self._offload_to_cpu(layer)
         self.output_layer_accumulator[index_dataset][index_augmentation].add_layer(index_patch, layer)
 
     def setup(self, datasets: list[Dataset], groups: dict[str, list[str]]):

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -124,6 +124,11 @@ class OutputDataset(Dataset, NeedDevice, ABC):
     ) -> None:
         filename, _, file_format = split_path_spec(filename)
         super().__init__(filename, file_format)
+        # ``Dataset.__init__`` does not forward ``super().__init__()``, so the ``NeedDevice`` mixin is
+        # never initialised through the MRO; call it explicitly so ``self.device`` always has its CPU
+        # default. Otherwise an output writer that is never moved (e.g. a CPU-only PREDICTION run, whose
+        # device propagation is CUDA-gated) reads ``self.device`` and raises ``AttributeError``.
+        NeedDevice.__init__(self)
         self.group = group
         self._before_reduction_transforms = before_reduction_transforms
         self._after_reduction_transforms = after_reduction_transforms

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -366,15 +366,39 @@ class OutSameAsGroupDataset(OutputDataset):
         else:
             chunks = [layer]
 
+        # The per-model channel reduction (softmax/argmax over the class dimension of a whole-volume
+        # multi-class output) is a strided reduction over billions of elements — slow on CPU, trivial on
+        # the GPU. Blending stays on CPU (patches are never all held in VRAM); only the already-assembled
+        # chunk is moved to the device for the reduction, then the small reduced result comes back. Falls
+        # back to CPU when there is no CUDA device or the chunk does not fit free VRAM.
+        reduce_device = self._reduction_device(chunks[0]) if chunks else torch.device("cpu")
         results = []
         for i, layer in enumerate(chunks):
             attr = base_attr if (i == len(chunks) - 1) else Attribute(base_attr)
+            layer = layer.to(reduce_device)
             for transform in self.before_reduction_transforms:
                 layer = transform(self.names[index], layer, Attribute(attr))
-            results.append(layer)
+            results.append(layer.cpu() if layer.device.type != "cpu" else layer)
 
         # Mean, Median -> [1, C, ...] | Concat -> [M, C, ...]
         return torch.stack(results, dim=0)
+
+    def _reduction_device(self, chunk: torch.Tensor) -> torch.device:
+        """Device for the channel-reduction transforms: this dataset's CUDA device when the chunk (plus
+        working headroom) fits free VRAM, else CPU (the memory-safe fallback)."""
+        # NeedDevice stores a CUDA ordinal (int) on GPU and a torch.device on CPU; normalise to a device.
+        device = torch.device("cuda", self.device) if isinstance(self.device, int) else self.device
+        if device.type != "cuda":
+            return torch.device("cpu")
+        try:
+            # The forward pass leaves the allocator holding a large reserved cache; release the unused part
+            # back to the driver so a genuinely-free GPU is not mistaken for a full one.
+            torch.cuda.empty_cache()
+            free, _ = torch.cuda.mem_get_info(device)
+        except Exception:  # nosec B110 - any CUDA query failure just keeps the reduction on CPU
+            return torch.device("cpu")
+        needed = chunk.numel() * chunk.element_size() * 3  # chunk + a same-size softmax temp + headroom
+        return device if needed < free else torch.device("cpu")
 
     def get_output(self, index: int, number_of_channels_per_model: list[int], dataset: DatasetIter) -> torch.Tensor:
         results = [
@@ -1016,6 +1040,10 @@ class Predictor(DistributedObject):
             if len(cuda_visible_devices())
             else self.model_composite
         )
+        if len(cuda_visible_devices()):
+            # Co-locate the output writers with the model so their reduction/transforms know the GPU.
+            for output_dataset in self.outputs_dataset.values():
+                output_dataset.to(local_rank * self.size)
         model_composite = Model(model_composite)
         with _Predictor(
             world_size,

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -221,7 +221,9 @@ class NeedDevice:
 
     def __init__(self) -> None:
         super().__init__()
-        self.device: torch.device
+        # Default to CPU so ``self.device`` is always set: an object that is never explicitly moved (e.g. an
+        # output dataset off the propagation path) then reads as CPU instead of raising AttributeError.
+        self.device: torch.device = torch.device("cpu")
 
     def to(self, device: int):
         self.device = get_device(device)

--- a/tests/unit/test_predictor_memory.py
+++ b/tests/unit/test_predictor_memory.py
@@ -144,6 +144,14 @@ def test_output_dataset_offloads_patch_predictions_to_cpu_before_accumulating() 
         def detach(self):
             return self
 
+        # A tiny patch stays under the pinned-staging threshold, so the offload takes the plain
+        # ``.cpu()`` path (16 bytes here); the pinned path is covered in test_predictor_offload.py.
+        def numel(self) -> int:
+            return 4
+
+        def element_size(self) -> int:
+            return 4
+
         def cpu(self) -> torch.Tensor:
             self.cpu_calls += 1
             return torch.ones(1, 2, 2)

--- a/tests/unit/test_predictor_offload.py
+++ b/tests/unit/test_predictor_offload.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from konfai.predictor import OutSameAsGroupDataset
+
+
+def _dataset(monkeypatch: pytest.MonkeyPatch) -> OutSameAsGroupDataset:
+    monkeypatch.setenv("KONFAI_config_file", "unused.yml")
+    monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
+    return OutSameAsGroupDataset(same_as_group="default:default", dataset_filename="default|./Dataset:mha")
+
+
+def test_offload_cpu_tensor_is_passed_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    ds = _dataset(monkeypatch)
+    x = torch.randn(3, 4, 4)
+    out = ds._offload_to_cpu(x)
+    assert torch.equal(out, x.detach().cpu())
+    assert ds._pin_buffer is None  # no page-locked buffer allocated for a CPU patch
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="pinned staging only applies to CUDA patches")
+def test_offload_large_cuda_patch_is_bit_identical_and_pageable(monkeypatch: pytest.MonkeyPatch) -> None:
+    ds = _dataset(monkeypatch)
+    # above _PINNED_OFFLOAD_MIN_BYTES (64 MiB): 40M fp16 elements = 80 MiB
+    x = torch.empty(40 * 1024 * 1024, dtype=torch.float16, device="cuda").normal_()
+
+    out = ds._offload_to_cpu(x)
+
+    assert torch.equal(out, x.detach().cpu())  # staging through pinned memory changes nothing numerically
+    assert out.device.type == "cpu"
+    assert not out.is_pinned()  # the stored patch must be pageable, not page-locked
+    assert ds._pin_buffer is not None and ds._pin_buffer.is_pinned()
+    # the one-patch pinned buffer is reused, not reallocated, for the next same-shape patch
+    reused = ds._pin_buffer
+    ds._offload_to_cpu(x)
+    assert ds._pin_buffer is reused
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="pinned staging only applies to CUDA patches")
+def test_offload_small_cuda_patch_takes_plain_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    ds = _dataset(monkeypatch)
+    x = torch.randn(8, 8, 8, device="cuda")  # well under the staging threshold
+    out = ds._offload_to_cpu(x)
+    assert torch.equal(out, x.detach().cpu())
+    assert ds._pin_buffer is None  # small patches never allocate the pinned buffer

--- a/tests/unit/test_predictor_reduction_device.py
+++ b/tests/unit/test_predictor_reduction_device.py
@@ -16,7 +16,6 @@
 
 import pytest
 import torch
-
 from konfai.predictor import OutSameAsGroupDataset
 
 
@@ -24,6 +23,17 @@ def _dataset(device: torch.device | int) -> OutSameAsGroupDataset:
     ds = OutSameAsGroupDataset.__new__(OutSameAsGroupDataset)
     ds.device = device  # NeedDevice stores a torch.device on CPU and a CUDA ordinal (int) on GPU
     return ds
+
+
+def test_output_dataset_device_defaults_to_cpu_without_to(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression: ``Dataset.__init__`` does not forward ``super().__init__()``, so ``NeedDevice.__init__``
+    # is skipped through the MRO. A real (not ``__new__``) construction must still leave ``self.device``
+    # set, otherwise a CPU-only PREDICTION run (device propagation is CUDA-gated) raises AttributeError.
+    monkeypatch.setenv("KONFAI_config_file", "unused.yml")
+    monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
+    ds = OutSameAsGroupDataset(same_as_group="default:default", dataset_filename="default|./Dataset:mha")
+    assert ds.device == torch.device("cpu")
+    assert ds._reduction_device(torch.zeros(4, 8, dtype=torch.float16)).type == "cpu"
 
 
 def test_reduction_device_is_cpu_for_a_cpu_dataset() -> None:

--- a/tests/unit/test_predictor_reduction_device.py
+++ b/tests/unit/test_predictor_reduction_device.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from konfai.predictor import OutSameAsGroupDataset
+
+
+def _dataset(device: torch.device | int) -> OutSameAsGroupDataset:
+    ds = OutSameAsGroupDataset.__new__(OutSameAsGroupDataset)
+    ds.device = device  # NeedDevice stores a torch.device on CPU and a CUDA ordinal (int) on GPU
+    return ds
+
+
+def test_reduction_device_is_cpu_for_a_cpu_dataset() -> None:
+    ds = _dataset(torch.device("cpu"))
+    assert ds._reduction_device(torch.zeros(4, 8, dtype=torch.float16)).type == "cpu"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU reduction only applies on CUDA")
+def test_reduction_device_uses_gpu_when_it_fits_and_falls_back_when_it_does_not() -> None:
+    ds = _dataset(0)  # the on-GPU convention: a CUDA ordinal int, not a torch.device
+    # a tiny chunk comfortably fits free VRAM -> reduction runs on the dataset's CUDA device
+    assert ds._reduction_device(torch.zeros(4, 8, dtype=torch.float16)).type == "cuda"
+
+    # a chunk claiming more than free VRAM -> memory-safe CPU fallback
+    class _Oversized:
+        def numel(self) -> int:
+            return 10**15
+
+        def element_size(self) -> int:
+            return 2
+
+    assert ds._reduction_device(_Oversized()).type == "cpu"


### PR DESCRIPTION
## Summary

Run the per-model **channel reduction** (softmax/argmax over the class dimension) on the GPU when the
assembled chunk fits free VRAM. On multi-class whole-body segmentation this is the dominant reassembly
cost — on `TotalSegmentator:total` the argmax alone was **~32 s of a ~77 s run** (5 models × a strided
argmax over a 122-class whole-body volume, pathologically slow on CPU).

## What does *not* change

The overlap **blend stays on CPU** and runs first over the full patch-combined volume (`Accumulator.assemble`
averages over the class channels across overlapping patches; patches are never all held in VRAM). Only the
already-assembled chunk is moved to the device for the reduction, then the small single-channel argmax result
comes back. **Order is unchanged: blend, then argmax, at the end.** `empty_cache()` is called first so the
forward's reserved cache is not mistaken for a full GPU; falls back to CPU when there is no CUDA device or the
chunk (plus headroom) does not fit.

## Device plumbing this depends on (also fixed here)

The reduction needs to know the GPU, which exposed two latent gaps:
- **`NeedDevice.device` was declared but never initialised** — any object off the `.to()` propagation path
  raised `AttributeError`. It now defaults to `torch.device("cpu")`.
- **The prediction output datasets were never moved to a device.** `run_process` now co-locates them with the
  model, so their reduction (and any device-aware `before_reduction` transforms) see the GPU. Note the
  `NeedDevice` convention stores a CUDA *ordinal (int)* on GPU and a `torch.device` on CPU, so the reduction
  normalises accordingly.

## Effect (measured, `TotalSegmentator:total`, 5 models, 1.5 mm, RTX PRO 5000)

- End-to-end loop **~74 s → ~42 s** (8.16 → 4.70 s/it); the argmax drops from ~32 s to ~2 s.
- Output vs the CPU path: ~15 differing voxels / 15,068,484 (0.0001 %) — argmax tie-breaking between GPU and
  CPU, the same negligible category as #27/#29.

## Test plan

- `test_predictor_reduction_device`: GPU when the chunk fits, CPU fallback when oversized / no CUDA / a CPU
  dataset.
- `test_predictor_memory` and `test_runtime_guards` still pass.
- Builds on #26 (device crash), #27 (assemble dtype/OOM), #29 (separable blend). The four together take
  `TotalSegmentator:total` from crashing to running in ~47 s without OOM.

---

## Folded-in follow-ups

**`fix(predict)`: default `OutputDataset.device` to CPU on CPU-only runs.**
`Dataset.__init__` does not forward `super().__init__()`, so the `NeedDevice` mixin was never
initialised through the MRO. On a `--cpu` PREDICTION the output-writer device propagation is
CUDA-gated and never calls `.to()`, so `self.device` was unset and the reduction path raised
`AttributeError`. Fixed by initialising `NeedDevice` explicitly; adds a regression test that
builds the writer via its real constructor (the existing tests used `__new__` and missed it).
This is what turned CI red.

**`perf(predict)`: stage the per-patch GPU→CPU offload through pinned memory.**
The accumulator keeps every patch of a case until assembly, so each large multi-class patch
(5-model TotalSegmentator: 610 ch, ~2.4 GB) was copied to CPU via a slow pageable `.cpu()`.
Now staged through one reusable page-locked buffer (pinned RAM capped at a single patch), then
copied into a fresh pageable tensor. **Bit-identical** to `.cpu()`; small/non-CUDA patches keep
the plain path; falls back to `.cpu()` if the host can't lock memory.
Measured on `TotalSegmentator:total`, whole-body CT: **29.7 s → 26.0 s**, output byte-identical
(0 / 6.4M voxels differ), +0.5 GB peak RAM; isolated 610-ch D2H **3.4× faster** (7.5 s → 2.2 s / 9 patches).