### PR TITLE
feat: tunable app parameters with type-derived constraints

### DIFF
--- a/apps/impact_reg/impact_reg_konfai/cli.py
+++ b/apps/impact_reg/impact_reg_konfai/cli.py
@@ -99,6 +99,15 @@ def main() -> None:
         help="Keep each preset's displacement field (under Ensemble/) so the ensemble spread can be "
         "measured afterwards by 'uncertainty'.",
     )
+    reg.add_argument(
+        "--set",
+        dest="config_overrides",
+        action="append",
+        metavar="NAME=VALUE",
+        default=None,
+        help="Tune a preset parameter, forwarded to 'konfai-apps infer --set' (applies to every preset), "
+        "e.g. --set iterations=300 (repeatable).",
+    )
     _add_device(reg)
 
     # eval -------------------------------------------------------------------
@@ -177,6 +186,7 @@ def main() -> None:
             quiet=args.quiet,
             tta=args.tta,
             keep_dvf=args.uncertainty,
+            config_overrides=args.config_overrides,
         )
 
     elif args.command == "eval":

--- a/apps/impact_reg/impact_reg_konfai/impact_reg.py
+++ b/apps/impact_reg/impact_reg_konfai/impact_reg.py
@@ -121,6 +121,7 @@ class ImpactRegKonfAIApp:
         cpu: int | None,
         quiet: bool,
         tta: int = 0,
+        config_overrides: list[str] | None = None,
     ) -> Path:
         """Run one preset app on the fixed/moving pair (+ masks); return the displacement-field path.
 
@@ -147,6 +148,9 @@ class ImpactRegKonfAIApp:
         ]
         if tta:
             command += ["--tta", str(tta)]
+        # Preset-parameter tuning: forwarded verbatim to `konfai-apps infer --set` (applies to every preset).
+        for override in config_overrides or []:
+            command += ["--set", override]
         if gpu:
             command += ["--gpu", *(str(g) for g in gpu)]
         elif cpu is not None:
@@ -173,6 +177,7 @@ class ImpactRegKonfAIApp:
         quiet: bool = False,
         tta: int = 0,
         keep_dvf: bool = False,
+        config_overrides: list[str] | None = None,
     ) -> None:
         """Register each fixed/moving pair with the selected presets and ensemble their DVFs.
 
@@ -198,7 +203,17 @@ class ImpactRegKonfAIApp:
                 dvf_paths = []
                 for preset in presets:
                     dvf = self._infer_preset(
-                        preset, fixed_image, moving_image, fixed_mask, moving_mask, work, gpu, cpu, quiet, tta
+                        preset,
+                        fixed_image,
+                        moving_image,
+                        fixed_mask,
+                        moving_mask,
+                        work,
+                        gpu,
+                        cpu,
+                        quiet,
+                        tta,
+                        config_overrides,
                     )
                     if keep_dvf:
                         member = case_out / _ENSEMBLE_DIR / f"{preset}.mha"

--- a/konfai-apps/konfai_apps/app.py
+++ b/konfai-apps/konfai_apps/app.py
@@ -937,6 +937,7 @@ class KonfAIApp(AbstractKonfAIApp):
         mc: int = 0,
         patch_size: list[int] | None = None,
         batch_size: int | None = None,
+        config_overrides: list[str] | None = None,
         uncertainty: bool = False,
         prediction_file: str = "Prediction.yml",
         gpu: list[int] = cuda_visible_devices(),
@@ -977,6 +978,7 @@ class KonfAIApp(AbstractKonfAIApp):
             available_vram,
             forced_patch_size=patch_size,
             forced_batch_size=batch_size,
+            config_overrides=config_overrides,
         )
         from konfai.predictor import predict
 
@@ -1066,6 +1068,7 @@ class KonfAIApp(AbstractKonfAIApp):
         mc: int = 0,
         patch_size: list[int] | None = None,
         batch_size: int | None = None,
+        config_overrides: list[str] | None = None,
         prediction_file: str = "Prediction.yml",
         mask: list[list[Path]] | None = None,
         evaluation_file: str = "Evaluation.yml",
@@ -1101,6 +1104,7 @@ class KonfAIApp(AbstractKonfAIApp):
             mc=mc,
             patch_size=patch_size,
             batch_size=batch_size,
+            config_overrides=config_overrides,
             uncertainty=uncertainty,
             prediction_file=prediction_file,
             gpu=gpu,

