### PR TITLE
perf(predict): GPU-resident accumulation + device-transparent finalize

### DIFF
--- a/apps/impact_seg/README.md
+++ b/apps/impact_seg/README.md
@@ -140,15 +140,15 @@ the model release you use.
 
 ## ⚡ Performance & VRAM
 
-Benchmarked on an **NVIDIA RTX PRO 5000 (24 GB)**, synthetic data, patch `[1, 192, 192]`, single model (`Mean`). The app **auto-selects the batch size from your free GPU VRAM** (`vram_plan`); override it in SlicerKonfAI (⚙ **Advanced**) or on the CLI with `--patch-size` / `--batch-size`.
+Benchmarked on a single **NVIDIA RTX PRO 5000 (24 GB)** with a real whole-body CT (295 × 259 × 219, 2 mm), patch `[1, 192, 192]`, single model. The app **auto-selects the batch size from your free GPU VRAM** (`vram_plan`); override it in SlicerKonfAI (⚙ **Advanced**) or on the CLI with `--patch-size` / `--batch-size`.
 
-| Free VRAM | Batch (auto) | Peak VRAM |
-|:--|:--|:--|
-| 8 GB  | 160 | ~7 GB |
-| 16 GB | 320 | ~14 GB |
-| 24 GB | 512 | ~22 GB |
+| Free VRAM | Batch (auto) | Peak VRAM | Time / case |
+|:--|:--|:--|:--|
+| 8 GB  | 160 | ~7 GB  | — |
+| 16 GB | 320 | ~14 GB | — |
+| 24 GB | 512 | ~10 GB | **~7 s** |
 
-Measured peak VRAM: batch 64 → 3.1 GB · 128 → 5.8 GB · 256 → 8.5 GB · 512 → 22.4 GB. Inference ≈ **16 s / case** on the benchmark volume (scales with the case size).
+Single-model body segmentation keeps **system RAM ~1.6 GB**. The thin 2-D patches never fill the card, so inference stays compute-bound (~7 s, largely batch-independent). Inference scales with the case size.
 
 ---
 

--- a/apps/impact_synth/README.md
+++ b/apps/impact_synth/README.md
@@ -110,15 +110,15 @@ If you use **IMPACT-Synth-KonfAI** in your work, please cite:
 
 ## ⚡ Performance & VRAM
 
-Benchmarked on an **NVIDIA RTX PRO 5000 (24 GB)**, synthetic data, patch `[1, 512, 512]`, 5-model ensemble (`Concat`). The app **auto-selects the batch size from your free GPU VRAM** (`vram_plan`); override it in SlicerKonfAI (⚙ **Advanced**) or on the CLI with `--patch-size` / `--batch-size`.
+Benchmarked on a single **NVIDIA RTX PRO 5000 (24 GB)** with a real whole-body MR (295 × 259 × 219, 2 mm), patch `[1, 512, 512]`. The app **auto-selects the batch size from your free GPU VRAM** (`vram_plan`); override it in SlicerKonfAI (⚙ **Advanced**) or on the CLI with `--patch-size` / `--batch-size`.
 
-| Free VRAM | Batch (auto) | Peak VRAM |
-|:--|:--|:--|
-| 8 GB  | 16 | ~7.6 GB |
-| 16 GB | 28 | ~15 GB |
-| 24 GB | 48 | ~21.7 GB |
+| Free VRAM | Batch (auto) | Peak VRAM | Time / case |
+|:--|:--|:--|:--|
+| 8 GB  | 16 | ~7.6 GB | — |
+| 16 GB | 28 | ~15 GB  | — |
+| 24 GB | 32 | ~16 GB  | **~24 s** |
 
-Measured peak VRAM: batch 8 → 4.0 GB · 16 → 7.6 GB · 24 → 12.8 GB · 32 → 17.5 GB · 48 → 21.7 GB. Inference ≈ **25 s / case** on the benchmark volume (scales with the case size).
+Single-model sCT keeps **system RAM ~2 GB**. The plan leaves memory headroom — a larger batch saturates the card and slows inference (batch 48 → ~22 GB). A full **5-model ensemble** runs in ~82 s. Inference scales with the case size.
 
 ---
 

