### PR TITLE
fix: synthesised input defaults on a multiscale dataset

### DIFF
--- a/konfai-apps/konfai_apps/app.py
+++ b/konfai-apps/konfai_apps/app.py
@@ -36,7 +36,7 @@ from konfai import RemoteServer, check_server, cuda_visible_devices, get_vram
 from konfai.utils.dataset import Dataset
 from konfai.utils.errors import AppRepositoryError, KonfAIAppClientError
 from konfai.utils.runtime import MinimalLog, State, safe_torch_load
-from konfai.utils.utils import SUPPORTED_EXTENSIONS
+from konfai.utils.utils import SUPPORTED_EXTENSIONS, split_format_level, split_path_spec
 from ruamel.yaml import YAML
 
 from .app_repository import LocalAppRepository, get_app_repository_info
@@ -943,7 +943,42 @@ class KonfAIApp(AbstractKonfAIApp):
             for idx, (source, suffix) in enumerate(KonfAIApp._list_input_units(input_path)):
                 KonfAIApp.symlink(source, dataset_path / f"P{idx:03d}" / f"Volume_{i}{suffix}")
 
-    def _fill_optional_inputs(self, provided: int) -> None:
+    @staticmethod
+    def _dataset_level(prediction_file: str, dataset_dir: Path) -> int:
+        """The level ``dataset_dir`` will be read at, per the resolved config's ``dataset_filenames``.
+
+        ``@N`` is a property of a dataset ENTRY: every group of that entry is read at that one level. So a
+        synthesised default must be readable at the same level as the inputs it stands in for, and the
+        config is the only place that level is declared.
+
+        Format-neutral by construction: ``split_format_level`` knows nothing about any backend, and an
+        entry that declares no ``@N`` — which is every non-pyramid format — yields 0, the level those
+        backends have always been read at.
+
+        Only the entry pointing at ``dataset_dir`` counts; a config listing several sources may read each
+        at its own level, and the staged inputs live in exactly one of them.
+        """
+        path = Path(prediction_file)
+        if not path.is_file():
+            return 0
+        from ruamel.yaml import YAML
+
+        with open(path, encoding="utf-8") as file:
+            data = YAML().load(file)
+        dataset = ((data or {}).get("Predictor") or {}).get("Dataset") or {}
+        target = dataset_dir.resolve()
+        for entry in dataset.get("dataset_filenames") or []:
+            filename, _, file_format = split_path_spec(
+                str(entry),
+                default_format="mha",
+                allowed_flags={"a", "i"},
+                supported_extensions=SUPPORTED_EXTENSIONS,
+            )
+            if Path(filename).resolve() == target:
+                return split_format_level(file_format)[1]
+        return 0
+
+    def _fill_optional_inputs(self, provided: int, prediction_file: str = "Prediction.yml") -> None:
         """Synthesise declared defaults for optional inputs the caller did not provide.
 
         Inputs map positionally to ``Volume_0..N-1`` in ``app.json`` declaration order, so only trailing
@@ -953,6 +988,12 @@ class KonfAIApp(AbstractKonfAIApp):
         inputs alone. The registration mask branches use ``"ones"`` (a whole-image mask restricts nothing).
         Optional inputs with no ``default`` are left absent; a genuinely-missing required input still fails
         downstream.
+
+        "Like ``Volume_0``" has to include the LEVEL it is read at. On a multiscale input, level 1 is not
+        the shape of level 0, so a default sized from level 0 is both the wrong shape and unopenable at
+        ``@1`` — the store has one level and the reader asks for the second. Taking the level from the
+        config keeps this one code path for every format: a flat input reports level 0 and behaves exactly
+        as before.
         """
         declared = list(self.app_repository.get_inputs().items())
         fills = {
@@ -963,7 +1004,10 @@ class KonfAIApp(AbstractKonfAIApp):
         if not fills:
             return
         fill_value = {"ones": 1, "zeros": 0}
-        dataset = Dataset("Dataset", KonfAIApp._detect_group_format(Path("Dataset"), "Volume_0"))
+        dataset_dir = Path("Dataset")
+        file_format = KonfAIApp._detect_group_format(dataset_dir, "Volume_0")
+        level = KonfAIApp._dataset_level(prediction_file, dataset_dir)
+        dataset = Dataset("Dataset", f"{file_format}@{level}" if level else file_format)
         for name in dataset.get_names("Volume_0"):
             shape, attributes = dataset.get_infos("Volume_0", name)  # header only, no pixel read
             for i, default in fills.items():
@@ -1076,7 +1120,6 @@ class KonfAIApp(AbstractKonfAIApp):
         - GPU defaults to `cuda_visible_devices()`.
         """
         self._write_inputs_to_dataset(inputs)
-        self._fill_optional_inputs(len(inputs))
         available_vram = None
         if len(gpu):
             available_vram_per_device: list[float] = []
@@ -1097,6 +1140,9 @@ class KonfAIApp(AbstractKonfAIApp):
             forced_batch_size=batch_size,
             config_overrides=config_overrides,
         )
+        # After install_inference, not before: the defaults are sized from the level the config asks for,
+        # and that config only exists here -- installation is what writes it out with any --set applied.
+        self._fill_optional_inputs(len(inputs), prediction_file)
         from konfai.predictor import predict
 
         # predictions_dir is passed explicitly: predict()'s default is resolved when konfai.predictor is

--- a/konfai/utils/ome_zarr.py
+++ b/konfai/utils/ome_zarr.py
@@ -89,10 +89,23 @@ def _read_konfai_attributes(store_path: str | Path) -> dict[str, Any]:
 
 
 def _load_image(store_path: str | Path, level: int) -> Any:
-    """Return the ``NgffImage`` for ``level`` of an OME-Zarr store."""
+    """Return the ``NgffImage`` for ``level`` of an OME-Zarr store.
+
+    ``@N`` selects among the levels a store offers, so a store with a single level has nothing to
+    select: its one level is read whatever ``N`` says. That is already how every other backend
+    behaves — ``SitkFile`` never reads ``self.level`` at all, so ``:mha@1`` quietly reads its only
+    image — and a one-level store is not a pyramid either. Enforcing ``@N`` on it made the same
+    dataset spec valid for a ``.mha`` group and fatal for its OME-Zarr neighbour.
+
+    Out of range on a store that IS a pyramid stays an error: asking level 3 of a three-level mask
+    beside a four-level image is a real mismatch (it silently pairs 160 µm against 320 µm), and
+    quietly falling back to level 0 would hide it.
+    """
     _require_ngff_zarr()
     try:
         multiscales = ngff_zarr.from_ngff_zarr(str(store_path))
+        if len(multiscales.images) == 1:
+            return multiscales.images[0]
         return multiscales.images[level]
     except (KeyError, IndexError, OSError, TypeError, ValueError) as exc:
         raise DatasetManagerError(


### PR DESCRIPTION
An optional input with a declared default (`"ones"`/`"zeros"`) was unusable as soon as the dataset was read at a level other than 0. Registering an OME-Zarr pair with `dataset_filenames: ./Dataset/:omezarr@1` and no masks failed with:

```
IndexError: list index out of range
[DatasetManager] Cannot open OME-Zarr store 'Dataset/P000/Volume_2.ome.zarr' (level 1).
→	Ensure the directory is a valid OME-NGFF store.
```

The store was valid. It just had one level.

## Why

Two assumptions contradicted each other:

- `app.json` — *an absent optional input is replaceable by a synthetic default*
- `@N` — *every group of that dataset entry is read at level N*

The default is built by konfai-apps from a header; the level is imposed by konfai, uniformly. Nobody owned their agreement.

## The fix

**konfai-apps** — the default is sized from the level the run actually reads, taken from the resolved config rather than assumed. It is filled after `install_inference`, which is what writes that config out with any `--set` applied; before it, the level is whatever the bundle shipped.

`split_format_level` knows no backend, so an entry without an `@N` yields 0 and every non-pyramid format keeps the shape it always had. Only the entry pointing at the staged directory counts — a config listing several sources may read each at its own level.

**konfai** — a single-level store now ignores `@N`. This removes a divergence rather than adding tolerance: `SitkFile` never reads `self.level`, so `:mha@1` already reads its only image quietly. A one-level store is not a pyramid either; there is nothing to select. Enforcing `@N` on it made one dataset spec valid for a `.mha` group and fatal for its OME-Zarr neighbour.

Out of range on a store that **is** a pyramid stays an error. Asking level 3 of a three-level mask sitting beside a four-level image is a real mismatch — it pairs 160 µm against 320 µm — and falling back to level 0 would hide it.

## Checks

- `test` and `test-apps` both green; `test_fill_optional_inputs_generates_declared_defaults` covers the `.mha` path and still passes
- 21 zarr/level tests pass
- ruff, ruff format, mypy, bandit clean
- verified end to end: an OME-Zarr pair registered at `@1` with no masks, `Moved` written on the level-1 grid (444, 332, 128 @ 120.3 µm)

## Cost of the default, measured

A constant `uint8` volume costs essentially nothing on disk — zarr compresses it away:

| level | shape | raw | on disk |
|---|---|---|---|
| `@1` | (1, 128, 332, 443) | 18.8 MB | **0.07 MB** |
| `@0` | (1, 513, 1331, 1776) | 1212.7 MB | **0.96 MB** |

What it does cost is the decompression on read: the model is handed a whole-image mask it then ignores, since `_is_partial_mask()` already treats an all-ones mask as *no mask*. Not addressed here — receiving every declared input is what keeps apps free of "what if the mask is missing" branches. Worth a separate look at whether an absent optional input could simply stay absent.