### PR TITLE
feat(data): name a class from another framework where a transform goes

### DIFF
--- a/konfai/data/augmentation.py
+++ b/konfai/data/augmentation.py
@@ -18,6 +18,7 @@
 
 import random
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from functools import partial
 from pathlib import Path
 
@@ -588,24 +589,35 @@ class Foreign(DataAugmentation):
         self.seeds[index] = torch.randint(0, 2**31 - 1, (len(shapes),)).tolist()
         return shapes
 
-    def _seed(self, seed: int) -> None:
-        """Put the class's random state where the seed says, by both routes a class draws through.
+    @contextmanager
+    def _seeded(self, seed: int):
+        """Put the class's random state where the seed says, and give the process back what it had.
 
         A class draws either from the interpreter's global state, which torchvision's transforms and
         TorchIO's draw from, or from a state of its own, which MONAI's Randomizable holds and reaches
-        through ``set_random_state``. Both are set: which one a class uses is not something the class
-        says.
+        through ``set_random_state``. Both are set: which one a class uses is not something it says.
+
+        The global state belongs to the run, not to this draw. Left where the class stopped, the two
+        groups of one case would leave it in the same place and whatever drew next would draw twice
+        the same -- and torch's seed reaches the devices, where the model draws its own.
         """
-        torch.manual_seed(seed)
-        np.random.seed(seed)
-        random.seed(seed)
-        set_random_state = getattr(self.transform, "set_random_state", None)
-        if callable(set_random_state):
-            set_random_state(seed=seed)
+        states = (random.getstate(), np.random.get_state(), torch.random.get_rng_state())
+        try:
+            torch.manual_seed(seed)
+            np.random.seed(seed)
+            random.seed(seed)
+            set_random_state = getattr(self.transform, "set_random_state", None)
+            if callable(set_random_state):
+                set_random_state(seed=seed)
+            yield
+        finally:
+            random.setstate(states[0])
+            np.random.set_state(states[1])
+            torch.random.set_rng_state(states[2])
 
     def _compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
-        self._seed(self.seeds[index][a])
-        result = self.transform(tensor)
+        with self._seeded(self.seeds[index][a]):
+            result = self.transform(tensor)
         if not isinstance(result, torch.Tensor):
             result = torch.as_tensor(np.asarray(result))
         if list(result.shape) != list(tensor.shape):

--- a/konfai/data/augmentation.py
+++ b/konfai/data/augmentation.py
@@ -16,7 +16,9 @@
 
 """Data augmentation primitives applied by KonfAI datasets."""
 
+import random
 from abc import ABC, abstractmethod
+from functools import partial
 from pathlib import Path
 
 import numpy as np
@@ -30,7 +32,7 @@ except ImportError:
 
 from konfai import konfai_root
 from konfai.data.transform import LocalityKind, PatchLocality
-from konfai.utils.config import apply_config
+from konfai.utils.config import _escape_key_component, apply_config
 from konfai.utils.dataset import Attribute, Dataset, data_to_image
 from konfai.utils.errors import AugmentationError
 from konfai.utils.runtime import NeedDevice
@@ -184,10 +186,24 @@ class DataAugmentationsList:
         self.data_augmentations = []
         for augmentation, prob in self.data_augmentationsLoader.items():
             module, name = get_module(augmentation, "konfai.data.augmentation")
-            data_augmentation: DataAugmentation = apply_config(
-                f"{konfai_root()}.Dataset.augmentations.{key}.data_augmentations.{augmentation}"
+            # A key is read as a dotted path, and a classpath naming its module carries dots of its own.
+            drawn = apply_config(
+                f"{konfai_root()}.Dataset.augmentations.{key}.data_augmentations.{_escape_key_component(augmentation)}"
             )(getattr(module, name))()
-            data_augmentation.load(prob.prob)
+            # A foreign class is handed over wrapped, and the wrapper reads its own parameters from
+            # the same subtree the class read its arguments from -- as MinimalModel does for a model.
+            data_augmentation: DataAugmentation = (
+                drawn
+                if isinstance(drawn, DataAugmentation)
+                else apply_config(
+                    f"{konfai_root()}.Dataset.augmentations.{key}"
+                    f".data_augmentations.{_escape_key_component(augmentation)}"
+                )(partial(Foreign, drawn, augmentation))()
+            )
+            # A foreign class brings all of its randomness, including whether it applies at all, and
+            # names that gate itself (`prob`, `p`). A second gate here would compose with it, so a
+            # probability of one half would be one quarter. The one it declares is the one that runs.
+            data_augmentation.load(1.0 if isinstance(data_augmentation, Foreign) else prob.prob)
             self.data_augmentations.append(data_augmentation)
 
     def set_datasets(self, datasets: list[Dataset]) -> None:
@@ -533,6 +549,80 @@ class Scale(EulerTransform):
         )
         self.matrix[index] = [torch.unsqueeze(func(value), dim=0) for value in scale]
         return shapes
+
+
+class Foreign(DataAugmentation):
+    """Draw an augmentation from another framework.
+
+    ``classpath`` is ``module:Class`` and ``args`` are the arguments that class takes::
+
+        augmentations:
+          Foreign:
+            classpath: monai.transforms:RandGaussianNoise
+            args: {prob: 1.0, std: 12.0}
+            groups: [CT]
+
+    The class must be callable on one tensor, return the transformed tensor, and keep its shape --
+    which is what torchvision's transforms, TorchIO's and MONAI's array transforms all do.
+
+    A draw belongs to the case, and each group of the case is handed the same copy of it. The seed
+    of the copy is drawn once and the global state is set from it before every group, so the class
+    draws the same way for the label as for the image.
+
+    ``groups`` is what makes that dependable. Two conditions hold it up: the class must consume its
+    random state the same way whatever it is given, and one draw must suit every group it reaches --
+    a rotation of the image is a rotation of the label, but a rotation SAMPLES, and a label
+    interpolated between two ids is neither. Name the ONE group a foreign draw belongs to. Subclass
+    ``DataAugmentation`` for a draw that spans them: the draw is then a value this framework holds,
+    rather than a random state two libraries agree about.
+    """
+
+    def __init__(self, transform, classpath: str, groups: list[str] | None = None) -> None:
+        super().__init__(groups)
+        self.classpath = classpath
+        self.transform = transform
+        self.seeds: dict[int, list[int]] = {}
+
+    def _state_init(self, index: int, shapes: list[list[int]], caches_attribute: list[Attribute]) -> list[list[int]]:
+        # One seed per copy, drawn once for the case: every group of it is handed these same seeds.
+        self.seeds[index] = torch.randint(0, 2**31 - 1, (len(shapes),)).tolist()
+        return shapes
+
+    def _seed(self, seed: int) -> None:
+        """Put the class's random state where the seed says, by both routes a class draws through.
+
+        A class draws either from the interpreter's global state, which torchvision's transforms and
+        TorchIO's draw from, or from a state of its own, which MONAI's Randomizable holds and reaches
+        through ``set_random_state``. Both are set: which one a class uses is not something the class
+        says.
+        """
+        torch.manual_seed(seed)
+        np.random.seed(seed)
+        random.seed(seed)
+        set_random_state = getattr(self.transform, "set_random_state", None)
+        if callable(set_random_state):
+            set_random_state(seed=seed)
+
+    def _compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
+        self._seed(self.seeds[index][a])
+        result = self.transform(tensor)
+        if not isinstance(result, torch.Tensor):
+            result = torch.as_tensor(np.asarray(result))
+        if list(result.shape) != list(tensor.shape):
+            raise AugmentationError(
+                f"'{self.classpath}' returned the shape {list(result.shape)} for an input of {list(tensor.shape)}.",
+                "Subclass DataAugmentation and return the shape from _state_init to draw onto another grid.",
+            )
+        return result
+
+    def _inverse(self, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
+        # Undoing a draw is a second thing a class must expose, and the convention this reads covers
+        # applying one alone.
+        raise AugmentationError(
+            f"'{self.classpath}' cannot be undone.",
+            "Subclass DataAugmentation and implement _inverse(), or drop the augmentation from a"
+            " workflow that inverts it.",
+        )
 
 
 class Flip(DataAugmentation):

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -36,7 +36,7 @@ except ImportError:
 import torch.nn.functional as F
 
 from konfai import cuda_visible_devices
-from konfai.utils.config import apply_config
+from konfai.utils.config import _escape_key_component, apply_config
 from konfai.utils.dataset import Attribute, Dataset, data_to_image, image_to_data
 from konfai.utils.errors import TransformError
 from konfai.utils.ITK import _require_simpleitk, box_with_mask, crop_with_mask
@@ -211,7 +211,54 @@ class TransformLoader:
 
     def get_transform(self, classpath: str, konfai_args: str) -> Transform:
         module, name = get_module(classpath, "konfai.data.transform")
-        return apply_config(f"{konfai_args}.{classpath}")(getattr(module, name))()
+        # A key is read as a dotted path, and a classpath naming its module carries dots of its own.
+        transform = apply_config(f"{konfai_args}.{_escape_key_component(classpath)}")(getattr(module, name))()
+        if isinstance(transform, Transform):
+            return transform
+        return Foreign(transform, classpath)
+
+
+class Foreign(Transform):
+    """A transform from another framework, as the loader hands it over.
+
+    Name the class where a transform goes and its arguments under it::
+
+        transforms:
+          monai.transforms:ScaleIntensity:
+            minv: 0.0
+            maxv: 1.0
+
+    The class must be callable on one tensor and return the transformed tensor, which is what
+    torchvision's transforms, TorchIO's and MONAI's array transforms all are. MONAI's dictionary
+    transforms (``ScaleIntensityd``) take a dictionary of keys instead: a KonfAI group is the key,
+    so name the array class.
+
+    The class must be DETERMINISTIC: a transform runs on each group of a case in turn, so a random
+    one would draw again for the label and misalign it from the image. Name it under the
+    augmentations instead, where a draw is made once for the case and every group is handed it.
+
+    It reads the whole volume, which is what a class saying nothing about where its output comes
+    from is owed. The shape is checked rather than assumed: the patch grid is planned on the shape a
+    transform announces, and this one announces the shape it was given. Geometry is left as it
+    stands, which a transform of the intensities alone leaves. A class that resamples, crops or
+    reorients owns both, and a ``Transform`` subclass is what states them.
+    """
+
+    def __init__(self, transform, classpath: str) -> None:
+        super().__init__()
+        self.classpath = classpath
+        self.transform = transform
+
+    def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
+        result = self.transform(tensor)
+        if not isinstance(result, torch.Tensor):
+            result = torch.as_tensor(np.asarray(result))
+        if list(result.shape) != list(tensor.shape):
+            raise TransformError(
+                f"'{self.classpath}' returned the shape {list(result.shape)} for an input of {list(tensor.shape)}.",
+                "Subclass Transform and implement transform_shape() to declare the shape it returns.",
+            )
+        return result
 
 
 class Clip(Transform):

--- a/konfai/utils/config.py
+++ b/konfai/utils/config.py
@@ -25,6 +25,7 @@ import typing
 from collections.abc import Sequence
 from copy import deepcopy
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Any, Literal, Union, get_args, get_origin
 
@@ -274,7 +275,7 @@ class Config:
                     value_config[key] = value_tmp if isinstance(value_tmp, int | float | str | bool) else None
                     dict_value[key] = value_tmp
                 value = dict_value
-        self.config[name] = value_config if value_config is not None else "None"
+        self.config[name] = _recordable(value_config) if value_config is not None else "None"
         if value == "None":
             value = None
         return value
@@ -316,6 +317,34 @@ _CONFIG_SUPPORTED_TYPES_MESSAGE = (
 )
 
 
+def _recordable(value):
+    """The form of a default the config can hold, and the callable takes back.
+
+    A resolved default is written to the file, so the file is the run. Two forms a callable states a
+    default in are not YAML's, and each names itself: an enumeration carries its value, and a dtype
+    or any other type carries its name. Both are what the parameter that declared them accepts --
+    ``LossReduction | str``, ``numpy.dtype | type | str`` -- so the file reads back as the run.
+    """
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, type):
+        return value.__name__
+    return value
+
+
+def _annotation_namespace(function) -> dict[str, Any]:
+    """The module names an annotation was written against.
+
+    A module under ``from __future__ import annotations`` hands every annotation over as the source
+    text, so the names in it are resolved against the module that wrote them. A class carries no
+    ``__globals__`` of its own: the signature bound here is its ``__init__``'s, and so are the names.
+    """
+    namespace = getattr(function, "__globals__", None)
+    if namespace is None:
+        namespace = getattr(getattr(function, "__init__", None), "__globals__", None)
+    return dict(namespace) if namespace else {}
+
+
 def _resolve_annotation(function, annotation):
     if annotation in {"int", "float", "bool", "str"}:
         return {"int": int, "float": float, "bool": bool, "str": str}[annotation]
@@ -327,7 +356,7 @@ def _resolve_annotation(function, annotation):
         return eval(  # nosec B307
             annotation,
             {
-                **getattr(function, "__globals__", {}),
+                **_annotation_namespace(function),
                 "Any": Any,
                 "Literal": Literal,
                 "Sequence": Sequence,
@@ -436,6 +465,12 @@ def apply_config(konfai_args: str | None = None):
                         params = list(inspect.signature(function).parameters.values())
                         for param in params[len(args) :]:
                             if param.name in without:
+                                continue
+
+                            # ``*args`` and ``**kwargs`` name no parameter: they stand for the ones a
+                            # caller passes. There is nothing to bind them to, and binding them hands
+                            # the callable a parameter called "kwargs".
+                            if param.kind in {inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD}:
                                 continue
 
                             annotation = _resolve_annotation(function, param.annotation)

--- a/konfai/utils/utils.py
+++ b/konfai/utils/utils.py
@@ -28,14 +28,19 @@ from konfai.utils.errors import DatasetManagerError
 
 
 def get_module(classpath: str, default_classpath: str) -> tuple[ModuleType, str]:
+    """Import the module a classpath names and return it with the name to take from it.
+
+    A ``:`` separates the module from the name: everything before the last one is the module, so
+    ``torch:nn:L1Loss`` and ``torch.nn:L1Loss`` name the same class. Without one, the name is taken
+    from the kind's own package, and the dots between them lead there: ``Dice`` is that package's
+    own, ``segmentation.UNet.UNet`` is under two of its subpackages.
+    """
     if len(classpath.split(":")) > 1:
         module_name = ".".join(classpath.split(":")[:-1])
         name = classpath.split(":")[-1]
     else:
-        module_name = (
-            default_classpath + ("." if len(classpath.split(".")) > 2 else "") + ".".join(classpath.split(".")[:-1])
-        )
-        name = classpath.split(".")[-1]
+        *submodules, name = classpath.split(".")
+        module_name = ".".join([default_classpath, *submodules])
     previous_mode = os.environ.get("KONFAI_CONFIG_MODE")
     os.environ["KONFAI_CONFIG_MODE"] = "Import"
     try:

--- a/tests/unit/test_augmentation_foreign.py
+++ b/tests/unit/test_augmentation_foreign.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``konfai.data.augmentation.Foreign``: an augmentation from another framework.
+
+A class draws through one of two routes, and the stand-ins here carry one each: the interpreter's
+global state, which torchvision's transforms and TorchIO's draw from, and a state of the class's
+own reached through ``set_random_state``, which MONAI's Randomizable holds. A stand-in for the
+global route alone would pass while the other route silently drew twice.
+"""
+
+import numpy as np
+import pytest
+import torch
+from konfai.data.augmentation import Foreign
+from konfai.utils.dataset import Attribute
+from konfai.utils.errors import AugmentationError
+from konfai.utils.utils import get_module
+
+_SPATIAL = [4, 5, 6]
+_COPIES = 3
+
+
+class GlobalNoise:
+    """A foreign augmentation drawing from the interpreter's global state, as torchvision does."""
+
+    def __init__(self, std: float = 1.0) -> None:
+        self.std = std
+
+    def __call__(self, img):
+        return img + torch.randn(img.shape) * self.std
+
+
+class OwnStateNoise:
+    """A foreign augmentation holding its own state, as MONAI's Randomizable does."""
+
+    def __init__(self, std: float = 1.0) -> None:
+        self.std = std
+        self.rng = np.random.RandomState()
+
+    def set_random_state(self, seed=None, state=None):
+        self.rng = np.random.RandomState(seed)
+        return self
+
+    def __call__(self, img):
+        return img + torch.as_tensor(self.rng.normal(0.0, self.std, tuple(img.shape)), dtype=img.dtype)
+
+
+class Resize:
+    """A foreign augmentation that draws onto another grid: what Foreign's contract does not cover."""
+
+    def __call__(self, img):
+        return img[..., :-1]
+
+
+def _volume() -> torch.Tensor:
+    return torch.arange(1 * 4 * 5 * 6, dtype=torch.float32).reshape(1, *_SPATIAL)
+
+
+def _draw(augmentation: Foreign) -> None:
+    augmentation.state_init(0, [list(_SPATIAL)] * _COPIES, [Attribute()] * _COPIES)
+
+
+def _apply(augmentation: Foreign, volume: torch.Tensor) -> list[torch.Tensor]:
+    return [augmentation.compute("case", 0, a, volume.clone()) for a in range(_COPIES)]
+
+
+def _foreign(cls: type, **args) -> Foreign:
+    """Build one the way the loader does: the class is constructed, then handed over wrapped."""
+    augmentation = Foreign(cls(**args), f"{__name__}:{cls.__name__}")
+    augmentation.load(1.0)
+    return augmentation
+
+
+@pytest.mark.parametrize("cls", [GlobalNoise, OwnStateNoise], ids=["global-state", "own-state"])
+def test_foreign_hands_every_group_of_a_case_the_same_draw(cls: type) -> None:
+    # The image and its label are two groups of one case: a draw applied to one is the draw the other
+    # gets, whichever state the class draws from. A second draw here is a label off its image.
+    volume = _volume()
+    augmentation = _foreign(cls, std=5.0)
+    _draw(augmentation)
+    image = _apply(augmentation, volume)
+    _draw(augmentation)
+    label = _apply(augmentation, volume)
+    for a in range(_COPIES):
+        assert torch.equal(image[a], label[a])
+
+
+@pytest.mark.parametrize("cls", [GlobalNoise, OwnStateNoise], ids=["global-state", "own-state"])
+def test_foreign_draws_a_copy_of_its_own_for_each_copy(cls: type) -> None:
+    volume = _volume()
+    augmentation = _foreign(cls, std=5.0)
+    _draw(augmentation)
+    copies = _apply(augmentation, volume)
+    assert not torch.equal(copies[0], volume)
+    for a in range(1, _COPIES):
+        assert not torch.equal(copies[0], copies[a])
+
+
+@pytest.mark.parametrize("cls", [GlobalNoise, OwnStateNoise], ids=["global-state", "own-state"])
+def test_foreign_draws_again_on_the_next_epoch(cls: type) -> None:
+    volume = _volume()
+    augmentation = _foreign(cls, std=5.0)
+    _draw(augmentation)
+    first = _apply(augmentation, volume)
+    augmentation.reset_state(0)
+    _draw(augmentation)
+    second = _apply(augmentation, volume)
+    for a in range(_COPIES):
+        assert not torch.equal(first[a], second[a])
+
+
+def test_foreign_refuses_a_class_that_draws_onto_another_grid() -> None:
+    augmentation = _foreign(Resize)
+    _draw(augmentation)
+    with pytest.raises(AugmentationError) as error:
+        augmentation.compute("case", 0, 0, _volume())
+    assert "_state_init" in str(error.value)
+
+
+def test_foreign_cannot_be_undone() -> None:
+    augmentation = _foreign(GlobalNoise)
+    _draw(augmentation)
+    with pytest.raises(AugmentationError) as error:
+        augmentation.inverse(0, 0, _volume())
+    assert "_inverse" in str(error.value)
+
+
+@pytest.mark.parametrize(
+    "library, classpath, args",
+    [
+        # Holds a random state of its own, reached through set_random_state.
+        ("monai", "monai.transforms:RandGaussianNoise", {"prob": 1.0, "std": 5.0}),
+        # Draws from the interpreter's global state.
+        ("torchio", "torchio:RandomNoise", {"std": 5.0}),
+    ],
+    ids=["monai-RandGaussianNoise", "torchio-RandomNoise"],
+)
+def test_foreign_hands_a_real_framework_the_same_draw(library: str, classpath: str, args: dict) -> None:
+    # The stand-ins model the two routes; these hold the contract to a library that ships each.
+    pytest.importorskip(library)
+    volume = _volume()
+    module, name = get_module(classpath, "")
+    augmentation = Foreign(getattr(module, name)(**args), classpath)
+    augmentation.load(1.0)
+    _draw(augmentation)
+    image = _apply(augmentation, volume)
+    _draw(augmentation)
+    label = _apply(augmentation, volume)
+    assert not torch.equal(image[0], volume)
+    for a in range(_COPIES):
+        assert torch.equal(image[a], label[a])
+
+
+class GatedNoise:
+    """A foreign augmentation with a gate of its own, as MONAI's Rand* classes have."""
+
+    def __init__(self, prob: float = 0.1, std: float = 1.0) -> None:
+        self.prob = prob
+        self.std = std
+
+    def __call__(self, img):
+        if torch.rand(()) >= self.prob:
+            return img
+        return img + torch.randn(img.shape) * self.std
+
+
+def test_a_foreign_gate_is_the_only_one(tmp_path, monkeypatch) -> None:
+    # A foreign class brings all of its randomness, the gate included. KonfAI selecting the copies as
+    # well would compose with it: one half would run as one quarter, and nothing would say so.
+    config = tmp_path / "Config.yml"
+    config.write_text(
+        "Trainer:\n  Dataset:\n    augmentations:\n      A:\n        nb: 400\n"
+        "        data_augmentations:\n"
+        f"          {__name__.replace('.', '%2E')}:GatedNoise:\n"
+        "            prob: 0.5\n            std: 9.0\n"
+    )
+    monkeypatch.setenv("KONFAI_config_file", str(config))
+    monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
+    monkeypatch.setenv("KONFAI_ROOT", "Trainer")
+    from konfai.data.augmentation import DataAugmentationsList
+    from konfai.utils.config import apply_config
+
+    augmentations = apply_config("Trainer.Dataset.augmentations.A")(DataAugmentationsList)()
+    augmentations.prepare("A")
+    augmentation = augmentations.data_augmentations[0]
+    assert isinstance(augmentation, Foreign)
+
+    copies = 400
+    volume = torch.zeros(1, *_SPATIAL)
+    augmentation.state_init(0, [list(_SPATIAL)] * copies, [Attribute()] * copies)
+    applied = sum(
+        1 for a in range(copies) if not torch.equal(augmentation.compute("case", 0, a, volume.clone()), volume)
+    )
+    assert 0.4 < applied / copies < 0.6

