### PR TITLE
ci(lint): lint the tests the way the workflow does

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,9 +33,9 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-        files: ^(konfai/|konfai-apps/konfai_apps/)
+        files: ^(konfai/|konfai-apps/konfai_apps/|tests/)
       - id: ruff-format
-        files: ^(konfai/|konfai-apps/konfai_apps/)
+        files: ^(konfai/|konfai-apps/konfai_apps/|tests/)
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.17.0


### PR DESCRIPTION
The workflow lints three trees:

```
ruff check konfai konfai-apps/konfai_apps tests
ruff format --check konfai konfai-apps/konfai_apps tests
```

The hooks were scoped to two of them, so a test file went through as `no files to check` and its lint came back from CI minutes later instead. On the same probe file:

```
before   ruff (legacy alias)......................(no files to check) Skipped
after    ruff (legacy alias)......................Failed
         B905 `zip()` without an explicit `strict=` parameter
```

`tests/` is clean today under both `ruff check` and `ruff format --check`, so nothing new is reported.

mypy (`^konfai/`) and bandit (`konfai`, `konfai-apps/konfai_apps`) already match the trees their own steps run over, and are left alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated formatting checks to include files under the test suite.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->