### PR TITLE
fix(config): honour a None default for an optional nested object

### DIFF
--- a/konfai/utils/config.py
+++ b/konfai/utils/config.py
@@ -347,17 +347,22 @@ def _resolve_annotation(function, annotation):
         return annotation
 
 
-def _unwrap_optional(annotation):
+def _unwrap_optional(annotation) -> tuple[Any, bool]:
+    """Return ``(bound type, was Optional[X])``.
+
+    The flag is what tells an ``X | None`` parameter from a plain ``X``: both bind on ``X``, but only
+    the first may legitimately stay ``None`` (see the nested-object binding in ``apply_config``).
+    """
     origin = get_origin(annotation)
     if origin not in {Union, types.UnionType}:
-        return annotation
+        return annotation, False
 
     args = [arg for arg in get_args(annotation) if arg not in {type(None), types.NoneType}]
     if len(args) == 1:
-        return args[0]
+        return args[0], True
     # Genuine unions (e.g. ``float | str``) are kept intact so the binding can try each
     # member type; only ``Optional[X]`` (``X | None``) collapses to ``X``.
-    return annotation
+    return annotation, False
 
 
 def _convert_union_sequence_value(
@@ -461,7 +466,7 @@ def apply_config(konfai_args: str | None = None):
                                     )
                                 kwargs[param.name] = value
                                 continue
-                            annotation = _unwrap_optional(annotation)
+                            annotation, is_optional = _unwrap_optional(annotation)
 
                             if annotation == inspect._empty:
                                 if param.name != "self":
@@ -583,6 +588,15 @@ def apply_config(konfai_args: str | None = None):
                                     raise ConfigError(f"{values} {exc}") from exc
                                 continue
 
+                            # ``X | None = None`` declares an object the config must ASK for: binding it
+                            # anyway would build X's defaults and write them back, turning "no patch" into
+                            # a patch nobody configured. A non-None default (``X | None = X()``) is the
+                            # opposite declaration and still binds.
+                            if is_optional and param.default is None:
+                                annotation_key = getattr(annotation, "_key", None)
+                                if annotation_key is None or config.get_value(annotation_key, None) is None:
+                                    kwargs[param.name] = None
+                                    continue
                             try:
                                 kwargs[param.name] = apply_config(key_tmp)(annotation)()
                             except Exception as exc:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -154,6 +154,55 @@ def test_apply_config_preserves_none_for_optional_nested_objects(write_config) -
     assert root.child is None
 
 
+def test_apply_config_keeps_a_none_default_when_the_config_is_silent(write_config) -> None:
+    """A config that never names an ``X | None = None`` object leaves it None, and records that.
+
+    Binding it anyway would construct X and write X's OWN defaults back, so a model declaring "no
+    patch" ran with a patch nobody configured -- and the resolved config, the record of the run,
+    described that phantom instead of what happened.
+    """
+    config_path = write_config("Root: {}\n")
+
+    @config("Child")
+    class Child:
+        def __init__(self, value: int = 1) -> None:
+            self.value = value
+
+    class Root:
+        def __init__(self, child: Child | None = None) -> None:
+            self.child = child
+
+    root = apply_config("Root")(Root)()
+
+    assert root.child is None
+    # "None" (the string) is how KonfAI spells an absent object in a resolved config, as every
+    # `overlap: None` / `augmentations: None` in the shipped configs does.
+    written = ruamel.yaml.YAML().load(config_path.read_text(encoding="utf-8"))
+    assert written["Root"]["Child"] == "None"
+
+
+def test_apply_config_binds_an_optional_with_a_non_none_default(write_config) -> None:
+    """``X | None = X()`` is the opposite declaration: the object exists unless the config says None.
+
+    This is what keeps ``DatasetPatch``-style defaults instantiated by a silent config.
+    """
+    write_config("Root: {}\n")
+
+    @config("Child")
+    class Child:
+        def __init__(self, value: int = 1) -> None:
+            self.value = value
+
+    class Root:
+        def __init__(self, child: Child | None = Child()) -> None:
+            self.child = child
+
+    root = apply_config("Root")(Root)()
+
+    assert isinstance(root.child, Child)
+    assert root.child.value == 1
+
+
 def test_apply_config_accepts_literal_value(write_config) -> None:
     write_config("Root:\n  mode: eval\n")
 


### PR DESCRIPTION
## Problem

A parameter declared `X | None = None` says the object exists only if the config asks for it. The
binder collapsed `X | None` to `X` (`_unwrap_optional`) and then instantiated it unconditionally,
never reading `param.default`:

```python
annotation = _unwrap_optional(annotation)            # ModelPatch | None  ->  ModelPatch
...
kwargs[param.name] = apply_config(key_tmp)(annotation)()   # built regardless of the None default
```

So a model declaring no `ModelPatch` silently ran with a 3D `[128, 128, 128]` one nobody configured,
and `apply_config` wrote that phantom back into the resolved config — the file that is supposed to be
the record of the run.

The split was invisible but systematic: `YamlNetwork` exposes `patch`, so **every `.yml`-built model**
was hit, while Python models, which pass `patch=None` themselves, were not. Three published apps were
broken by it (IMPACTSeg, MRSegmentator, IMPACTSynth); MRSegmentator is fixed by this change alone,
with its published config untouched.

## Change

Bind such a parameter to `None` when the config is silent, and record the decision as `None` so the
resolved config still describes what ran. `X | None = X()` is the opposite declaration and still
instantiates — that is what keeps `DatasetPatch`-style defaults working.

## Blast radius

Measured by introspecting every config-bound `X | None = None` parameter where `X` is a `@config`
class. On a fresh config the whole diff is:

```diff
-      ModelPatch:
-        patch_size: [128, 128, 128]
-        overlap: None ...
+      ModelPatch: None
```

Optimizers/schedulers are unaffected: concrete `Network` subclasses declare non-`None` defaults, so
they keep binding (verified — the resolved config still writes `optimizer: name: AdamW`).

## Tests

- `test_apply_config_keeps_a_none_default_when_the_config_is_silent` — fails on `main`, passes here;
  also asserts the write-back records `None`.
- `test_apply_config_binds_an_optional_with_a_non_none_default` — the counterpart, passes both sides.

The pre-existing `test_apply_config_preserves_none_for_optional_nested_objects` only covered an
**explicit** `child: None` in the YAML, which already worked; the silent-config case was the gap.

Full `tests/unit` + `tests/integration` green (TRAIN workflows included). Verified end-to-end by
running the published IMPACTSeg, MRSegmentator, IMPACTSynth and TotalSegmentator apps.