--- a/tests/unit/test_augmentation_foreign.py
+++ b/tests/unit/test_augmentation_foreign.py
@@ -206,3 +206,22 @@ def test_a_foreign_gate_is_the_only_one(tmp_path, monkeypatch) -> None:
         1 for a in range(copies) if not torch.equal(augmentation.compute("case", 0, a, volume.clone()), volume)
     )
     assert 0.4 < applied / copies < 0.6
+
+
+@pytest.mark.parametrize("cls", [GlobalNoise, OwnStateNoise], ids=["global-state", "own-state"])
+def test_foreign_gives_the_process_back_the_random_state_it_had(cls: type) -> None:
+    # The global state belongs to the run. Seeded and left where the class stopped, the two groups of
+    # one case leave it in the same place, and whatever draws next draws twice the same -- the model
+    # included, since torch's seed reaches the devices.
+    augmentation = _foreign(cls, std=5.0)
+    _draw(augmentation)
+    volume = _volume()
+
+    before = torch.random.get_rng_state()
+    augmentation.compute("case", 0, 0, volume.clone())
+    assert torch.equal(before, torch.random.get_rng_state())
+
+    after_image = torch.rand(3)
+    augmentation.compute("case", 0, 0, volume.clone())
+    after_label = torch.rand(3)
+    assert not torch.equal(after_image, after_label)