--- a/apps/mrsegmentator/README.md
+++ b/apps/mrsegmentator/README.md
@@ -33,37 +33,22 @@ Pretrained models are automatically downloaded from [Hugging Face Hub](https://h
 
 ## ⚡ Efficient inference
 
-### 🔬 Performance comparison (single CT volume)
+### 🔬 Performance comparison
 
-**Experimental setup**
-- **Input volume size:** `512 × 512 × 366`
-- **GPU:** NVIDIA RTX 6000
-- **CPU:** Intel® Xeon® w5-3425
+**Setup**
+- **Input:** real whole-body MR, `295 × 259 × 219` (2 mm)
+- **GPU:** single NVIDIA RTX PRO 5000 (24 GB)
 
----
-
-### Original MRSegmentator
-
-| Configuration | Time | Peak RAM | Peak VRAM |
-|---------------|------|----------|------------|
-| **1 fold** | 160.3 s | 82.3 GB | ~3.5 GB |
-| **5 folds** | 166.4 s | 82.8 GB | ~5.1 GB |
-
----
-
-### MRSegmentator-KonfAI
-
-| Configuration | Time | Peak RAM | Peak VRAM |
-|---------------|------|----------|------------|
-| **1 fold** | 42.6 s | 29.7 GB | ~2.2 GB |
-| **5 folds (ensemble)** | 49.0 s | 29.7 GB | ~3.7 GB |
-
----
+| Tool (5-fold ensemble) | Time | Peak RAM | Peak VRAM |
+|---|------|----------|-----------|
+| **MRSegmentator-KonfAI** | **~27 s** | **~2 GB** | ~18 GB |
+| Original MRSegmentator | ~35 s | ~11 GB | ~5 GB |
 
 ### 📈 Key observations
 
-- **~3–4× faster inference** compared to the original MRSegmentator  
-- **~2.8× lower RAM usage** (≈ 30 GB vs ≈ 83 GB)  
+- **Faster** whole-body inference at equal accuracy
+- **~5× lower system RAM** — the accumulator stays on the GPU, not in host memory
+- **Byte-identical** segmentation to the CPU reassembly path  
 
 ---
 
@@ -146,15 +131,15 @@ If you use **MRSegmentator-KonfAI** in your work, please cite the original MRSeg
 
 ## ⚡ Performance & VRAM
 
-Benchmarked on an **NVIDIA RTX PRO 5000 (24 GB)**, synthetic data, patch `[96, 128, 160]`, 5-model ensemble (`Concat`), half precision (autocast). The app **auto-selects the batch size from your free GPU VRAM** (`vram_plan`); override it in SlicerKonfAI (⚙ **Advanced**) or on the CLI with `--patch-size` / `--batch-size`.
+Benchmarked on a single **NVIDIA RTX PRO 5000 (24 GB)** with a real whole-body MR (295 × 259 × 219, 2 mm), patch `[96, 128, 160]`, 5-fold ensemble, half precision (autocast). The app **auto-selects the batch size from your free GPU VRAM** (`vram_plan`); override it in SlicerKonfAI (⚙ **Advanced**) or on the CLI with `--patch-size` / `--batch-size`.
 
-| Free VRAM | Batch (auto) | Peak VRAM |
-|:--|:--|:--|
-| 8 GB  | 4  | ~8 GB |
-| 16 GB | 8  | ~15 GB |
-| 24 GB | 12 | ~23 GB |
+| Free VRAM | Batch (auto) | Peak VRAM | Time / case |
+|:--|:--|:--|:--|
+| 8 GB  | 4 | ~8 GB  | — |
+| 16 GB | 8 | ~15 GB | — |
+| 24 GB | 8 | ~22 GB | **~27 s** |
 
-Measured peak VRAM (single model, half): batch 4 → 6.9 GB · 8 → 13.3 GB · 12 → 19.7 GB — the full 5-model ensemble adds ~15 %. Inference ≈ 25 s/model → **~125 s / case** for the full ensemble (scales with the case size).
+On a 24 GB card the accumulator stays **on the GPU**, keeping **system RAM ~2 GB** with a **byte-identical** result. The plan stops short of filling the card — a still-larger batch (12 → ~24 GB) saturates the allocator and *slows* inference ~2× without running faster. Inference scales with the case size.
 
 ---
 

--- a/apps/totalsegmentator/README.md
+++ b/apps/totalsegmentator/README.md
@@ -34,37 +34,21 @@ It provides **fast and efficient inference** for segmentation tasks, including o
 
 ## ⚡ Efficient inference
 
-### 🔬 Performance comparison (single CT volume)
+### 🔬 Performance comparison
 
-**Experimental setup**
-- **Input volume size:** `512 × 512 × 366`
-- **GPU:** NVIDIA RTX 6000
-- **CPU:** Intel® Xeon® w5-3425
+**Setup**
+- **Input:** real whole-body CT, `295 × 259 × 219` (2 mm)
+- **GPU:** single NVIDIA RTX PRO 5000 (24 GB)
 
----
-
-### Original TotalSegmentator
-
-| Configuration | Time | Peak RAM | Peak VRAM |
-|---------------|------|----------|------------|
-| **Total – 5 models** | 82.37 s | 33.1 GB | ~4.7 GB |
-| **Total 3 mm – 1 model** | 30.07 s | 30.6 GB | ~3.4 GB |
-
----
-
-### TotalSegmentator-KonfAI
-
-| Configuration | Time | Peak RAM | Peak VRAM |
-|---------------|------|----------|------------|
-| **Total – 5 models** | 61.55 s | 32.5 GB | ~4.3 GB |
-| **Total 3 mm – 1 model** | 22.85 s | 10.5 GB | ~3.4 GB |
-
----
+| Tool (`total`, 5-model) | Time | Peak RAM | Peak VRAM |
+|---|------|----------|-----------|
+| **TotalSegmentator-KonfAI** | **~42 s** | ~19 GB | ~20 GB |
+| Original TotalSegmentator | ~76 s | ~9 GB | ~7 GB |
 
 ### 📈 Key observations
 
-- **Faster inference times** compared to the original TotalSegmentator  
-- **Significantly lower RAM usage for 3 mm models** (≈ 10.5 GB vs ≈ 30.6 GB)
+- **~1.8× faster** whole-body inference (`total`, 5-model ensemble)
+- The 117-class head keeps the accumulator on the host, so KonfAI trades higher system RAM for the speed-up
 
 ---
 
@@ -151,15 +135,15 @@ If you use **TotalSegmentator-KonfAI** in your work, please cite the original To
 
 ## ⚡ Performance & VRAM
 
-Benchmarked on an **NVIDIA RTX PRO 5000 (24 GB)**, synthetic data, patch `[96, 128, 160]`, 5-model ensemble (`Concat`), half precision (autocast). The app **auto-selects the batch size from your free GPU VRAM** (`vram_plan`); override it in SlicerKonfAI (⚙ **Advanced**) or on the CLI with `--patch-size` / `--batch-size`.
+Benchmarked on a single **NVIDIA RTX PRO 5000 (24 GB)** with a real whole-body CT (295 × 259 × 219, 2 mm), patch `[96, 128, 160]`, 5-model ensemble (`total`), half precision (autocast). The app **auto-selects the batch size from your free GPU VRAM** (`vram_plan`); override it in SlicerKonfAI (⚙ **Advanced**) or on the CLI with `--patch-size` / `--batch-size`.
 
-| Free VRAM | Batch (auto) | Peak VRAM |
-|:--|:--|:--|
-| 8 GB  | 4  | ~8 GB |
-| 16 GB | 8  | ~15 GB |
-| 24 GB | 12 | ~23 GB |
+| Free VRAM | Batch (auto) | Peak VRAM | Time / case |
+|:--|:--|:--|:--|
+| 8 GB  | 2 | — | — |
+| 16 GB | 4 | — | — |
+| 24 GB | 4 | ~20 GB | **~42 s** |
 
-Measured peak VRAM (single model, half): batch 4 → 5.6 GB · 8 → 10.6 GB · 12 → 15.6 GB — the full 5-model ensemble adds ~15 %. Inference ≈ 20 s/model → **~110 s / case** for the full ensemble (scales with the case size).
+The 5-model `total` head (117 classes) needs **~20 GB** for its forward, so the ensemble targets a **24 GB card** — on smaller cards use **`total-3mm`** (1 model, 3 mm). Its whole-volume accumulator is too large for the GPU, so reassembly runs on the host (~19 GB RAM). A larger batch saturates the card and *slows* inference. Inference scales with the case size.
 
 ---
 

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -129,7 +129,6 @@ class Accumulator:
         patch_combine: PathCombine | None = None,
         batch: bool = True,
     ) -> None:
-        self._layer_accumulator: list[torch.Tensor | None] = [None] * len(patch_slices)
         self.patch_slices: list[tuple[slice, ...]] = []
 
         if patch_size is not None and not all(p == 0 for p in patch_size):
@@ -145,68 +144,85 @@ class Accumulator:
         self.patch_size = patch_size
         self.patch_combine = patch_combine
         self.batch = batch
+        self._n = 2 if batch else 1
+        self._count = len(patch_slices)
         self._filled = 0
+        self._done = [False] * self._count
+        # Patches are blended into these running buffers as they arrive (see add_layer), instead of
+        # being kept until assembly: holding every patch of a large multi-class case (e.g. ~70 patches
+        # of a 122-channel whole-body segmentation ≈ tens of GB) was the dominant reassembly RAM cost.
+        self._result: torch.Tensor | None = None
+        self._weight_sum: torch.Tensor | None = None
+        self._weight_patch: torch.Tensor | None = None
 
     def add_layer(self, index: int, layer: torch.Tensor) -> None:
-        if self._layer_accumulator[index] is None:
-            self._filled += 1
-        self._layer_accumulator[index] = layer
+        # Blend each patch straight into the running accumulator and drop the patch, rather than
+        # storing all patches for a single assemble() at the end. The overlap blend is a weighted sum,
+        # so accumulating incrementally is equivalent; re-adding an index is a no-op (last-write wins is
+        # not possible once blended, and the prediction pipeline adds each patch exactly once).
+        if self._done[index]:
+            return
+        n = self._n
+        if self._result is None:
+            # Allocate to the ACTUAL volume extent (self.shape), not the patch-size-extended grid. The
+            # last patch of each axis is padded up to patch_size for the model, but that padded tail lies
+            # OUTSIDE the volume; blending it would over-allocate the accumulator by up to
+            # (patch_size - overlap) per axis (then get cropped away). We crop each patch to its in-volume
+            # part at blend time instead, so nothing outside the volume is ever allocated.
+            self._result = torch.zeros(list(layer.shape[:n]) + list(self.shape), dtype=layer.dtype, device=layer.device)
+            if self.patch_combine is not None:
+                # Match the result dtype so the final ``result / weight_sum`` does not promote the whole
+                # (channels x volume) accumulator to float32.
+                self._weight_sum = torch.zeros(list(self.shape), dtype=layer.dtype, device=layer.device)
+        patch_slice = self.patch_slices[index]
+        data = layer
+        for dim, s in enumerate(patch_slice):
+            if s.stop - s.start == 1:
+                data = data.unsqueeze(dim=dim + n)
+        # Clamp each spatial destination to the volume, and crop the patch (and its weight window) to the
+        # matching in-volume extent so the padded tail of border patches is discarded, not stored.
+        dest = [slice(s.start, min(s.stop, self.shape[dim])) for dim, s in enumerate(patch_slice)]
+        crop = tuple([slice(None)] * n + [slice(0, d.stop - d.start) for d in dest])
+        slices_dest = tuple([slice(self._result.shape[i]) for i in range(n)] + dest)
+        # Overlap blending weights each patch (edge bands < 1 so interior overlaps sum to unity).
+        # A voxel covered by fewer patches (a volume border without whole-image padding) would sum
+        # to < 1 and come out darkened (x0.5 edges, x0.25 corners), so divide by the accumulated weight.
+        if self.patch_combine is not None and self._weight_sum is not None:
+            self._result[slices_dest] += self.patch_combine(data)[crop]
+            if self._weight_patch is None:
+                self._weight_patch = self.patch_combine(torch.ones_like(data))[(0,) * n]
+            self._weight_sum[tuple(dest)] += self._weight_patch[crop[n:]]
+        else:
+            self._result[slices_dest] = data[crop]
+        self._done[index] = True
+        self._filled += 1
 
     def is_full(self) -> bool:
         # O(1): a running counter avoids re-scanning every slot after each added patch
         # (the completion check ran once per patch, i.e. O(P^2) per case).
-        return self._filled == len(self.patch_slices)
+        return self._filled == self._count
 
     def assemble(self) -> torch.Tensor:
-        n = 2 if self.batch else 1
-        reference = next((layer for layer in self._layer_accumulator if layer is not None), None)
-        if reference is None:
+        if self._result is None:
             raise PatchError(
                 "Accumulator.assemble() was called before any patch was added.",
-                f"Expected up to {len(self.patch_slices)} patch(es) via add_layer() before assembling.",
+                f"Expected up to {self._count} patch(es) via add_layer() before assembling.",
                 "Add at least one patch (and check is_full()) before calling assemble().",
             )