--- a/konfai-apps/konfai_apps/app_repository.py
+++ b/konfai-apps/konfai_apps/app_repository.py
@@ -19,6 +19,8 @@
 from __future__ import annotations
 
 import importlib.metadata
+import importlib.util
+import inspect
 import json
 import os
 import re
@@ -29,17 +31,57 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path, PurePosixPath
-from typing import Any
+from typing import Any, Literal, get_args, get_origin
 
 import numpy as np
 import requests
 from huggingface_hub import HfApi, hf_hub_download, snapshot_download
 from huggingface_hub.hf_api import RepoFolder
 from konfai import RemoteServer
+from konfai.utils.config import Choices, Range
 from konfai.utils.errors import AppMetadataError, AppRepositoryError, ConfigError
 from konfai.utils.utils import is_windows_absolute_path
 from packaging.requirements import InvalidRequirement, Requirement
 from ruamel.yaml import YAML
+
+
+def _plain(value: Any) -> Any:
+    """ruamel scalars/containers -> plain python, recursively (so the returned tree is JSON-clean)."""
+    if isinstance(value, dict):
+        return {key: _plain(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_plain(item) for item in value]
+    return value
+
+
+def _constraint_of_annotation(annotation: Any) -> dict[str, Any] | None:
+    """UI constraint for one type: ``Literal`` -> ``{choices}``, ``Annotated[.., Range|Choices]`` ->
+    ``{min,max}`` / ``{choices}``, ``dict[str, <class>]`` -> ``{"*": <class constraints>}``. Else ``None``."""
+    if get_origin(annotation) is Literal:
+        return {"choices": list(get_args(annotation))}
+    for meta in getattr(annotation, "__metadata__", ()):  # Annotated[T, *metas]
+        if isinstance(meta, Range):
+            return {"min": meta.min, "max": meta.max}
+        if isinstance(meta, Choices):
+            return {"choices": meta.resolve()}
+    if get_origin(annotation) is dict:
+        args = get_args(annotation)
+        if len(args) == 2 and inspect.isclass(args[1]):
+            inner = _constraints_of_class(args[1])
+            return {"*": inner} if inner else None
+    return None
+
+
+def _constraints_of_class(cls: type) -> dict[str, Any]:
+    """Constraints of every configurable arg of ``cls.__init__`` (recursing into nested ``@config`` classes)."""
+    out: dict[str, Any] = {}
+    for name, param in inspect.signature(cls.__init__).parameters.items():
+        if name == "self":
+            continue
+        constraint = _constraint_of_annotation(param.annotation)
+        if constraint:
+            out[name] = constraint
+    return out
 
 
 def get_available_apps_on_remote_server(remote_server: RemoteServer) -> list[str]:
@@ -501,6 +543,170 @@ class LocalAppRepository(AppRepositoryInfo):
         with open(inference_file_path, "w") as file:
             yaml.dump(data, file)
 
+    def _apply_config_overrides(self, inference_file_path: str, overrides: list[str] | None) -> None:
+        """Apply ``--set NAME=VALUE`` overrides to the resolved prediction config before it runs.
+
+        A bare ``NAME`` is a **model parameter** (the common case): it resolves inside
+        ``Predictor.Model.<ClassName>``, so ``--set iterations=300`` tunes the model directly. A dotted
+        ``NAME`` (e.g. ``Predictor.Dataset.batch_size``) is a full path from the config root, for any other
+        key. Either way the key must already exist — the resolved config lists every parameter, so a typo
+        raises here instead of silently adding a dead key. ``VALUE`` is parsed as YAML: ``300`` is an int,
+        ``2.0`` a float, ``true`` a bool, ``[1, 2, 3]`` a list, and ``L1`` a string (KonfAI's literal ``None``
+        string is preserved). This is the generic override the UI (SlicerKonfAI) drives to tune a preset.
+        """
+        if not overrides:
+            return
+        yaml = YAML()
+        value_parser = YAML(typ="safe")
+        with open(inference_file_path) as file:
+            data = yaml.load(file)
+        _, model_params = self._model_param_block(data)
+
+        for override in overrides:
+            key_path, sep, raw_value = override.partition("=")
+            if not sep:
+                raise AppRepositoryError(f"Invalid --set '{override}': expected NAME=VALUE (e.g. iterations=300).")
+            key_path = key_path.strip()
+            if not key_path:
+                raise AppRepositoryError(f"Invalid --set '{override}': empty parameter name.")
+            if "." in key_path:
+                # Full dotted path from the config root (any key, for advanced overrides).
+                keys = [key for key in key_path.split(".") if key]
+                node = data
+                for key in keys[:-1]:
+                    if not isinstance(node, dict) or key not in node:
+                        raise AppRepositoryError(
+                            f"Cannot apply --set '{override}': config path '{key_path}' has no key '{key}'."
+                        )
+                    node = node[key]
+                target, leaf = node, keys[-1]
+            else:
+                # A bare name is a model parameter: resolve it in Predictor.Model.<ClassName>.
+                if model_params is None:
+                    raise AppRepositoryError(
+                        f"Cannot apply --set '{override}': the config has no model parameter block "
+                        "(use a full dotted path for non-model keys)."
+                    )
+                target, leaf = model_params, key_path
+            if not isinstance(target, dict) or leaf not in target:
+                raise AppRepositoryError(
+                    f"Cannot apply --set '{override}': parameter '{key_path}' does not exist in the config."
+                )
+            target[leaf] = value_parser.load(raw_value)
+
+        with open(inference_file_path, "w") as file:
+            yaml.dump(data, file)
+
+    def get_parameters(self, prediction_file: str = "Prediction.yml") -> dict[str, Any]:
+        """The model's configurable parameters + their constraints — the single reader a UI needs.
+
+        Returns ``{"values": <nested dict>, "constraints": <parallel sparse dict>}``. ``values`` is the model
+        block of the resolved config (scalars / lists / nested dicts / dict-of-objects) minus structural
+        wiring — a clean tree the CLI edits directly via ``--set``. ``constraints`` is read from the model's
+        TYPES: ``Literal`` / ``Annotated[.., Choices]`` -> ``{"choices"}`` (a ``Choices`` resolver is run by
+        the app, so nothing is fetched here), ``Annotated[.., Range]`` -> ``{"min","max"}``. It mirrors
+        ``values``; ``"*"`` holds the per-entry constraints of a ``dict[str, <@config>]``. Interpreting the
+        structure (widgets, add/remove) is the UI's job; the meaning of any field is never assumed here.
+        """
+        filenames = self._all_repo_filenames()
+        config_filename = self._find_repo_filename(prediction_file, filenames)
+        if config_filename is None:
+            return {"values": {}, "constraints": {}}
+        with open(self._download(config_filename), encoding="utf-8") as file:
+            data = YAML().load(file)
+        _, params = self._model_param_block(data)
+        structural = {"outputs_criterions", "optimizer", "schedulers", "engine", "parameter_maps", "classpath"}
+        values = {name: _plain(value) for name, value in (params or {}).items() if name not in structural}
+
+        constraints: dict[str, Any] = {}
+        model = ((data or {}).get("Predictor") or {}).get("Model") or {}
+        classpath = model.get("classpath") if isinstance(model, dict) else None
+        if isinstance(classpath, str) and ":" in classpath:
+            stem, class_name = (part.strip() for part in classpath.split(":", 1))
+            try:
+                constraints = _constraints_of_class(self._import_model_class(stem, class_name, filenames))
+            except Exception:  # constraints are an optional UI hint — a load/inspect failure just omits them
+                constraints = {}
+        return {"values": values, "constraints": constraints}
+
+    def _import_model_class(self, module_stem: str, class_name: str, filenames: list[str]) -> type:
+        """Import the app's model module (the ``classpath`` stem) and return the CLASS without instantiating
+        it — only its typed signature is read. The bundle dir is on ``sys.path`` so its sibling imports load."""
+        path = Path(self._download(self._require_repo_filename(f"{module_stem}.py", filenames)))
+        sys.path.insert(0, str(path.parent))
+        try:
+            spec = importlib.util.spec_from_file_location(f"_konfai_app_model_{module_stem}", path)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return getattr(module, class_name)
+        finally:
+            if str(path.parent) in sys.path:
+                sys.path.remove(str(path.parent))
+
+    @staticmethod
+    def _model_param_block(data: Any) -> tuple[str | None, Any]:
+        """Return ``(class_name, params_mapping)`` for ``Predictor.Model.<ClassName>``, or ``(None, None)``.
+
+        The model's constructor arguments live under a single ``<ClassName>`` mapping next to ``classpath``;
+        this is both the source of the tunable list and the target a bare ``--set NAME=VALUE`` resolves into.
+        """
+        model = ((data or {}).get("Predictor") or {}).get("Model") or {}
+        for key, value in model.items():
+            if key != "classpath" and isinstance(value, dict):
+                return key, value
+        return None, None
+
+    def save_default_parameters(self, overrides: list[str] | None, prediction_file: str = "Prediction.yml") -> None:
+        """Persist ``--set`` overrides into the app config so they become its defaults for the next run.
+
+        Only local-directory apps support this (their config file is edited in place). An app resolved from a
+        shared source such as the Hugging Face cache raises, because edits there are overwritten on refresh
+        and shared across every user of the cache — copy it into a local folder to keep tuned defaults.
+        """
+        raise AppRepositoryError(
+            f"Saving parameters as defaults is only supported for local-directory apps. App '{self._app_name}' "
+            "is resolved from a shared source (e.g. the Hugging Face cache), where edits are not durable — "
+            "copy it into a local folder and run against that to keep tuned defaults."
+        )
+
+    def export_app(
+        self,
+        path: Path,
+        display_name: str | None = None,
+        config_overrides: list[str] | None = None,
+        prediction_file: str = "Prediction.yml",
+    ) -> None:
+        """Materialise this app into the local folder ``path`` as a self-contained, editable copy.
+
+        Every app file (config, code, checkpoints, ``app.json``, ``requirements.txt``) is copied into
+        ``path``, so it can be reopened as a :class:`LocalAppRepositoryFromDirectory`. With
+        ``config_overrides`` the tuned ``--set`` values are written into the copied ``prediction_file`` so the
+        new local app runs with them as its defaults — the inference-side "save as a local app" that mirrors
+        :meth:`install_fine_tune`. ``display_name`` renames the copy in ``app.json``.
+        """
+        filenames = self._get_filenames()
+        if not is_app_repo(filenames):
+            raise AppRepositoryError(f"'{self._app_name}' is not a valid KonfAI app (no app.json); cannot export.")
+        path.mkdir(parents=True, exist_ok=True)
+        for filename in filenames:
+            dest = path / filename
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(self._download(filename), dest)
+
+        if display_name is not None:
+            metadata_file = path / "app.json"
+            with open(metadata_file, encoding="utf-8") as file:
+                metadata = json.load(file)
+            metadata["display_name"] = display_name
+            with open(metadata_file, "w", encoding="utf-8") as file:
+                json.dump(metadata, file, indent=2, ensure_ascii=False)
+
+        if config_overrides:
+            config = path / prediction_file
+            if not config.is_file():
+                raise AppRepositoryError(f"Cannot apply tuned defaults: '{prediction_file}' not found in the export.")
+            self._apply_config_overrides(str(config), config_overrides)
+
     @abstractmethod
     def _get_filenames(self) -> list[str]:
         raise NotImplementedError()
@@ -674,6 +880,7 @@ class LocalAppRepository(AppRepositoryInfo):
         available_vram: float | None,
         forced_patch_size: list[int] | None = None,
         forced_batch_size: int | None = None,
+        config_overrides: list[str] | None = None,
     ) -> list[Path]:
         if len(name_of_models) == 0 and number_of_model == 0:
             number_of_model = len(self._checkpoints_name)