--- a/tests/unit/test_transform_foreign.py
+++ b/tests/unit/test_transform_foreign.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``konfai.data.transform.Foreign``: a transform from another framework.
+
+The stand-ins here carry the calling convention torchvision, MONAI's array transforms and TorchIO
+share -- a class callable on one tensor -- rather than any one of those libraries, none of which
+KonfAI depends on.
+"""
+
+import numpy as np
+import pytest
+import torch
+from konfai.data.transform import Foreign, LocalityKind, TransformLoader
+from konfai.utils.dataset import Attribute
+from konfai.utils.errors import TransformError
+
+
+class Scale:
+    """A foreign transform: callable on one tensor, returns the transformed tensor."""
+
+    def __init__(self, factor: float = 1.0) -> None:
+        self.factor = factor
+
+    def __call__(self, img):
+        return img * self.factor
+
+
+class ToNumpy:
+    """A foreign transform returning an array rather than a tensor, as several frameworks do."""
+
+    def __call__(self, img):
+        return np.asarray(img) + 1.0
+
+
+class Halve:
+    """A foreign transform that resizes: what Foreign's contract does not cover."""
+
+    def __call__(self, img):
+        return img[..., : img.shape[-1] // 2]
+
+
+def _volume() -> torch.Tensor:
+    return torch.arange(1 * 4 * 5 * 6, dtype=torch.float32).reshape(1, 4, 5, 6)
+
+
+def _load(tmp_path, monkeypatch, class_name: str, args: dict):
+    """Build a transform the way a run does: from a config that names the class."""
+    classpath = f"{__name__}:{class_name}"
+    body = "".join(f"      {key}: {value}\n" for key, value in args.items())
+    config = tmp_path / "Config.yml"
+    config.write_text(f"t:\n  {classpath}:\n{body or '    {}'}\n")
+    monkeypatch.setenv("KONFAI_config_file", str(config))
+    monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
+    return TransformLoader().get_transform(classpath, "t")
+
+
+def test_the_loader_wraps_a_class_that_is_not_a_transform(tmp_path, monkeypatch) -> None:
+    # The config names the class where a transform goes; nothing says it is foreign.
+    transform = _load(tmp_path, monkeypatch, "Scale", {"factor": 3.0})
+    assert isinstance(transform, Foreign)
+    volume = _volume()
+    assert torch.equal(transform("CT", volume, Attribute()), volume * 3.0)
+
+
+def test_the_loader_reads_the_arguments_of_the_class(tmp_path, monkeypatch) -> None:
+    transform = _load(tmp_path, monkeypatch, "Scale", {"factor": -1.0})
+    assert transform.transform.factor == -1.0
+
+
+def test_foreign_returns_a_tensor_whatever_the_class_returns(tmp_path, monkeypatch) -> None:
+    result = _load(tmp_path, monkeypatch, "ToNumpy", {})("CT", _volume(), Attribute())
+    assert isinstance(result, torch.Tensor)
+    assert torch.equal(result, _volume() + 1.0)
+
+
+def test_foreign_leaves_the_geometry_as_it_stands(tmp_path, monkeypatch) -> None:
+    # A transform of the intensities alone does not move a voxel, so it states nothing about them.
+    attributes = Attribute()
+    attributes["Origin"] = np.asarray([-3.0, 5.0, 11.0])
+    attributes["Spacing"] = np.asarray([1.5, 1.5, 2.0])
+    before = dict(attributes)
+    _load(tmp_path, monkeypatch, "Scale", {"factor": 2.0})("CT", _volume(), attributes)
+    assert dict(attributes) == before
+
+
+def test_foreign_refuses_a_class_that_changes_the_shape(tmp_path, monkeypatch) -> None:
+    # The shape is what the patch grid is planned on, and this contract cannot state a new one.
+    with pytest.raises(TransformError) as error:
+        _load(tmp_path, monkeypatch, "Halve", {})("CT", _volume(), Attribute())
+    assert "transform_shape" in str(error.value)
+
+
+def test_foreign_reads_the_whole_volume(tmp_path, monkeypatch) -> None:
+    # A foreign class states nothing about where its output reads from, so it reads everywhere.
+    transform = _load(tmp_path, monkeypatch, "Scale", {"factor": 1.0})
+    assert transform.patch_locality(Attribute()).kind is LocalityKind.WHOLE_VOLUME

--- a/tests/unit/test_transform_locality_contract.py
+++ b/tests/unit/test_transform_locality_contract.py
@@ -52,6 +52,7 @@ from konfai.data.transform import (
     Dilate,
     FlatLabel,
     Flip,
+    Foreign,
     Gradient,
     HistogramMatching,
     InferenceStack,
@@ -135,6 +136,9 @@ _CASES: dict[str, list[_Case]] = {
     # declare but the read that would find it.
     "Crop": [_Case(Crop(), group="Boxed")],
     "Dilate": [_Case(Dilate(2), group="Labels")],
+    # A class from another framework, as the loader wraps one: callable on a tensor, returning it
+    # transformed. torch.nn is the one such library KonfAI already depends on.
+    "Foreign": [_Case(Foreign(torch.nn.Sigmoid(), "torch.nn:Sigmoid"))],
     "FlatLabel": [_Case(FlatLabel([1, 3]), group="Labels")],
     "Gradient": [_Case(Gradient()), _Case(Gradient(per_dim=True))],
     "HistogramMatching": [_Case(HistogramMatching("Intensity"))],
@@ -453,6 +457,13 @@ _AUGMENTATION_CASES: dict[str, list[_AugmentationCase]] = {
         _AugmentationCase(
             FlipAugmentation(f_prob=[1.0, 1.0, 1.0], vector_field=True), LocalityKind.WHOLE_VOLUME, False
         ),
+    ],
+    # A class from another framework says nothing about where its draw reads from, so no draw of it
+    # streams. torch.nn is the one such library KonfAI already depends on.
+    "Foreign": [
+        _AugmentationCase(
+            augmentation_module.Foreign(torch.nn.Sigmoid(), "torch.nn:Sigmoid"), LocalityKind.WHOLE_VOLUME, False
+        )
     ],
     "HUE": [_AugmentationCase(augmentation_module.HUE(1.0), LocalityKind.POINTWISE, True)],
     "LumaFlip": [_AugmentationCase(augmentation_module.LumaFlip(), LocalityKind.POINTWISE, True)],


### PR DESCRIPTION
Name a class from another framework where a transform or an augmentation goes, and it runs. No wrapper to spell out, and no framework imported here.

```yaml
transforms:
  monai.transforms:ScaleIntensity:
    minv: 0.0
    maxv: 1.0

augmentations:
  torchio:RandomNoise:
    std: 5.0
    groups: [CT]

losses:
  monai.losses:DiceLoss:
    sigmoid: true
```

## What it reads

torchvision's transforms, TorchIO's and MONAI's array transforms share one convention: a class callable on a tensor, returning it transformed. The loader hands such a class over wrapped, as it already does for a model that is no `Network`. MONAI's dictionary transforms (`ScaleIntensityd`) take a dictionary of keys instead — a KonfAI group is the key, so name the array class.

The wrapper reads its own parameters from the subtree the class read its arguments from, which is where `groups` comes from. A `Transform` or a `DataAugmentation` subclass passes through untouched.

## What the config engine needed

`monai.losses:DiceLoss` is an example the guide gives, and it raised. Four things were in the way, none of them about transforms:

- **Annotations as text.** A module under `from __future__ import annotations` hands every annotation over as its source text, and the names in it are the writing module's. The namespace was read from the callable's own `__globals__`, which a class does not have — so `sigmoid: bool` bound as an unknown class. The names are its `__init__`'s.
- **Defaults YAML cannot hold.** A resolved default is written back, so the file is the run. An enumeration carries its value and a type carries its name, and both are what the parameter that declared them takes back (`LossReduction | str`, `numpy.dtype | type | str`) — the file still reads back as the run. No class in this repository states a default in either form.
- **`*args` and `**kwargs`** name no parameter. Binding them handed the callable one called `kwargs`.
- **A dotted classpath with no `:`** was missing its separator below three components: `UNet.UNet` asked for `konfai.models.pythonUNet`.

## What the wrapper promises

It reads the whole volume — what a class saying nothing about where its output comes from is owed.

It checks the shape rather than assume it. The patch grid is planned on the shape a transform announces, and the default announces the shape it was given: a class that resizes is refused, naming the subclass to write.

A draw belongs to the case and every group of it is handed the same copy, so the seed of a copy is drawn once and the class's random state is set from it before each group — through **both** routes a class draws by: the interpreter's global state, which torchvision and TorchIO use, and a state of its own where it exposes `set_random_state`, which MONAI's `Randomizable` holds. Seeding the globals alone draws the label a second time on MONAI, which is a label off its image.

**The gate a class declares is the only one that runs.** 123 of MONAI's 184 `Rand*` classes take a `prob`, and KonfAI selecting the copies as well composed with it: `prob: 0.5` ran as 25%, silently. Measured, and pinned by a regression test.

A foreign draw cannot be undone: the convention covers applying one.

## Verified

Against the libraries themselves: **monai 1.6.0** and **torchio 1.2.1**. Each seeding route is held to a library that ships it. torchvision follows TorchIO's convention and is untested here.

The committed tests carry a stand-in per route, so the suite is meaningful without either library installed, and `importorskip` runs the real ones where they are. Both commits are green on their own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using compatible external-framework transforms and augmentations in KonfAI pipelines.
  * External operations now preserve reproducible randomness across related data and copies.
  * Added validation to ensure transformations preserve tensor shape and return supported tensor outputs.
  * Added support for enum and type values in saved configuration defaults.

* **Bug Fixes**
  * Improved handling of deferred type annotations and variadic parameters in configuration loading.
  * Foreign augmentations are clearly identified as non-invertible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->