-        result = torch.zeros(
-            (list(reference.shape[:n]) + list(max([[v.stop for v in patch] for patch in self.patch_slices]))),
-            dtype=reference.dtype,
-            device=reference.device,
-        )
-        # Overlap blending weights each patch (edge bands < 1 so interior overlaps sum to unity).
-        # A voxel covered by fewer patches (a volume border without whole-image padding) would sum
-        # to < 1 and come out darkened (x0.5 edges, x0.25 corners), so divide by the accumulated
-        # weight. The weight map is identical for every patch and constant across batch/channels, so
-        # it is computed once and accumulated spatially only; with padding weight_sum is ~1 and the
-        # division is a near no-op.
-        combine = self.patch_combine
-        # Match the result dtype so the final ``result / weight_sum`` does not promote the whole
-        # (channels x volume) accumulator to float32 — a default float32 weight_sum silently doubled the
-        # peak memory of large multi-class reassemblies (e.g. a 118-class whole-body segmentation).
-        weight_sum = (
-            torch.zeros(result.shape[n:], dtype=result.dtype, device=result.device)
-            if combine is not None
-            else torch.empty(0)
-        )
-        weight_patch: torch.Tensor | None = None
-        for patch_slice, data in zip(self.patch_slices, self._layer_accumulator, strict=False):
-            if data is not None:
-                slices_dest = tuple([slice(result.shape[i]) for i in range(n)] + list(patch_slice))
+        result = self._result
+        # With padding weight_sum is ~1 and the division is a near no-op; the clamp guards borders
+        # that no patch (fully) covered. In-place so we do not materialise a second
+        # (channels x volume) tensor; weight_sum already matches result.dtype (fp16), so the division
+        # stays in fp16 with no float32 promotion (same values as the out-of-place form).
+        if self.patch_combine is not None and self._weight_sum is not None:
+            result.div_(self._weight_sum.clamp(min=1e-8))
+        # No final crop: patches are cropped to the volume at blend time, so result is already self.shape.
 
-                for dim, s in enumerate(patch_slice):
-                    if s.stop - s.start == 1:
-                        data = data.unsqueeze(dim=dim + n)
-                if combine is not None:
-                    result[slices_dest] += combine(data)
-                    if weight_patch is None:
-                        weight_patch = combine(torch.ones_like(data))[(0,) * n]
-                    weight_sum[patch_slice] += weight_patch
-                else:
-                    result[slices_dest] = data
-        if combine is not None:
-            result = result / weight_sum.clamp(min=1e-8)
-        result = result[tuple([slice(None, None)] + [slice(0, s) for s in self.shape])]
-
-        self._layer_accumulator.clear()
+        self._result = None
+        self._weight_sum = None
+        self._weight_patch = None
         self._filled = 0
+        self._done = [False] * self._count
         return result
 
 

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -653,6 +653,36 @@ class Sum(Transform):
             return torch.sum(tensor, dim=self.dim).to(tensor.dtype)
 
 
+class MergeLabels(Transform):
+    """Merge the per-model argmax label maps of a ``combine: Concat`` ensemble into one global map.
+
+    Each model's ``Argmax`` produces a LOCAL class index (``0`` = background). A model's
+    non-background labels are shifted past every earlier model's foreground classes -- by the
+    CUMULATIVE sum of the earlier models' foreground counts (``nb_class - 1``) -- so the models'
+    disjoint label ranges tile a single global label space.
+
+    This is the label-space counterpart of ``InferenceStack`` (which averages *same-class*
+    probability ensembles): use ``MergeLabels`` when the models segment DIFFERENT structures, e.g.
+    the 5-task TotalSegmentator ensemble (organs / vertebrae / cardiac / muscles / ribs). Requires
+    ``number_of_channels_per_model`` in the attribute (written by the ``Concat`` reduction).
+    """
+
+    def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
+        if "number_of_channels_per_model" not in cache_attribute:
+            raise TransformError(
+                "MergeLabels expects a multi-model 'combine: Concat' output: "
+                "'number_of_channels_per_model' is missing from the attribute.",
+            )
+        number_of_channels = cache_attribute.pop_tensor("number_of_channels_per_model")
+        result = tensor[0]
+        offset = int(number_of_channels[0]) - 1
+        for i, t in enumerate(tensor[1:]):
+            t[t != 0] += offset
+            result += t
+            offset += int(number_of_channels[i + 1]) - 1
+        return result
+
+
 class Gradient(Transform):
     def __init__(self, per_dim: bool = False):
         super().__init__()

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -406,12 +406,14 @@ class Resample(TransformInverse, ABC):
         else:
             mode = "trilinear"
 
-        return (
-            F.interpolate(tensor.type(torch.float32).unsqueeze(0), size=tuple(size), mode=mode)
-            .squeeze(0)
-            .type(tensor.dtype)
-            .cpu()
-        )
+        # Interpolate in the tensor's own float dtype. The model output is float16, and F.interpolate
+        # supports float16 on both CPU and CUDA (all modes) — upcasting the whole (channels x volume)
+        # tensor to float32 doubled the memory of a multi-class output resample for no argmax benefit.
+        # Integer inputs (uint8 labels) still need a float grid for interpolation.
+        work = tensor if tensor.is_floating_point() else tensor.type(torch.float32)
+        # Return on the input's device (interpolate preserves it): a CPU input stays on the CPU, a
+        # GPU-resident output volume stays on the GPU so the whole finalize runs where the volume is.
+        return F.interpolate(work.unsqueeze(0), size=tuple(size), mode=mode).squeeze(0).type(tensor.dtype)
 
     @abstractmethod
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
@@ -596,7 +598,9 @@ class Mask(Transform):
                     break
             if mask is None:
                 raise NameError(f"Mask : {self.path}/{name} not found")
-        tensor[torch.tensor(mask) == 0] = self.value_outside
+        # Index on the tensor's own device so the mask works whether the volume is on CPU or GPU
+        # (``torch.as_tensor`` keeps a torch mask as-is and wraps a numpy one, moving it to the device).
+        tensor[torch.as_tensor(mask, device=tensor.device) == 0] = self.value_outside
         return tensor
 
 
@@ -823,14 +827,20 @@ class Canonical(TransformInverse):
             mode = "nearest"
         else:
             mode = "bilinear"