@@ -704,6 +911,8 @@ class LocalAppRepository(AppRepositoryInfo):
             forced_patch_size if forced_patch_size is not None else plan_patch_size,
             forced_batch_size if forced_batch_size is not None else plan_batch_size,
         )
+        # Applied last, after the VRAM plan / patch-batch override, so an explicit --set always wins.
+        self._apply_config_overrides(prediction_file, config_overrides)
 
         return models_path
 
@@ -844,6 +1053,20 @@ class LocalAppRepositoryFromDirectory(LocalAppRepository):
 
     def get_name(self) -> str:
         return str(self._app_directory / self._app_name)
+
+    def save_default_parameters(self, overrides: list[str] | None, prediction_file: str = "Prediction.yml") -> None:
+        """Edit the app-folder config in place so the tuned ``--set`` values become its defaults.
+
+        The config file lives in the app directory, so applying the overrides to it persists them: the next
+        run of this local app uses the tuned values as its defaults. ``overrides`` use the same
+        ``PATH=VALUE`` syntax as ``--set`` / :meth:`_apply_config_overrides`.
+        """
+        if not overrides:
+            return
+        config = self._app_directory / self._app_name / prediction_file
+        if not config.is_file():
+            raise AppRepositoryError(f"Cannot save defaults: '{prediction_file}' not found in app '{self._app_name}'.")
+        self._apply_config_overrides(str(config), overrides)
 
 
 class LocalAppRepositoryFromHF(LocalAppRepository):

