### PR TITLE
fix: unblock Slicer inference (restore current_free_vram + file_system tensor sharing)

### DIFF
--- a/konfai-apps/konfai_apps/app_repository.py
+++ b/konfai-apps/konfai_apps/app_repository.py
@@ -150,6 +150,24 @@ def is_app_repo(filenames: list[str]) -> bool:
     return "app.json" in filenames
 
 
+def current_free_vram(devices: list[int], remote_server: RemoteServer | None = None) -> float | None:
+    """Free VRAM (GB) available on ``devices`` — the minimum across them, mirroring how inference picks
+    its VRAM plan. Returns ``None`` on CPU (no devices) or when VRAM cannot be read; a device whose VRAM
+    query fails is skipped rather than failing the whole measurement. UIs pair it with
+    :meth:`AppRepositoryInfo.resolve_vram_plan` to preview the plan for the current machine."""
+    from konfai import get_vram
+
+    frees = []
+    for device in devices:
+        # A device whose VRAM query fails (NVML/remote hiccup) is skipped, not fatal.
+        try:
+            used_gb, total_gb = get_vram([int(device)], remote_server)
+            frees.append(total_gb - used_gb)
+        except Exception:  # nosec B112
+            continue
+    return min(frees) if frees else None
+
+
 class VolumeType(Enum):
     SEGMENTATION = "SEGMENTATION"
     VOLUME = "VOLUME"

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -726,6 +726,10 @@ def execute_distributed_object(
                 if world_size == 0:
                     world_size = cpu_workers
                 configured_object.setup(world_size)
+                # Share tensors through /dev/shm files instead of one file descriptor per tensor:
+                # spawning a worker that pickles a loaded model can otherwise exhaust the process
+                # open-file limit ("Too many open files"), e.g. under Slicer's embedded Python.
+                mp.set_sharing_strategy("file_system")
                 with TensorBoard(configured_object.name):
                     mp.spawn(configured_object, nprocs=world_size)
     finally:


### PR DESCRIPTION
PR #33's params cleanup removed `current_free_vram` alongside the genuinely-unused `resolve_vram_plan_for_devices` — but **SlicerKonfAI** imports `current_free_vram` to feed `resolve_vram_plan` for the advanced-dialog patch/batch preview, so `on_advanced_clicked` raised `ImportError` at runtime.

Restores the helper (unchanged signature `current_free_vram(devices, remote_server=None) -> float | None`). `resolve_vram_plan_for_devices` stays removed — nothing calls it. My earlier dead-code grep only covered the KonfAI repo, missing the external SlicerKonfAI dependency.