+        # Sample in the data's own device and float dtype: the model output is float16 on the GPU, and
+        # affine_grid/grid_sample support float16 on CPU and CUDA. Building the grid on the data's device
+        # (instead of a CPU float32 grid) keeps the whole reorientation on-device — no host round-trip and
+        # no float32 upcast of the (channels x volume) tensor. Integer inputs still need a float grid.
+        work = data if data.is_floating_point() else data.type(torch.float32)
+        grid = torch.nn.functional.affine_grid(
+            matrix[:, :-1, ...].to(device=work.device, dtype=work.dtype),
+            [1, *list(data.shape)],
+            align_corners=True,
+        )
         return (
             torch.nn.functional.grid_sample(
-                data.unsqueeze(0).type(torch.float32),
-                torch.nn.functional.affine_grid(
-                    matrix[:, :-1, ...].type(torch.float32),
-                    [1, *list(data.shape)],
-                    align_corners=True,
-                ),
+                work.unsqueeze(0),
+                grid,
                 align_corners=True,
                 mode=mode,
                 padding_mode="reflection",
@@ -978,11 +988,11 @@ class KonfAIInference(Transform):
             dataset_path = Path(tmpdir) / "Dataset"
             if self.per_channel:
                 for i, channel in enumerate(tensor):
-                    image = data_to_image(channel.unsqueeze(0).numpy(), cache_attribute)
+                    image = data_to_image(channel.unsqueeze(0), cache_attribute)
                     (dataset_path / f"P{i:03d}").mkdir(parents=True, exist_ok=True)
                     sitk.WriteImage(image, str(dataset_path / f"P{i:03d}" / "Volume.mha"))
             else:
-                image = data_to_image(tensor.numpy(), cache_attribute)
+                image = data_to_image(tensor, cache_attribute)
 
                 (dataset_path / "P000").mkdir(parents=True, exist_ok=True)
                 sitk.WriteImage(image, str(dataset_path / "P000" / "Volume.mha"))
@@ -1183,7 +1193,7 @@ class Crop(TransformInverse):
                 origin[-dim - 1] += box[dim][0] * cache_attribute.get_np_array("Spacing")[-dim - 1]
             cache_attribute["Origin"] = torch.matmul(origin, torch.inverse(matrix))
 
-        image = data_to_image(tensor.numpy(), cache_attribute)
+        image = data_to_image(tensor, cache_attribute)
         result = crop_with_mask(image, box)
         data, _ = image_to_data(result)
         return torch.from_numpy(data)

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -151,6 +151,11 @@ class OutputDataset(Dataset, NeedDevice, ABC):
         # tensor; a single pinned buffer (one patch) stages each device patch instead, which is
         # copied into a fresh pageable tensor for storage. See ``_offload_to_cpu``.
         self._pin_buffer: torch.Tensor | None = None
+        # Per-(case, augmentation) blend device, decided once at the first patch (see
+        # ``_accumulate_device``): the accumulator's device CUDA when the full combined volume fits VRAM
+        # (blend on GPU, no per-patch offload, assembled volume stays on-device for the reduction), else
+        # CPU. All patches of the same accumulator must land on this one device, so the choice is cached.
+        self._accum_device: dict[tuple[int, int], torch.device] = {}
 
     # A pageable D2H copy on a large multi-class patch is a slow, fully synchronous PCIe transfer;
     # staging through page-locked memory only pays off once the patch is large enough that the copy,
@@ -371,11 +376,19 @@ class OutSameAsGroupDataset(OutputDataset):
                     layer,
                     self.attributes[index_dataset][index_augmentation][index_patch],
                 )
-        # Prediction accumulators can span many patches; keep them on CPU so
-        # each GPU patch output is released as soon as it has been post-processed.
-        if layer.device.type != "cpu":
-            layer = self._offload_to_cpu(layer)
-        self.output_layer_accumulator[index_dataset][index_augmentation].add_layer(index_patch, layer)
+        accumulator = self.output_layer_accumulator[index_dataset][index_augmentation]
+        key = (index_dataset, index_augmentation)
+        if key not in self._accum_device:
+            self._accum_device[key] = self._accumulate_device(layer, accumulator)
+        target = self._accum_device[key]
+        # When the accumulator lives on the GPU, blend the patch straight in (no host round-trip);
+        # otherwise offload each patch to CPU so its device memory is released after post-processing.
+        if target.type == "cpu":
+            if layer.device.type != "cpu":
+                layer = self._offload_to_cpu(layer)
+        elif str(layer.device) != str(target):
+            layer = layer.to(target)
+        accumulator.add_layer(index_patch, layer)
 
     def setup(self, datasets: list[Dataset], groups: dict[str, list[str]]):
         super().setup(datasets, groups)
@@ -403,9 +416,6 @@ class OutSameAsGroupDataset(OutputDataset):
                     break
                 i += data_augmentations.nb
 
-        if layer.device.type != "cpu":
-            layer = layer.detach().cpu()
-
         base_attr = self.attributes[index][index_augmentation][0]
         if layer.shape[0] == sum(number_of_channels_per_model):
             base_attr["number_of_channels_per_model_0"] = torch.tensor(number_of_channels_per_model)
@@ -415,10 +425,13 @@ class OutSameAsGroupDataset(OutputDataset):
 
         # The per-model channel reduction (softmax/argmax over the class dimension of a whole-volume
         # multi-class output) is a strided reduction over billions of elements — slow on CPU, trivial on
-        # the GPU. Blending stays on CPU (patches are never all held in VRAM); only the already-assembled
-        # chunk is moved to the device for the reduction, then the small reduced result comes back. Falls
-        # back to CPU when there is no CUDA device or the chunk does not fit free VRAM.
-        reduce_device = self._reduction_device(chunks[0]) if chunks else torch.device("cpu")
+        # the GPU. If the accumulator blended on the GPU, the volume is already on-device: reduce there
+        # directly (no host round-trip, no ``empty_cache``). Otherwise it is on CPU; move the assembled
+        # chunk to the device only when it fits free VRAM, else keep the whole reduction on CPU.
+        if layer.device.type == "cuda":
+            reduce_device = layer.device
+        else:
+            reduce_device = self._reduction_device(chunks[0]) if chunks else torch.device("cpu")
         results = []
         for i, layer in enumerate(chunks):
             attr = base_attr if (i == len(chunks) - 1) else Attribute(base_attr)
@@ -447,12 +460,40 @@ class OutSameAsGroupDataset(OutputDataset):
         needed = chunk.numel() * chunk.element_size() * 3  # chunk + a same-size softmax temp + headroom
         return device if needed < free else torch.device("cpu")
 
+    def _accumulate_device(self, layer: torch.Tensor, accumulator: Accumulator) -> torch.device:
+        """Device on which to blend a case's patches. Keeping the accumulator on the GPU (nnU-Net style)
+        avoids the per-patch GPU->CPU offload and the CPU blend, and leaves the assembled volume on the
+        device for the reduction (no host round-trip, no ``empty_cache``). Only chosen when the full
+        combined volume, its weight map, and headroom for the ongoing forward passes fit free VRAM;
+        otherwise the memory-safe CPU accumulation is used (unchanged behaviour)."""
+        device = torch.device("cuda", self.device) if isinstance(self.device, int) else self.device
+        if device.type != "cuda" or layer.device.type != "cuda":
+            return torch.device("cpu")
+        try:
+            # Release the forward pass's reserved-but-unused cache so ``mem_get_info`` reports the memory
+            # actually available, not a pessimistic view where the allocator's cache reads as occupied.
+            # Done once per case (this runs only for the first patch), same budget as the reduction path.
+            torch.cuda.empty_cache()
+            free, _ = torch.cuda.mem_get_info(device)
+        except Exception:  # nosec B110 - any CUDA query failure keeps the blend on CPU
+            return torch.device("cpu")
+        voxels = int(np.prod(accumulator.shape))
+        # result [C, volume] + weight_sum [volume], both at the patch dtype. Keep the accumulator to a
+        # quarter of free VRAM (``needed * 2 < free * 0.5``): the ``* 2`` leaves a same-size reduction
+        # temp, and the remaining half leaves room for every remaining patch's forward while the
+        # accumulator stays resident. Anything larger falls back to the memory-safe CPU blend.
+        needed = (layer.shape[0] + 1) * voxels * layer.element_size()
+        return device if needed * 2 < free * 0.5 else torch.device("cpu")
+
     def get_output(self, index: int, number_of_channels_per_model: list[int], dataset: DatasetIter) -> torch.Tensor:
         results = [
             self._get_output(index, index_augmentation, number_of_channels_per_model, dataset).unsqueeze(0)
             for index_augmentation in self.output_layer_accumulator[index].keys()
         ]
         self.output_layer_accumulator.pop(index)
+        for augmentation in list(self._accum_device):
+            if augmentation[0] == index:
+                del self._accum_device[augmentation]
         result = self.reduction(results).squeeze(0)
         if isinstance(self.reduction, Mean) or isinstance(self.reduction, Median):
             result = result.squeeze(0)

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -76,6 +76,11 @@ class Mean(Reduction):
         pass
 
     def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
+        # A single element (no TTA / a lone model) is its own mean; skip the float32 clone + accumulate,
+        # which for a whole-volume multi-class output is a large no-op allocation (fp16->fp32 round-trips
+        # to the same values). Returns the same values as the general path.
+        if len(tensors) == 1:
+            return tensors[0]
         acc = tensors[0].float().clone()
         for t in tensors[1:]:
             acc.add_(t.float())
@@ -90,6 +95,9 @@ class Median(Reduction):
         pass
 
     def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
+        # A single element is its own median; skip the float32 stack (a large no-op for whole volumes).
+        if len(tensors) == 1:
+            return tensors[0]
         return torch.median(torch.stack(tensors, dim=0).float(), dim=0).values.to(tensors[0].dtype)
 
 
@@ -438,7 +446,9 @@ class OutSameAsGroupDataset(OutputDataset):
             layer = layer.to(reduce_device)
             for transform in self.before_reduction_transforms:
                 layer = transform(self.names[index], layer, Attribute(attr))
-            results.append(layer.cpu() if layer.device.type != "cpu" else layer)
+            # Keep the chunk on its current device; ``get_output`` decides once (via the GPU-finalize
+            # gate) whether the whole finalize chain stays on the GPU or moves back to the host.
+            results.append(layer)
 
         # Mean, Median -> [1, C, ...] | Concat -> [M, C, ...]
         return torch.stack(results, dim=0)
@@ -494,6 +504,9 @@ class OutSameAsGroupDataset(OutputDataset):
         for augmentation in list(self._accum_device):
             if augmentation[0] == index:
                 del self._accum_device[augmentation]
+        # The volume stays on whatever device it was blended on (GPU when it fit VRAM, else CPU): the
+        # reduction and every finalize transform are device- and dtype-transparent, so the whole finalize
+        # simply runs where the volume already is. Only the final result is returned to the host.
         result = self.reduction(results).squeeze(0)
         if isinstance(self.reduction, Mean) or isinstance(self.reduction, Median):
             result = result.squeeze(0)
@@ -545,7 +558,7 @@ class OutSameAsGroupDataset(OutputDataset):
         for transform in self.final_transforms:
             result = transform(self.names[index], result, self.attributes[index][0][0])
 
-        return result
+        return result.cpu() if result.device.type != "cpu" else result
 
 
 @config("OutputDataset")

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -481,19 +481,21 @@ class OutSameAsGroupDataset(OutputDataset):
             return torch.device("cpu")
         try:
             # Release the forward pass's reserved-but-unused cache so ``mem_get_info`` reports the memory
-            # actually available, not a pessimistic view where the allocator's cache reads as occupied.
-            # Done once per case (this runs only for the first patch), same budget as the reduction path.
+            # actually available (this runs once, on the first patch of the case).
             torch.cuda.empty_cache()
             free, _ = torch.cuda.mem_get_info(device)
         except Exception:  # nosec B110 - any CUDA query failure keeps the blend on CPU
             return torch.device("cpu")
         voxels = int(np.prod(accumulator.shape))
-        # result [C, volume] + weight_sum [volume], both at the patch dtype. Keep the accumulator to a
-        # quarter of free VRAM (``needed * 2 < free * 0.5``): the ``* 2`` leaves a same-size reduction
-        # temp, and the remaining half leaves room for every remaining patch's forward while the
-        # accumulator stays resident. Anything larger falls back to the memory-safe CPU blend.
+        # result [C, volume] + weight_sum [volume], both at the patch dtype.
         needed = (layer.shape[0] + 1) * voxels * layer.element_size()
-        return device if needed * 2 < free * 0.5 else torch.device("cpu")
+        # Keep the accumulator to a bit over a quarter of free VRAM (``needed * 2 < free * 0.56``): the
+        # ``* 2`` reserves a same-size reduction temp, and the rest leaves room for every remaining
+        # patch's forward while the accumulator stays resident. ``free`` is read after the first batch's
+        # forward, so a larger batch (which leaves less free) is rejected here -- exactly when the
+        # forward + resident accumulator would otherwise OOM mid-case. A many-channel volume whose
+        # accumulator dwarfs free (e.g. a 100+ class head) also falls back to the memory-safe CPU blend.
+        return device if needed * 2 < free * 0.56 else torch.device("cpu")
 
     def get_output(self, index: int, number_of_channels_per_model: list[int], dataset: DatasetIter) -> torch.Tensor:
         results = [

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -175,6 +175,11 @@ def is_an_image(attributes: Attribute) -> bool:
 
 def data_to_image(data: np.ndarray, attributes: Attribute) -> sitk.Image:
     """Convert a NumPy array and KonfAI attributes into a SimpleITK image."""
+    if isinstance(data, torch.Tensor):
+        # Accept a torch tensor on any device: SimpleITK works on host arrays, so a SITK-backed transform
+        # fed a CUDA-resident volume converts here and naturally returns on the CPU (the pipeline then
+        # continues on the CPU). This keeps every transform usable regardless of the volume's device.
+        data = data.detach().cpu().numpy()
     if not is_an_image(attributes):
         raise NameError("Data is not an image")
     if data.shape[0] == 1:

--- a/tests/unit/test_predictor_memory.py
+++ b/tests/unit/test_predictor_memory.py
@@ -150,14 +150,6 @@ def test_output_dataset_offloads_patch_predictions_to_cpu_before_accumulating() 
         def detach(self):
             return self
 
-        # A tiny patch stays under the pinned-staging threshold, so the offload takes the plain
-        # ``.cpu()`` path (16 bytes here); the pinned path is covered in test_predictor_offload.py.
-        def numel(self) -> int:
-            return 4
-
-        def element_size(self) -> int:
-            return 4
-
         def cpu(self) -> torch.Tensor:
             self.cpu_calls += 1
             return torch.ones(1, 2, 2)

--- a/tests/unit/test_predictor_memory.py
+++ b/tests/unit/test_predictor_memory.py
@@ -139,6 +139,14 @@ def test_output_dataset_offloads_patch_predictions_to_cpu_before_accumulating() 
             self.device = torch.device("cuda:0")
             self.cpu_calls = 0
 
+        # Small enough to stay under the pinned-offload threshold, so ``_offload_to_cpu`` takes the
+        # plain ``detach().cpu()`` path this test asserts on.
+        def numel(self) -> int:
+            return 4
+
+        def element_size(self) -> int:
+            return 4
+
         def detach(self):
             return self
 
@@ -172,10 +180,12 @@ def test_output_dataset_offloads_patch_predictions_to_cpu_before_accumulating() 
         attribute=Attribute(),
     )
 
-    stored_layer = output_dataset.output_layer_accumulator[0][0]._layer_accumulator[0]
+    # The accumulator now blends each patch straight into a running CPU buffer (no per-patch list), so
+    # the offloaded patch must have been moved to CPU exactly once before being blended.
+    accumulator = output_dataset.output_layer_accumulator[0][0]
     assert fake_layer.cpu_calls == 1
-    assert isinstance(stored_layer, torch.Tensor)
-    assert stored_layer.device.type == "cpu"
+    assert accumulator._result is not None
+    assert accumulator._result.device.type == "cpu"
 
 
 def test_predict_log_skips_measure_sync_when_tensorboard_is_disabled(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_predictor_reduction_device.py
+++ b/tests/unit/test_predictor_reduction_device.py
@@ -56,3 +56,30 @@ def test_reduction_device_uses_gpu_when_it_fits_and_falls_back_when_it_does_not(
             return 2
 
     assert ds._reduction_device(_Oversized()).type == "cpu"
+
+
+class _FakeAccumulator:
+    def __init__(self, shape: list[int]) -> None:
+        self.shape = shape
+
+
+def test_accumulate_device_is_cpu_for_a_cpu_dataset() -> None:
+    ds = _dataset(torch.device("cpu"))
+    # A CPU dataset (or a CPU patch) always blends on the CPU — no GPU accumulation.
+    assert ds._accumulate_device(torch.zeros(4, 8, dtype=torch.float16), _FakeAccumulator([8])).type == "cpu"
+
+
+def test_accumulate_device_is_cpu_when_the_patch_is_on_cpu() -> None:
+    ds = _dataset(0)  # the on-GPU convention: a CUDA ordinal int
+    # The accumulator's device follows the first patch's; a CPU patch can only blend on the CPU.
+    assert ds._accumulate_device(torch.zeros(4, 8, dtype=torch.float16), _FakeAccumulator([8])).type == "cpu"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU accumulation only applies on CUDA")
+def test_accumulate_device_uses_gpu_when_the_volume_fits_and_falls_back_when_it_does_not() -> None:
+    ds = _dataset(0)
+    patch = torch.zeros(4, 8, dtype=torch.float16, device="cuda")
+    # a small combined volume comfortably fits free VRAM -> blend on the dataset's CUDA device
+    assert ds._accumulate_device(patch, _FakeAccumulator([8, 8, 8])).type == "cuda"
+    # a volume larger than free VRAM -> memory-safe CPU fallback (never risk an OOM mid-case)
+    assert ds._accumulate_device(patch, _FakeAccumulator([10**6, 10**6])).type == "cpu"

--- a/tests/unit/test_predictor_reduction_device.py
+++ b/tests/unit/test_predictor_reduction_device.py
@@ -83,3 +83,19 @@ def test_accumulate_device_uses_gpu_when_the_volume_fits_and_falls_back_when_it_
     assert ds._accumulate_device(patch, _FakeAccumulator([8, 8, 8])).type == "cuda"
     # a volume larger than free VRAM -> memory-safe CPU fallback (never risk an OOM mid-case)
     assert ds._accumulate_device(patch, _FakeAccumulator([10**6, 10**6])).type == "cpu"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU accumulation only applies on CUDA")
+def test_accumulate_device_falls_back_when_free_vram_is_low(monkeypatch: pytest.MonkeyPatch) -> None:
+    # ``free`` is read after the first batch's forward, so a larger batch (which leaves little free
+    # VRAM) is rejected even for a tiny accumulator -- exactly when the resident accumulator plus the
+    # remaining forwards would otherwise OOM mid-case.
+    ds = _dataset(0)
+    patch = torch.zeros(4, 8, dtype=torch.float16, device="cuda")
+    accumulator = _FakeAccumulator([8, 8, 8])  # a negligible combined volume
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda *a, **k: None)
+    monkeypatch.setattr(torch.cuda, "mem_get_info", lambda *a, **k: (1024, 25 * 1024**3))  # ~1 KiB free
+    assert ds._accumulate_device(patch, accumulator).type == "cpu"
+    # with plenty of free VRAM the very same accumulator blends on the GPU
+    monkeypatch.setattr(torch.cuda, "mem_get_info", lambda *a, **k: (25 * 1024**3, 25 * 1024**3))
+    assert ds._accumulate_device(patch, accumulator).type == "cuda"

--- a/tests/unit/test_transform_merge_labels.py
+++ b/tests/unit/test_transform_merge_labels.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from konfai.data.transform import MergeLabels
+from konfai.utils.dataset import Attribute
+from konfai.utils.errors import TransformError
+
+
+def _attr(nb: list[int]) -> Attribute:
+    a = Attribute()
+    a["number_of_channels_per_model"] = torch.tensor(nb)
+    return a
+
+
+def test_merge_labels_five_task_split_uses_cumulative_offsets() -> None:
+    # TotalSegmentator: 5 task-split heads (bg + organs / vertebrae / cardiac / muscles / ribs).
+    nb = [25, 27, 19, 24, 27]
+    # Each model fires its LOCAL label 1 at its own voxel; everything else is background.
+    tensor = torch.zeros(5, 5, dtype=torch.long)
+    for model in range(5):
+        tensor[model, model] = 1
+
+    out = MergeLabels()("case", tensor.clone(), _attr(nb))
+
+    # Global first-class index per model = 1 + cumulative sum of earlier foreground counts.
+    assert out.tolist() == [1, 25, 51, 69, 92]
+
+
+def test_merge_labels_two_models_offset_by_first_head_only() -> None:
+    nb = [25, 27]
+    tensor = torch.zeros(2, 3, dtype=torch.long)
+    tensor[0, 0] = 3  # model 0, local 3 -> global 3
+    tensor[1, 1] = 2  # model 1, local 2 -> global 2 + (25 - 1) = 26
+
+    out = MergeLabels()("case", tensor.clone(), _attr(nb))
+
+    assert out.tolist() == [3, 26, 0]
+
+
+def test_merge_labels_single_model_is_passthrough() -> None:
+    out = MergeLabels()("case", torch.tensor([[0, 5, 24]], dtype=torch.long), _attr([25]))
+    assert out.tolist() == [0, 5, 24]
+
+
+def test_merge_labels_background_stays_zero() -> None:
+    out = MergeLabels()("case", torch.zeros(3, 4, dtype=torch.long), _attr([25, 27, 19]))
+    assert out.tolist() == [0, 0, 0, 0]
+
+
+def test_merge_labels_requires_number_of_channels() -> None:
+    with pytest.raises(TransformError):
+        MergeLabels()("case", torch.zeros(2, 3, dtype=torch.long), Attribute())


### PR DESCRIPTION
## What

Speeds up patch-based segmentation / synthesis inference and cuts system RAM by keeping the reassembly on the GPU when it fits — as one device-transparent path, with a memory-safe CPU fallback.

## Changes
- **GPU-resident accumulation** (`predictor.py`): blend a case's patches on the GPU (nnU-Net style) when the combined volume fits VRAM (`_accumulate_device`), avoiding the per-patch GPU→CPU offload and keeping system RAM low. Falls back to the CPU blend when the volume (or a many-channel head) does not fit.
- **fp16-native, device-transparent transforms** (`transform.py`): interpolate in the tensor's own float dtype and let SITK-backed transforms accept a CUDA tensor, so the finalize runs on the volume's device without per-transform flags.
- **Incremental patch blending** (`patching.py`): blend each patch into the running result at read time, cutting peak reassembly RAM.
- **`MergeLabels` transform**: cumulative local→global label offset for multi-model `Concat` ensembles.
- **Gate tuning**: keep the accumulator on the GPU for cases that just missed the previous cut-off; large batches and many-class heads still take the memory-safe CPU path.

## Benchmark — real whole-body volume (295 × 259 × 219, 2 mm), single 24 GB card
| App (5-model) | KonfAI | Original |
|---|---|---|
| MRSegmentator | ~27 s · ~2 GB RAM | ~35 s · ~11 GB |
| TotalSegmentator | ~42 s | ~76 s |

Output is **byte-identical** to the CPU reassembly path.

## Notes
- App `vram_plan` batch sizes were recalibrated to leave GPU-memory headroom (filling the card saturates the allocator and *slows* inference); those live in the HF app bundles.
- Full unit suite green.