--- a/konfai-apps/konfai_apps/cli.py
+++ b/konfai-apps/konfai_apps/cli.py
@@ -187,6 +187,23 @@ def _add_patch_overrides(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_config_overrides(parser: argparse.ArgumentParser) -> None:
+    """Add the generic config override (``--set NAME=VALUE``, repeatable).
+
+    A bare ``NAME`` tunes a model parameter (e.g. ``--set iterations=300``); a dotted ``NAME`` is a full
+    path from the config root (e.g. ``Predictor.Dataset.batch_size=2``). The value is parsed as YAML (int /
+    float / bool / list / string). This is the generic mechanism a UI drives to tune a preset's parameters.
+    """
+    parser.add_argument(
+        "--set",
+        dest="config_overrides",
+        action="append",
+        metavar="NAME=VALUE",
+        default=None,
+        help="Tune a model parameter, e.g. --set iterations=300 (repeatable; a dotted NAME targets any config key).",
+    )
+
+
 def build_app_cli(
     prog: str,
     description: str,
@@ -228,6 +245,7 @@ def build_app_cli(
         _add_app_io(run_p)
         knobs(run_p)
         _add_patch_overrides(run_p)
+        _add_config_overrides(run_p)
         if with_uncertainty:
             run_p.add_argument("-uncertainty", action="store_true", help="Also write the inference stack.")
         run_p.add_argument(
@@ -270,6 +288,7 @@ def build_app_cli(
         _add_app_io(pipe_p)
         knobs(pipe_p)
         _add_patch_overrides(pipe_p)
+        _add_config_overrides(pipe_p)
         _add_gt(pipe_p, required=False)
         _add_mask(pipe_p)
         pipe_p.add_argument(
@@ -312,6 +331,7 @@ def build_app_cli(
                 prediction_file=args.prediction_file,
                 patch_size=args.patch_size,
                 batch_size=args.batch_size,
+                config_overrides=args.config_overrides,
                 **infer_kwargs(args),
             )
         elif args.command == "eval":
@@ -352,6 +372,7 @@ def build_app_cli(
                 quiet=args.quiet,
                 patch_size=args.patch_size,
                 batch_size=args.batch_size,
+                config_overrides=args.config_overrides,
                 **infer_kwargs(args),
             )
 
@@ -475,6 +496,7 @@ def main_apps() -> None:
     infer_p.add_argument("--tta", type=int, default=0, help="Number of Test-Time Augmentations")
     infer_p.add_argument("--mc", type=int, default=0, help="Monte Carlo dropout samples")
     _add_patch_overrides(infer_p)
+    _add_config_overrides(infer_p)
     infer_p.add_argument("-uncertainty", action="store_true", help="If enabled, inference write the inference stack")
     infer_p.add_argument(
         "--prediction-file",
@@ -535,6 +557,7 @@ def main_apps() -> None:
     pipe_p.add_argument("--tta", type=int, default=0, help="Number of Test-Time Augmentations.")
     pipe_p.add_argument("--mc", type=int, default=0, help="Number of Monte Carlo dropout samples.")
     _add_patch_overrides(pipe_p)
+    _add_config_overrides(pipe_p)
     pipe_p.add_argument(
         "--prediction-file",
         "--prediction_file",

--- a/konfai-apps/tests/unit/test_app_repository.py
+++ b/konfai-apps/tests/unit/test_app_repository.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from konfai.utils.errors import AppMetadataError
+from konfai.utils.errors import AppMetadataError, AppRepositoryError
 from konfai_apps import app_repository as app_repository_module
 
 
@@ -650,3 +650,200 @@ def test_install_requirements_skips_protected_and_non_pep508_lines(
     assert "torch==1.0.0" not in cmd
     assert "konfai==0.0.1" not in cmd
     assert not any(part.startswith(("-r", "--extra-index-url", "git+")) for part in cmd[4:])
+
+
+def _local_repo_with_config(tmp_path: Path, config: str) -> tuple[object, Path]:
+    app_root = tmp_path / "repo" / "demo_app"
+    app_root.mkdir(parents=True)
+    (app_root / "app.json").write_text(
+        json.dumps(
+            {"display_name": "Demo", "description": "Demo", "short_description": "Demo", "tta": 0, "mc_dropout": 0}
+        ),
+        encoding="utf-8",
+    )
+    prediction = app_root / "Prediction.yml"
+    prediction.write_text(config, encoding="utf-8")
+    repo = app_repository_module.LocalAppRepositoryFromDirectory(app_root.parent, app_root.name)
+    return repo, prediction
+
+
+_CONFIG = (
+    "Predictor:\n"
+    "  Model:\n"
+    "    RegistrationNet:\n"
+    "      iterations: 150\n"
+    "      learning_rate: 0.2\n"
+    "      linear: true\n"
+    "      subset_features: []\n"
+)
+
+
+def test_apply_config_overrides_patches_typed_values(tmp_path: Path) -> None:
+    from ruamel.yaml import YAML
+
+    repo, prediction = _local_repo_with_config(tmp_path, _CONFIG)
+    repo._apply_config_overrides(
+        str(prediction),
+        [
+            "iterations=300",  # bare model-parameter name (the common form)
+            "Predictor.Model.RegistrationNet.learning_rate=0.05",  # full dotted path still works
+            "linear=false",
+            "subset_features=[0, 1, 2]",
+        ],
+    )
+    net = YAML().load(prediction.read_text())["Predictor"]["Model"]["RegistrationNet"]
+    assert net["iterations"] == 300 and isinstance(net["iterations"], int)
+    assert float(net["learning_rate"]) == 0.05
+    assert net["linear"] is False
+    assert list(net["subset_features"]) == [0, 1, 2]
+
+
+def test_apply_config_overrides_noop_when_empty(tmp_path: Path) -> None:
+    repo, prediction = _local_repo_with_config(tmp_path, _CONFIG)
+    before = prediction.read_text()
+    repo._apply_config_overrides(str(prediction), None)
+    repo._apply_config_overrides(str(prediction), [])
+    assert prediction.read_text() == before
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        "does_not_exist=1",  # unknown bare model parameter
+        "Predictor.Model.RegistrationNet.does_not_exist=1",  # unknown leaf key (dotted)
+        "Predictor.Missing.iterations=1",  # unknown intermediate key (dotted)
+        "no_equals_sign",  # not NAME=VALUE
+    ],
+)
+def test_apply_config_overrides_rejects_bad_override(tmp_path: Path, override: str) -> None:
+    repo, prediction = _local_repo_with_config(tmp_path, _CONFIG)
+    with pytest.raises(AppRepositoryError):
+        repo._apply_config_overrides(str(prediction), [override])
+
+
+_MODEL_CONFIG = (
+    "Predictor:\n"
+    "  Model:\n"
+    "    classpath: Model:RegistrationNet\n"
+    "    RegistrationNet:\n"
+    "      iterations: 150\n"  # int -> tunable
+    "      learning_rate: 0.2\n"  # float -> tunable
+    "      linear: true\n"  # bool -> tunable
+    "      voxel_size: [3.0, 3.0, 3.0]\n"  # list[float] -> tunable
+    "      pca: [0]\n"  # list[int] -> tunable
+    "      subset_features: []\n"  # empty list -> tunable ("list"; compound name, not locked)
+    "      distance: [L1]\n"  # list[str] -> tunable
+    "      models: [repo:MIND.pt]\n"  # list[str] -> tunable (feature-model choice)
+    "      mode: bilinear\n"  # str -> tunable
+    "      num_channels: 1\n"  # int -> tunable (config exposes it; hardcode in Model.py to hide it)
+    "      channels: [1, 32, 64]\n"  # list[int] -> tunable (idem: hardcode the architecture to hide it)
+    "      layers_mask: [true, false]\n"  # list[bool] -> tunable (which model layers to use)
+    "      outputs_criterions: None\n"  # structural + KonfAI None string -> excluded
+    "      disabled_option: None\n"  # KonfAI None string -> excluded
+    "      optimizer:\n"  # structural nested mapping -> excluded
+    "        AdamW: {}\n"
+)
+
+
+# A typed model module: the constructor's annotations ARE the constraint declaration.
+# No `from __future__ import annotations` — get_parameters reads runtime annotation objects.
+_TYPED_MODEL_PY = (
+    "from typing import Annotated, Literal\n"
+    "from konfai.utils.config import Choices, Range\n"
+    "\n\n"
+    "class RegistrationNet:\n"
+    "    def __init__(\n"
+    "        self,\n"
+    "        mode: Literal['Static', 'Jacobian'] = 'Static',\n"
+    "        spatial_samples: Annotated[int, Range(0, 100000)] = 0,\n"
+    "        ref: Annotated[str, Choices(lambda: ['a:x.pt', 'b:y.pt'])] = '',\n"
+    "        note: str = '',\n"
+    "    ) -> None:\n"
+    "        pass\n"
+)
+
+_TYPED_MODEL_CONFIG = (
+    "Predictor:\n"
+    "  Model:\n"
+    "    classpath: Model:RegistrationNet\n"
+    "    RegistrationNet:\n"
+    "      mode: Jacobian\n"
+    "      spatial_samples: 2000\n"
+    "      ref: a:x.pt\n"
+    "      note: hello\n"
+)
+
+
+def test_get_parameters_values_are_the_clean_model_block(tmp_path: Path) -> None:
+    # `values` is the model block minus structural wiring — a JSON-clean tree the CLI edits via --set.
+    repo, _prediction = _local_repo_with_config(tmp_path, _MODEL_CONFIG)
+    result = repo.get_parameters()
+
+    values = result["values"]
+    assert values["iterations"] == 150 and isinstance(values["iterations"], int)
+    assert values["voxel_size"] == [3.0, 3.0, 3.0]  # nested list -> plain python
+    assert values["mode"] == "bilinear"
+    assert values["disabled_option"] == "None"  # generic: no value is filtered, only structural KEYS are
+    for structural in ("outputs_criterions", "optimizer"):
+        assert structural not in values
+    # No typed Model.py present -> constraints degrade to empty (an optional UI hint, never fatal).
+    assert result["constraints"] == {}
+
+
+def test_get_parameters_constraints_read_from_model_types(tmp_path: Path) -> None:
+    repo, prediction = _local_repo_with_config(tmp_path, _TYPED_MODEL_CONFIG)
+    (prediction.parent / "Model.py").write_text(_TYPED_MODEL_PY, encoding="utf-8")
+    result = repo.get_parameters()
+
+    assert result["values"] == {"mode": "Jacobian", "spatial_samples": 2000, "ref": "a:x.pt", "note": "hello"}
+    # Constraints come from the constructor TYPES: Literal -> choices, Range -> min/max, Choices resolver run
+    # by the app (so nothing is fetched here); an untyped field (`note`) simply carries no constraint.
+    assert result["constraints"] == {
+        "mode": {"choices": ["Static", "Jacobian"]},
+        "spatial_samples": {"min": 0, "max": 100000},
+        "ref": {"choices": ["a:x.pt", "b:y.pt"]},
+    }
+
+
+def test_save_default_parameters_persists_to_local_config(tmp_path: Path) -> None:
+    from ruamel.yaml import YAML
+
+    repo, prediction = _local_repo_with_config(tmp_path, _MODEL_CONFIG)
+    repo.save_default_parameters(["iterations=999"])  # bare model-parameter name
+    data = YAML().load(prediction.read_text())
+    assert data["Predictor"]["Model"]["RegistrationNet"]["iterations"] == 999  # persisted on disk
+
+
+def test_save_default_parameters_noop_when_empty(tmp_path: Path) -> None:
+    repo, prediction = _local_repo_with_config(tmp_path, _MODEL_CONFIG)
+    before = prediction.read_text()
+    repo.save_default_parameters(None)
+    repo.save_default_parameters([])
+    assert prediction.read_text() == before
+
+
+def test_save_default_parameters_missing_config_raises(tmp_path: Path) -> None:
+    repo, prediction = _local_repo_with_config(tmp_path, _MODEL_CONFIG)
+    prediction.unlink()
+    with pytest.raises(AppRepositoryError):
+        repo.save_default_parameters(["iterations=1"])
+
+
+def test_export_app_materialises_local_copy_with_overrides(tmp_path: Path) -> None:
+    repo, prediction = _local_repo_with_config(tmp_path, _MODEL_CONFIG)
+    (prediction.parent / "model.pt").write_text("weights", encoding="utf-8")
+
+    dest = tmp_path / "exported" / "MyTunedApp"
+    repo.export_app(
+        dest,
+        display_name="My Tuned App",
+        config_overrides=["iterations=777"],  # bare model-parameter name
+    )
+
+    assert (dest / "Prediction.yml").is_file()
+    assert (dest / "model.pt").is_file()  # checkpoints come along
+    assert json.loads((dest / "app.json").read_text())["display_name"] == "My Tuned App"
+
+    # Reopen the export as a local app: the tuned default is baked in.
+    exported = app_repository_module.LocalAppRepositoryFromDirectory(dest.parent, dest.name)
+    assert exported.get_parameters()["values"]["iterations"] == 777

--- a/konfai/utils/config.py
+++ b/konfai/utils/config.py
@@ -24,6 +24,7 @@ import types
 import typing
 from collections.abc import Sequence
 from copy import deepcopy
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, Union, get_args, get_origin
 
@@ -35,6 +36,35 @@ from konfai.utils.errors import ConfigError
 
 yaml = ruamel.yaml.YAML()
 _log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Range:
+    """UI hint attached to a parameter's type — its inclusive numeric bounds.
+
+    Use ``Annotated[int, Range(0, 100)]`` (or ``float``) in a config-bound signature: the binder ignores the
+    metadata and validates the base type, while a UI reads the bounds to size a spinbox. Introspection-only.
+    """
+
+    min: float
+    max: float
+
+
+class Choices:
+    """UI hint attached to a parameter's type — its allowed values.
+
+    Use ``Annotated[str, Choices([...])]`` for a fixed list, or ``Annotated[str, Choices(resolver)]`` where
+    ``resolver`` is a zero-arg callable the app owns (e.g. one that lists a model registry it already
+    fetches). ``resolve()`` returns the list — a reader calls it lazily, so the app resolves its own values
+    and no tool re-fetches. Introspection-only; the binder ignores it (a value outside the list is still
+    accepted, e.g. a local path). For a small FIXED, binder-validated set, prefer ``Literal[...]``.
+    """
+
+    def __init__(self, values) -> None:
+        self.values = values
+
+    def resolve(self) -> list:
+        return list(self.values() if callable(self.values) else self.values)
 
 
 def _escape_key_component(component: str) -> str:
@@ -404,6 +434,8 @@ def apply_config(konfai_args: str | None = None):
                                 continue
 
                             annotation = _resolve_annotation(function, param.annotation)
+                            if hasattr(annotation, "__metadata__"):  # Annotated[T, meta]: bind on T, meta is a UI hint
+                                annotation = get_args(annotation)[0]
                             if get_origin(annotation) is Literal:
                                 allowed_values = get_args(annotation)
                                 default_value = param.default if param.default != inspect._empty else allowed_values[0]


### PR DESCRIPTION
## What

One primitive for reading **and** writing an app's tunable parameters, so a UI (SlicerKonfAI) renders bounded editors and applies edits generically — no per-app glue.

**Read** — `KonfAIApp.get_parameters()` returns `{values, constraints}`:
- `values`: the resolved model config block (clean nested dict).
- `constraints`: derived from the model's `__init__` type hints —
  - `Literal[...]` → `{choices}`
  - `Annotated[int | float, Range(lo, hi)]` → `{min, max}`
  - `Annotated[str, Choices(list | resolver)]` → `{choices}`
  - `dict[str, <config class>]` → nested `{"*": ...}`

**Write** — `--set NAME=VALUE` (repeatable) on `infer` / `pipeline`: parsed as YAML and written into the copied `Prediction.yml` before inference. A bare `NAME` tunes a model parameter; a dotted `NAME` targets any config key.

**config** — new `Range` / `Choices` annotations; the reflection binder unwraps `Annotated[T, ...]`, binds on `T`, and ignores the metadata (pure UI hint — no change to config binding behaviour).

**impact_reg** — forwards `--set` verbatim across every ensemble preset.

## Why

Constraints now live in the model signatures themselves: a single typed source of truth, read by reflection. This replaces the earlier ad-hoc matrix/tunable readers with one primitive, so there is nothing to keep in sync between the model and the UI.

## Notes

- Base: `main`. Independent of the `perf/gpu-accumulation` PR — **zero file overlap**, so the two merge in any order.
- `konfai-apps` unit tests updated (`get_parameters` values + type-derived constraints).
- Commits are split by layer: config primitive → konfai-apps consumer → impact_reg adoption.
