### PR TITLE
DO NOT MERGE — review-only mirror of #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Most frameworks focus on *models*. **KonfAI focuses on *pipelines*.**
 - 🧩 **Compose** full workflows from modular, named components — no glue code.
 - 🔁 **Iterate** by editing YAML, not rewriting Python.
 - 🔬 **Reproduce** every run: KonfAI resolves and writes back the full config.
-- 🩻 **Scale to real volumes**: data is always read lazily as overlapping patches — never loaded whole into RAM.
+- 🩻 **Scale to real volumes**: volumes are read as patches, and a preprocessing chain that allows it is [streamed](https://konfai.readthedocs.io/en/latest/concepts/streaming.html) from disk rather than loaded.
 - 📦 **Ship** a mature workflow as a reusable [**KonfAI App**](https://konfai.readthedocs.io/en/latest/usage/apps.html) (CLI, HTTP server, 3D Slicer).
 - 🤖 **Drive it with an agent**: KonfAI-MCP lets an LLM inspect data, author configs, and launch runs.
 
@@ -110,6 +110,28 @@ konfai TRAIN -y --gpu 0 --config Config.yml     # use --cpu 1 if you have no GPU
 The full walkthrough (predict, evaluate, what to inspect, common first issues,
 notebook entry points) lives in the
 [**Quickstart**](https://konfai.readthedocs.io/en/latest/quickstart.html).
+
+---
+
+## 🩻 How volumes are read
+
+Volumes are read as patches. Whether the volume is *also* held in RAM depends on
+`use_cache` and on whether your preprocessing chain can be streamed — KonfAI
+derives streamability from the transforms you declared:
+
+| Regime | When | Memory held |
+| --- | --- | --- |
+| **Cache** | `use_cache: true` (training default) | every case, resident for the whole run |
+| **Stream** | `use_cache: false`, chain is streamable | one patch |
+| **Buffer** | `use_cache: false`, chain is not streamable | a FIFO of `max(batch_size + 1, shuffle_window)` cases |
+
+A chain streams when every step declares the region it needs: the exact patch
+(`OneHot`), a halo (`Dilate`), a remap (`Flip`), a resample (`ResampleToShape`),
+or a whole-volume statistic read once from disk (`Normalize`). On the stream
+path, a 16 GiB uncompressed `.mha` trains at patch 64³ under an 8 GiB memory cap
+with a peak resident set of 0.46 GiB.
+
+→ [**Patch streaming**](https://konfai.readthedocs.io/en/latest/concepts/streaming.html) — what streams, what does not, and why.
 
 ---
 

--- a/docs/source/concepts/index.md
+++ b/docs/source/concepts/index.md
@@ -1,12 +1,14 @@
 # Core concepts
 
-KonfAI is easiest to understand when you keep four ideas in mind:
+KonfAI is easiest to understand when you keep five ideas in mind:
 
 1. **YAML builds Python objects** rather than acting as a loose parameter blob.
 2. **Datasets are organized by groups** such as `CT`, `MR`, `SEG`, or `MASK`.
-3. **Model outputs are addressable by module path**, which is how losses,
+3. **Volumes are read as patches**, and a preprocessing chain that allows it is
+   streamed from disk rather than loaded.
+4. **Model outputs are addressable by module path**, which is how losses,
    metrics, and exported predictions are attached.
-4. **The same low-level workflow can later be packaged as a KonfAI App**.
+5. **The same low-level workflow can later be packaged as a KonfAI App**.
 
 Two topics have moved out of this section: imaging-format specifics (DICOM,
 OME-Zarr) now live at {doc}`../reference/components/storage-backends`, and
@@ -18,6 +20,7 @@ packaging a finished workflow as a KonfAI App is covered in
 
 configuration
 datasets
+streaming
 model-graph
 yaml-model-builder
 execution-flow

--- a/docs/source/concepts/streaming.md
+++ b/docs/source/concepts/streaming.md
@@ -1,0 +1,288 @@
+# Patch streaming
+
+When a preprocessing chain allows it, KonfAI reads each patch's source region
+straight from disk and never materializes the volume. This page explains what
+decides whether that happens, and what you control.
+
+Streaming is **derived, not configured**. Nothing in YAML asks for it. KonfAI
+reads your preprocessing chain, works out whether each patch's answer can be
+computed from a bounded region of the file, and streams when it can. When it
+cannot, it loads the volume. Both paths give the same patches; they differ in
+memory and speed.
+
+A 16 GiB uncompressed `.mha` at patch 64³, batch 2, two workers, cache off,
+under an 8 GiB memory cap trains at a peak anonymous RSS of **0.46 GiB**, stable
+across epochs, with VRAM equal to one batch.
+
+## The three regimes
+
+Which one a case takes follows from `use_cache` and from the chain itself.
+
+| Regime | When | Memory held |
+| --- | --- | --- |
+| **Cache** | `use_cache: true` | every case, resident for the whole run |
+| **Stream** | `use_cache: false` and the chain is streamable | one patch |
+| **Buffer** | `use_cache: false` and the chain is not streamable | a FIFO of `batch_size + 1` cases (or `shuffle_window` cases, whichever is larger) |
+
+**The cache wins over streaming.** `use_cache: true` preloads every case, and a
+preloaded case is cut from the resident volume even when its chain would stream.
+Set `use_cache: false` to get the streaming path at all.
+
+Stream and buffer coexist inside one run. The decision is made per case *and*
+per augmented copy, not once per dataset, so a chain that streams for one
+augmentation draw may load the volume for the next.
+
+`use_cache` is a training key: only `Trainer:` accepts it. Prediction declares
+`false` and evaluation declares `true`. A `memory_budget` overrides that
+declared value in every workflow — see below.
+
+## What you control
+
+Three keys under `Dataset:`:
+
+| Key | Default | Where | Effect |
+| --- | --- | --- | --- |
+| `use_cache` | `true` | `Trainer:` | `false` opens the stream/buffer path. |
+| `memory_budget` | `null` | all three workflows | Derives `use_cache` from the dataset's size. |
+| `subset.shuffle_window` | `null` | `Trainer:` | Bounds how many cases stay resident on the buffer path. |
+
+All three are listed in {doc}`../config_guide/training`.
+
+`memory_budget` compares the estimated per-rank dataset size against the budget
+and sets `use_cache` accordingly, printing its decision once. A bare number is
+GiB (`24` means 24 GiB), a string may name its unit (`"24GB"`, `"32 GiB"`,
+`"512mb"`), and `"auto"` offers 80% of the detected node memory, cgroup limit
+included, divided by the ranks sharing it. `null` leaves `use_cache` exactly as
+declared.
+
+`memory_budget` replaces the declared `use_cache`, in both directions and in
+every workflow. A prediction under `memory_budget: auto` caches its dataset
+whenever it fits the budget; an evaluation under a budget smaller than its
+dataset does not cache. Set the budget on the workflow you mean to bound.
+
+To take the stream/buffer path on every case, declare `use_cache` and leave the
+budget out:
+
+```yaml
+Dataset:
+  use_cache: false
+```
+
+To let the dataset's size decide, declare a budget. It settles `use_cache`
+whatever the config says, so the two keys together are not a way to force
+streaming on a dataset that fits:
+
+```yaml
+Dataset:
+  memory_budget: auto
+```
+
+```{warning}
+`memory_budget` is an **estimate, not a guarantee**. The figure is computed from
+file headers alone — `prod(shape) × 4 bytes` per source group — so it ignores
+the dtype you actually stored, any size-changing transform, the augmented copies
+of each case, and the transient peak while a case is being built. Treat it as a
+coarse switch, not as a memory bound.
+```
+
+```{warning}
+Do not combine `shuffle_window` with multi-GPU training. Each rank sizes its
+sampler from its own shard, so ranks can disagree on the number of batches and
+the run hangs in NCCL.
+```
+
+## What decides whether a chain streams
+
+Every transform declares how its output at one voxel depends on its input. That
+declaration — its **patch locality** — is what the dispatcher reads to work out
+which region of the file a patch needs.
+
+| Kind | Meaning | What KonfAI reads |
+| --- | --- | --- |
+| `POINTWISE` | the voxel depends only on itself | the exact patch |
+| `HALO` | a bounded neighbourhood of radius `halo` | the patch enlarged by `halo`, cropped after |
+| `ORIENTATION` | flip or permute | the index-remapped region |
+| `CROP` | the source region is the target translated | the region — reading it *is* the answer |
+| `GLOBAL_STAT` | needs whole-volume `Min`/`Max`/`Mean`/`Std` | the statistic once from disk, then the exact patch |
+| `RESCALE` | resample | the region through the scale mapping, plus an interpolation halo |
+| `WHOLE_VOLUME` | genuinely needs everything | the volume — the fallback |
+
+`WHOLE_VOLUME` is the default. A transform that declares nothing loads the
+volume and is correct.
+
+A chain streams when it has the shape
+
+```text
+[pointwise*] [at most one region stage] [pointwise*]
+```
+
+where `GLOBAL_STAT` counts as pointwise, and the region stages are `HALO`,
+`ORIENTATION`, `CROP`, and `RESCALE`. The chain planned is the group's
+`transforms` followed by the copy's own augmentation draw — one list, so a
+region transform and a region augmentation are two regions.
+
+Six conditions reject streaming:
+
+1. any `WHOLE_VOLUME` declaration;
+2. more than one region stage;
+3. a halo wider than half the read extent on any axis;
+4. a `GLOBAL_STAT` preceded by a stage that does not preserve statistics;
+5. a `GLOBAL_STAT` whose statistic cannot be read from disk;
+6. a `RESCALE` on a case with no `Spacing`.
+
+### Why `[Clip(-200, 400), Standardize()]` does not stream
+
+This is rule 4.
+
+`Standardize` is `GLOBAL_STAT`: it needs the volume's `Mean` and `Std`, which
+KonfAI reads once from disk. The statistic on disk is the **stored** volume's,
+while `Standardize`'s input here is the *clipped* volume. `Clip` maps values, so
+the two differ. Streaming this chain would standardize every patch by the
+pre-`Clip` statistic, so KonfAI loads the volume instead.
+
+Swap the first stage and the chain streams:
+
+```yaml
+transforms:
+  Canonical: {}
+  Normalize: {}
+```
+
+`Canonical` is `ORIENTATION`, the one kind that preserves statistics: a flip or a
+permute moves voxels without changing any of them, so the multiset of values —
+and every statistic over it — is untouched. The stored volume's `Min` and `Max`
+are `Normalize`'s own input, and the chain streams.
+
+The rule generalizes: a `GLOBAL_STAT` stage streams only when **every** stage
+before it preserves statistics. `TensorCast` is the one built-in that declares
+this for itself — casting to a float dtype changes no value, so
+`[TensorCast('float32'), Standardize()]` streams, while
+`[TensorCast('uint8'), Standardize()]` does not.
+
+### Why two region stages do not stream
+
+A region stage is a rewrite of *which* source voxels a target patch needs. One
+such rewrite composes with the read: KonfAI maps the patch back through it and
+asks the file for the result. A second stage's region is expressed in the first
+stage's output space, which does not exist on disk. `[Dilate(1), Gradient()]` is
+two halos; `[Canonical(), Permute('2|1|0')]` is two reorientations. Both load the
+volume.
+
+Rule 3 is about cost, not correctness. Every patch pays its halo on every side,
+so streaming reads `prod(1 + 2·halo/extent)` times the case's bytes, where the
+extent is the patch or the volume, whichever is smaller. At half the extent that
+is 8× in 3D, against the single load streaming avoids. At patch 8, `Dilate(4)`
+streams and `Dilate(5)` does not.
+
+## What each built-in declares
+
+| Kind | Transforms |
+| --- | --- |
+| `POINTWISE` | `Argmax`, `Softmax`, `Sum` (all `dim=0`), `OneHot`, `MergeLabels`, `FlatLabel`, `SelectLabel`, `UnNormalize`, `Percentage`, `Variance`, `StandardDeviation`, `SegmentationDisagreement`, `TensorCast`, `Clip` with fixed bounds, `Standardize` with both `mean` and `std`, `Dilate(0)` |
+| `GLOBAL_STAT` | `Normalize`, `Standardize`, `Clip` with `'min'`/`'max'` bounds |
+| `HALO` | `Dilate(n>0)`, `Gradient` |
+| `ORIENTATION` | `Flip`, `Permute`, `Canonical` (only on axis-aligned direction cosines) |
+| `CROP` | `Crop` (only once its box is on the case) |
+| `RESCALE` | `ResampleToResolution`, `ResampleToShape` |
+
+Augmentations declare per **(case, draw)** — two copies of the same case can
+answer differently. `Permute`, `Flip` (when `vector_field: false`), and `Rotate`
+(when the draw is a quarter turn) are `ORIENTATION`; `ColorTransform` and its
+subclasses are `POINTWISE`; `Translate` is `HALO`. `Scale`, `Noise`, `CutOUT`,
+`Mask`, and `Elastix` load the volume.
+
+These transforms load the volume because their answer needs it:
+
+- `Mask`, and `Clip`/`Standardize` with a `mask`, read a second full volume that
+  a patch cannot locate itself in.
+- `Clip` with percentile bounds needs the whole histogram, as does
+  `HistogramMatching`.
+- `Save` writes the whole preprocessed volume. A `Save` whose cache already
+  exists becomes the streaming source instead, and only the transforms after it
+  are planned.
+- `Argmax`, `Softmax`, and `Sum` over a spatial `dim` reduce across the whole
+  extent.
+- `Canonical` on an oblique direction resamples.
+
+## Reading regions from disk
+
+Streaming is only as cheap as the format underneath it.
+
+| Backend | Serves a disk region |
+| --- | --- |
+| HDF5 | yes, natively |
+| OME-Zarr | yes, chunked (`level` selects the pyramid resolution) |
+| DICOM | yes, per slice |
+| SimpleITK | only uncompressed MetaImage and non-gzipped NIfTI |
+
+A format that cannot serve a region — NRRD, or any compressed file — still
+returns the right voxels: it decodes the whole volume for every patch. That
+costs speed, never correctness, and KonfAI warns once per format with the
+remedy. Convert such datasets to OME-Zarr, HDF5, or uncompressed `.mha`/`.nii`.
+
+The same table governs the `GLOBAL_STAT` seed. On a backend that serves regions,
+the statistic is a chunked running pass in float64 — slab by slab, never the
+whole volume in RAM. On a format that cannot serve one, reading the statistic
+decodes the volume in one go, once per case.
+
+## `transforms` vs `patch_transforms`
+
+`transforms` runs once on the case; `patch_transforms` runs on each patch after
+it is cut. Only `POINTWISE` and `GLOBAL_STAT` are admissible per patch, and
+KonfAI rejects anything else at config time with the reason and the remedy —
+move it to `transforms`.
+
+A per-patch `GLOBAL_STAT` means *derive the statistic from this patch*. To
+standardize patches by the volume's statistic instead, pair a case-level
+`Standardize(lazy=True)` with a per-patch `Standardize()`.
+
+## Custom transforms
+
+Subclass `konfai.data.transform.Transform` and you inherit the safe default:
+your transform reports `WHOLE_VOLUME`, KonfAI loads the volume, and your patches
+are correct without you knowing streaming exists.
+
+Subclassing is **required**. A class that merely looks like a transform fails
+inside the planner with a bare `AttributeError` rather than a KonfAI error with a
+remedy.
+
+To opt in, override `patch_locality` under three rules:
+
+- **Read-only.** Never write to `cache_attribute`. The declaration is made once
+  for the whole case; a write is handed a private copy and lost.
+- **No I/O.** Read the attribute in hand and nothing else. Whether the
+  declaration can be honoured is the dispatcher's call.
+- **Total.** Answer for any case, including one with no metadata. A missing key
+  returns `WHOLE_VOLUME`; it never raises.
+
+`ORIENTATION` and `CROP` must also implement `stream_region_source`, mapping a
+target patch to the source region. Declaring a region kind without it raises a
+`TransformError` on the first patch read. `HALO` and `RESCALE` need no remap; the
+dispatcher derives their regions.
+
+## Equivalence
+
+A streamed patch is byte-identical to the same patch cut from the loaded volume
+— border padding included — for `POINTWISE`, `HALO`, `ORIENTATION`, and `CROP`.
+
+Two cases carry a bounded numerical difference instead.
+
+A `GLOBAL_STAT` stage seeded from `Mean`/`Std` — `Standardize` — reads its
+statistic from a numpy pass over the file while the whole-volume path recomputes
+it in torch. Same values, different summation order, so a standardized voxel may
+land a few float32 ulp away. A stage seeded from `Min`/`Max` — `Normalize`,
+`Clip('min', 'max')` — is byte-identical: a min and a max have no summation
+order to disagree on.
+
+A streamed `RESCALE` computes interpolation weights in the sub-region's
+coordinate frame, so the deviation scales with the local gradient rather than
+with the voxel's own value: within a few ulp of the volume's peak on float
+volumes, within 1 LSB on integer ones. A nearest-neighbour resample — what a
+`uint8` label volume gets — uses no weights and stays exact. The `Translate`
+augmentation interpolates on the same terms as `RESCALE`.
+
+## Next steps
+
+- {doc}`datasets` — the grouped layout, `groups_src`, and where patching sits
+- {doc}`../config_guide/training` — `use_cache`, `memory_budget`, and `shuffle_window` in a full config
+- {doc}`../reference/components/storage-backends` — format tokens and the per-backend APIs

--- a/docs/source/config_guide/training.md
+++ b/docs/source/config_guide/training.md
@@ -129,6 +129,7 @@ Common fields:
 | `inline_augmentations` | bool | `false` | Keeps base samples cached and generates augmentation tensors only when an augmented sample is requested; augmentation states are re-sampled on each epoch. |
 | `Patch` | mapping or null | `DatasetPatch()` | Dataset-level patch extraction. |
 | `use_cache` | bool | `true` | Cache transformed data in memory. |
+| `memory_budget` | number / string / null | `null` | RAM budget from which `use_cache` is derived. `null` keeps `use_cache` as given; a number is GiB, a string carries a unit (`"24GB"`, `"32GiB"`); `"auto"` reads the available RAM (cgroup-aware). |
 | `subset` | object | `TrainSubset()` | Restricts which cases are used. |
 | `batch_size` | int | `1` | Batch size. |
 | `num_workers` | int or null | `None` | Number of DataLoader workers. When `use_cache: false`, `None` auto-enables worker prefetching. |
@@ -138,8 +139,11 @@ Common fields:
 | `validation` | float / string / list / null | `0.2` | Validation split or explicit validation set. |
 | `validation_augmentations` | bool | `true` | Whether validation also iterates over augmented variants. Set `false` to validate only on base (non-augmented) samples. |
 | `shuffle` | bool | `true` through subset | Shuffles the training sampler. |
+| `shuffle_window` | int or null | `null` through subset | Locality-aware shuffle: keeps only this many cases resident at once (their patches shuffled together) before advancing. Bounds the per-case load buffer so each volume is read about once per epoch on the non-streamable path. `null` (default) or a value `>=` the number of cases keeps the historical global shuffle. |
 
-When `use_cache: false`, KonfAI now tries to stream patches directly from disk instead of materializing full volumes in RAM. This path is used automatically when the configured preprocessing chain is compatible with patch-wise loading; otherwise KonfAI falls back to the existing full-volume loading path.
+When `use_cache: false`, KonfAI now tries to stream patches directly from disk instead of materializing full volumes in RAM. This path is used automatically when the configured preprocessing chain is compatible with patch-wise loading; otherwise KonfAI falls back to the existing full-volume loading path. On the non-streamable fallback, a global `shuffle` reloads each volume once per patch that follows a buffer eviction; set `shuffle_window` to keep a bounded set of cases resident and read each volume about once. Cases are also sharded across `num_workers` so a volume is loaded by only one worker.
+
+Instead of hand-picking `use_cache`, declare a `memory_budget` and let KonfAI derive the regime: it estimates the dataset size from image headers alone (no voxel read), caches iff the per-rank share (`dataset_size / world_size`, since cases are sharded across ranks) fits the budget, and otherwise falls back to the streaming/buffer path. A number is read as GiB, a string carries its own unit (`"24GB"` decimal, `"32GiB"` binary), and `"auto"` uses a fraction of the detected RAM — read from the **cgroup limit** when running under a container or SLURM, so it is not fooled by the host's total. The chosen regime, the estimate, and the budget (with its source) are logged once at startup. The estimate is the raw header size and deliberately ignores transforms that shrink (resample-down, crop) or grow (pad, one-hot) the cached tensor, so treat it as an honest approximation rather than an exact footprint.
 
 ### `groups_src`
 

--- a/docs/source/config_guide/training.md
+++ b/docs/source/config_guide/training.md
@@ -123,27 +123,115 @@ Common fields:
 
 | Field | Type | Default in code | Effect |
 | --- | --- | --- | --- |
-| `dataset_filenames` | list[str] | `["./Dataset:mha"]` | Dataset sources and selection mode. |
+| `dataset_filenames` | list[str] | `["default\|./Dataset:mha"]` | Dataset sources and selection mode. |
 | `groups_src` | mapping | required in practice | Maps on-disk groups to loaded tensors. |
 | `augmentations` | mapping or null | one default augmentation list | Data augmentations sampled during training. |
 | `inline_augmentations` | bool | `false` | Keeps base samples cached and generates augmentation tensors only when an augmented sample is requested; augmentation states are re-sampled on each epoch. |
 | `Patch` | mapping or null | `DatasetPatch()` | Dataset-level patch extraction. |
-| `use_cache` | bool | `true` | Cache transformed data in memory. |
-| `memory_budget` | number / string / null | `null` | RAM budget from which `use_cache` is derived. `null` keeps `use_cache` as given; a number is GiB, a string carries a unit (`"24GB"`, `"32GiB"`); `"auto"` reads the available RAM (cgroup-aware). |
+| `use_cache` | bool | `true` | Holds the whole prepared dataset in RAM. `false` reads patches from disk instead. |
+| `memory_budget` | number / string / null | `null` | RAM budget from which `use_cache` is derived. `null` keeps `use_cache` as given. |
 | `subset` | object | `TrainSubset()` | Restricts which cases are used. |
 | `batch_size` | int | `1` | Batch size. |
-| `num_workers` | int or null | `None` | Number of DataLoader workers. When `use_cache: false`, `None` auto-enables worker prefetching. |
+| `num_workers` | int or null | `None` | Number of DataLoader workers. `None` resolves to `0` under `use_cache: true`, and to `max(1, min(cpu_count, 4))` otherwise. A `KonfAIInference` transform in any group forces `0` whatever the value. |
 | `pin_memory` | bool | `false` | Enables pinned host memory for DataLoader batches. |
-| `prefetch_factor` | int or null | `None` | Number of prefetched batches per worker when workers are enabled. |
-| `persistent_workers` | bool or null | `None` | Keep workers alive across epochs when workers are enabled. |
+| `prefetch_factor` | int or null | `None` | Prefetched batches per worker. Applies only when workers are enabled, where `None` resolves to `2`. |
+| `persistent_workers` | bool or null | `None` | Keep workers alive across epochs. Applies only when workers are enabled, where `None` resolves to `true`. |
 | `validation` | float / string / list / null | `0.2` | Validation split or explicit validation set. |
 | `validation_augmentations` | bool | `true` | Whether validation also iterates over augmented variants. Set `false` to validate only on base (non-augmented) samples. |
 | `shuffle` | bool | `true` through subset | Shuffles the training sampler. |
-| `shuffle_window` | int or null | `null` through subset | Locality-aware shuffle: keeps only this many cases resident at once (their patches shuffled together) before advancing. Bounds the per-case load buffer so each volume is read about once per epoch on the non-streamable path. `null` (default) or a value `>=` the number of cases keeps the historical global shuffle. |
+| `shuffle_window` | int or null | `null` through subset | Locality-aware training order: shuffles cases, then keeps this many cases in play at a time with their patches shuffled together. Single-process training only. |
 
-When `use_cache: false`, KonfAI now tries to stream patches directly from disk instead of materializing full volumes in RAM. This path is used automatically when the configured preprocessing chain is compatible with patch-wise loading; otherwise KonfAI falls back to the existing full-volume loading path. On the non-streamable fallback, a global `shuffle` reloads each volume once per patch that follows a buffer eviction; set `shuffle_window` to keep a bounded set of cases resident and read each volume about once. Cases are also sharded across `num_workers` so a volume is loaded by only one worker.
+### Cache, stream, and buffer
 
-Instead of hand-picking `use_cache`, declare a `memory_budget` and let KonfAI derive the regime: it estimates the dataset size from image headers alone (no voxel read), caches iff the per-rank share (`dataset_size / world_size`, since cases are sharded across ranks) fits the budget, and otherwise falls back to the streaming/buffer path. A number is read as GiB, a string carries its own unit (`"24GB"` decimal, `"32GiB"` binary), and `"auto"` uses a fraction of the detected RAM — read from the **cgroup limit** when running under a container or SLURM, so it is not fooled by the host's total. The chosen regime, the estimate, and the budget (with its source) are logged once at startup. The estimate is the raw header size and deliberately ignores transforms that shrink (resample-down, crop) or grow (pad, one-hot) the cached tensor, so treat it as an honest approximation rather than an exact footprint.
+`use_cache` picks how a loader turns a case into patches. It applies to the
+training and validation subsets alike.
+
+- **Cache** (`use_cache: true`, the default). Every case is loaded, preprocessed,
+  and held in RAM before the first epoch; patches are cut from the resident
+  volume. RAM follows the dataset. `num_workers` defaults to `0` here.
+- **Stream** (`use_cache: false`, patch-compatible preprocessing). Each patch is
+  read from its own region of the source file. No volume is materialized.
+- **Buffer** (`use_cache: false`, preprocessing that needs the whole volume).
+  The case is loaded whole into a FIFO of `batch_size + 1` cases —
+  `max(batch_size + 1, shuffle_window)` when a window is set — evicting the
+  oldest.
+
+Nothing in YAML selects streaming. KonfAI derives it from the declared transforms
+and augmentations, per case and per augmented copy, so stream and buffer coexist
+in one run: a group that needs its whole volume loads that case, while the others
+still stream.
+
+A cached case is resident, so its patches are cut from RAM even when its chain
+would stream.
+
+A 16 GiB uncompressed `.mha` at patch 64³, batch 2, 2 workers and
+`use_cache: false`, run under an 8 GiB memory cap, streams at a peak anonymous
+RSS of 0.46 GiB, flat across epochs, with one batch (2 MiB) resident on the GPU.
+
+### `memory_budget`
+
+`memory_budget` derives `use_cache` from a RAM budget. KonfAI estimates the
+dataset size from image headers alone (no voxel read), caches when the per-rank
+share fits the budget, and takes the streaming/buffer path otherwise. A budget
+decides the regime on its own: the declared `use_cache` is ignored. The decision
+is made once on the launcher, before any rank is spawned, and the estimate, the
+budget, its source, and the chosen regime are printed. `null` (the default)
+leaves `use_cache` exactly as declared.
+
+| Value | Read as |
+| --- | --- |
+| `24`, `"24"` | 24 GiB — a bare number is GiB |
+| `"24GB"`, `"512MB"` | decimal, 10^n |
+| `"32GiB"`, `"512MiB"` | binary, 2^n |
+| `"1024b"` | bytes |
+| `"auto"` | 80% of the detected RAM |
+
+Case is folded and the space before the unit is optional: `"32 gib"` and
+`"32GiB"` name the same budget.
+
+An explicit budget is **per rank**: the comparison is
+`dataset_size / world_size <= budget`, because cases are sharded across ranks.
+`"auto"` divides the detected memory by `world_size` too, so the ranks cancel and
+it reduces to "does the whole dataset fit 80% of the detected memory". `"auto"`
+takes whichever is tighter of the **cgroup limit** — set under a container or
+SLURM — and the host's available RAM; the log names which one won.
+
+```{warning}
+The dataset size is an estimate, not a guarantee. It sums `prod(header_shape) x 4`
+bytes over the source groups: it models a float32 cached tensor, so a `uint8`
+source is over-counted and a `float64` one under-counted. It reads the raw header
+shape and ignores transforms that shrink (resample-down, crop) or grow (pad,
+one-hot) the tensor. It also counts one copy per case, while the cache holds every
+augmented copy of every case — with augmentations declared, the real footprint is a
+multiple of the estimate. `inline_augmentations: true` defers those copies rather
+than dropping them: they are built on demand and released once per epoch, so the
+peak is the same. Caching also peaks above its steady state while it runs. Leave
+headroom.
+```
+
+### `shuffle_window`
+
+Each non-streamable case is loaded into the FIFO buffer, so a global patch shuffle
+reloads a volume once per patch that lands after an eviction. A window keeps
+`shuffle_window` cases in play at a time — their patches shuffled together, all
+emitted before advancing — which reads each volume about once per epoch. `1` is
+perfect locality and no decorrelation; larger windows trade one back for the other.
+
+The window applies to the training loader only. Validation is scored over the whole
+subset whatever the order, so it follows `shuffle` without a window.
+
+The window resolves back to a plain global shuffle — byte for byte — when it is
+`null` (the default), when it is `>=` the number of cases, or when `num_workers`
+exceeds the number of cases. Under a window, cases are partitioned across workers
+and the per-worker batches interleaved, so every volume is read by exactly one
+worker. The buffer is sized to hold the window, so a non-streamable run holds
+`max(batch_size + 1, shuffle_window)` volumes per worker.
+
+```{warning}
+`shuffle_window` is for single-process training. Each rank windows its own shard,
+so the ranks can disagree on the number of batches in an epoch and the collective
+will hang. Leave it `null` for multi-GPU runs.
+```
 
 ### `groups_src`
 

--- a/docs/source/reference/api/extension-points.md
+++ b/docs/source/reference/api/extension-points.md
@@ -84,6 +84,183 @@ Runtime contracts:
   `TransformInverse`
 - augmentations should inherit `konfai.data.augmentation.DataAugmentation`
 
+Inheriting the base class is required, not conventional. The loader resolves a
+`classpath` with `getattr` and applies no type check, so a class that is not a
+`Transform` is admitted and then fails inside the patch planner with a bare
+`AttributeError` on the first contract method it lacks — `transform_shape`, then
+`patch_locality`. Subclass the base and you get every contract method with a safe
+default.
+
+## Patch locality
+
+A transform declares how its output at one voxel depends on its input. The
+patch-streaming dispatcher (`konfai.data.patching`) reads that declaration and
+reads only the source region a target patch needs, instead of materialising the
+whole volume.
+
+The safe default is to declare nothing:
+
+- `Transform.patch_locality` returns `WHOLE_VOLUME`
+- `DataAugmentation._patch_locality` returns `WHOLE_VOLUME`
+
+A transform that overrides only `__call__` therefore takes the whole-volume path.
+The case is loaded, your `__call__` sees the tensor it always would, and patches
+are cut from the result. Custom transforms never have to know streaming exists.
+
+To opt in, override `patch_locality(cache_attribute)` and return a
+`PatchLocality`. Augmentations override `_patch_locality(index, a,
+cache_attribute)`: an augmentation declares per case *and* per copy, because the
+halo of a geometric draw is that draw's own.
+
+| Declared kind | Meaning | What you must also implement |
+| --- | --- | --- |
+| `POINTWISE` | output voxel depends only on the same voxel, across channels | nothing |
+| `HALO` | bounded neighbourhood, radius `halo` per axis in array order (Z, Y, X) | nothing — the dispatcher reads the enlarged region and crops |
+| `ORIENTATION` | flip or permute | `stream_region_source` |
+| `CROP` | source region is the target region translated | `stream_region_source` |
+| `GLOBAL_STAT` | needs whole-volume statistics, `stat_keys` a subset of Min/Max/Mean/Std | nothing — the dispatcher seeds the statistic from disk |
+| `RESCALE` | resample | subclass `Resample` |
+| `WHOLE_VOLUME` | needs the whole volume | nothing — this is the default |
+
+A declaration is bound by three rules:
+
+- **read-only** — never write to `cache_attribute`. A declaration is made once for
+  the whole case, so anything it wrote would be one patch's answer imposed on
+  every other. The dispatcher hands over a private copy, so a write is contained
+  and silently lost.
+- **no I/O** — read the attribute in hand, nothing else. Whether the outside world
+  can honour the declaration is the dispatcher's call.
+- **total** — answer for any case, including one with no metadata. A missing key
+  must return `WHOLE_VOLUME`, never raise. The config-time checks probe with an
+  empty `Attribute`.
+
+`ORIENTATION` and `CROP` are the kinds that need the remap, and declaring one
+without it is a loud failure rather than a wrong answer:
+`Transform.stream_region_source` raises `TransformError` and
+`DataAugmentation._stream_region_source` raises `AugmentationError`. A `HALO`
+never calls it — the dispatcher derives the enlarged region from the radius.
+
+Any region kind that rewrites geometry must also implement
+`write_stream_cache_attribute(cache_attribute, source_spatial_shape)`. A region
+stage runs on the region, so the `Origin`, `Spacing` or `Direction` its `__call__`
+records describe that region rather than the case; those writes land on a throwaway
+`Attribute` and are dropped. `write_stream_cache_attribute` is called once per
+case, on the persistent attribute, with the full source spatial shape: write the
+case-level geometry there. Omitting it is silent — the case keeps its source
+geometry and every key the stage wrote is lost. `Canonical` is an `ORIENTATION`
+transform and implements it: its new origin is the corner the volume mirrors onto,
+which only the full extent gives. The base is a no-op, for a transform that leaves
+geometry alone.
+
+The rule stops at the region stage. A pointwise stage needs no extra method: a key
+it adds reaches the case on its own, which is how `TensorCast` keeps the source
+dtype its `inverse()` reads.
+
+What a declaration costs you:
+
+- A streamed patch must equal what the whole-volume path produces on the same
+  grid. This is what the declaration promises and what the test suite checks for
+  every built-in.
+- A halo is paid on every side of every patch, so streaming reads
+  `prod(1 + 2 * halo_k / patch_k)` times the case's bytes. A radius above half the
+  patch — or half the case, whichever is smaller — on any axis is rejected, and
+  the case falls back to a full load.
+- A chain streams only as `[pointwise*][at most one region][pointwise*]`, where
+  `GLOBAL_STAT` counts as pointwise. Two region stages, or any `WHOLE_VOLUME`,
+  falls back.
+
+`patch_transforms` is stricter than `transforms`: only `POINTWISE` and
+`GLOBAL_STAT` are accepted, and any other kind raises a `ConfigError` pointing at
+`transforms` instead.
+
+## `preserves_statistics`
+
+`PatchLocality.preserves_statistics` overrides the kind's own answer to "does this
+leave every whole-volume statistic of its input untouched". Only `ORIENTATION`
+says yes by default: a flip or a permute is a bijection on the voxels, so the
+multiset of values — and therefore Min/Max/Mean/Std — is exactly the input's.
+
+It exists because it decides whether a later `GLOBAL_STAT` stage may seed from the
+stored volume's statistics. `[Canonical(), Normalize()]` streams.
+`[Clip(-200., 400.), Normalize()]` falls back, because the clip moves the
+statistics the normalise would then read.
+
+One built-in overrides it: `TensorCast` declares
+`POINTWISE, preserves_statistics=self.dtype.is_floating_point`. A cast to a float
+dtype maps no value, so a later `Standardize` may still seed from disk.
+
+Declaring `preserves_statistics=True` on a transform that is not a bijection is a
+silent-correctness bug, not an error. Nothing validates the claim against what
+your `__call__` does. The chain streams, every patch is seeded with a statistic
+taken before your transform ran, and the result quietly disagrees with the
+whole-volume answer. Set it only when your transform permutes voxels or maps
+values one-to-one.
+
+## Transforms from another framework
+
+A foreign class named directly as a `classpath` is admitted and then fails. The
+loader imports the module and calls `getattr` with no type check, so nothing
+rejects it at resolution, and how far it gets depends on its constructor:
+
+- Defaults that YAML can represent: the class is instantiated, and the patch
+  planner then raises a bare `AttributeError` on `transform_shape`, the first
+  contract method a foreign class lacks.
+- A default YAML cannot represent: config binding raises
+  `yaml.representer.RepresenterError` before the class is ever built. Resolved
+  defaults are written back to the config file, and a value that cannot be written
+  stops the run. `monai.transforms:ScaleIntensity` takes this path — its `dtype`
+  defaults to `np.float32`.
+
+Wrap it instead, in a local module next to your YAML. The wrapper's own signature
+is what YAML binds, which keeps the foreign constructor out of the config file:
+
+```python
+# MonaiTransform.py
+import torch
+from monai.transforms import ScaleIntensity
+
+from konfai.data.transform import Transform
+from konfai.utils.dataset import Attribute
+
+
+class MonaiScaleIntensity(Transform):
+    """Adapt a MONAI array transform to the KonfAI transform contract."""
+
+    def __init__(self, minv: float = 0.0, maxv: float = 1.0) -> None:
+        super().__init__()
+        # Expose only the arguments YAML should bind, and pass them on.
+        self.transform = ScaleIntensity(minv=minv, maxv=maxv)
+
+    def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
+        return self.transform(tensor)
+```
+
+Referenced as `MonaiTransform:MonaiScaleIntensity`. KonfAI tensors are
+channel-first `[C, (Z), Y, X]`.
+
+The wrapper is safe by default: it declares no locality, so it takes the
+whole-volume path and sees exactly the tensor the foreign transform expects. Add a
+`patch_locality` only once you can state which kind is honest for it.
+
+Two traps:
+
+- **A random per-voxel augmentation is not `POINTWISE`.** The kind is about the
+  voxel's position, not the arithmetic's shape. A field drawn per call is a
+  different field on every call, so overlapping patches sample unrelated fields
+  and the overlap blend suppresses the variance the augmentation exists to add.
+  The built-in `Noise` declares `WHOLE_VOLUME` for this reason. Declared
+  `POINTWISE`, two reads of the same patch return different values.
+- **Wrap the array transform, not the dict one.** A MONAI `*d` transform takes a
+  dict and pairs image and label through its `keys`. `__call__` is handed one
+  tensor and returns one tensor, so there is no dict for `keys` to select from.
+  Let the group configuration do the pairing.
+
+A transform reads another group through `self.datasets`, by group name — the
+built-in `Mask` does, and so can yours. It reads that group whole: `__call__` is
+not told where its tensor sits in the volume, so it cannot ask for the matching
+region. That is why `Mask` is a whole-volume transform, and why a wrapper that
+reaches for a second group should stay one.
+
 ## Criteria and schedulers
 
 KonfAI lets you attach multiple losses and metrics to multiple outputs and

--- a/docs/source/reference/components/augmentations.md
+++ b/docs/source/reference/components/augmentations.md
@@ -28,24 +28,39 @@ test-time augmentation reassembly.
 code). Everything else preserves geometry.
 ```
 
+```{note}
+**Patch streaming.** The **Stream** column says whether a copy's patches can be
+cut straight from disk or whether the augmentation needs the case loaded whole
+(see {doc}`transforms`). An augmentation answers per **copy**, not per
+transform: the answer follows the draw, so two copies of the same case can differ
+and the same copy can differ next epoch. A copy the draw did not select is the
+identity, which streams. The draw is planned as part of the group's chain, so
+a region augmentation and a region transform (`Dilate`, `Canonical`, a resampler)
+in the same chain load the volume whole — only one of them can shape the read. An
+augmentation you write yourself starts at the whole volume and streams nothing
+until it declares otherwise.
+```
+
 ## Spatial (Euler transforms)
 
 Reversible affine warps via `grid_sample` (nearest-neighbour for label tensors).
 
-| Name | Purpose | Key args (defaults) | Shape | Inv |
-| --- | --- | --- | --- | --- |
-| `Translate` | Random translation (voxels). | `t_min=-10, t_max=10, is_int=False` | no | **yes** |
-| `Rotate` | Random rotation (degrees). | `a_min=0, a_max=360, is_quarter=False` | no | **yes** |
-| `Scale` | Random log2-normal isotropic scale. | `s_std=0.2` | no | **yes** |
-| `Flip` | Per-axis random flip; optional vector-field channel negation. | `f_prob=[0.33,0.33,0.33], vector_field=False` | no | **yes** (self-inverse) |
-| `Elastix` | Random BSpline elastic warp (SimpleITK). | `grid_spacing=16, max_displacement=16` | no | no |
-| `Permute` | Random spatial-axis permutation (**3-D only**). | `prob_permute=[0.5,0.5]` | **yes** | **yes** |
-| `Mask` | Randomly place a mask volume; outside → `value` (SimpleITK). | `mask` (required), `value` (required) | **yes** | no |
+| Name | Purpose | Key args (defaults) | Shape | Inv | Stream |
+| --- | --- | --- | --- | --- | --- |
+| `Translate` | Random translation (voxels). | `t_min=-10, t_max=10, is_int=False` | no | **yes** | **yes** — a halo of the drawn shift (plus a voxel for interpolation), while that stays within half the patch |
+| `Rotate` | Random rotation (degrees). | `a_min=0, a_max=360, is_quarter=False` | no | **yes** | **yes** with `is_quarter: true` (an index remap); no for a free angle — the shift grows with distance from the centre |
+| `Scale` | Random log2-normal isotropic scale. | `s_std=0.2` | no | **yes** | no — the shift grows with distance from the centre, so no fixed halo covers it |
+| `Flip` | Per-axis random flip; optional vector-field channel negation. | `f_prob=[0.33,0.33,0.33], vector_field=False` | no | **yes** (self-inverse) | **yes** — index remap; no with `vector_field: true` (negating a channel changes values) |
+| `Elastix` | Random BSpline elastic warp (SimpleITK). | `grid_spacing=16, max_displacement=16` | no | no | no — the displacement field is built at the full shape and indexed by absolute position |
+| `Permute` | Random spatial-axis permutation (**3-D only**). | `prob_permute=[0.5,0.5]` | **yes** | **yes** | **yes** — index remap |
+| `Mask` | Randomly place a mask volume; outside → `value` (SimpleITK). | `mask` (required), `value` (required) | **yes** | no | no — the output grid is the mask's, and the mask is already resident |
 
 ## Intensity (colour transforms)
 
 Apply a per-index colour affine to RGB(3-ch) or L(1-ch) tensors. Their inverse is
-a no-op (colour changes don't move voxels).
+a no-op (colour changes don't move voxels). The draw is a colour matrix applied to
+each voxel on its own — no neighbour, no coordinate, no extent — so every one of
+them streams: a voxel comes out the same whatever region it was read in.
 
 | Name | Purpose | Key args (defaults) |
 | --- | --- | --- |
@@ -57,10 +72,10 @@ a no-op (colour changes don't move voxels).
 
 ## Other
 
-| Name | Purpose | Key args (defaults) | Notes |
-| --- | --- | --- | --- |
-| `Noise` | Diffusion-style forward noising (zero-terminal-SNR β schedule). | `n_std` (required), `noise_step=1000` | Its `prob` is the max noise timestep, not an apply probability; it always applies. |
-| `CutOUT` | Random cutout box filled with `value`. | `c_prob`, `cutout_size`, `value` (all required) | Gating uses the base probability. |
+| Name | Purpose | Key args (defaults) | Notes | Stream |
+| --- | --- | --- | --- | --- |
+| `Noise` | Diffusion-style forward noising (zero-terminal-SNR β schedule). | `n_std` (required), `noise_step=1000` | Its `prob` is the max noise timestep, not an apply probability; it always applies. | no — the field is drawn per call, so overlapping patches would draw unrelated fields and the blend would suppress the variance |
+| `CutOUT` | Random cutout box filled with `value`. | `c_prob`, `cutout_size`, `value` (all required) | Gating uses the base probability. | no — the box is normalised to the tensor in hand, so per patch it would land in every patch |
 
 ```{note}
 `Elastix` and `Mask` require SimpleITK. The `vector_field` flag on `Flip` should

--- a/docs/source/reference/components/transforms.md
+++ b/docs/source/reference/components/transforms.md
@@ -27,69 +27,120 @@ below flags those. Transforms that only change the **channel** count (`OneHot`,
 channel axis first). **Inv** flags whether a working `inverse()` exists.
 ```
 
+## Patch streaming
+
+A patch is cut straight from disk when every transform in the chain can name the
+source region that patch depends on. A chain that cannot name it falls back to
+the whole volume: the case is loaded whole, and the result is the same, just
+resident. The **Stream** column below is that answer, per transform.
+
+Streaming happens where the cache is off. A cached case is already in memory, so
+its patches are cut from memory whatever the column says. Training exposes
+`use_cache` under `Dataset:` and defaults it to `true`; PREDICTION carries no
+`use_cache` key and does not cache; EVALUATION caches. A `memory_budget` under
+`Dataset:` overrides all three with a size estimate.
+
+Three rules apply to the chain rather than to any single transform:
+
+- **One region transform per chain.** `Dilate`, `Gradient`, `Crop`, `Canonical`,
+  `Flip`, `Permute` and the resamplers each read a region other than the patch
+  itself. Two of them in one chain — `[Dilate, Gradient]`, `[Canonical, Permute]`
+  — load the whole volume. Augmentations count: a copy's draw is planned as part
+  of the same chain.
+- **A statistic is seeded from the stored volume.** `Normalize`, `Standardize`
+  and `Clip(min_value="min")` read their statistic from disk, which is their input
+  only if every earlier stage left the values alone. Reorienting does; mapping
+  values does not. `[Canonical(), Normalize()]` streams, `[Clip(-200, 400),
+  Normalize()]` loads whole. A cast to a **float** dtype keeps the statistic, an
+  integer cast does not.
+- **A halo must stay within half the patch.** `Dilate(4)` streams at patch 64 and
+  at patch 8, and loads whole at patch 4. The bound is checked per axis against
+  the patch size, or against the case's own extent where that is smaller.
+
+A streamed patch reproduces the whole-volume result exactly, borders included.
+Four kinds round rather than diverge:
+
+- A **seeded statistic** is summed in a different order than the whole-volume
+  pass, so a standardised voxel can land a few float32 ulps away.
+- A **trilinear resample** computes its interpolation weights in the read
+  sub-region's frame. The deviation scales with the local intensity gradient and
+  with the extent, not with the voxel's own value, and is a small fraction of the
+  intensity range. Nearest-neighbour interpolation uses no weights and stays
+  exact.
+- A **`Translate` draw** is sampled the same way and rounds for the same reason.
+- An **integer volume** through a streamed resample quantises that rounding, so a
+  voxel can land one least-significant bit away.
+
+A transform you write yourself starts at the whole volume and streams nothing
+until it declares otherwise.
+
 ## Intensity & normalisation
 
-| Name | Purpose | Key args (defaults) | Shape | Inv |
-| --- | --- | --- | --- | --- |
-| `Clip` | Clamp intensities to a fixed or data-dependent range. | `min_value=-1024, max_value=1024, mask=None` | no | no |
-| `Normalize` | Linear map to `[min,max]`; caches Min/Max. | `min_value=-1, max_value=1, channels=None, lazy=False, inverse=True` | no | **yes** |
-| `UnNormalize` | Map `[-1,1] → [min,max]` (fixed). | `min_value=-1024, max_value=3071` | no | no |
-| `Standardize` | Zero-mean / unit-std from cached, given, or mask-derived stats. | `mean=None, std=None, mask=None, lazy=False, inverse=True` | no | **yes** |
-| `HistogramMatching` | SimpleITK histogram match to a reference group. | `reference_group` | no | no |
+| Name | Purpose | Key args (defaults) | Shape | Inv | Stream |
+| --- | --- | --- | --- | --- | --- |
+| `Clip` | Clamp intensities to a fixed or data-dependent range. | `min_value=-1024, max_value=1024, mask=None` | no | no | **yes** — fixed bounds clamp each voxel on its own, and a `"min"`/`"max"` bound is read from disk; no with `mask=` (a second volume) or a `"percentile:<float>"` bound (the whole histogram) |
+| `Normalize` | Linear map to `[min,max]`; caches Min/Max. | `min_value=-1, max_value=1, channels=None, lazy=False, inverse=True` | no | **yes** | **yes** — Min/Max read from disk |
+| `UnNormalize` | Map `[-1,1] → [min,max]` (fixed). | `min_value=-1024, max_value=3071` | no | no | **yes** |
+| `Standardize` | Zero-mean / unit-std from cached, given, or mask-derived stats. | `mean=None, std=None, mask=None, lazy=False, inverse=True` | no | **yes** | **yes** — Mean/Std read from disk, or neither when both are given; no with `mask=` (a second volume) |
+| `HistogramMatching` | SimpleITK histogram match to a reference group. | `reference_group` | no | no | no — the LUT needs the volume's whole histogram |
 
 ## Geometry & resampling
 
-| Name | Purpose | Key args (defaults) | Shape | Inv |
-| --- | --- | --- | --- | --- |
-| `Padding` | `F.pad`; updates Origin. `mode` supports `"constant:<val>"`. | `padding=[0,0,0,0,0,0], mode="constant", inverse=True` | **yes** | **yes** |
-| `Crop` | Crop to foreground bounding box; caches the box; updates Origin. | `inverse=True` | **yes** | **yes** (pads back) |
-| `ResampleToResolution` | Resample to a target voxel spacing (per-axis `<0` = keep). | `spacing=[1,1,1], inverse=True` | **yes** | **yes** |
-| `ResampleToShape` | Resample to a target shape (per-axis `0/<0` = keep). | `shape=[100,256,256], inverse=True` | **yes** | **yes** |
-| `ResampleTransform` | Warp by stored SimpleITK transforms read from the dataset. | `transforms`, `inverse=True` | no | no |
-| `Canonical` | Reorient to canonical direction (3-D); updates Origin/Direction. | `inverse=True` | no | **yes** |
-| `Permute` | Permute spatial axes. `dims` is a pipe-separated axis list. | `dims="1\|0\|2", inverse=True` | **yes** | **yes** |
-| `Flip` | Flip spatial axes. | `dims="1\|0\|2", inverse=True` | no | **yes** (self-inverse) |
-| `Squeeze` | `tensor.squeeze(dim)`. `transform_shape` drops a squeezed spatial axis and leaves a channel-axis squeeze shape-preserving, so the patch grid folds it. | `dim` (required), `inverse=True` | **yes** | **yes** |
-| `Flatten` | Flatten to 1-D. | — | **yes** | no |
+| Name | Purpose | Key args (defaults) | Shape | Inv | Stream |
+| --- | --- | --- | --- | --- | --- |
+| `Padding` | `F.pad`; updates Origin. `mode` supports `"constant:<val>"`. | `padding=[0,0,0,0,0,0], mode="constant", inverse=True` | **yes** | **yes** | no‡ |
+| `Crop` | Crop to foreground bounding box; caches the box; updates Origin. | `inverse=True` | **yes** | **yes** (pads back) | **yes** — once the `box` is on the case; the region is the patch translated |
+| `ResampleToResolution` | Resample to a target voxel spacing (per-axis `<0` = keep). | `spacing=[1,1,1], inverse=True` | **yes** | **yes** | **yes** — resampled from the source region |
+| `ResampleToShape` | Resample to a target shape (per-axis `0/<0` = keep). | `shape=[100,256,256], inverse=True` | **yes** | **yes** | **yes** — resampled from the source region |
+| `ResampleTransform` | Warp by stored SimpleITK transforms read from the dataset. | `transforms`, `inverse=True` | no | no | no — nothing bounds how far the stored displacement reaches |
+| `Canonical` | Reorient to canonical direction (3-D); updates Origin/Direction. | `inverse=True` | no | **yes** | **yes** — when the case's direction is a signed axis permutation; no on an oblique one (it is resampled) |
+| `Permute` | Permute spatial axes. `dims` is a pipe-separated axis list. | `dims="1\|0\|2", inverse=True` | **yes** | **yes** | **yes** — index remap |
+| `Flip` | Flip spatial axes. | `dims="1\|0\|2", inverse=True` | no | **yes** (self-inverse) | **yes** — index remap |
+| `Squeeze` | `tensor.squeeze(dim)`. `transform_shape` drops a squeezed spatial axis and leaves a channel-axis squeeze shape-preserving, so the patch grid folds it. | `dim` (required), `inverse=True` | **yes** | **yes** | no‡ |
+| `Flatten` | Flatten to 1-D. | — | **yes** | no | no‡ |
 
 ## Labels & masks
 
-| Name | Purpose | Key args (defaults) | Shape | Inv |
-| --- | --- | --- | --- | --- |
-| `TensorCast` | Cast dtype; caches original for inverse. | `dtype="float32", inverse=True` | no | **yes** |
-| `OneHot` | One-hot encode a label map (changes **channels**). | `num_classes, inverse=True` | no† | **yes** |
-| `Argmax` | `argmax(dim)` then unsqueeze. | `dim=0` | no† | no |
-| `Softmax` | `softmax(dim)`. | `dim=0` | no | no |
-| `FlatLabel` | Binarise selected labels (else `>0`) → 1. | `labels=None` | no | no |
-| `SelectLabel` | Remap labels; entries are `"(old,new)"` strings. | `labels` | no | no |
-| `Mask` | Set voxels where mask==0 to `value_outside`. | `path="./default.mha", value_outside=0` | no | no |
-| `Dilate` | Binary dilation via max-pool (2D/3D). | `dilate=1` | no | no |
-| `Sum` | Sum over `dim` (merges multi-model label maps). | `dim=0` | no† | no |
-| `Gradient` | Gradient-magnitude image (or components). | `per_dim=False` | no† | no |
+| Name | Purpose | Key args (defaults) | Shape | Inv | Stream |
+| --- | --- | --- | --- | --- | --- |
+| `TensorCast` | Cast dtype; caches original for inverse. | `dtype="float32", inverse=True` | no | **yes** | **yes** |
+| `OneHot` | One-hot encode a label map (changes **channels**). | `num_classes, inverse=True` | no† | **yes** | **yes** |
+| `Argmax` | `argmax(dim)` then unsqueeze. | `dim=0` | no† | no | **yes** at `dim=0`; no over a spatial axis (the reduction spans the extent) |
+| `Softmax` | `softmax(dim)`. | `dim=0` | no | no | **yes** at `dim=0`; no over a spatial axis (the reduction spans the extent) |
+| `FlatLabel` | Binarise selected labels (else `>0`) → 1. | `labels=None` | no | no | **yes** |
+| `SelectLabel` | Remap labels; entries are `"(old,new)"` strings. | `labels` | no | no | **yes** |
+| `Mask` | Set voxels where mask==0 to `value_outside`. | `path="./default.mha", value_outside=0` | no | no | no — it cannot tell where its tensor sits, so it cannot read the matching mask region |
+| `Dilate` | Binary dilation via max-pool (2D/3D). | `dilate=1` | no | no | **yes** — halo of `dilate` voxels, within half the patch |
+| `Sum` | Sum over `dim` (merges multi-model label maps). | `dim=0` | no† | no | **yes** at `dim=0`; no over a spatial axis (the reduction spans the extent) |
+| `Gradient` | Gradient-magnitude image (or components). | `per_dim=False` | no† | no | **yes** — halo of 1 voxel |
 
 ## Ensemble / uncertainty post-processing
 
 Operate on a stacked `[N, …]` ensemble axis (prediction post-processing).
 
-| Name | Purpose | Key args | Shape |
-| --- | --- | --- | --- |
-| `InferenceStack` | Aggregate an ensemble stack (mean / median / seg-argmax); writes an `InferenceStack` volume. | `dataset, name, mode="mean"` | no |
-| `Norm` | Vector magnitude over the trailing axis (drops it). | — | **yes** |
-| `Variance` | Per-voxel variance over N. | — | no† |
-| `StandardDeviation` | Per-voxel std over N. | — | no† |
-| `SegmentationDisagreement` | Per-voxel label disagreement across N segmentations. | `ignore_background=False` | no† |
-| `Percentage` | `tensor / baseline * 100`. | `baseline` | no |
+| Name | Purpose | Key args | Shape | Stream |
+| --- | --- | --- | --- | --- |
+| `InferenceStack` | Aggregate an ensemble stack (mean / median / seg-argmax); writes an `InferenceStack` volume. | `dataset, name, mode="mean"` | no | no — it writes the whole per-member stack |
+| `Norm` | Vector magnitude over the trailing axis (drops it). | — | **yes** | no‡ |
+| `Variance` | Per-voxel variance over N. | — | no† | **yes** |
+| `StandardDeviation` | Per-voxel std over N. | — | no† | **yes** |
+| `SegmentationDisagreement` | Per-voxel label disagreement across N segmentations. | `ignore_background=False` | no† | **yes** |
+| `Percentage` | `tensor / baseline * 100`. | `baseline` | no | **yes** |
 
 ## Side-effect & advanced
 
-| Name | Purpose |
-| --- | --- |
-| `Statistics` | Records ImageMin/Max/Mean/Std to the attribute cache and returns the tensor unchanged (feeds the perceptual criteria `SAM_Perceptual`, `IMPACTSynth`, `IMPACTReg`). Order in the transform list matters. |
-| `Save` | Marker — a no-op passthrough (a checkpoint hint, not a saver). |
-| `KonfAIInference` | Run a nested KonfAI app inference in a spawned subprocess. Needs `konfai-apps` and `num_workers: 0`; defaults to a specific HF repo. |
+| Name | Purpose | Stream |
+| --- | --- | --- |
+| `Statistics` | Records ImageMin/Max/Mean/Std to the attribute cache and returns the tensor unchanged (feeds the perceptual criteria `SAM_Perceptual`, `IMPACTSynth`, `IMPACTReg`). Order in the transform list matters. | no‡ |
+| `Save` | Writes the preprocessed volume to a cache dataset and passes the tensor through. Once that cache exists it is read instead, and the transforms before it are skipped. | no — it needs the whole volume to write |
+| `KonfAIInference` | Run a nested KonfAI app inference in a spawned subprocess. Needs `konfai-apps` and `num_workers: 0`; defaults to a specific HF repo. | no‡ |
 
 `†` changes the **channel** dimension, not spatial — no `transform_shape`
 override needed.
+
+`‡` declares no patch locality, so the case is loaded whole. That is the safe
+default every `Transform` inherits, not a statement that the operation could not
+be streamed.
 
 ## Next steps
 

--- a/docs/source/reference/components/transforms.md
+++ b/docs/source/reference/components/transforms.md
@@ -49,7 +49,7 @@ channel axis first). **Inv** flags whether a working `inverse()` exists.
 | `Canonical` | Reorient to canonical direction (3-D); updates Origin/Direction. | `inverse=True` | no | **yes** |
 | `Permute` | Permute spatial axes. `dims` is a pipe-separated axis list. | `dims="1\|0\|2", inverse=True` | **yes** | **yes** |
 | `Flip` | Flip spatial axes. | `dims="1\|0\|2", inverse=True` | no | **yes** (self-inverse) |
-| `Squeeze` | `tensor.squeeze(dim)`. Does not override `transform_shape` — use on the channel axis or in post-processing. | `dim` (required), `inverse=True` | no | **yes** |
+| `Squeeze` | `tensor.squeeze(dim)`. `transform_shape` drops a squeezed spatial axis and leaves a channel-axis squeeze shape-preserving, so the patch grid folds it. | `dim` (required), `inverse=True` | **yes** | **yes** |
 | `Flatten` | Flatten to 1-D. | — | **yes** | no |
 
 ## Labels & masks

--- a/konfai/data/augmentation.py
+++ b/konfai/data/augmentation.py
@@ -29,6 +29,7 @@ except ImportError:
     sitk = None  # type: ignore[assignment]
 
 from konfai import konfai_root
+from konfai.data.transform import LocalityKind, PatchLocality
 from konfai.utils.config import apply_config
 from konfai.utils.dataset import Attribute, Dataset, data_to_image
 from konfai.utils.errors import AugmentationError
@@ -260,24 +261,60 @@ class DataAugmentation(NeedDevice, ABC):
     def _state_init(self, index: int, shapes: list[list[int]], caches_attribute: list[Attribute]) -> list[list[int]]:
         pass
 
+    def patch_locality(self, index: int, a: int, cache_attribute: Attribute) -> PatchLocality:
+        """Declare how the draw of copy *a* makes its output depend on its input, for patch streaming.
+
+        The same contract as :meth:`konfai.data.transform.Transform.patch_locality` -- read-only, no
+        I/O, total, ``WHOLE_VOLUME`` by default -- asked of one copy of one case, because that is the
+        grain an augmentation is parameterised at: the halo of a geometric draw is the draw's own, so
+        two copies of the same case answer differently and the same copy answers differently next
+        epoch. A copy the draw did not select is the identity, which the base answers for.
+        """
+        if a not in self.who_index[index]:
+            return PatchLocality(LocalityKind.POINTWISE)
+        return self._patch_locality(index, self.who_index[index].index(a), cache_attribute)
+
+    def _patch_locality(self, index: int, a: int, cache_attribute: Attribute) -> PatchLocality:
+        return PatchLocality(LocalityKind.WHOLE_VOLUME)
+
+    def stream_region_source(
+        self,
+        index: int,
+        a: int,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+    ) -> list[slice]:
+        """Map a target patch's spatial slices to the source region copy *a* reads (region kinds)."""
+        return self._stream_region_source(index, self.who_index[index].index(a), target_slices, source_spatial_shape)
+
+    def _stream_region_source(
+        self,
+        index: int,
+        a: int,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+    ) -> list[slice]:
+        raise AugmentationError(
+            f"{type(self).__name__} declared a region patch-locality but does not implement _stream_region_source().",
+            "Implement _stream_region_source() or declare a non-region _patch_locality().",
+        )
+
+    def compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
+        """Apply the draw of copy *a* to one tensor -- the forward counterpart of :meth:`inverse`."""
+        if a in self.who_index[index]:
+            tensor = self._compute(name, index, self.who_index[index].index(a), tensor)
+        return tensor
+
     def __call__(
         self,
         name: str,
         index: int,
         tensors: list[torch.Tensor],
     ) -> list[torch.Tensor]:
-        if len(self.who_index[index]) > 0:
-            for i, result in enumerate(self._compute(name, index, [tensors[i] for i in self.who_index[index]])):
-                tensors[self.who_index[index][i]] = result
-        return tensors
+        return [self.compute(name, index, a, tensor) for a, tensor in enumerate(tensors)]
 
     @abstractmethod
-    def _compute(
-        self,
-        name: str,
-        index: int,
-        tensors: list[torch.Tensor],
-    ) -> list[torch.Tensor]:
+    def _compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
         pass
 
     def inverse(self, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
@@ -295,40 +332,18 @@ class EulerTransform(DataAugmentation):
         super().__init__()
         self.matrix: dict[int, list[torch.Tensor]] = {}
 
-    def _compute(
-        self,
-        name: str,
-        index: int,
-        tensors: list[torch.Tensor],
-    ) -> list[torch.Tensor]:
-        results = []
-        for tensor, matrix in zip(tensors, self.matrix[index], strict=False):
-            # Integer tensors are label maps: interpolating them blends class ids into
-            # non-existent labels, so resample them with nearest-neighbour instead.
-            mode = "nearest" if not tensor.dtype.is_floating_point else "bilinear"
-            results.append(
-                F.grid_sample(
-                    tensor.unsqueeze(0).type(torch.float32),
-                    F.affine_grid(matrix[:, :-1, ...], [1, *list(tensor.shape)], align_corners=True).to(tensor.device),
-                    align_corners=True,
-                    mode=mode,
-                    padding_mode="reflection",
-                )
-                .type(tensor.dtype)
-                .squeeze(0)
-            )
-        return results
+    def _grid_matrix(self, index: int, a: int, shape: list[int]) -> torch.Tensor:
+        """Copy *a*'s affine, in the normalised coordinates ``affine_grid`` spans over ``shape``."""
+        return self.matrix[index][a]
 
-    def _inverse(self, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
+    def _sample(self, matrix: torch.Tensor, tensor: torch.Tensor) -> torch.Tensor:
+        # Integer tensors are label maps: interpolating them blends class ids into
+        # non-existent labels, so resample them with nearest-neighbour instead.
         mode = "nearest" if not tensor.dtype.is_floating_point else "bilinear"
         return (
             F.grid_sample(
                 tensor.unsqueeze(0).type(torch.float32),
-                F.affine_grid(
-                    self.matrix[index][a].inverse()[:, :-1, ...],
-                    [1, *list(tensor.shape)],
-                    align_corners=True,
-                ).to(tensor.device),
+                F.affine_grid(matrix[:, :-1, ...], [1, *list(tensor.shape)], align_corners=True).to(tensor.device),
                 align_corners=True,
                 mode=mode,
                 padding_mode="reflection",
@@ -337,6 +352,12 @@ class EulerTransform(DataAugmentation):
             .squeeze(0)
         )
 
+    def _compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
+        return self._sample(self._grid_matrix(index, a, list(tensor.shape[1:])), tensor)
+
+    def _inverse(self, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
+        return self._sample(self._grid_matrix(index, a, list(tensor.shape[1:])).inverse(), tensor)
+
 
 class Translate(EulerTransform):
     def __init__(self, t_min: float = -10, t_max=10, is_int: bool = False):
@@ -344,23 +365,43 @@ class Translate(EulerTransform):
         self.t_min = t_min
         self.t_max = t_max
         self.is_int = is_int
+        self.translate: dict[int, torch.Tensor] = {}
 
     def _state_init(self, index: int, shapes: list[list[int]], caches_attribute: list[Attribute]) -> list[list[int]]:
         dim = len(shapes[0])
-        func = _translate_3d_matrix if dim == 3 else _translate_2d_matrix
         translate = torch.rand((len(shapes), dim)) * torch.tensor(self.t_max - self.t_min) + torch.tensor(self.t_min)
-        if self.is_int:
-            translate = torch.round(translate)
-        matrices = []
-        for value, shape in zip(translate, shapes, strict=False):
-            sizes = torch.tensor(list(reversed(shape)), dtype=torch.float32)
-            normalized = value * 2.0 / (sizes - 1)
-            matrices.append(torch.unsqueeze(func(normalized), dim=0))
-        self.matrix[index] = matrices
+        self.translate[index] = torch.round(translate) if self.is_int else translate
         return shapes
+
+    def _grid_matrix(self, index: int, a: int, shape: list[int]) -> torch.Tensor:
+        # The draw is a shift in VOXELS, in (x, y, z). ``affine_grid`` spans [-1, 1] over whatever
+        # extent it is given, so the same shift is a different matrix on a patch than on the volume:
+        # normalise it against the extent it is about to be applied to, never against a fixed one.
+        func = _translate_3d_matrix if len(shape) == 3 else _translate_2d_matrix
+        sizes = torch.tensor(list(reversed(shape)), dtype=torch.float32)
+        return torch.unsqueeze(func(self.translate[index][a] * 2.0 / (sizes - 1)), dim=0)
+
+    def _patch_locality(self, index: int, a: int, cache_attribute: Attribute) -> PatchLocality:
+        # A uniform shift sends a target patch to that same patch displaced by the draw, so the source
+        # is a bounded neighbourhood of it. One voxel past the ceiling covers the far tap a fractional
+        # shift interpolates from. The draw is in (x, y, z); a halo is in array order.
+        radius = (torch.ceil(self.translate[index][a].abs()).to(torch.int64) + 1).tolist()
+        return PatchLocality(LocalityKind.HALO, halo=tuple(int(r) for r in reversed(radius)))
 
 
 class Rotate(EulerTransform):
+    """Rotate a copy of the case about its centre.
+
+    A quarter draw is a signed permutation of the axes: an exact index remap (permute + flip), never an
+    interpolation, and it transposes the extents it swaps, so the copy is cut on its own grid. A free
+    angle displaces a voxel by 2 * R * sin(theta / 2) from the centre, which no constant halo bounds --
+    it stays whole-volume.
+    """
+
+    # A quarter angle's cosines are computed in float32, so an entry of the composed matrix lands within
+    # ~1e-7 of the 0 or +/-1 it stands for rather than on it.
+    _QUARTER_ATOL = 1e-6
+
     def __init__(self, a_min: float = 0, a_max: float = 360, is_quarter: bool = False):
         super().__init__()
         self.a_min = a_min
@@ -382,10 +423,104 @@ class Rotate(EulerTransform):
             )
 
         self.matrix[index] = [torch.unsqueeze(func(value), dim=0) for value in angles]
-        return shapes
+        # A quarter turn transposes the extents it swaps, so a copy whose draw is one is cut on the grid
+        # that draw lands on. A sampled draw keeps the grid it was applied to.
+        return [Rotate._draw_shape(self.matrix[index][a], shape) for a, shape in enumerate(shapes)]
+
+    @classmethod
+    def _index_remap(cls, matrix: torch.Tensor) -> tuple[list[int], list[int]] | None:
+        """The permute dims and flip axes reproducing a rotation exactly, or ``None`` if it must be sampled.
+
+        ``matrix`` maps an output coordinate onto the input it comes from, so it is a signed permutation
+        exactly when every row and column has a single +/-1: output axis ``pi(k)`` then reads input axis
+        ``k``, mirrored where the sign is negative. An orthonormal row of L1 norm 1 has one such entry,
+        which is what separates a quarter turn from any other angle.
+
+        Dims and axes are channel-first, where physical axis ``k`` is dim ``n - k``.
+        """
+        linear = matrix[0, :-1, :-1]
+        n = linear.shape[0]
+        unit = torch.ones(n)
+        if not torch.allclose(linear.abs().sum(0), unit, atol=cls._QUARTER_ATOL):
+            return None
+        if not torch.allclose(linear.abs().sum(1), unit, atol=cls._QUARTER_ATOL):
+            return None
+
+        dims = [0] * (n + 1)
+        flips: list[int] = []
+        for k in range(n):
+            source = int(linear[k].abs().argmax())
+            dims[n - source] = n - k
+            if linear[k, source] < 0:
+                flips.append(n - source)
+        return dims, flips
+
+    @classmethod
+    def _draw_shape(cls, matrix: torch.Tensor, shape: list[int]) -> list[int]:
+        """The spatial extents a draw lands on, given the ones it is applied to.
+
+        Output dim ``i`` reads input dim ``dims[i]``, so it carries that axis's extent with it -- what a
+        turn preserves is the volume, not which axis holds an extent. A sampled draw spans the extent it
+        is given. ``dims`` is channel-first, so spatial axis k is dim k + 1.
+        """
+        remap = cls._index_remap(matrix)
+        if remap is None:
+            return list(shape)
+        dims, _ = remap
+        return [shape[dim - 1] for dim in dims[1:]]
+
+    def _reorient(self, index: int, a: int, matrix: torch.Tensor, tensor: torch.Tensor) -> torch.Tensor:
+        remap = Rotate._index_remap(matrix)
+        if remap is None:
+            return self._sample(matrix, tensor)
+        dims, flips = remap
+        # flip materialises the permuted view, so the copy never aliases the tensor it was drawn from.
+        return tensor.permute(dims).flip(flips)
+
+    def _compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
+        return self._reorient(index, a, self._grid_matrix(index, a, list(tensor.shape[1:])), tensor)
+
+    def _inverse(self, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
+        return self._reorient(index, a, self._grid_matrix(index, a, list(tensor.shape[1:])).inverse(), tensor)
+
+    def _patch_locality(self, index: int, a: int, cache_attribute: Attribute) -> PatchLocality:
+        # Permuting and mirroring voxels is a bijection on them, which is what ORIENTATION promises and
+        # what LocalityKind.preserves_statistics lets a later stage trust. Only the draw can say whether
+        # this one is that, and the draw is a property of the copy rather than of the case.
+        if Rotate._index_remap(self.matrix[index][a]) is None:
+            return PatchLocality(LocalityKind.WHOLE_VOLUME)
+        return PatchLocality(LocalityKind.ORIENTATION)
+
+    def _stream_region_source(
+        self,
+        index: int,
+        a: int,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+    ) -> list[slice]:
+        # Output axis o reads input axis dims[o], so placing o's target slice at that input axis yields
+        # the region whose remap reproduces the patch; a MIRRORED output axis reads the mirror region
+        # ``[n - stop, n - start)`` of it. Dims and flips are channel-first, so spatial axis k is dim k + 1.
+        remap = Rotate._index_remap(self.matrix[index][a])
+        if remap is None:
+            raise AugmentationError(
+                "Rotate declared a region patch-locality for a draw it cannot remap exactly.",
+                "Report this: _patch_locality() and _stream_region_source() disagree about the draw.",
+            )
+        dims, flips = remap
+        source_slices = [slice(0, n) for n in source_spatial_shape]
+        for out_dim in range(1, len(dims)):
+            in_axis = dims[out_dim] - 1
+            sl = target_slices[out_dim - 1]
+            n = source_spatial_shape[in_axis]
+            source_slices[in_axis] = slice(n - sl.stop, n - sl.start) if out_dim in flips else slice(sl.start, sl.stop)
+        return source_slices
 
 
 class Scale(EulerTransform):
+    # WHOLE_VOLUME on purpose: a scale about the volume centre displaces a voxel by |s - 1| * its
+    # distance from that centre, so the source region depends on where the patch sits -- no constant
+    # halo is both correct at the border and cheap in the middle.
     def __init__(self, s_std: float = 0.2):
         super().__init__()
         self.s_std = s_std
@@ -426,16 +561,38 @@ class Flip(DataAugmentation):
                 result[tensor.dim() - 1 - dim] = -result[tensor.dim() - 1 - dim]
         return result
 
-    def _compute(
+    def _patch_locality(self, index: int, a: int, cache_attribute: Attribute) -> PatchLocality:
+        # Mirroring voxels is a bijection on them, which is exactly what ORIENTATION promises and what
+        # LocalityKind.preserves_statistics lets a later stage trust. Negating a component channel is
+        # not one: it maps values, so the multiset -- and every statistic over it -- moves (a DVF's Mean
+        # changes sign). Whether it fires is a property of the tensor's channel count rather than of the
+        # case, so a declaration made from the header cannot tell, and only WHOLE_VOLUME is honest here.
+        if self.vector_field:
+            return PatchLocality(LocalityKind.WHOLE_VOLUME)
+        return PatchLocality(LocalityKind.ORIENTATION)
+
+    def _stream_region_source(
         self,
-        name: str,
         index: int,
-        tensors: list[torch.Tensor],
-    ) -> list[torch.Tensor]:
-        results = []
-        for tensor, flip in zip(tensors, self.flip[index], strict=False):
-            results.append(self._flip(tensor, flip))
-        return results
+        a: int,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+    ) -> list[slice]:
+        # A flipped spatial axis reads the mirror region ``[n - stop, n - start)``; flipping that
+        # sub-region reproduces the target patch. Non-flipped axes read the identity region. ``flip``
+        # holds channel-first tensor dims, so spatial axis k is dim k + 1.
+        dims = self.flip[index][a]
+        return [
+            (
+                slice(source_spatial_shape[k] - sl.stop, source_spatial_shape[k] - sl.start)
+                if (k + 1) in dims
+                else slice(sl.start, sl.stop)
+            )
+            for k, sl in enumerate(target_slices)
+        ]
+
+    def _compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
+        return self._flip(tensor, self.flip[index][a])
 
     def _inverse(self, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
         return self._flip(tensor, self.flip[index][a])
@@ -446,25 +603,23 @@ class ColorTransform(DataAugmentation):
         super().__init__(groups)
         self.matrix: dict[int, list[torch.Tensor]] = {}
 
-    def _compute(
-        self,
-        name: str,
-        index: int,
-        tensors: list[torch.Tensor],
-    ) -> list[torch.Tensor]:
-        results = []
-        for tensor, matrix in zip(tensors, self.matrix[index], strict=False):
-            result = tensor.reshape([*tensor.shape[:1], int(np.prod(tensor.shape[1:]))])
-            if tensor.shape[0] == 3:
-                matrix = matrix.to(tensor.device)
-                result = matrix[:, :3, :3] @ result.float() + matrix[:, :3, 3:]
-            elif tensor.shape[0] == 1:
-                matrix = matrix[:, :3, :].mean(dim=1, keepdims=True).to(tensor.device)
-                result = result.float() * matrix[:, :, :3].sum(dim=2, keepdims=True) + matrix[:, :, 3:]
-            else:
-                raise AugmentationError("Image must be RGB (3 channels) or L (1 channel)")
-            results.append(result.reshape(tensor.shape))
-        return results
+    def _patch_locality(self, index: int, a: int, cache_attribute: Attribute) -> PatchLocality:
+        # The draw is a colour matrix applied to each voxel on its own: no neighbour, no coordinate,
+        # no extent. Whatever region a voxel is read in, it comes out the same.
+        return PatchLocality(LocalityKind.POINTWISE)
+
+    def _compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
+        matrix = self.matrix[index][a]
+        result = tensor.reshape([*tensor.shape[:1], int(np.prod(tensor.shape[1:]))])
+        if tensor.shape[0] == 3:
+            matrix = matrix.to(tensor.device)
+            result = matrix[:, :3, :3] @ result.float() + matrix[:, :3, 3:]
+        elif tensor.shape[0] == 1:
+            matrix = matrix[:, :3, :].mean(dim=1, keepdims=True).to(tensor.device)
+            result = result.float() * matrix[:, :, :3].sum(dim=2, keepdims=True) + matrix[:, :, 3:]
+        else:
+            raise AugmentationError("Image must be RGB (3 channels) or L (1 channel)")
+        return result.reshape(tensor.shape)
 
     def _inverse(self, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
         return tensor
@@ -583,20 +738,15 @@ class Noise(DataAugmentation):
             self.ts[index] = [torch.randint(0, int(self.max_T), (1,)) for _ in shapes]
         return shapes
 
-    def _compute(
-        self,
-        name: str,
-        index: int,
-        tensors: list[torch.Tensor],
-    ) -> list[torch.Tensor]:
-        results = []
-        for tensor, t in zip(tensors, self.ts[index], strict=False):
-            alpha_hat_t = self.alpha_hat[t].to(tensor.device).reshape(*[1 for _ in range(len(tensor.shape))])
-            results.append(
-                alpha_hat_t.sqrt() * tensor
-                + (1 - alpha_hat_t).sqrt() * torch.randn_like(tensor.float()).to(tensor.device) * self.n_std
-            )
-        return results
+    # WHOLE_VOLUME on purpose: the noise field is drawn per call, not per voxel position, so two
+    # overlapping patches would sample unrelated fields and the overlap blend would suppress the
+    # variance this exists to add.
+    def _compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
+        alpha_hat_t = self.alpha_hat[self.ts[index][a]].to(tensor.device).reshape(*[1 for _ in tensor.shape])
+        return (
+            alpha_hat_t.sqrt() * tensor
+            + (1 - alpha_hat_t).sqrt() * torch.randn_like(tensor.float()).to(tensor.device) * self.n_std
+        )
 
     def _inverse(self, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
         return tensor
@@ -620,33 +770,26 @@ class CutOUT(DataAugmentation):
         self.centers[index] = [torch.rand((3) if len(shape) == 3 else (2)) for shape in shapes]
         return shapes
 
-    def _compute(
-        self,
-        name: str,
-        index: int,
-        tensors: list[torch.Tensor],
-    ) -> list[torch.Tensor]:
-        results = []
-        for tensor, center in zip(tensors, self.centers[index], strict=False):
-            masks = []
-            for i, w in enumerate(tensor.shape[1:]):
-                re = [1] * i + [-1] + [1] * (len(tensor.shape[1:]) - i - 1)
-                masks.append(
-                    ((torch.arange(w).reshape(re) + 0.5) / w - center[i].reshape([1, 1])).abs()
-                    >= torch.tensor(self.cutout_size).reshape([1, 1]) / 2
-                )
-            result = masks[0]
-            for mask in masks[1:]:
-                result = torch.logical_or(result, mask)
-            result = result.unsqueeze(0).repeat([tensor.shape[0], *[1 for _ in range(len(tensor.shape) - 1)]])
-            results.append(
-                torch.where(
-                    result.to(tensor.device) == 1,
-                    tensor,
-                    torch.tensor(self.value).to(tensor.device),
-                )
+    # WHOLE_VOLUME on purpose: the cutout box is normalised to the extent of the tensor in hand, so
+    # applied per patch it would land in every patch instead of once in the volume.
+    def _compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
+        center = self.centers[index][a]
+        masks = []
+        for i, w in enumerate(tensor.shape[1:]):
+            re = [1] * i + [-1] + [1] * (len(tensor.shape[1:]) - i - 1)
+            masks.append(
+                ((torch.arange(w).reshape(re) + 0.5) / w - center[i].reshape([1, 1])).abs()
+                >= torch.tensor(self.cutout_size).reshape([1, 1]) / 2
             )
-        return results
+        result = masks[0]
+        for mask in masks[1:]:
+            result = torch.logical_or(result, mask)
+        result = result.unsqueeze(0).repeat([tensor.shape[0], *[1 for _ in range(len(tensor.shape) - 1)]])
+        return torch.where(
+            result.to(tensor.device) == 1,
+            tensor,
+            torch.tensor(self.value).to(tensor.device),
+        )
 
     def _inverse(self, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
         return tensor
@@ -718,28 +861,23 @@ class Elastix(DataAugmentation):
             print(f"[KonfAI] Compute in progress : {(i + 1) / len(shapes) * 100:.2f} %")
         return shapes
 
-    def _compute(
-        self,
-        name: str,
-        index: int,
-        tensors: list[torch.Tensor],
-    ) -> list[torch.Tensor]:
-        results = []
-        for tensor, displacement_field in zip(tensors, self.displacement_fields[index], strict=False):
-            # Integer tensors are label maps: nearest-neighbour keeps class ids intact.
-            mode = "nearest" if not tensor.dtype.is_floating_point else "bilinear"
-            results.append(
-                F.grid_sample(
-                    tensor.type(torch.float32).unsqueeze(0),
-                    displacement_field.to(tensor.device),
-                    align_corners=True,
-                    mode=mode,
-                    padding_mode="border",
-                )
-                .type(tensor.dtype)
-                .squeeze(0)
+    # WHOLE_VOLUME on purpose: _state_init materialises the displacement field at the full shape and
+    # indexes it by absolute position, so streaming the image saves nothing while the field is
+    # resident.
+    def _compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
+        # Integer tensors are label maps: nearest-neighbour keeps class ids intact.
+        mode = "nearest" if not tensor.dtype.is_floating_point else "bilinear"
+        return (
+            F.grid_sample(
+                tensor.type(torch.float32).unsqueeze(0),
+                self.displacement_fields[index][a].to(tensor.device),
+                align_corners=True,
+                mode=mode,
+                padding_mode="border",
             )
-        return results
+            .type(tensor.dtype)
+            .squeeze(0)
+        )
 
     def _inverse(self, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
         raise NotImplementedError("Elastix augmentation has no inverse; do not use it for invertible TTA.")
@@ -767,24 +905,40 @@ class Permute(DataAugmentation):
                 if len(shapes) != 2:
                     raise ValueError("The number of augmentation images must be equal to 2")
                 self.permute[index] = torch.eye(2, dtype=torch.bool)
-            for i, prob in enumerate(self.permute[index]):
-                for permute in self._permute_dims[prob]:
-                    shapes[i] = [shapes[i][dim - 1] for dim in permute[1:]]
+            for i in range(len(shapes)):
+                shapes[i] = [shapes[i][axis] for axis in self._source_axes(index, i)]
         return shapes
 
-    def _compute(
+    def _source_axes(self, index: int, a: int) -> list[int]:
+        """Which source spatial axis each output spatial axis is drawn from, for copy *a*."""
+        axes = list(range(3))
+        for permute in self._permute_dims[self.permute[index][a]]:
+            axes = [axes[dim - 1] for dim in permute[1:]]
+        return axes
+
+    def _patch_locality(self, index: int, a: int, cache_attribute: Attribute) -> PatchLocality:
+        # Reordering axes moves every voxel and touches none, so the multiset of values is the input's:
+        # a bijection, which is what ORIENTATION promises.
+        return PatchLocality(LocalityKind.ORIENTATION)
+
+    def _stream_region_source(
         self,
-        name: str,
         index: int,
-        tensors: list[torch.Tensor],
-    ) -> list[torch.Tensor]:
-        results = []
-        for tensor, prob in zip(tensors, self.permute[index], strict=False):
-            res = tensor
-            for permute in self._permute_dims[prob]:
-                res = res.permute(tuple(permute))
-            results.append(res)
-        return results
+        a: int,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+    ) -> list[slice]:
+        # Output axis k is source axis ``_source_axes()[k]``, so placing each target slice back on its
+        # source axis gives the region whose permutation is the target patch.
+        source_slices = [slice(0, n) for n in source_spatial_shape]
+        for k, sl in enumerate(target_slices):
+            source_slices[self._source_axes(index, a)[k]] = slice(sl.start, sl.stop)
+        return source_slices
+
+    def _compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
+        for permute in self._permute_dims[self.permute[index][a]]:
+            tensor = tensor.permute(tuple(permute))
+        return tensor
 
     def _inverse(self, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
         for permute in reversed(self._permute_dims[self.permute[index][a]]):
@@ -820,39 +974,28 @@ class Mask(DataAugmentation):
         ]
         return [list(self.mask_shape) for _ in shapes]
 
-    def _compute(
-        self,
-        name: str,
-        index: int,
-        tensors: list[torch.Tensor],
-    ) -> list[torch.Tensor]:
+    # WHOLE_VOLUME on purpose: the output grid is the mask's, and the mask volume is already resident
+    # at that extent -- there is no whole-volume read left for a declaration to save.
+    def _compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
         mask = self._load_mask()
-        results = []
-        for tensor, position in zip(tensors, self.positions[index], strict=False):
-            slices = [slice(None, None)] + [
-                slice(int(s1), int(s1) + s2) for s1, s2 in zip(position, mask.shape, strict=False)
-            ]
-            padding = []
-            for s1, s2 in zip(reversed(tensor.shape), reversed(mask.shape), strict=False):
-                if s1 < s2:
-                    pad = s2 - s1
-                else:
-                    pad = 0
-                padding.append(0)
-                padding.append(pad)
-            value = (
-                torch.tensor(0, dtype=torch.uint8)
-                if tensor.dtype == torch.uint8
-                else torch.tensor(self.value).to(tensor.device)
-            )
-            results.append(
-                torch.where(
-                    mask.to(tensor.device) == 1,
-                    torch.nn.functional.pad(tensor, tuple(padding), mode="constant", value=value)[tuple(slices)],
-                    value,
-                )
-            )
-        return results
+        position = self.positions[index][a]
+        slices = [slice(None, None)] + [
+            slice(int(s1), int(s1) + s2) for s1, s2 in zip(position, mask.shape, strict=False)
+        ]
+        padding = []
+        for s1, s2 in zip(reversed(tensor.shape), reversed(mask.shape), strict=False):
+            padding.append(0)
+            padding.append(s2 - s1 if s1 < s2 else 0)
+        value = (
+            torch.tensor(0, dtype=torch.uint8)
+            if tensor.dtype == torch.uint8
+            else torch.tensor(self.value).to(tensor.device)
+        )
+        return torch.where(
+            mask.to(tensor.device) == 1,
+            torch.nn.functional.pad(tensor, tuple(padding), mode="constant", value=value)[tuple(slices)],
+            value,
+        )
 
     def _inverse(self, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
         raise NotImplementedError("Mask augmentation has no inverse; do not use it for invertible TTA.")

--- a/konfai/data/augmentation.py
+++ b/konfai/data/augmentation.py
@@ -562,11 +562,9 @@ class Flip(DataAugmentation):
         return result
 
     def _patch_locality(self, index: int, a: int, cache_attribute: Attribute) -> PatchLocality:
-        # Mirroring voxels is a bijection on them, which is exactly what ORIENTATION promises and what
-        # LocalityKind.preserves_statistics lets a later stage trust. Negating a component channel is
-        # not one: it maps values, so the multiset -- and every statistic over it -- moves (a DVF's Mean
-        # changes sign). Whether it fires is a property of the tensor's channel count rather than of the
-        # case, so a declaration made from the header cannot tell, and only WHOLE_VOLUME is honest here.
+        # A mirror is a bijection on the voxels (ORIENTATION). Negating a component channel is not: it
+        # maps values, so a later GLOBAL_STAT could no longer seed from the stored volume -- and only
+        # the tensor's channel count says whether it fires, which a header-time declaration cannot see.
         if self.vector_field:
             return PatchLocality(LocalityKind.WHOLE_VOLUME)
         return PatchLocality(LocalityKind.ORIENTATION)

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -53,11 +53,9 @@ from konfai.utils.runtime import (
 )
 from konfai.utils.utils import SUPPORTED_EXTENSIONS, split_path_spec
 
-# A cached case is a float32 torch tensor -- torch's default float dtype and the target of the default
-# TensorCast -- so bytes are estimated at 4/element. This models the RAM the cache actually holds rather
-# than the on-disk dtype (an un-cast uint8 mask is over-counted, a rare float64 source under-counted).
-# The estimate reads the raw header shape but no voxels, and deliberately does not model transforms that
-# shrink (resample-down, crop) or grow (pad, one-hot) the cached tensor: an honest over/under-estimate.
+# A cached case is a float32 tensor (torch's default dtype, and the default TensorCast's target), so
+# bytes are counted at 4/element from the header shape alone -- not the on-disk dtype, and without
+# modelling transforms that shrink or grow the cached tensor.
 _CACHE_ELEMENT_BYTES = 4
 
 # Fraction of the detected node memory an ``"auto"`` budget offers the cache; the rest is reserved for
@@ -393,11 +391,19 @@ class WindowedCaseSampler(Sampler[int]):
         for start in range(0, self._batches_per_worker() * batch, batch):
             for stream in streams:
                 order += [stream[i % len(stream)] for i in range(start, start + batch)]
-        return order
+        # An epoch is `mapping` long whatever order it is walked in, so the round-robin -- whole
+        # batches, a short stream wrapping its own head to fill one -- is cut back to it. Each worker
+        # is therefore walked over its share of the epoch, len(mapping) / num_workers: a partition
+        # holding more than that leaves a tail for another epoch to reach, one holding less repeats.
+        # Both scale with how uneven the partitions are, NOT with a batch -- cases are split by
+        # position (`_partitions`), so a dataset ordered big-then-small can leave a worker's tail cut
+        # by half an epoch. Each epoch reshuffles the cases, so the cut falls elsewhere and nothing is
+        # starved; what this must never do is change the epoch's length, which every rank agrees on.
+        return order[: len(self.mapping)]
 
     def _batches_per_worker(self) -> int:
-        patches = [sum(len(self.case_entries[case]) for case in partition) for partition in self._partitions()]
-        return max((math.ceil(count / self.batch_size) for count in patches), default=0)
+        """Whole batches each worker is walked through to cover an epoch (the last one is cut back)."""
+        return math.ceil(len(self.mapping) / (self.num_workers * self.batch_size))
 
     def __iter__(self) -> Iterator[int]:
         if not self.shuffle:
@@ -407,9 +413,11 @@ class WindowedCaseSampler(Sampler[int]):
         return iter(self._windowed_order())
 
     def __len__(self) -> int:
-        if not self.shuffle or self.window is None:
-            return len(self.mapping)
-        return self._batches_per_worker() * self.num_workers * self.batch_size
+        # One epoch is one pass over the mapping -- windowing chooses the ORDER, not the size. This is
+        # what keeps the ranks in step: `Data._split` gives them equal-length shards, but not equal
+        # cases, so any length read from the per-rank cases (their partitions, or even whether the
+        # window engages at all) would differ and hang DDP's collectives.
+        return len(self.mapping)
 
 
 @dataclass(frozen=True)
@@ -900,15 +908,25 @@ class Data(ABC):
     def _estimate_cached_bytes(self) -> int:
         """Raw in-RAM size of the whole prepared dataset, from headers alone (no voxel read).
 
-        Sums ``prod(shape) x 4`` over every case of every source group (train and validation), taking
-        the raw header shape recorded on each :class:`DatasetManager`. See ``_CACHE_ELEMENT_BYTES``:
-        this is an honest header-only estimate that ignores size-changing transforms.
+        Sums ``prod(shape) x 4`` over every case of every source group, once per COPY the cache holds:
+        a cached case is its base tensor PLUS one per augmentation draw, which validation only makes
+        when ``validation_augmentations``. See ``_CACHE_ELEMENT_BYTES``: this is an honest header-only
+        estimate that ignores size-changing transforms (an augmentation's ``Mask`` included). It also
+        counts the tensors themselves, not the allocator's arenas around them: those settle about a
+        third higher (measured), which is over the "auto" safety fraction, so a dataset landing within
+        a few percent of an "auto" budget can still be caching more than the budget names.
         """
         total = 0
-        for prepared in (self._prepared_data, self._prepared_validation_data):
+        for prepared, copies in (
+            (self._prepared_data, Data._get_nb_augmentation(self._get_data_augmentations(True))),
+            (
+                self._prepared_validation_data,
+                Data._get_nb_augmentation(self._get_data_augmentations(self.validation_augmentations)),
+            ),
+        ):
             for managers in (prepared or {}).values():
                 for manager in managers:
-                    total += int(np.prod(manager.base_shape, dtype=np.int64)) * _CACHE_ELEMENT_BYTES
+                    total += int(np.prod(manager.base_shape, dtype=np.int64)) * _CACHE_ELEMENT_BYTES * copies
         return total
 
     def _resolve_cache_regime(self, world_size: int) -> None:

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -19,6 +19,7 @@
 import math
 import os
 import random
+import re
 import threading
 import traceback
 from abc import ABC, abstractmethod
@@ -38,18 +39,200 @@ from torch.utils.data import DataLoader, Sampler
 from konfai import konfai_root, konfai_state
 from konfai.data.augmentation import DataAugmentationsList
 from konfai.data.patching import DatasetManager, DatasetPatch
-from konfai.data.transform import Transform, TransformLoader
+from konfai.data.transform import LocalityKind, Transform, TransformInverse, TransformLoader
 from konfai.utils.config import config
 from konfai.utils.dataset import Attribute, Dataset
-from konfai.utils.errors import DatasetManagerError
-from konfai.utils.runtime import State, get_cpu_info, get_memory, get_memory_info, memory_forecast
+from konfai.utils.errors import ConfigError, DatasetManagerError
+from konfai.utils.runtime import (
+    State,
+    available_memory_bytes,
+    get_cpu_info,
+    get_memory,
+    get_memory_info,
+    memory_forecast,
+)
 from konfai.utils.utils import SUPPORTED_EXTENSIONS, split_path_spec
+
+# A cached case is a float32 torch tensor -- torch's default float dtype and the target of the default
+# TensorCast -- so bytes are estimated at 4/element. This models the RAM the cache actually holds rather
+# than the on-disk dtype (an un-cast uint8 mask is over-counted, a rare float64 source under-counted).
+# The estimate reads the raw header shape but no voxels, and deliberately does not model transforms that
+# shrink (resample-down, crop) or grow (pad, one-hot) the cached tensor: an honest over/under-estimate.
+_CACHE_ELEMENT_BYTES = 4
+
+# Fraction of the detected node memory an ``"auto"`` budget offers the cache; the rest is reserved for
+# the model's optimizer/gradient state, DataLoader worker copies, CUDA pinned staging buffers, and
+# allocator slack. Caching runs with zero DataLoader workers, so a fifth of the node held back is ample.
+_AUTO_MEMORY_SAFETY_FRACTION = 0.8
+
+# Decimal (10^n) and binary (2^n) suffixes; "" / "b" are bytes. Case is folded before lookup.
+_MEMORY_UNIT_BYTES: dict[str, int] = {
+    "": 1, "b": 1,
+    "k": 10**3, "kb": 10**3, "kib": 2**10,
+    "m": 10**6, "mb": 10**6, "mib": 2**20,
+    "g": 10**9, "gb": 10**9, "gib": 2**30,
+    "t": 10**12, "tb": 10**12, "tib": 2**40,
+}  # fmt: skip
+
+
+def _format_gib(num_bytes: float) -> str:
+    return f"{num_bytes / 2**30:.2f} GiB"
+
+
+def _parse_memory_budget_bytes(value: str | float) -> int:
+    """Parse an explicit memory budget to bytes: a bare number is GiB, a string carries its own unit.
+
+    KonfAI reports RAM in GiB throughout, so an unadorned ``24`` reads as ``24 GiB`` -- whether it
+    arrives as a number or, through the YAML binding, as the string ``"24"``. A string may name its
+    unit -- decimal ``GB``/``MB`` (10^n) or binary ``GiB``/``MiB`` (2^n), case-insensitive, optional
+    space (``"24GB"``, ``"32 GiB"``, ``"512mb"``); ``"b"`` means bytes. ``"auto"`` is resolved by the
+    caller, not here.
+    """
+    if not isinstance(value, str):
+        if float(value) <= 0:
+            raise ConfigError(
+                f"memory_budget: {value!r} must be a positive size.",
+                "Use a positive number in GiB (e.g. 24), a unit string ('24GB'), 'auto', or None.",
+            )
+        return int(float(value) * 2**30)
+    match = re.fullmatch(r"\s*(?P<number>[0-9]*\.?[0-9]+)\s*(?P<unit>[a-z]*)\s*", value.lower())
+    if match is not None and match.group("unit") in _MEMORY_UNIT_BYTES:
+        if float(match.group("number")) <= 0:
+            raise ConfigError(
+                f"memory_budget: '{value}' must be a positive size.",
+                "Use a positive number in GiB (e.g. 24), a unit string ('24GB'), 'auto', or None.",
+            )
+        unit = match.group("unit")
+        # A bare numeric string is the YAML face of a bare number: GiB, not bytes.
+        factor = 2**30 if unit == "" else _MEMORY_UNIT_BYTES[unit]
+        return int(float(match.group("number")) * factor)
+    raise ConfigError(
+        f"memory_budget: '{value}' is not a valid memory size.",
+        "Use a number in GiB (e.g. 24), a unit string ('24GB', '32GiB', '512MB'), 'auto', or None to "
+        "keep 'use_cache' as given.",
+    )
 
 
 def _cache_worker_count(cpu_count: int, device_count: int) -> int:
     """Number of caching threads: CPUs shared across devices, but never below one."""
     divisor = device_count if device_count > 0 else 1
     return max(1, cpu_count // divisor)
+
+
+def _check_patch_transform_locality(transform: Transform, group_src: str, group_dest: str) -> None:
+    """Reject a transform whose per-patch result cannot equal its case-level result.
+
+    Only POINTWISE and GLOBAL_STAT are correct on one patch (per-patch GLOBAL_STAT means: derive the
+    statistic from this patch; use ``lazy=True`` case-level to feed it the volume's). The messages in
+    ``reasons`` below say why each other kind is rejected. Probed with an empty ``Attribute`` (config
+    time has no case), so an image-decided kind answers WHOLE_VOLUME -- the right answer here.
+    """
+    kind = transform.patch_locality(Attribute()).kind
+    if kind in (LocalityKind.POINTWISE, LocalityKind.GLOBAL_STAT):
+        return
+    name = type(transform).__name__
+    location = f"{konfai_root()}.Dataset.groups_src.{group_src}.groups_dest.{group_dest}"
+    reasons = {
+        LocalityKind.HALO: (
+            f"'{name}' reads a neighbourhood around each voxel, so run per-patch it would see no data"
+            " beyond the patch border and corrupt every patch edge. Running it per-patch is not"
+            " supported yet."
+        ),
+        LocalityKind.ORIENTATION: (
+            f"'{name}' reorients its input: applied to one patch it reorients that patch about its own"
+            " extent, which is not the whole volume reoriented and then cut into patches."
+        ),
+        LocalityKind.CROP: (
+            f"'{name}' crops its input to a box measured on the whole volume: applied to one patch it"
+            " crops that patch about its own extent, and cuts the patch grid predictions are"
+            " reassembled onto down to what is left."
+        ),
+        LocalityKind.RESCALE: (
+            f"'{name}' resamples its input: applied to one patch it rescales that patch about its own"
+            " extent and changes the patch grid predictions are reassembled onto."
+        ),
+        LocalityKind.WHOLE_VOLUME: f"'{name}' needs the whole volume.",
+    }
+    raise ConfigError(
+        f"{location}.patch_transforms: {reasons[kind]}",
+        f"Move '{name}' to {location}.transforms, where it runs once on the whole volume.",
+    )
+
+
+def _check_patch_transform_shape(transform: Transform, group_src: str, group_dest: str) -> None:
+    """Reject a patch_transform that resizes the patch it is handed.
+
+    The patch grid is folded from the CASE-level ``transforms`` only (``DatasetManager``), so a
+    patch_transform that changes the spatial shape hands back a patch the batch cannot collate and the
+    ``Accumulator`` cannot write onto the grid. ``_check_patch_transform_locality`` above takes the
+    transform at its word; this is the structural check, and it is asked of ``transform_shape`` -- the
+    contract every transform already owes the patch planner -- with distinct extents, so a swap or a
+    resize of any single axis shows up. Only the SPATIAL shape is at stake: patching hands
+    ``transform_shape`` the channel-stripped shape, so a transform that changes only the channel count
+    (``OneHot``) is not caught here, and must not be -- the grid it feeds is spatial.
+
+    Runs after the locality check, which is what makes the bare probe attribute safe: by here the
+    transform is POINTWISE or GLOBAL_STAT, and the kinds whose ``transform_shape`` needs real geometry
+    (``Resample`` reads ``Spacing``) have already been rejected.
+    """
+    spatial_shape = [7, 11, 13]
+    shape = list(transform.transform_shape(group_src, "", list(spatial_shape), Attribute()))
+    if shape == spatial_shape:
+        return
+    name = type(transform).__name__
+    location = f"{konfai_root()}.Dataset.groups_src.{group_src}.groups_dest.{group_dest}"
+    raise ConfigError(
+        f"{location}.patch_transforms: '{name}' changes the spatial shape of its input"
+        f" ({spatial_shape} -> {shape}), but a patch must keep the shape the patch grid cut it to.",
+        f"Move '{name}' to {location}.transforms, where the patch grid is folded from its"
+        " transform_shape(); a patch_transform must be spatially shape-preserving.",
+    )
+
+
+def _check_patch_transform_invertible(
+    transform: Transform, case_transforms: list[Transform], group_src: str, group_dest: str
+) -> None:
+    """Reject a per-patch global statistic at prediction, whose inverse cannot be reconstructed.
+
+    A ``GLOBAL_STAT`` transform is allowed in ``patch_transforms`` (see
+    ``_check_patch_transform_locality``): run per patch it standardizes each patch by that patch's OWN
+    statistic, which is what asking for it per-patch means -- correct, and the deliberate training use.
+    But the per-patch statistic lives in the per-patch attribute scope and never reaches the case
+    attribute, so at prediction the finalize inverse -- which seeds every patch from the CASE attribute
+    and pops the statistic -- has nothing to pop. Nor could it: the reassembled volume was normalised
+    patch by patch with different coefficients, so a single case-level inverse cannot un-apply it. Refuse
+    here, at config time, rather than fail deep in the inverse with a bare ``NameError``.
+
+    A case-level ``transforms`` entry that derives the SAME statistic rescues it: run once on the whole
+    volume it caches that statistic on the case attribute (``Standardize(lazy=True)`` caches Mean/Std and
+    applies nothing), which the per-patch inverse then inherits and pops. So the patch transform is only
+    un-invertible when nothing case-level captures its statistic.
+
+    Training-only use stays valid: the check is gated on the prediction state, where the inverse actually
+    runs (``RESUME``/``TRAIN`` never invert patch_transforms, and evaluation drops them entirely).
+    """
+    if konfai_state() != str(State.PREDICTION):
+        return
+    if not (isinstance(transform, TransformInverse) and transform.apply_inverse):
+        return
+    locality = transform.patch_locality(Attribute())
+    if locality.kind is not LocalityKind.GLOBAL_STAT:
+        return
+    if any(
+        (case_locality := case.patch_locality(Attribute())).kind is LocalityKind.GLOBAL_STAT
+        and locality.stat_keys <= case_locality.stat_keys
+        for case in case_transforms
+    ):
+        return
+    name = type(transform).__name__
+    location = f"{konfai_root()}.Dataset.groups_src.{group_src}.groups_dest.{group_dest}"
+    raise ConfigError(
+        f"{location}.patch_transforms: '{name}' derives its statistic from each patch, but prediction"
+        " must invert it and a per-patch statistic cannot be un-applied to the reassembled volume.",
+        f"Capture the volume-global statistic case-level instead: put '{name}(lazy=True)' in"
+        f" {location}.transforms (it traverses the whole volume, caches the statistic and applies"
+        f" nothing), and keep '{name}()' in patch_transforms to consume it.",
+    )
 
 
 class GroupTransform:
@@ -88,6 +271,9 @@ class GroupTransform:
                     konfai_args=f"{konfai_root()}.Dataset.groups_src.{group_src}"
                     f".groups_dest.{group_dest}.patch_transforms",
                 )
+                _check_patch_transform_locality(transform, group_src, group_dest)
+                _check_patch_transform_shape(transform, group_src, group_dest)
+                _check_patch_transform_invertible(transform, self.transforms, group_src, group_dest)
                 self.patch_transforms.append(transform)
 
     def set_datasets(self, datasets: list[Dataset]) -> None:
@@ -142,18 +328,88 @@ class GroupMetric(dict[str, GroupTransformMetric]):
         super().__init__(groups_dest)
 
 
-class CustomSampler(Sampler[int]):
-    """Simple sampler that optionally shuffles indices without distributed logic."""
+class WindowedCaseSampler(Sampler[int]):
+    """Locality-aware training order: shuffle cases, window them, shuffle patches within each window.
 
-    def __init__(self, size: int, shuffle: bool = False) -> None:
-        self.size = size
+    ``DatasetIter`` loads each non-streamable case into a FIFO buffer, so a global patch shuffle
+    reloads a volume once per patch that lands after an eviction (7-56x redundant reads). Keeping only
+    ``window`` cases in play at a time — their patches shuffled together, emitted before advancing —
+    reads each volume ~once. ``window`` is the decorrelation knob: ``1`` is perfect locality, and
+    ``None`` (default) or ``>= n_cases`` is a single all-cases window, i.e. a plain global shuffle,
+    byte for byte.
+
+    A map-style ``DataLoader`` sends batch ``j`` to worker ``j % num_workers`` and gives each worker its
+    own buffer, so the cases are partitioned across workers (``position % num_workers``) and the
+    per-worker windowed batches are round-robin interleaved: batch ``j`` then carries only worker
+    ``j % num_workers``'s cases, and every volume is read by exactly one worker.
+    """
+
+    def __init__(
+        self,
+        mapping: list[tuple[int, int, int]],
+        shuffle: bool,
+        window: int | None,
+        batch_size: int,
+        num_workers: int,
+    ) -> None:
+        self.mapping = mapping
         self.shuffle = shuffle
+        self.batch_size = max(1, batch_size)
+        self.num_workers = max(1, num_workers)
+        self.case_entries: dict[int, list[int]] = {}
+        for index, entry in enumerate(mapping):
+            self.case_entries.setdefault(entry[0], []).append(index)
+        # Windowing bites only when a window is both smaller than the case count and shardable across
+        # the workers; anything else is a single all-cases window, i.e. a plain global shuffle.
+        n_cases = len(self.case_entries)
+        self.window = window if window is not None and 0 < window < n_cases and self.num_workers <= n_cases else None
+
+    def _partitions(self) -> list[list[int]]:
+        cases = list(self.case_entries)
+        return [cases[worker :: self.num_workers] for worker in range(self.num_workers)]
+
+    def _windowed_order(self) -> list[int]:
+        generator = torch.Generator().manual_seed(int(torch.randint(0, 2**31 - 1, (1,)).item()))
+        window = cast(int, self.window)
+
+        def shuffled(items: list[int]) -> list[int]:
+            return [items[i] for i in torch.randperm(len(items), generator=generator).tolist()]
+
+        streams: list[list[int]] = []
+        for partition in self._partitions():
+            cases = shuffled(partition)
+            stream: list[int] = []
+            for start in range(0, len(cases), window):
+                stream += shuffled(
+                    [index for case in cases[start : start + window] for index in self.case_entries[case]]
+                )
+            streams.append(stream)
+
+        # Round-robin interleave equal-length per-worker batches so batch j lands on worker
+        # j % num_workers. The modulo wraps each stream's head to fill its final short batch and to pad
+        # up to the longest worker -- the same bounded duplication the DDP shard split relies on.
+        batch = self.batch_size
+        order: list[int] = []
+        for start in range(0, self._batches_per_worker() * batch, batch):
+            for stream in streams:
+                order += [stream[i % len(stream)] for i in range(start, start + batch)]
+        return order
+
+    def _batches_per_worker(self) -> int:
+        patches = [sum(len(self.case_entries[case]) for case in partition) for partition in self._partitions()]
+        return max((math.ceil(count / self.batch_size) for count in patches), default=0)
 
     def __iter__(self) -> Iterator[int]:
-        return iter(torch.randperm(len(self)).tolist() if self.shuffle else list(range(len(self))))
+        if not self.shuffle:
+            return iter(range(len(self.mapping)))
+        if self.window is None:
+            return iter(torch.randperm(len(self.mapping)).tolist())
+        return iter(self._windowed_order())
 
     def __len__(self) -> int:
-        return self.size
+        if not self.shuffle or self.window is None:
+            return len(self.mapping)
+        return self._batches_per_worker() * self.num_workers * self.batch_size
 
 
 @dataclass(frozen=True)
@@ -405,9 +661,11 @@ class Subset:
         self,
         subset: str | list[int] | list[str] | None = None,
         shuffle: bool = True,
+        shuffle_window: int | None = None,
     ) -> None:
         self.subset = subset
         self.shuffle = shuffle
+        self.shuffle_window = shuffle_window
 
     @staticmethod
     def _read_names_from_file(filename: str) -> list[str]:
@@ -487,7 +745,14 @@ class Subset:
         return {names[i] for i in index}
 
     def __str__(self):
-        return "Subset : " + str(self.subset) + " shuffle : " + str(self.shuffle)
+        return (
+            "Subset : "
+            + str(self.subset)
+            + " shuffle : "
+            + str(self.shuffle)
+            + " shuffle_window : "
+            + str(self.shuffle_window)
+        )
 
 
 class TrainSubset(Subset):
@@ -495,13 +760,14 @@ class TrainSubset(Subset):
         self,
         subset: str | list[int] | list[str] | None = None,
         shuffle: bool = True,
+        shuffle_window: int | None = None,
     ) -> None:
-        super().__init__(subset, shuffle)
+        super().__init__(subset, shuffle, shuffle_window)
 
 
 class PredictionSubset(Subset):
     def __init__(self, subset: str | list[int] | list[str] | None = None) -> None:
-        super().__init__(subset, False)
+        super().__init__(subset, False, None)
 
 
 class Data(ABC):
@@ -561,6 +827,7 @@ class Data(ABC):
         pin_memory: bool,
         prefetch_factor: int | None,
         persistent_workers: bool | None,
+        memory_budget: str | float | None,
     ) -> None:
         self.dataset_filenames = dataset_filenames
         self.subset = subset
@@ -570,32 +837,22 @@ class Data(ABC):
         self.validation_augmentations = validation_augmentations
         self.data_augmentations_list = data_augmentations_list
         self.batch_size = batch_size
-        self.use_cache = use_cache
         self.inline_augmentations = inline_augmentations
+        self.memory_budget = memory_budget
         self.requires_single_process_loading = self._groups_require_single_process_loading(groups_src)
 
-        self.datasetIter = partial(
-            DatasetIter,
-            groups_src=self.groups_src,
-            inline_augmentations=inline_augmentations,
-            patch_size=self.patch.patch_size if self.patch is not None else None,
-            overlap=self.patch.overlap if self.patch is not None else None,
-            buffer_size=batch_size + 1,
-            use_cache=use_cache,
-        )
-        resolved_num_workers = num_workers
-        if self.requires_single_process_loading:
-            resolved_num_workers = 0
-        elif resolved_num_workers is None:
-            resolved_num_workers = max(1, min(os.cpu_count() or 1, 4)) if not use_cache else 0
-        self.dataLoader_args = {
-            "num_workers": resolved_num_workers,
-            "pin_memory": pin_memory,
-            "collate_fn": collate_konfai,
-        }
-        if resolved_num_workers > 0:
-            self.dataLoader_args["prefetch_factor"] = 2 if prefetch_factor is None else prefetch_factor
-            self.dataLoader_args["persistent_workers"] = True if persistent_workers is None else persistent_workers
+        # A window keeps ``shuffle_window`` cases resident, so the FIFO buffer must be at least that
+        # large or a window would evict its own cases before their patches are consumed. Unwindowed,
+        # one batch plus the case being read is all a loader ever holds at once.
+        window = subset.shuffle_window
+        self._buffer_size = batch_size + 1 if window is None else max(batch_size + 1, window)
+        self._num_workers = num_workers
+        self._pin_memory = pin_memory
+        self._prefetch_factor = prefetch_factor
+        self._persistent_workers = persistent_workers
+        # ``memory_budget`` may later override ``use_cache`` (once the dataset size is known, in
+        # ``get_data``), which reshapes the loader; both paths funnel through the same builder.
+        self._configure_data_loading(use_cache)
         self.data: list[list[dict[str, list[DatasetManager]]]] = []
         self.mapping: list[list[list[tuple[int, int, int]]]] = []
         self.datasets: dict[str, Dataset] = {}
@@ -605,6 +862,95 @@ class Data(ABC):
         self._prepared_validation_mapping: list[tuple[int, int, int]] = []
         self._prepared_train_names: list[str] = []
         self._prepared_validation_names: list[str] = []
+
+    def _configure_data_loading(self, use_cache: bool) -> None:
+        """Build the loader from the cache regime: the DatasetIter factory and the worker settings.
+
+        Called once from ``__init__`` with the declared ``use_cache`` and, when a ``memory_budget``
+        overrides it, again from ``get_data`` with the derived value. Caching preloads every case up
+        front, so it defaults to zero DataLoader workers; the streaming/buffer path spins workers up.
+        """
+        self.use_cache = use_cache
+        self.datasetIter = partial(
+            DatasetIter,
+            groups_src=self.groups_src,
+            inline_augmentations=self.inline_augmentations,
+            patch_size=self.patch.patch_size if self.patch is not None else None,
+            overlap=self.patch.overlap if self.patch is not None else None,
+            buffer_size=self._buffer_size,
+            use_cache=use_cache,
+        )
+        resolved_num_workers = self._num_workers
+        if self.requires_single_process_loading:
+            resolved_num_workers = 0
+        elif resolved_num_workers is None:
+            resolved_num_workers = max(1, min(os.cpu_count() or 1, 4)) if not use_cache else 0
+        self.resolved_num_workers: int = resolved_num_workers
+        self.dataLoader_args: dict[str, object] = {
+            "num_workers": resolved_num_workers,
+            "pin_memory": self._pin_memory,
+            "collate_fn": collate_konfai,
+        }
+        if resolved_num_workers > 0:
+            self.dataLoader_args["prefetch_factor"] = 2 if self._prefetch_factor is None else self._prefetch_factor
+            self.dataLoader_args["persistent_workers"] = (
+                True if self._persistent_workers is None else self._persistent_workers
+            )
+
+    def _estimate_cached_bytes(self) -> int:
+        """Raw in-RAM size of the whole prepared dataset, from headers alone (no voxel read).
+
+        Sums ``prod(shape) x 4`` over every case of every source group (train and validation), taking
+        the raw header shape recorded on each :class:`DatasetManager`. See ``_CACHE_ELEMENT_BYTES``:
+        this is an honest header-only estimate that ignores size-changing transforms.
+        """
+        total = 0
+        for prepared in (self._prepared_data, self._prepared_validation_data):
+            for managers in (prepared or {}).values():
+                for manager in managers:
+                    total += int(np.prod(manager.base_shape, dtype=np.int64)) * _CACHE_ELEMENT_BYTES
+        return total
+
+    def _resolve_cache_regime(self, world_size: int) -> None:
+        """Derive ``use_cache`` from ``memory_budget``, or leave the declared value untouched.
+
+        ``None`` keeps today's behaviour exactly. Otherwise the cache is chosen iff the per-rank
+        dataset (``dataset / world_size`` -- ``Data._split`` shards cases across ranks) fits the
+        per-rank budget: an explicit budget is taken as declared per rank; ``"auto"`` divides the
+        detected node memory (cgroup-capped) by the ranks sharing it, so its ``world_size`` cancels
+        and it reduces to "does the whole dataset fit the node". The decision is logged once here --
+        ``get_data`` runs on the launcher alone, before any worker is spawned.
+        """
+        if self.memory_budget is None:
+            return
+        world_size = max(1, world_size)
+        n_cases = len(self._prepared_train_names) + len(self._prepared_validation_names)
+        dataset_bytes = self._estimate_cached_bytes()
+        per_rank_bytes = dataset_bytes / world_size
+
+        if isinstance(self.memory_budget, str) and self.memory_budget.strip().lower() == "auto":
+            node_bytes, source = available_memory_bytes()
+            per_rank_budget = node_bytes * _AUTO_MEMORY_SAFETY_FRACTION / world_size
+            budget_desc = f"auto: {_format_gib(node_bytes)} {source} x {_AUTO_MEMORY_SAFETY_FRACTION:.0%}, per-rank"
+        else:
+            per_rank_budget = float(_parse_memory_budget_bytes(self.memory_budget))
+            budget_desc = f"{self.memory_budget!r}, per-rank"
+
+        use_cache = per_rank_bytes <= per_rank_budget
+        self._configure_data_loading(use_cache)
+
+        decision = f"CACHE the whole dataset in RAM ({self.resolved_num_workers} loader workers)"
+        if not use_cache:
+            case_bytes = dataset_bytes / max(1, n_cases)
+            decision = (
+                f"STREAM/BUFFER, no cache; FIFO working set ~= {self._buffer_size} cases x "
+                f"{_format_gib(case_bytes)} = {_format_gib(self._buffer_size * case_bytes)} per worker"
+            )
+        print(
+            f"[KonfAI] memory_budget: dataset ~= {_format_gib(dataset_bytes)} over {n_cases} cases | "
+            f"per-rank ~= {_format_gib(per_rank_bytes)} across {world_size} rank(s) | "
+            f"budget {_format_gib(per_rank_budget)} ({budget_desc}) -> {decision}"
+        )
 
     def _get_data_augmentations(self, apply_augmentations: bool = True) -> list[DataAugmentationsList]:
         return list(self.data_augmentations_list.values()) if apply_augmentations else []
@@ -1035,6 +1381,7 @@ class Data(ABC):
         if self._prepared_data is None or self._prepared_validation_data is None:
             raise DatasetManagerError("Dataset configuration was not prepared before runtime data loading.")
 
+        self._resolve_cache_regime(world_size)
         self.data = []
         self.mapping = []
         train_mappings = Data._split(self._prepared_mapping, world_size)
@@ -1056,6 +1403,10 @@ class Data(ABC):
         for i, (datas, mappings) in enumerate(zip(self.data, self.mapping, strict=False)):
             data_loaders.append([])
             for loader_index, (dataset_items, mapping) in enumerate(zip(datas, mappings, strict=False)):
+                # Windowing is a training-order knob, so it reaches the shuffled training loader only
+                # (loader_index == 0). Validation is scored over the whole subset whatever the order,
+                # and ``None`` keeps it on the plain global one.
+                window = self.subset.shuffle_window if loader_index == 0 else None
                 data_loaders[i].append(
                     DataLoader(
                         dataset=self.datasetIter(
@@ -1067,7 +1418,13 @@ class Data(ABC):
                             ),
                             apply_augmentations=loader_index == 0 or self.validation_augmentations,
                         ),
-                        sampler=CustomSampler(len(mapping), self.subset.shuffle),
+                        sampler=WindowedCaseSampler(
+                            mapping,
+                            self.subset.shuffle,
+                            window,
+                            self.batch_size,
+                            self.resolved_num_workers,
+                        ),
                         batch_size=self.batch_size,
                         **self.dataLoader_args,
                     )
@@ -1080,6 +1437,7 @@ class Data(ABC):
             "groups_src": self.groups_src,
             "patch": self.patch,
             "use_cache": self.use_cache,
+            "memory_budget": self.memory_budget,
             "subset": self.subset,
             "batch_size": self.batch_size,
             "validation": self.validation,
@@ -1105,6 +1463,7 @@ class DataTrain(Data):
         inline_augmentations: bool = False,
         patch: DatasetPatch | None = DatasetPatch(),
         use_cache: bool = True,
+        memory_budget: str | float | None = None,
         subset: TrainSubset = TrainSubset(),
         batch_size: int = 1,
         validation: float | str | list[int] | list[str] | None = 0.2,
@@ -1129,6 +1488,7 @@ class DataTrain(Data):
             pin_memory,
             prefetch_factor,
             persistent_workers,
+            memory_budget,
         )
 
 
@@ -1142,6 +1502,7 @@ class DataPrediction(Data):
         groups_src: dict[str, Group] = {"default": Group()},
         augmentations: dict[str, DataAugmentationsList] | None = {"DataAugmentation_0": DataAugmentationsList()},
         patch: DatasetPatch | None = DatasetPatch(),
+        memory_budget: str | float | None = None,
         subset: PredictionSubset = PredictionSubset(),
         batch_size: int = 1,
         num_workers: int | None = None,
@@ -1165,6 +1526,7 @@ class DataPrediction(Data):
             pin_memory=pin_memory,
             prefetch_factor=prefetch_factor,
             persistent_workers=False if persistent_workers is None else persistent_workers,
+            memory_budget=memory_budget,
         )
 
 
@@ -1176,6 +1538,7 @@ class DataMetric(Data):
         self,
         dataset_filenames: list[str] = ["default|./Dataset:mha"],
         groups_src: dict[str, GroupMetric] = {"default": GroupMetric()},
+        memory_budget: str | float | None = None,
         subset: PredictionSubset = PredictionSubset(),
         validation: str | list[int] | list[str] | None = None,
         num_workers: int | None = None,
@@ -1199,4 +1562,5 @@ class DataMetric(Data):
             pin_memory=pin_memory,
             prefetch_factor=prefetch_factor,
             persistent_workers=persistent_workers,
+            memory_budget=memory_budget,
         )

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -20,17 +20,96 @@ import copy
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from dataclasses import dataclass
+from typing import Protocol, cast
 
 import numpy as np
 import torch
 import torch.nn.functional as F
 
-from konfai.data.augmentation import DataAugmentationsList
-from konfai.data.transform import Clip, Normalize, Save, Standardize, TensorCast, Transform
+from konfai.data.augmentation import DataAugmentation, DataAugmentationsList
+from konfai.data.transform import LocalityKind, PatchLocality, Resample, Save, Transform
 from konfai.utils.config import apply_config, config
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import PatchError
 from konfai.utils.utils import SUPPORTED_EXTENSIONS, get_module, get_patch_slices_from_shape, split_path_spec
+
+# How far a halo may reach, as a fraction of the patch it surrounds. See DatasetManager._affords_halo.
+_MAX_HALO_FRACTION = 0.5
+
+
+def _halo_radii(halo: tuple[int, ...], n_axes: int) -> list[int]:
+    """The per-axis radius a declared halo means, in array order (one radius covers every axis)."""
+    if not halo:
+        return [0] * n_axes
+    return [halo[k] if k < len(halo) else halo[-1] for k in range(n_axes)]
+
+
+class Stage(Protocol):
+    """One step of what a case's copy is made of, as the patch-streaming dispatcher sees it.
+
+    A copy is its group's transforms followed by the augmentations drawn for it, and streaming asks the
+    same three things of every step: what its output depends on, which source region a target patch
+    needs, and to run on one tensor. A ``Transform`` answers them as itself. An augmentation is
+    parameterised per case and per copy, so it answers them bound to one (see :class:`AugmentedStage`).
+    """
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality: ...
+
+    def stream_region_source(
+        self,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+        cache_attribute: Attribute,
+    ) -> list[slice]: ...
+
+    def write_stream_cache_attribute(self, cache_attribute: Attribute, source_spatial_shape: list[int]) -> None: ...
+
+    def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor: ...
+
+
+@dataclass(frozen=True)
+class AugmentedStage:
+    """One augmentation, bound to the case and the copy whose draw it carries.
+
+    An augmentation is parameterised per (case, copy); binding both makes it answer the Stage
+    protocol like a plain transform.
+    """
+
+    augmentation: DataAugmentation
+    index: int
+    a: int
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        return self.augmentation.patch_locality(self.index, self.a, cache_attribute)
+
+    def stream_region_source(
+        self,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+        cache_attribute: Attribute,
+    ) -> list[slice]:
+        return self.augmentation.stream_region_source(self.index, self.a, target_slices, source_spatial_shape)
+
+    def write_stream_cache_attribute(self, cache_attribute: Attribute, source_spatial_shape: list[int]) -> None:
+        """An augmentation draws a copy of the case rather than restating its geometry: nothing to record."""
+
+    def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
+        return self.augmentation.compute(name, self.index, self.a, tensor)
+
+
+@dataclass(frozen=True)
+class _PatchStreamSource:
+    """What a copy's patches are read from, and what runs on them once read.
+
+    ``region_index`` locates the single stage of ``stages`` that reads somewhere other than the target
+    patch, if there is one; the rest are pointwise, so they run wherever the region put them.
+    """
+
+    dataset: Dataset
+    group: str
+    shape: list[int]
+    stages: list[Stage]
+    region_index: int | None
 
 
 @dataclass(frozen=True)
@@ -449,23 +528,35 @@ class DatasetManager:
             else DatasetPatch(_shape)
         )
         self.patch.load(_shape, 0)
-        self.shape = _shape
+        # The spatial grid each copy's patches are cut on: the un-augmented copy's is the source shape
+        # folded by the transforms, and a copy whose draw changes shape (Permute, Mask) has its own.
+        self.shapes: list[list[int]] = [_shape]
         self.data_augmentations_list = data_augmentations_list
-        self._patch_stream_sources: dict[bool, tuple[Dataset, str, list[int], list[Transform]] | None] = {}
+        self._patch_stream_sources: dict[tuple[int, bool], _PatchStreamSource | None] = {}
         self._stream_attributes_persisted: set[int] = set()
-        self.reset_augmentation()
+        self._disk_statistics: dict[tuple[Dataset, str, tuple[int, ...] | None], dict[str, float]] = {}
+        # reset_state=False: the first manager built for a case draws (state_init draws a missing
+        # index), and every later group's manager reuses that draw -- redrawing here would give each
+        # group its own geometry and desynchronise the per-copy patch grids across groups.
+        self.reset_augmentation(reset_state=False)
         self.cache_attributes_bak = copy.deepcopy(self.cache_attributes)
 
     def reset_augmentation(self, reset_state: bool = True):
         self.cache_attributes[:] = self.cache_attributes[:1]
+        self.shapes[:] = self.shapes[:1]
         self.augmented_data.clear()
+        # An augmented copy's stream source is only as good as the draw it was planned for: a halo is
+        # the draw's own, and a re-draw is a new one. Drop every plan, so the next request replans
+        # against the draw the copies actually carry.
+        self._patch_stream_sources.clear()
+        self._stream_attributes_persisted.clear()
         self.total_augmentations = 0
         i = 1
         for data_augmentations in self.data_augmentations_list:
             shape = []
             caches_attribute = []
             for _ in range(data_augmentations.nb):
-                shape.append(self.shape)
+                shape.append(self.shapes[0])
                 caches_attribute.append(copy.deepcopy(self.cache_attributes[0]))
 
             for data_augmentation in data_augmentations.data_augmentations:
@@ -474,6 +565,7 @@ class DatasetManager:
                 shape = data_augmentation.state_init(self.index, shape, caches_attribute)
             for it, s in enumerate(shape):
                 self.cache_attributes.append(caches_attribute[it])
+                self.shapes.append(s)
                 self.patch.load(s, i)
                 i += 1
             self.total_augmentations += data_augmentations.nb
@@ -567,46 +659,55 @@ class DatasetManager:
             self.augmented_data[index] = data
         self.augmentationLoaded = len(self.augmented_data) == self.total_augmentations
 
+    def _augmentation_group(self, a: int) -> tuple[int, DataAugmentationsList]:
+        """The augmentation list copy *a* belongs to, and the copy index that list starts at."""
+        start_index = 1
+        for data_augmentations in self.data_augmentations_list:
+            if start_index <= a < start_index + data_augmentations.nb:
+                return start_index, data_augmentations
+            start_index += data_augmentations.nb
+        raise IndexError(f"Augmentation index {a} out of range for dataset '{self.name}'.")
+
+    def _augmentation_stages(self, a: int) -> list[Stage]:
+        """The augmentations copy *a* is made of, each bound to it.
+
+        Copy 0 is made of none: it is the tensor the transforms produced, which is why it is the one
+        copy that has a counterpart on disk to stream from at all. The rest carry their list's draw,
+        minus whatever that draw does not address to this group.
+        """
+        if a == 0:
+            return []
+        start_index, data_augmentations = self._augmentation_group(a)
+        return [
+            AugmentedStage(data_augmentation, self.index, a - start_index)
+            for data_augmentation in data_augmentations.data_augmentations
+            if data_augmentation.groups is None or self.group_dest in data_augmentation.groups
+        ]
+
     def _get_tensor(self, a: int) -> torch.Tensor:
         if a == 0:
             return self.data[0]
-
         if a not in self.augmented_data:
-            start_index = 1
-            for data_augmentations in self.data_augmentations_list:
-                stop_index = start_index + data_augmentations.nb
-                if start_index <= a < stop_index:
-                    self._load_augmentation_group(start_index, data_augmentations)
-                    break
-                start_index = stop_index
-            else:
-                raise IndexError(f"Augmentation index {a} out of range for dataset '{self.name}'.")
-
+            self._load_augmentation_group(*self._augmentation_group(a))
         return self.augmented_data[a]
 
-    @staticmethod
-    def _required_stream_stats(transform: Transform) -> tuple[set[str], list[int] | None] | None:
-        if isinstance(transform, Normalize):
-            return {"Min", "Max"}, transform.channels
-        if isinstance(transform, Standardize):
-            required_stats = set()
-            if transform.mean is None:
-                required_stats.add("Mean")
-            if transform.std is None:
-                required_stats.add("Std")
-            return required_stats, None
-        if isinstance(transform, Clip):
-            required_stats = set()
-            if isinstance(transform.min_value, str):
-                if transform.min_value != "min":
-                    return None
-                required_stats.add("Min")
-            if isinstance(transform.max_value, str):
-                if transform.max_value != "max":
-                    return None
-                required_stats.add("Max")
-            return required_stats, None
-        return None
+    def _read_disk_statistics(
+        self,
+        source_dataset: Dataset,
+        source_group: str,
+        channels: list[int] | None,
+    ) -> dict[str, float]:
+        """Read (and memoise) the whole-volume statistics of one on-disk group for this case.
+
+        ``read_data_statistics`` scans the stored volume without materialising it, but it is still a
+        full pass: memoise it per (dataset, group, channels) so a per-patch consumer -- whose
+        ``inverse()`` pops the seeded keys back out of the cache attribute at prediction time -- does
+        not re-scan the volume once per patch.
+        """
+        key = (source_dataset, source_group, tuple(channels) if channels is not None else None)
+        if key not in self._disk_statistics:
+            self._disk_statistics[key] = source_dataset.read_data_statistics(source_group, self.name, channels)
+        return self._disk_statistics[key]
 
     def _ensure_stream_stats(
         self,
@@ -620,7 +721,7 @@ class DatasetManager:
         if not missing_stats:
             return True
 
-        stats = source_dataset.read_data_statistics(source_group, self.name, channels)
+        stats = self._read_disk_statistics(source_dataset, source_group, channels)
         stats_mapping = {
             "Min": stats["min"],
             "Max": stats["max"],
@@ -634,24 +735,75 @@ class DatasetManager:
                 cache_attribute[key] = stats_mapping[key]
         return all(key in cache_attribute for key in required_stats)
 
-    def _supports_patch_stream_transform(
+    def _affords_halo(self, a: int, halo: tuple[int, ...]) -> bool:
+        """Whether a halo of this radius still buys copy *a* anything over loading the volume.
+
+        Every patch pays the halo on every side and the patches tile the volume, so streaming a case
+        reads ``prod(1 + 2 * halo_k / patch_k)`` times its bytes -- the multiple streaming pays to keep
+        one volume off the heap. Half a patch doubles every axis: 8x the reads in 3D, measured on a
+        160^3 mha at patch 64 as 8.6x the wall-clock of the load it avoids, against 3.0x for a halo of
+        2 (the per-patch read overhead streaming costs whatever the halo). Past that the multiple runs
+        away -- a halo of one whole patch is 27x -- while the saving is still just the one volume.
+        """
+        patch_size = self.patch.patch_size
+        extent = (
+            self.shapes[a]
+            if patch_size is None or all(p == 0 for p in patch_size)
+            else [min(p, s) for p, s in zip(patch_size, self.shapes[a], strict=False)]
+        )
+        return all(
+            radius <= _MAX_HALO_FRACTION * size
+            for radius, size in zip(_halo_radii(halo, len(extent)), extent, strict=False)
+        )
+
+    def _plan_stream_region(
         self,
-        transform: Transform,
+        a: int,
+        localities: list[PatchLocality],
         source_dataset: Dataset,
         source_group: str,
         cache_attribute: Attribute,
-    ) -> bool:
-        if isinstance(transform, TensorCast):
-            return True
-        if isinstance(transform, Clip) and transform.mask is not None:
-            return False
-        if isinstance(transform, Standardize) and transform.mask is not None:
-            return False
-        required_stream_stats = self._required_stream_stats(transform)
-        if required_stream_stats is None:
-            return False
-        required_stats, channels = required_stream_stats
-        return self._ensure_stream_stats(source_dataset, source_group, cache_attribute, required_stats, channels)
+    ) -> tuple[bool, int | None]:
+        """Validate a copy's locality declarations and locate the single region stage among them.
+
+        Returns ``(streamable, region_index)``. The chain streams only when it is
+        ``[pre-pointwise*][at most one region: HALO|ORIENTATION|RESCALE][post-pointwise*]`` where
+        ``GLOBAL_STAT`` counts as pointwise (exact patch + a pre-populated stat). Any
+        ``WHOLE_VOLUME`` declaration, more than one region stage, an unreadable ``GLOBAL_STAT``, a
+        ``RESCALE`` without a known source ``Spacing``, or a halo too wide to be worth reading rejects
+        streaming. Nothing here names a stage: each declares its own contract, and this is where the
+        declarations are read -- which is why a transform and an augmentation are planned side by side.
+        """
+        if any(loc.kind is LocalityKind.WHOLE_VOLUME for loc in localities):
+            return False, None
+        region_kinds = (LocalityKind.HALO, LocalityKind.ORIENTATION, LocalityKind.CROP, LocalityKind.RESCALE)
+        region_indices = [index for index, loc in enumerate(localities) if loc.kind in region_kinds]
+        if len(region_indices) > 1:
+            return False, None
+        if any(loc.kind is LocalityKind.HALO and not self._affords_halo(a, loc.halo) for loc in localities):
+            return False, None
+        for index, loc in enumerate(localities):
+            if loc.kind is not LocalityKind.GLOBAL_STAT:
+                continue
+            # The seed is the STORED volume's statistic, which is this transform's input only when
+            # every earlier stage preserves it; otherwise ([Clip(-200, 400), Standardize()]) every
+            # patch would be standardized by the pre-Clip statistic -- fall back to the whole volume.
+            if not all(previous.statistics_preserving for previous in localities[:index]):
+                return False, None
+            if not self._ensure_stream_stats(
+                source_dataset, source_group, cache_attribute, set(loc.stat_keys), loc.stat_channels
+            ):
+                return False, None
+        region_index = region_indices[0] if region_indices else None
+        if (
+            region_index is not None
+            and localities[region_index].kind is LocalityKind.RESCALE
+            and "Spacing" not in cache_attribute
+        ):
+            # A resample is patch-native only when the source geometry is known: the scale is read
+            # from cache_attribute['Spacing'] (a free geometry stat, no read_data_statistics).
+            return False, None
+        return True, region_index
 
     @staticmethod
     def _dataset_from_spec(dataset_spec: str) -> Dataset:
@@ -662,17 +814,16 @@ class DatasetManager:
         )
         return Dataset(filename, file_format)
 
-    def _resolve_patch_stream_source(
-        self,
-        apply_augmentations: bool = True,
-    ) -> tuple[Dataset, str, list[int], list[Transform]] | None:
-        if apply_augmentations in self._patch_stream_sources:
-            return self._patch_stream_sources[apply_augmentations]
+    def _resolve_patch_stream_source(self, a: int, apply_augmentations: bool = True) -> _PatchStreamSource | None:
+        key = (a, apply_augmentations)
+        if key in self._patch_stream_sources:
+            return self._patch_stream_sources[key]
 
         source_dataset = self.dataset
         source_group = self.group_src
         source_shape = self.base_shape
-        trailing_transforms = self.transforms
+        boundary_attributes: Attribute | None = None
+        trailing_transforms: list[Stage] = list(self.transforms)
 
         for index in range(len(self.transforms) - 1, -1, -1):
             transform = self.transforms[index]
@@ -682,34 +833,42 @@ class DatasetManager:
                 if dataset.is_dataset_exist(group, self.name):
                     source_dataset = dataset
                     source_group = group
-                    source_shape, _ = dataset.get_infos(group, self.name)
-                    trailing_transforms = self.transforms[index + 1 :]
+                    source_shape, boundary_attributes = dataset.get_infos(group, self.name)
+                    trailing_transforms = list(self.transforms[index + 1 :])
                     break
 
-        stream_cache_attribute = Attribute(self.cache_attributes[0])
-        if (not apply_augmentations or len(self.data_augmentations_list) == 0) and all(
-            self._supports_patch_stream_transform(
-                transform,
-                source_dataset,
-                source_group,
-                stream_cache_attribute,
-            )
-            for transform in trailing_transforms
-        ):
-            self.cache_attributes[0] = Attribute(stream_cache_attribute)
-            self.cache_attributes_bak[0] = Attribute(stream_cache_attribute)
-            self._patch_stream_sources[apply_augmentations] = (
-                source_dataset,
-                source_group,
-                list(source_shape),
-                trailing_transforms,
+        # What copy `a` is: the trailing transforms, then its own draw. The draw is applied to the
+        # transformed volume, so it goes last, and the whole thing is planned as one chain -- a region
+        # transform and a region augmentation are then two regions, which is exactly what they are.
+        stages = trailing_transforms + (self._augmentation_stages(a) if apply_augmentations else [])
+
+        # Plan from the case as STORED (the pristine backup), never from the live attribute: the live
+        # one carries what earlier patches or epochs wrote (a Resample's target Spacing, a Canonical's
+        # canonical Direction), and planning from it would hand a stage its own output as the
+        # description of its input on every epoch after the first.
+        stream_cache_attribute = Attribute(self.cache_attributes_bak[0])
+        if boundary_attributes is not None:
+            # Streaming from a Save cache: the stored volume is the cache, so the stages after the
+            # boundary read its geometry -- stacked over the source keys exactly as the whole-volume
+            # cache-hit merges the cached header.
+            for attribute_key, attribute_value in boundary_attributes.items():
+                stream_cache_attribute[attribute_key] = attribute_value
+        localities = [stage.patch_locality(Attribute(stream_cache_attribute)) for stage in stages]
+        streamable, region_index = self._plan_stream_region(
+            a, localities, source_dataset, source_group, stream_cache_attribute
+        )
+        if streamable:
+            self.cache_attributes[a] = Attribute(stream_cache_attribute)
+            self.cache_attributes_bak[a] = Attribute(stream_cache_attribute)
+            self._patch_stream_sources[key] = _PatchStreamSource(
+                source_dataset, source_group, list(source_shape), stages, region_index
             )
         else:
-            self._patch_stream_sources[apply_augmentations] = None
-        return self._patch_stream_sources[apply_augmentations]
+            self._patch_stream_sources[key] = None
+        return self._patch_stream_sources[key]
 
     def can_stream_patch(self, a: int, apply_augmentations: bool = True) -> bool:
-        return a == 0 and self._resolve_patch_stream_source(apply_augmentations) is not None
+        return self._resolve_patch_stream_source(a, apply_augmentations) is not None
 
     def _get_streamed_data(
         self,
@@ -718,30 +877,210 @@ class DatasetManager:
         is_input: bool,
         apply_augmentations: bool = True,
     ) -> tuple[torch.Tensor, Attribute]:
-        stream_source = self._resolve_patch_stream_source(apply_augmentations)
+        stream_source = self._resolve_patch_stream_source(a, apply_augmentations)
         if stream_source is None:
             raise RuntimeError("Patch streaming requested on a dataset manager without a streaming source.")
 
-        source_dataset, source_group, source_shape, transforms = stream_source
-        plan = self.patch.get_read_plan(source_shape, index, a, is_input)
-        data, attributes = source_dataset.read_data_slice(source_group, self.name, plan.data_slices)
-        tensor = self.patch.apply_read_plan(torch.from_numpy(data), plan)
-        cache_attribute = Attribute(self.cache_attributes[a])
+        region_index = stream_source.region_index
+
+        # RESCALE keeps its dedicated body: its own scale/geometry maths and attribute-persist stack.
+        # The other region kinds go through the generic path below.
+        if region_index is not None and isinstance(stream_source.stages[region_index], Resample):
+            return self._get_streamed_resample_data(index, a, stream_source, region_index, is_input)
+
+        if region_index is None:
+            # POINTWISE / GLOBAL_STAT only: read the exact patch and run the whole chain on it.
+            plan = self.patch.get_read_plan(stream_source.shape, index, a, is_input)
+            data, attributes = stream_source.dataset.read_data_slice(stream_source.group, self.name, plan.data_slices)
+            tensor = torch.from_numpy(data)
+            cache_attribute = Attribute(self.cache_attributes_bak[a])
+            cache_attribute.update(attributes)
+            persist = a not in self._stream_attributes_persisted
+            keys_before = set(cache_attribute.keys()) if persist else set()
+            for stage in stream_source.stages:
+                tensor = stage(self.name, tensor, cache_attribute)
+            # The chain runs on the raw read extent and the read plan is applied AFTER it, exactly as
+            # the whole-volume path transforms the volume before Patch.get_data cuts it: a border patch
+            # is padded with the min of the TRANSFORMED patch (pad_value=None) and the transform never
+            # sees the padding. Padding first would feed f(pad) to the model wherever the volume does
+            # not tile the patch grid.
+            tensor = self.patch.apply_read_plan(tensor, plan)
+            if persist:
+                self._persist_stream_attributes(a, cache_attribute, keys_before)
+            return tensor, cache_attribute
+
+        return self._get_streamed_region_data(index, a, stream_source, region_index, is_input)
+
+    def _finalize_stream_patch(self, tensor: torch.Tensor, index: int, a: int, is_input: bool) -> torch.Tensor:
+        """Pad/format a target-extent streamed patch to ``patch_size`` like the whole-volume path.
+
+        The region and RESCALE streamed paths produce a patch at the raw target-slice extent, but the
+        overlap tiling can leave the last patch narrower than ``patch_size`` (integer-floor stride).
+        The whole-volume ``Patch.get_data`` pads that border patch up to ``patch_size`` via
+        ``apply_read_plan``; running the streamed patch through the SAME read plan makes border patches
+        byte-identical between the two paths instead of one voxel short. The plan is built on
+        ``self.shapes[a]`` -- the spatial grid this copy's patch slices were themselves cut on, which is
+        the source shape reordered by a Permute and resized by a Resample.
+        """
+        plan = self.patch.get_read_plan(self.shapes[a], index, a, is_input)
+        return self.patch.apply_read_plan(tensor, plan)
+
+    def _persist_stream_attributes(self, a: int, cache_attribute: Attribute, keys_before: set[str]) -> None:
+        # Streaming applies the trailing transforms per patch on a throwaway attribute copy, but
+        # state they record for their own inversion (e.g. TensorCast's source dtype) must survive on
+        # the persistent case attribute, exactly as the non-streamed path stores it while
+        # transforming the full volume. Only NEWLY-added keys are copied, so a pre-seeded GLOBAL_STAT
+        # or a case-level geometry key is never overwritten by a patch-local value.
+        persistent = self.cache_attributes[a]
+        persistent_keys = set(persistent.keys())
+        for key, value in cache_attribute.items():
+            if key not in keys_before and key not in persistent_keys:
+                dict.__setitem__(persistent, key, value)
+        self._stream_attributes_persisted.add(a)
+
+    def _get_streamed_region_data(
+        self,
+        index: int,
+        a: int,
+        stream_source: _PatchStreamSource,
+        region_index: int,
+        is_input: bool,
+    ) -> tuple[torch.Tensor, Attribute]:
+        """Patch-native HALO/ORIENTATION: read the source region a target patch maps to.
+
+        The chain is ``[pre-pointwise*][region][post-pointwise*]``. HALO reads the patch enlarged by the
+        declared per-axis radius (clamped to the volume) and crops the halo back after the stage; the
+        stage's own edge padding reproduces the whole-volume border once the clamp reaches the true
+        border, so seams agree. ORIENTATION reads the index-remapped source region
+        (``stream_region_source``) and applies the flip/permute -- same extent, no crop. No whole volume
+        is loaded.
+        """
+        region_stage = stream_source.stages[region_index]
+        pre_stages = stream_source.stages[:region_index]
+        post_stages = stream_source.stages[region_index + 1 :]
+        region_loc = region_stage.patch_locality(Attribute(self.cache_attributes_bak[a]))
+
+        target_slices = tuple(self.patch.get_patch_slices(a)[index])
+        n_prefix = len(stream_source.shape) - len(target_slices)
+        slices_pre = [slice(None) for _ in range(n_prefix)]
+        source_spatial = [int(s) for s in stream_source.shape[n_prefix:]]
+
+        crop_offsets: list[int] | None = None
+        if region_loc.kind is LocalityKind.HALO:
+            source_slices = []
+            crop_offsets = []
+            for k, (sl, radius) in enumerate(
+                zip(target_slices, _halo_radii(region_loc.halo, len(target_slices)), strict=False)
+            ):
+                start = max(0, sl.start - radius)
+                stop = min(source_spatial[k], sl.stop + radius)
+                source_slices.append(slice(start, stop))
+                crop_offsets.append(sl.start - start)
+        else:
+            source_slices = region_stage.stream_region_source(
+                target_slices, source_spatial, Attribute(self.cache_attributes_bak[a])
+            )
+
+        data_slices = tuple(slices_pre + source_slices)
+        data, attributes = stream_source.dataset.read_data_slice(stream_source.group, self.name, data_slices)
+        sub = torch.from_numpy(data)
+
+        # Each patch re-runs the chain from the state the whole-volume pass started from: the case as
+        # stored (plus planned stats), never the live attribute -- that one carries the chain's own
+        # output.
+        cache_attribute = Attribute(self.cache_attributes_bak[a])
         cache_attribute.update(attributes)
         persist = a not in self._stream_attributes_persisted
         keys_before = set(cache_attribute.keys()) if persist else set()
-        for transform in transforms:
-            tensor = transform(self.name, tensor, cache_attribute)
+
+        for stage in pre_stages:
+            sub = stage(self.name, sub, cache_attribute)
+        # The region stage's geometry writes describe the patch's extent, not the volume's: give it a
+        # throwaway scope, and write the case-level answer once from the FULL source shape below
+        # (write_stream_cache_attribute). A CROP's remap IS its action: the region read is already the
+        # target patch, so the stage is not re-applied.
+        if region_loc.kind is LocalityKind.CROP:
+            tensor = sub
+        else:
+            tensor = region_stage(self.name, sub, Attribute(cache_attribute))
+        if crop_offsets is not None:
+            n_channel_axes = tensor.dim() - len(target_slices)
+            crop = tuple(
+                [slice(None)] * n_channel_axes
+                + [slice(off, off + (sl.stop - sl.start)) for off, sl in zip(crop_offsets, target_slices, strict=False)]
+            )
+            tensor = tensor[crop]
+        for stage in post_stages:
+            tensor = stage(self.name, tensor, cache_attribute)
+
+        tensor = self._finalize_stream_patch(tensor, index, a, is_input)
+
         if persist:
-            # Streaming applies the trailing transforms per patch on this throwaway
-            # copy, but state they record for their own inversion (e.g. TensorCast's
-            # source dtype) must survive on the persistent case attribute, exactly as
-            # the non-streamed path stores it while transforming the full volume.
+            # The region stage's own geometry writes went to the patch-scoped copy above, so this is
+            # where the case gets them: computed once, from the FULL source shape, against the attribute
+            # that still describes the whole volume.
+            region_stage.write_stream_cache_attribute(self.cache_attributes[a], source_spatial)
+            self._persist_stream_attributes(a, cache_attribute, keys_before)
+        return tensor, cache_attribute
+
+    def _get_streamed_resample_data(
+        self,
+        index: int,
+        a: int,
+        stream_source: _PatchStreamSource,
+        resample_pos: int,
+        is_input: bool,
+    ) -> tuple[torch.Tensor, Attribute]:
+        """Patch-native resample: read ONLY the source region a target patch maps to.
+
+        The chain is ``[pre-pointwise][Resample][post-pointwise]``. The target-grid
+        patch slices (already on the post-resample shape) are mapped back to a
+        bounded source region via ``resample.resample_source_region``; only that region
+        is read (``read_data_slice``); pre-pointwise stages run on the sub-region,
+        then the gather kernel interpolates to the target extent, then post-pointwise
+        stages run on the patch. No whole volume is loaded.
+        """
+        source_shape = stream_source.shape
+        resample = cast(Resample, stream_source.stages[resample_pos])
+        pre_stages = stream_source.stages[:resample_pos]
+        post_stages = stream_source.stages[resample_pos + 1 :]
+
+        # Target-grid spatial slices for this patch (built on the post-resample shape).
+        target_slices = tuple(self.patch.get_patch_slices(a)[index])
+        source_spatial = list(source_shape[len(source_shape) - len(target_slices) :])
+
+        source_slices, region_starts, scales, n_in, _ = resample.resample_source_region(
+            target_slices, source_spatial, Attribute(self.cache_attributes_bak[a])
+        )
+
+        slices_pre = [slice(None) for _ in range(len(source_shape) - len(target_slices))]
+        data_slices = tuple(slices_pre + source_slices)
+        data, attributes = stream_source.dataset.read_data_slice(stream_source.group, self.name, data_slices)
+        sub = torch.from_numpy(data)
+
+        cache_attribute = Attribute(self.cache_attributes_bak[a])
+        cache_attribute.update(attributes)
+        persist = a not in self._stream_attributes_persisted
+        keys_before = set(cache_attribute.keys()) if persist else set()
+
+        for stage in pre_stages:
+            sub = stage(self.name, sub, cache_attribute)
+        tensor = resample.resample_region(sub, target_slices, region_starts, scales, n_in)
+        for stage in post_stages:
+            tensor = stage(self.name, tensor, cache_attribute)
+
+        tensor = self._finalize_stream_patch(tensor, index, a, is_input)
+
+        if persist:
             persistent = self.cache_attributes[a]
             persistent_keys = set(persistent.keys())
             for key, value in cache_attribute.items():
                 if key not in keys_before and key not in persistent_keys:
                     dict.__setitem__(persistent, key, value)
+            # Record the same Spacing/Size stack a whole-volume __call__ would, so
+            # inverse() at prediction time pops exactly what the non-streamed path
+            # pushed. Uses the FULL source shape, never the halo'd sub-region.
+            resample.write_stream_cache_attribute(persistent, source_spatial)
             self._stream_attributes_persisted.add(a)
         return tensor, cache_attribute
 
@@ -767,8 +1106,13 @@ class DatasetManager:
             data, _ = self._get_streamed_data(index, a, is_input, apply_augmentations)
         else:
             data = self.patch.get_data(self._get_tensor(a), index, a, is_input)
-        for transform_function in patch_transforms:
-            data = transform_function(self.name, data, self.cache_attributes[a])
+        if patch_transforms:
+            # Per-patch scope: writing to the shared case attribute would freeze the first patch's
+            # derived statistic for every other patch. A case-level statistic (`Standardize(lazy=True)`
+            # in `transforms`) is inherited through the copy.
+            cache_attribute = Attribute(self.cache_attributes[a])
+            for transform_function in patch_transforms:
+                data = transform_function(self.name, data, cache_attribute)
         return data
 
     def get_size(self, a: int) -> int:

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -994,10 +994,11 @@ class DatasetManager:
         # throwaway scope, and write the case-level answer once from the FULL source shape below
         # (write_stream_cache_attribute). A CROP's remap IS its action: the region read is already the
         # target patch, so the stage is not re-applied.
+        scoped = Attribute(cache_attribute)
         if region_loc.kind is LocalityKind.CROP:
             tensor = sub
         else:
-            tensor = region_stage(self.name, sub, Attribute(cache_attribute))
+            tensor = region_stage(self.name, sub, scoped)
         if crop_offsets is not None:
             n_channel_axes = tensor.dim() - len(target_slices)
             crop = tuple(
@@ -1015,8 +1016,32 @@ class DatasetManager:
             # where the case gets them: computed once, from the FULL source shape, against the attribute
             # that still describes the whole volume.
             region_stage.write_stream_cache_attribute(self.cache_attributes[a], source_spatial)
+            self._check_region_geometry_reaches_the_case(region_stage, scoped, cache_attribute)
             self._persist_stream_attributes(a, cache_attribute, keys_before)
         return tensor, cache_attribute
+
+    def _check_region_geometry_reaches_the_case(
+        self, region_stage: Stage, scoped: Attribute, cache_attribute: Attribute
+    ) -> None:
+        """Refuse a region stage that records geometry nowhere the case can read it.
+
+        A region stage is handed a patch, so what it records about the extent is one patch's answer:
+        the scope it records into is thrown away, and ``write_stream_cache_attribute`` is what reaches
+        the case. A stage that records in ``__call__`` alone streams a whole run and leaves the case
+        the geometry it was stored with. Recording in both is what a reorientation does -- the check
+        is on recording in neither.
+        """
+        recorded = {key for key in scoped.keys() if key not in cache_attribute or scoped[key] != cache_attribute[key]}
+        if not recorded:
+            return
+        if type(region_stage).write_stream_cache_attribute is not Transform.write_stream_cache_attribute:
+            return
+        raise PatchError(
+            f"'{type(region_stage).__name__}' recorded {sorted(recorded)} on the scope a streamed region"
+            " is handed, which is dropped, and implements no write_stream_cache_attribute().",
+            "Record the case's answer in write_stream_cache_attribute(): it is given the whole volume's"
+            " shape, where a patch's extent cannot say it.",
+        )
 
     def _get_streamed_resample_data(
         self,

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -899,11 +899,8 @@ class DatasetManager:
             keys_before = set(cache_attribute.keys()) if persist else set()
             for stage in stream_source.stages:
                 tensor = stage(self.name, tensor, cache_attribute)
-            # The chain runs on the raw read extent and the read plan is applied AFTER it, exactly as
-            # the whole-volume path transforms the volume before Patch.get_data cuts it: a border patch
-            # is padded with the min of the TRANSFORMED patch (pad_value=None) and the transform never
-            # sees the padding. Padding first would feed f(pad) to the model wherever the volume does
-            # not tile the patch grid.
+            # The read plan is applied AFTER the chain, as the whole-volume path transforms before
+            # Patch.get_data cuts: padding first would feed f(pad) to the model on every border patch.
             tensor = self.patch.apply_read_plan(tensor, plan)
             if persist:
                 self._persist_stream_attributes(a, cache_attribute, keys_before)
@@ -926,11 +923,9 @@ class DatasetManager:
         return self.patch.apply_read_plan(tensor, plan)
 
     def _persist_stream_attributes(self, a: int, cache_attribute: Attribute, keys_before: set[str]) -> None:
-        # Streaming applies the trailing transforms per patch on a throwaway attribute copy, but
-        # state they record for their own inversion (e.g. TensorCast's source dtype) must survive on
-        # the persistent case attribute, exactly as the non-streamed path stores it while
-        # transforming the full volume. Only NEWLY-added keys are copied, so a pre-seeded GLOBAL_STAT
-        # or a case-level geometry key is never overwritten by a patch-local value.
+        # State a transform records for its own inversion (TensorCast's source dtype) must reach the
+        # persistent attribute, as it would on the whole-volume path. Only NEWLY-added keys are copied:
+        # a seeded GLOBAL_STAT or a case-level geometry key must not take a patch-local value.
         persistent = self.cache_attributes[a]
         persistent_keys = set(persistent.keys())
         for key, value in cache_attribute.items():

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -637,22 +637,9 @@ class Resample(TransformInverse, ABC):
             cache_attribute.pop_np_array("Spacing")
         return self._resample(tensor, [int(size) for size in size_1])
 
-    # ------------------------------------------------------------------
-    # Patch-native streaming support.
-    #
-    # These methods let the patch pipeline resample ONE output patch by
-    # reading only the corresponding source region (+ a small halo) instead
-    # of materialising the whole volume. They are numerically identical to a
-    # whole-volume F.interpolate down to fp32 weight-rounding, and byte-
-    # identical patch-to-patch (zero seam error) because every patch derives
-    # its source coordinates from the SAME global mapping:
-    #
-    #     scale_k = n_in_k / n_out_k        (integer sizes, align_corners=False)
-    #     src(o)  = clamp(scale_k*(o+0.5) - 0.5, min=0)
-    #
-    # `transform_shape` already returns n_out (array order Z,Y,X), so the scale
-    # is taken from the truncated integer sizes exactly as F.interpolate does.
-    # ------------------------------------------------------------------
+    # Every patch derives its source coordinates from the same global scale (n_in / n_out, from the
+    # truncated integer sizes F.interpolate itself uses), which is what makes the streamed patches
+    # agree with the whole-volume call and with each other across a seam.
     def _stream_mode(self, tensor: torch.Tensor) -> str:
         if tensor.dtype == torch.uint8:
             return "nearest"
@@ -1174,11 +1161,8 @@ class Save(Transform):
         self.dataset = dataset
         self.group = group
 
-    # patch_locality stays the WHOLE_VOLUME default on purpose. Although Save is a spatial identity,
-    # a Save that survives in the trailing chain (its cached dataset does not yet exist) must WRITE
-    # the fully preprocessed volume to disk. The streaming path applies transforms per patch and never
-    # materialises the whole volume, so it has no volume to write: declaring whole-volume is what keeps
-    # the caching side effect. A Save whose cache already exists is handled earlier, as a source boundary.
+    # WHOLE_VOLUME on purpose: a Save still in the chain must WRITE the preprocessed volume, and the
+    # streamed path never has one to write. (A Save whose cache exists is a source boundary instead.)
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         return tensor
@@ -1384,11 +1368,8 @@ class Canonical(TransformInverse):
         )
 
     def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
-        # ``shape`` is the channel-stripped SPATIAL shape -- patching strips [C, *spatial] before folding
-        # transform_shape -- and the patch grid is folded from what this returns, so a remap that
-        # transposes extents moves the grid onto the reoriented volume, which is where its patches are.
-        # Read-only, like every answer given from the case metadata: the attribute folded through here is
-        # the case's own, before a single voxel has been read.
+        # ``shape`` is the channel-stripped SPATIAL shape, and the patch grid is folded from what this
+        # returns: a remap that transposes extents moves the grid onto the reoriented volume.
         remap = self._orthogonal_remap(cache_attribute)
         if remap is None:
             return shape

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -16,9 +16,12 @@
 
 """Tensor and image transforms used in KonfAI preprocessing and postprocessing."""
 
+import itertools
 import os
 import tempfile
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
 from multiprocessing import current_process, get_context
 from pathlib import Path
 from typing import Any
@@ -41,6 +44,73 @@ from konfai.utils.runtime import NeedDevice
 from konfai.utils.utils import get_module, split_path_spec
 
 
+class LocalityKind(Enum):
+    """How a transform's output at one voxel depends on its input (its patch-locality contract).
+
+    A transform DECLARES its contract via :meth:`Transform.patch_locality`; the patch-streaming
+    dispatcher (``konfai.data.patching``) reads the declaration and reads only the source region a
+    target patch actually needs, instead of materialising the whole volume.
+
+    - ``POINTWISE``   -- output voxel depends only on the same voxel (and its channels): read the
+      exact patch.
+    - ``HALO``        -- bounded neighbourhood: read the patch enlarged by ``halo`` per axis, crop after.
+    - ``ORIENTATION`` -- flip/permute: read the index-remapped source region.
+    - ``CROP``        -- the source region is the target region TRANSLATED: reading it IS the answer,
+      so the stage is not re-applied to it. Unlike a reorientation this drops the voxels outside the
+      box, so it is no bijection and the stored volume's statistics are not its output's.
+    - ``GLOBAL_STAT`` -- needs whole-volume stats (``stat_keys`` subset of Min/Max/Mean/Std), obtained
+      once from disk and cached: read the exact patch + the cached stat.
+    - ``RESCALE``     -- resample: source region via the scale mapping + interpolation halo.
+    - ``WHOLE_VOLUME``-- genuinely needs the whole volume: the dispatcher falls back to a full load.
+    """
+
+    POINTWISE = "pointwise"
+    HALO = "halo"
+    ORIENTATION = "orientation"
+    CROP = "crop"
+    GLOBAL_STAT = "global_stat"
+    RESCALE = "rescale"
+    WHOLE_VOLUME = "whole_volume"
+
+    @property
+    def preserves_statistics(self) -> bool:
+        """Whether this kind leaves every whole-volume statistic of its input untouched.
+
+        Only a reorientation does: a flip or a permute is a bijection on the voxels, so the multiset of
+        values -- and therefore Min/Max/Mean/Std over it -- is exactly the input's. Every other kind may
+        map values (``POINTWISE``, ``GLOBAL_STAT``), mix neighbours (``HALO``) or interpolate
+        (``RESCALE``). This is what decides whether the statistics of the STORED volume are still those
+        of a later transform's own input (see ``DatasetManager._plan_stream_region``).
+        """
+        return self is LocalityKind.ORIENTATION
+
+
+@dataclass(frozen=True)
+class PatchLocality:
+    """A transform's declared patch-locality contract (see :class:`LocalityKind`).
+
+    ``halo`` is the per-spatial-axis neighbourhood radius in array order (Z, Y, X); a length-1
+    tuple broadcasts to every axis. ``stat_keys`` are the ``Attribute`` keys a ``GLOBAL_STAT``
+    transform reads before running (a subset of ``Min``/``Max``/``Mean``/``Std``). ``stat_channels``
+    restricts the statistic to those channels (``Normalize.channels``).
+    """
+
+    kind: LocalityKind
+    halo: tuple[int, ...] = ()
+    stat_keys: frozenset[str] = field(default_factory=frozenset)
+    stat_channels: list[int] | None = None
+    # Overrides the kind-level default (see LocalityKind.preserves_statistics): a POINTWISE transform
+    # that maps no value (TensorCast to a float dtype) may declare True so a later GLOBAL_STAT can
+    # still seed from the stored volume.
+    preserves_statistics: bool | None = None
+
+    @property
+    def statistics_preserving(self) -> bool:
+        if self.preserves_statistics is not None:
+            return self.preserves_statistics
+        return self.kind.preserves_statistics
+
+
 class Transform(NeedDevice, ABC):
     """Base class for transforms operating on tensors and cached attributes."""
 
@@ -55,6 +125,66 @@ class Transform(NeedDevice, ABC):
 
     def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
         return shape
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        """Declare how this transform's output depends on its input, for patch streaming.
+
+        Answered from the transform's own ``__init__`` config and, where the honest answer depends on
+        the image, from ``cache_attribute`` -- the case's SOURCE metadata, as the volume is stored.
+        The dispatcher reads the header before any voxel, so a transform whose contract the image
+        decides (a reorientation that is only a flip when the direction cosines are axis-aligned, a
+        resample whose halo is the case's own scale) can still declare it up front.
+
+        The default ``WHOLE_VOLUME`` is the safety net: any transform (including third-party custom
+        ones) that does not override this falls to the whole-volume path, so nothing silently breaks.
+
+        An override is bound by three rules:
+
+        - **READ-ONLY.** Never write to ``cache_attribute``. A declaration is made once, for the whole
+          case, and what it wrote would be one patch's answer imposed on every other -- the
+          first-patch-wins bug the streamed paths are built to avoid. The dispatcher hands over a
+          private copy, so a write cannot reach the case; it is simply lost.
+        - **NO I/O.** Read the attribute already in hand, nothing else. Whether the outside world can
+          honour the declaration (are the disk statistics readable, does a mask group exist) is the
+          dispatcher's call, and it already makes it.
+        - **TOTAL.** Answer for ANY case. The metadata may be absent -- the config-time checks probe
+          with an empty ``Attribute``, and a group carries only what its writer stored -- so a missing
+          key must return ``WHOLE_VOLUME``, never raise.
+        """
+        return PatchLocality(LocalityKind.WHOLE_VOLUME)
+
+    def stream_region_source(
+        self,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+        cache_attribute: Attribute,
+    ) -> list[slice]:
+        """Map a target-patch's spatial slices to the source spatial region to read (region kinds).
+
+        Overridden by the kinds whose source region is an index remap of the target's -- ``ORIENTATION``
+        maps it and reorients what it reads, ``CROP`` maps it and is done. ``HALO`` and ``RESCALE`` are
+        handled generically by the dispatcher, so the base raises for any transform that declares a
+        region kind without providing the remap.
+
+        ``cache_attribute`` is the case's SOURCE metadata, under the same rules as
+        :meth:`patch_locality`: a remap the image decides (a reorientation whose mirrored axes are the
+        case's own direction cosines) reads it here, and reads nothing else.
+        """
+        raise TransformError(
+            f"{type(self).__name__} declared a region patch-locality but does not implement stream_region_source().",
+            "Implement stream_region_source() or declare a non-region patch_locality().",
+        )
+
+    def write_stream_cache_attribute(self, cache_attribute: Attribute, source_spatial_shape: list[int]) -> None:
+        """Record the geometry a whole-volume ``__call__`` would, given the FULL source shape.
+
+        Called once per case, on the persistent attribute, for the stage that owns a streamed region.
+        A transform whose geometry rewrite depends on the volume's EXTENT (a reorientation's new
+        origin is the corner it mirrors onto) cannot compute it from a patch, which is all its
+        ``__call__`` is handed while streaming: it writes the case-level answer here instead, and the
+        patch-local one it wrote on the way is dropped rather than persisted. The base is a no-op --
+        a transform that leaves geometry alone has nothing to record.
+        """
 
     @abstractmethod
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
@@ -105,6 +235,23 @@ class Clip(Transform):
         self.save_clip_min = save_clip_min
         self.save_clip_max = save_clip_max
         self.mask = mask
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # A mask reads a separate full volume, and a percentile bound needs the whole histogram:
+        # both force a whole-volume load. A 'min'/'max' bound needs a global disk statistic
+        # (GLOBAL_STAT); fixed float bounds clip each voxel independently (POINTWISE).
+        if self.mask is not None:
+            return PatchLocality(LocalityKind.WHOLE_VOLUME)
+        stat_keys: set[str] = set()
+        for bound, key in ((self.min_value, "Min"), (self.max_value, "Max")):
+            if isinstance(bound, str):
+                if bound.lower() == key.lower():
+                    stat_keys.add(key)
+                else:
+                    return PatchLocality(LocalityKind.WHOLE_VOLUME)
+        if not stat_keys:
+            return PatchLocality(LocalityKind.POINTWISE)
+        return PatchLocality(LocalityKind.GLOBAL_STAT, stat_keys=frozenset(stat_keys))
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         mask = None
@@ -208,6 +355,11 @@ class Normalize(TransformInverse):
         self.max_value = max_value
         self.channels = channels
 
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # Rescaling uses the volume-global Min/Max (restricted to self.channels); the dispatcher reads
+        # those once from disk and seeds them so every patch (and inverse()) sees the same range.
+        return PatchLocality(LocalityKind.GLOBAL_STAT, stat_keys=frozenset({"Min", "Max"}), stat_channels=self.channels)
+
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         if "Min" not in cache_attribute:
             if self.channels:
@@ -257,6 +409,9 @@ class UnNormalize(Transform):
         self.min_value = min_value
         self.max_value = max_value
 
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        return PatchLocality(LocalityKind.POINTWISE)
+
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         return (tensor + 1) / 2 * (self.max_value - self.min_value) + self.min_value
 
@@ -277,6 +432,21 @@ class Standardize(TransformInverse):
         self.mean = mean
         self.std = std
         self.mask = mask
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # A mask reads a separate full volume (whole-volume). Any of mean/std left unset is taken from
+        # a volume-global disk statistic (GLOBAL_STAT); when both are given, the standardization is a
+        # per-voxel affine map with constant coefficients (POINTWISE).
+        if self.mask is not None:
+            return PatchLocality(LocalityKind.WHOLE_VOLUME)
+        stat_keys: set[str] = set()
+        if self.mean is None:
+            stat_keys.add("Mean")
+        if self.std is None:
+            stat_keys.add("Std")
+        if not stat_keys:
+            return PatchLocality(LocalityKind.POINTWISE)
+        return PatchLocality(LocalityKind.GLOBAL_STAT, stat_keys=frozenset(stat_keys))
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         mask = None
@@ -339,6 +509,12 @@ class TensorCast(TransformInverse):
         super().__init__(inverse)
         self.dtype: torch.dtype = getattr(torch, dtype)
 
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # A cast to a floating dtype keeps every value (up to fp rounding on a downcast), so the stored
+        # volume's Min/Max/Mean/Std are still a later GLOBAL_STAT's input statistics; an integer cast
+        # truncates and may not preserve them.
+        return PatchLocality(LocalityKind.POINTWISE, preserves_statistics=self.dtype.is_floating_point)
+
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         cache_attribute["dtype"] = str(tensor.dtype).replace("torch.", "")
         return tensor.type(self.dtype)
@@ -396,6 +572,16 @@ class Squeeze(TransformInverse):
         super().__init__(inverse)
         self.dim = dim
 
+    def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
+        # ``shape`` is the channel-stripped spatial shape (patching strips [C, *spatial] before folding),
+        # so the runtime tensor is [C, *shape] and ``self.dim`` indexes into that. Squeezing the channel
+        # (axis 0) leaves the spatial grid untouched; squeezing a spatial axis drops it from the grid --
+        # but only when it is size 1, exactly as ``torch.squeeze`` does (a non-singleton axis is a no-op).
+        axis = self.dim if self.dim >= 0 else self.dim + len(shape) + 1
+        if 1 <= axis <= len(shape) and shape[axis - 1] == 1:
+            return shape[: axis - 1] + shape[axis:]
+        return shape
+
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         return tensor.squeeze(self.dim)
 
@@ -406,6 +592,11 @@ class Squeeze(TransformInverse):
 class Resample(TransformInverse, ABC):
     def __init__(self, inverse: bool) -> None:
         super().__init__(inverse)
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # The source region is derived from the scale mapping (read from cache_attribute['Spacing']
+        # by the dispatcher); a small interpolation halo is added by resample_source_region.
+        return PatchLocality(LocalityKind.RESCALE)
 
     def _resample(self, tensor: torch.Tensor, size: list[int]) -> torch.Tensor:
         if tensor.dtype == torch.uint8:
@@ -446,6 +637,121 @@ class Resample(TransformInverse, ABC):
             cache_attribute.pop_np_array("Spacing")
         return self._resample(tensor, [int(size) for size in size_1])
 
+    # ------------------------------------------------------------------
+    # Patch-native streaming support.
+    #
+    # These methods let the patch pipeline resample ONE output patch by
+    # reading only the corresponding source region (+ a small halo) instead
+    # of materialising the whole volume. They are numerically identical to a
+    # whole-volume F.interpolate down to fp32 weight-rounding, and byte-
+    # identical patch-to-patch (zero seam error) because every patch derives
+    # its source coordinates from the SAME global mapping:
+    #
+    #     scale_k = n_in_k / n_out_k        (integer sizes, align_corners=False)
+    #     src(o)  = clamp(scale_k*(o+0.5) - 0.5, min=0)
+    #
+    # `transform_shape` already returns n_out (array order Z,Y,X), so the scale
+    # is taken from the truncated integer sizes exactly as F.interpolate does.
+    # ------------------------------------------------------------------
+    def _stream_mode(self, tensor: torch.Tensor) -> str:
+        if tensor.dtype == torch.uint8:
+            return "nearest"
+        return "bilinear" if len(tensor.shape) < 4 else "trilinear"
+
+    def resample_source_region(
+        self,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+        cache_attribute: Attribute,
+        halo: int = 1,
+    ) -> tuple[list[slice], list[int], list[float], list[int], list[int]]:
+        """Map a TARGET-grid patch to the minimal SOURCE region to read.
+
+        Returns ``(source_slices, region_starts, scales, n_in, n_out)`` — all in
+        array axis order (Z, Y, X). The ``halo`` is a pure safety margin (the
+        formula's ``+2`` already captures the i1 neighbour); nearest needs none.
+        """
+        n_in = [int(s) for s in source_spatial_shape]
+        n_out = [int(s) for s in self.transform_shape("", "", list(n_in), cache_attribute)]
+        scales = [n_in[k] / n_out[k] for k in range(len(n_in))]
+        source_slices: list[slice] = []
+        region_starts: list[int] = []
+        for k, sl in enumerate(target_slices):
+            o0, o1 = sl.start, sl.stop
+            smin = int(np.floor(scales[k] * (o0 + 0.5) - 0.5))
+            smax = int(np.floor(scales[k] * ((o1 - 1) + 0.5) - 0.5))
+            a = max(0, smin - halo)
+            b = min(n_in[k], smax + 2 + halo)
+            source_slices.append(slice(a, b))
+            region_starts.append(a)
+        return source_slices, region_starts, scales, n_in, n_out
+
+    def resample_region(
+        self,
+        sub_tensor: torch.Tensor,
+        target_slices: tuple[slice, ...],
+        region_starts: list[int],
+        scales: list[float],
+        n_in: list[int],
+    ) -> torch.Tensor:
+        """Interpolate a source sub-region to the target patch extent.
+
+        ``sub_tensor`` is ``[C, (z, y, x)]`` covering ``source_slices``;
+        ``region_starts`` are the global source indices of its first voxel per
+        axis. Uses the same global coordinate formula as the whole-volume path,
+        indexing the sub-region as ``sub[i - region_start]``.
+        """
+        mode = self._stream_mode(sub_tensor)
+        dev = sub_tensor.device
+        ndim = len(target_slices)
+        if mode == "nearest":
+            out = sub_tensor
+            for k in range(ndim):
+                # Take the axis's index map from F.interpolate itself, so streamed nearest picks the
+                # same source voxel as the whole-volume call for every size ratio.
+                src = torch.arange(n_in[k], device=dev, dtype=torch.float32).reshape(1, 1, -1)
+                n_out_k = round(n_in[k] / scales[k])
+                index = F.interpolate(src, size=n_out_k, mode="nearest").long().flatten()
+                index = index[target_slices[k].start : target_slices[k].stop] - region_starts[k]
+                out = out.index_select(k + 1, index)
+            return out
+
+        if not sub_tensor.is_floating_point() or (
+            sub_tensor.device.type == "cpu" and sub_tensor.dtype in (torch.float16, torch.bfloat16)
+        ):
+            work = sub_tensor.type(torch.float32)
+        else:
+            work = sub_tensor
+        taps: list[tuple[tuple[torch.Tensor, torch.Tensor], tuple[torch.Tensor, torch.Tensor]]] = []
+        for k in range(ndim):
+            o = torch.arange(target_slices[k].start, target_slices[k].stop, device=dev, dtype=work.dtype)
+            src = torch.clamp(scales[k] * (o + 0.5) - 0.5, min=0.0)
+            i0 = torch.floor(src).long()
+            i1 = torch.clamp(i0 + 1, max=n_in[k] - 1)
+            lam = src - i0.to(work.dtype)
+            taps.append(((i0 - region_starts[k], 1 - lam), (i1 - region_starts[k], lam)))
+        out_shape = [work.shape[0]] + [sl.stop - sl.start for sl in target_slices]
+        out = torch.zeros(out_shape, device=dev, dtype=work.dtype)
+        for combo in itertools.product(*taps):
+            gathered = work
+            weight = torch.ones([1] * (ndim + 1), device=dev, dtype=work.dtype)
+            for k, (idx, lam) in enumerate(combo):
+                gathered = gathered.index_select(k + 1, idx)
+                shape = [1] * (ndim + 1)
+                shape[k + 1] = -1
+                weight = weight * lam.reshape(shape)
+            out += gathered * weight
+        return out.type(sub_tensor.dtype)
+
+    @abstractmethod
+    def write_stream_cache_attribute(self, cache_attribute: Attribute, source_spatial_shape: list[int]) -> None:
+        """Record the same 'Spacing'/'Size' stack a whole-volume ``__call__`` would.
+
+        Called once per case on the persistent attribute so ``inverse()`` at
+        prediction time pops exactly what the non-streamed path pushed. Uses the
+        FULL source shape, never the halo'd sub-region.
+        """
+
 
 class ResampleToResolution(Resample):
     def __init__(self, spacing: list[float] = [1.0, 1.0, 1.0], inverse: bool = True) -> None:
@@ -483,6 +789,19 @@ class ResampleToResolution(Resample):
         cache_attribute["Size"] = np.asarray(size)
         return self._resample(tensor, size)
 
+    def write_stream_cache_attribute(self, cache_attribute: Attribute, source_spatial_shape: list[int]) -> None:
+        image_spacing = cache_attribute.get_tensor("Spacing")
+        spacing = self.spacing
+        resize_factor = torch.tensor(
+            [s / i_s if s > 0 else 1.0 for s, i_s in zip(self.spacing, image_spacing, strict=False)]
+        )
+        cache_attribute["Spacing"] = torch.tensor(
+            [float(s) if s > 0 else float(i_s) for s, i_s in zip(spacing, image_spacing, strict=False)]
+        )
+        cache_attribute["Size"] = np.asarray([int(x) for x in source_spatial_shape])
+        size = [int(x) for x in (torch.tensor([int(s) for s in source_spatial_shape]) * 1 / resize_factor.flip(0))]
+        cache_attribute["Size"] = np.asarray(size)
+
 
 class ResampleToShape(Resample):
     def __init__(self, shape: list[float] = [100, 256, 256], inverse: bool = True) -> None:
@@ -518,8 +837,28 @@ class ResampleToShape(Resample):
         cache_attribute["Size"] = shape
         return self._resample(tensor, shape)
 
+    def write_stream_cache_attribute(self, cache_attribute: Attribute, source_spatial_shape: list[int]) -> None:
+        shape = self.shape.clone()
+        image_shape = torch.tensor([int(s) for s in source_spatial_shape])
+        for i, s in enumerate(self.shape):
+            if s == 0:
+                shape[i] = image_shape[i]
+        if "Spacing" in cache_attribute:
+            cache_attribute["Spacing"] = torch.flip(
+                image_shape / shape * torch.flip(cache_attribute.get_tensor("Spacing"), dims=[0]),
+                dims=[0],
+            )
+        cache_attribute["Size"] = image_shape
+        cache_attribute["Size"] = shape
+
 
 class ResampleTransform(TransformInverse):
+    """Resample a volume through stored transforms (a displacement field, an affine).
+
+    Whole-volume: nothing in the format bounds the stored displacement, so no halo can be declared
+    from the header alone.
+    """
+
     def __init__(self, transforms: dict[str, bool], inverse: bool = True) -> None:
         super().__init__(inverse)
         self.transforms = transforms
@@ -598,6 +937,13 @@ class ResampleTransform(TransformInverse):
 
 
 class Mask(Transform):
+    """Set everything outside a mask to a constant.
+
+    Whole-volume: ``__call__`` does not know where its tensor sits, so it cannot read the matching
+    region of the mask (``Clip(mask=)`` and ``Standardize(mask=)`` load whole volumes for the same
+    reason).
+    """
+
     def __init__(self, path: str = "./default.mha", value_outside: int = 0) -> None:
         super().__init__()
         self.path = path
@@ -630,6 +976,14 @@ class Dilate(Transform):
         if dilate < 0:
             raise ValueError(f"[Dilate] 'dilate' must be >= 0, got {dilate}")
         self.dilate = dilate
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # A box dilation of radius ``dilate`` spreads foreground by at most ``dilate`` voxels per axis:
+        # a bounded HALO. At the true border the separable max-pool padding matches the whole-volume
+        # result once the halo clamps, so seams are byte-identical. Radius 0 is a spatial identity.
+        if self.dilate == 0:
+            return PatchLocality(LocalityKind.POINTWISE)
+        return PatchLocality(LocalityKind.HALO, halo=(self.dilate,))
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         if self.dilate == 0:
@@ -665,6 +1019,13 @@ class Sum(Transform):
         super().__init__()
         self.dim = dim
 
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # Pointwise only when reducing the leading channel/model axis (dim 0); a spatial sum spans
+        # the whole extent, so it falls back to the whole volume.
+        if self.dim == 0:
+            return PatchLocality(LocalityKind.POINTWISE)
+        return PatchLocality(LocalityKind.WHOLE_VOLUME)
+
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         if "number_of_channels_per_model" in cache_attribute:
             number_of_channels = cache_attribute.pop_tensor("number_of_channels_per_model")
@@ -695,6 +1056,10 @@ class MergeLabels(Transform):
     ids instead would fabricate a label belonging to neither model).
     """
 
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # Merges the leading model axis per voxel; spatial support is a single voxel.
+        return PatchLocality(LocalityKind.POINTWISE)
+
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         if "number_of_channels_per_model" not in cache_attribute:
             raise TransformError(
@@ -715,6 +1080,11 @@ class Gradient(Transform):
     def __init__(self, per_dim: bool = False):
         super().__init__()
         self.per_dim = per_dim
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # First-difference gradient: each output voxel reads its immediate neighbour, a HALO of radius
+        # 1. The far-edge ConstantPad reproduces the whole-volume border once the halo clamps there.
+        return PatchLocality(LocalityKind.HALO, halo=(1,))
 
     @staticmethod
     def _image_gradient_2d(image: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
@@ -753,6 +1123,13 @@ class Argmax(Transform):
         super().__init__()
         self.dim = dim
 
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # Pointwise ONLY when reducing the channel axis (dim 0). Over a spatial axis the argmax spans
+        # the whole extent, so a per-patch argmax would diverge -- fall back to the whole volume.
+        if self.dim == 0:
+            return PatchLocality(LocalityKind.POINTWISE)
+        return PatchLocality(LocalityKind.WHOLE_VOLUME)
+
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         return torch.argmax(tensor, dim=self.dim).unsqueeze(self.dim)
 
@@ -762,6 +1139,13 @@ class Softmax(Transform):
         super().__init__()
         self.dim = dim
 
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # Pointwise ONLY when reducing the channel axis (dim 0). Over a spatial axis softmax normalises
+        # across the whole extent, so a per-patch softmax would diverge -- fall back to the whole volume.
+        if self.dim == 0:
+            return PatchLocality(LocalityKind.POINTWISE)
+        return PatchLocality(LocalityKind.WHOLE_VOLUME)
+
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         return torch.softmax(tensor, dim=self.dim)
 
@@ -770,6 +1154,9 @@ class FlatLabel(Transform):
     def __init__(self, labels: list[int] | None = None) -> None:
         super().__init__()
         self.labels = labels
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        return PatchLocality(LocalityKind.POINTWISE)
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         data = torch.zeros_like(tensor)
@@ -786,6 +1173,12 @@ class Save(Transform):
         super().__init__()
         self.dataset = dataset
         self.group = group
+
+    # patch_locality stays the WHOLE_VOLUME default on purpose. Although Save is a spatial identity,
+    # a Save that survives in the trailing chain (its cached dataset does not yet exist) must WRITE
+    # the fully preprocessed volume to disk. The streaming path applies transforms per patch and never
+    # materialises the whole volume, so it has no volume to write: declaring whole-volume is what keeps
+    # the caching side effect. A Save whose cache already exists is handled earlier, as a source boundary.
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         return tensor
@@ -810,6 +1203,23 @@ class Permute(TransformInverse):
     def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
         return [shape[it - 1] for it in self.dims[1:]]
 
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        return PatchLocality(LocalityKind.ORIENTATION)
+
+    def stream_region_source(
+        self,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+        cache_attribute: Attribute,
+    ) -> list[slice]:
+        # Output spatial axis k comes from input axis ``self.dims[k + 1] - 1`` (self.dims is
+        # channel-inclusive). Placing each target slice at its source axis yields the source region
+        # whose permutation reproduces the target patch exactly.
+        source_slices = [slice(0, n) for n in source_spatial_shape]
+        for k, sl in enumerate(target_slices):
+            source_slices[self.dims[k + 1] - 1] = slice(sl.start, sl.stop)
+        return source_slices
+
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         return tensor.permute(tuple(self.dims))
 
@@ -823,6 +1233,26 @@ class Flip(TransformInverse):
 
         self.dims = [int(d) + 1 for d in str(dims).split("|")]
 
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        return PatchLocality(LocalityKind.ORIENTATION)
+
+    def stream_region_source(
+        self,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+        cache_attribute: Attribute,
+    ) -> list[slice]:
+        # A flipped spatial axis reads the mirror region ``[n - stop, n - start)``; applying the flip
+        # to that sub-region reproduces the target patch. Non-flipped axes read the identity region.
+        source_slices: list[slice] = []
+        for k, sl in enumerate(target_slices):
+            n = source_spatial_shape[k]
+            if (k + 1) in self.dims:
+                source_slices.append(slice(n - sl.stop, n - sl.start))
+            else:
+                source_slices.append(slice(sl.start, sl.stop))
+        return source_slices
+
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         return tensor.flip(tuple(self.dims))
 
@@ -831,9 +1261,87 @@ class Flip(TransformInverse):
 
 
 class Canonical(TransformInverse):
+    """Reorient a volume onto the canonical (LPS) direction cosines.
+
+    An orthogonal reorientation is a signed permutation of the axes: an exact index remap (values only
+    change place, so whole-volume statistics survive); only an oblique direction is resampled. A remap
+    that permutes axes transposes the extents it swaps, so ``transform_shape`` folds the patch grid
+    onto the reoriented shape.
+    """
+
+    # An orthonormal direction's entries are exactly 0 or +/-1 when it is axis-aligned, but the
+    # reorientation is a product with an inverse, so it lands within a few double ulps of them.
+    _AXIS_ALIGNED_ATOL = 1e-9
+
     def __init__(self, inverse: bool = True) -> None:
         super().__init__(inverse)
         self.canonical_direction = torch.diag(torch.tensor([-1, -1, 1])).to(torch.double)
+
+    def _reorientation(self, cache_attribute: Attribute) -> torch.Tensor:
+        """The map taking an output coordinate onto the input it comes from, in (x, y, z).
+
+        A voxel sits at ``D @ (spacing * index) + origin``, so the map is ``D^-1 @ C`` (with the
+        target spacing carried along the permutation, see ``_carried``) -- NOT the rotation
+        ``C @ D^-1``, which only agrees where the two commute.
+        """
+        initial_matrix = cache_attribute.get_tensor("Direction").reshape(3, 3).to(torch.double)
+        return initial_matrix.inverse() @ self.canonical_direction
+
+    @classmethod
+    def _index_remap(cls, reorientation: torch.Tensor) -> list[tuple[int, bool]] | None:
+        """Per output SPATIAL axis, the source axis it reads and whether it reads it mirrored.
+
+        ``reorientation`` maps an output coordinate onto the input it comes from, so it is an exact
+        remap exactly when it is a signed permutation: output physical axis ``c`` then reads input
+        physical axis ``r``, backwards where the sign is negative. Anything else mixes axes. Axes are
+        returned in array order, where physical axis k is array axis ``n - 1 - k``. The test (every
+        column of L1 norm 1 with peak 1) admits exactly the signed permutations: unit column sums
+        alone would also pass an axis-averaging matrix.
+        """
+        n = reorientation.shape[0]
+        unit = torch.ones(n, dtype=reorientation.dtype)
+        columns = reorientation.abs()
+        if not torch.allclose(columns.sum(0), unit, atol=cls._AXIS_ALIGNED_ATOL):
+            return None
+        if not torch.allclose(columns.amax(0), unit, atol=cls._AXIS_ALIGNED_ATOL):
+            return None
+        remap = []
+        for c in reversed(range(n)):
+            r = int(columns[:, c].argmax())
+            remap.append((n - 1 - r, bool(reorientation[r, c] < 0)))
+        return remap
+
+    def _orthogonal_remap(self, cache_attribute: Attribute) -> list[tuple[int, bool]] | None:
+        """The exact index remap this case's reorientation is, or ``None`` where it is not one.
+
+        Total: a case whose header carries no usable direction cosines has no remap to make, and an
+        oblique one has none to make either -- both answer ``None`` rather than raise, and the resample
+        is what answers for them.
+        """
+        if "Direction" not in cache_attribute or cache_attribute.get_np_array("Direction").size != 9:
+            return None
+        return Canonical._index_remap(self._reorientation(cache_attribute))
+
+    @staticmethod
+    def _carried(per_physical_axis: torch.Tensor, remap: list[tuple[int, bool]] | None) -> torch.Tensor:
+        """Carry a per-physical-axis quantity along a remap: output axis c takes the axis it reads.
+
+        A spacing and a half-extent travel with the axis they belong to -- what a reorientation
+        preserves is the volume's physical extent, not which axis carries it. An oblique direction is
+        resampled onto the input's own grid, so without a remap nothing moves.
+        """
+        if remap is None:
+            return per_physical_axis
+        # The remap is in array order and these are (x, y, z): read in array order, gather, restore.
+        return per_physical_axis.flip(0)[[source for source, _ in remap]].flip(0)
+
+    @staticmethod
+    def _half_extent(spatial_shape: list[int], spacing: torch.Tensor) -> torch.Tensor:
+        """Half a grid's physical extent along each axis, in (x, y, z). A shape is in array order."""
+        return torch.tensor(
+            [(spatial_shape[-axis - 1] - 1) * spacing[axis] / 2 for axis in range(len(spatial_shape))],
+            dtype=torch.double,
+        )
 
     @staticmethod
     def _affine_matrix(matrix: torch.Tensor, translation: torch.Tensor) -> torch.Tensor:
@@ -875,34 +1383,102 @@ class Canonical(TransformInverse):
             .type(data.dtype)
         )
 
-    def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
-        spacing = cache_attribute.get_tensor("Spacing")
+    def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
+        # ``shape`` is the channel-stripped SPATIAL shape -- patching strips [C, *spatial] before folding
+        # transform_shape -- and the patch grid is folded from what this returns, so a remap that
+        # transposes extents moves the grid onto the reoriented volume, which is where its patches are.
+        # Read-only, like every answer given from the case metadata: the attribute folded through here is
+        # the case's own, before a single voxel has been read.
+        remap = self._orthogonal_remap(cache_attribute)
+        if remap is None:
+            return shape
+        return [shape[source] for source, _ in remap]
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # Only the case can say which reorientation this is, so only the header can answer. An orthogonal
+        # one -- mirroring or permuting -- remaps indices, which is what ORIENTATION streams; an oblique
+        # one is resampled from the whole volume.
+        if self._orthogonal_remap(cache_attribute) is None:
+            return PatchLocality(LocalityKind.WHOLE_VOLUME)
+        return PatchLocality(LocalityKind.ORIENTATION)
+
+    def stream_region_source(
+        self,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+        cache_attribute: Attribute,
+    ) -> list[slice]:
+        # Target axis k reads source axis ``source``, so the target slice IS the source's -- taken at the
+        # far end ``[n - stop, n - start)`` where the remap reads that axis backwards. Flipping the region
+        # read reproduces the patch: a flip restricted to a contiguous region is that region reversed.
+        # Both the slices and the remap are in array order, and the remap covers every axis exactly once.
+        remap = self._orthogonal_remap(cache_attribute)
+        if remap is None:
+            raise TransformError(
+                "Canonical declared a region patch-locality for a direction it cannot remap exactly.",
+                "Report this: patch_locality() and stream_region_source() disagree about the case.",
+            )
+        source_slices = [slice(None)] * len(remap)
+        for target, (source, mirrored) in zip(target_slices, remap, strict=False):
+            extent = source_spatial_shape[source]
+            source_slices[source] = (
+                slice(extent - target.stop, extent - target.start) if mirrored else slice(target.start, target.stop)
+            )
+        return source_slices
+
+    def write_stream_cache_attribute(self, cache_attribute: Attribute, source_spatial_shape: list[int]) -> None:
         initial_matrix = cache_attribute.get_tensor("Direction").reshape(3, 3).to(torch.double)
         initial_origin = cache_attribute.get_tensor("Origin")
-        cache_attribute["Direction"] = (self.canonical_direction).flatten()
-        matrix = Canonical._affine_matrix(self.canonical_direction @ initial_matrix.inverse(), torch.tensor([0, 0, 0]))
-        center_voxel = torch.tensor(
-            [(tensor.shape[-i - 1] - 1) * spacing[i] / 2 for i in range(3)],
-            dtype=torch.double,
-        )
-        center_physical = initial_matrix @ center_voxel + initial_origin
-        cache_attribute["Origin"] = center_physical - (self.canonical_direction @ center_voxel)
-        return Canonical._resample_affine(tensor, matrix.unsqueeze(0))
+        spacing = cache_attribute.get_tensor("Spacing").to(torch.double)
+        remap = self._orthogonal_remap(cache_attribute)
+        half_extent = Canonical._half_extent(source_spatial_shape, spacing)
+        cache_attribute["Direction"] = self.canonical_direction.flatten()
+        cache_attribute["Spacing"] = Canonical._carried(spacing, remap)
+        # The reorientation fixes the volume's centre, so the new origin is that centre stepped back by
+        # the canonical half-extent -- the TARGET grid's, which a permutation has carried onto other
+        # axes. The extent is the VOLUME's, never a patch's: it is an argument rather than the handed
+        # tensor's shape.
+        center = initial_matrix @ half_extent + initial_origin
+        cache_attribute["Origin"] = center - self.canonical_direction @ Canonical._carried(half_extent, remap)
+
+    def _reorient(self, tensor: torch.Tensor, reorientation: torch.Tensor) -> torch.Tensor:
+        """Apply a reorientation: an exact index remap where it is one, a resample where it is not.
+
+        An orthogonal reorientation is a bijection on the voxels, so it must reproduce the input's
+        multiset bit for bit -- which only a permute and a flip do.
+        """
+        remap = Canonical._index_remap(reorientation)
+        if remap is None:
+            matrix = Canonical._affine_matrix(reorientation, torch.tensor([0, 0, 0]))
+            return Canonical._resample_affine(tensor, matrix.unsqueeze(0))
+        # The remap is spatial and the tensor is channel-first, so the channel axes lead it unpermuted.
+        offset = tensor.dim() - len(remap)
+        dims = list(range(offset)) + [offset + source for source, _ in remap]
+        flips = [offset + axis for axis, (_, mirrored) in enumerate(remap) if mirrored]
+        # flip materialises the permuted view, so the result never aliases the tensor it was read from.
+        return tensor.permute(dims).flip(flips)
+
+    def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
+        # Read the source geometry before recording the canonical one over it: the attribute stacks.
+        reorientation = self._reorientation(cache_attribute)
+        self.write_stream_cache_attribute(cache_attribute, list(tensor.shape[1:]))
+        return self._reorient(tensor, reorientation)
 
     def inverse(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
+        # Popping restores the source geometry, which is what the inverse remap is then read from.
         cache_attribute.pop("Direction")
+        cache_attribute.pop("Spacing")
         cache_attribute.pop("Origin")
-        matrix = Canonical._affine_matrix(
-            (
-                self.canonical_direction
-                @ cache_attribute.get_tensor("Direction").to(torch.double).reshape(3, 3).inverse()
-            ).inverse(),
-            torch.tensor([0, 0, 0]),
-        )
-        return Canonical._resample_affine(tensor, matrix.unsqueeze(0))
+        return self._reorient(tensor, self._reorientation(cache_attribute).inverse())
 
 
 class HistogramMatching(Transform):
+    """Match a volume's intensity distribution onto a reference group's.
+
+    Whole-volume: the LUT is built from the volume's 256-bin histogram, which is not a statistic
+    ``GLOBAL_STAT`` names and cannot be read back out of the sitk filter.
+    """
+
     def __init__(self, reference_group: str) -> None:
         super().__init__()
         self.reference_group = reference_group
@@ -929,6 +1505,9 @@ class SelectLabel(Transform):
         super().__init__()
         self.labels = [label[1:-1].split(",") for label in labels]
 
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        return PatchLocality(LocalityKind.POINTWISE)
+
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         data = torch.zeros_like(tensor)
         for old_label, new_label in self.labels:
@@ -940,6 +1519,10 @@ class OneHot(TransformInverse):
     def __init__(self, num_classes: int, inverse: bool = True) -> None:
         super().__init__(inverse)
         self.num_classes = num_classes
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # Expands each voxel's scalar label into a one-hot channel vector (spatially pointwise).
+        return PatchLocality(LocalityKind.POINTWISE)
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         result = (
@@ -1062,6 +1645,10 @@ class InferenceStack(Transform):
         self.name = name
         self.mode = mode
 
+    # patch_locality stays the WHOLE_VOLUME default: the member reduction is pointwise, but __call__
+    # also WRITES the whole per-member stack to disk (like Save), which a per-patch pass cannot do. It
+    # is an ensemble/finalize transform, never in a streaming input chain, so this costs no streaming.
+
     def __call__(self, name: str, tensors: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         if tensors.shape[0] == 1:
             return tensors.squeeze(0)
@@ -1109,6 +1696,10 @@ class Variance(Transform):
     def __init__(self) -> None:
         super().__init__()
 
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # Variance across the leading member axis at each voxel -- no spatial neighbour.
+        return PatchLocality(LocalityKind.POINTWISE)
+
     def __call__(self, name: str, tensors: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         # Keep the leading member axis in BOTH branches: the N>1 var(0) drops it and re-adds it via
         # unsqueeze(0), so the single-member zeros must unsqueeze too or the output rank is off by one.
@@ -1121,6 +1712,12 @@ class SegmentationDisagreement(Transform):
     def __init__(self, ignore_background: bool = False) -> None:
         super().__init__()
         self.ignore_background = ignore_background
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # Per-voxel majority disagreement across the members. The global torch.unique only widens the
+        # label set with labels absent at a given voxel, which contribute zero counts there and never
+        # change that voxel's majority -- so the result is decided voxel by voxel.
+        return PatchLocality(LocalityKind.POINTWISE)
 
     def __call__(self, name: str, tensors: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         # tensors shape: [N, ...] with N segmentations and integer labels per voxel
@@ -1157,6 +1754,9 @@ class Percentage(Transform):
         super().__init__()
         self.baseline = baseline
 
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        return PatchLocality(LocalityKind.POINTWISE)
+
     def __call__(self, name: str, tensors: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         return tensors / self.baseline * 100.0
 
@@ -1164,6 +1764,10 @@ class Percentage(Transform):
 class StandardDeviation(Transform):
     def __init__(self) -> None:
         super().__init__()
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # Standard deviation across the leading member axis at each voxel -- no spatial neighbour.
+        return PatchLocality(LocalityKind.POINTWISE)
 
     def __call__(self, name: str, tensors: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         return (
@@ -1184,8 +1788,54 @@ class Statistics(Transform):
 
 
 class Crop(TransformInverse):
+    """Crop a volume to the bounding box of its foreground.
+
+    The content-dependent box is computed once (``transform_shape``) and kept on the case as ``box``
+    margins; cropping is then the translation ``out[o] = volume[o + start]``, so a target patch reads
+    its shifted source region. Dropped voxels mean the stored volume's statistics are not the output's
+    (hence ``LocalityKind.CROP``).
+    """
+
     def __init__(self, inverse: bool = True) -> None:
         super().__init__(inverse)
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # Total: the box is a fact ``transform_shape`` puts on the case before the dispatcher reads any
+        # declaration, but a group carries only what its writer stored, and without it there is no
+        # translation to make -- only the read that would find one.
+        if "box" not in cache_attribute:
+            return PatchLocality(LocalityKind.WHOLE_VOLUME)
+        return PatchLocality(LocalityKind.CROP)
+
+    def stream_region_source(
+        self,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+        cache_attribute: Attribute,
+    ) -> list[slice]:
+        # Output index o holds source index o + start, so the region behind a target patch is that
+        # patch's own slices stepped forward by the box's near margin.
+        box = Crop._parse_box(cache_attribute["box"])
+        return [
+            slice(target.start + int(start), target.stop + int(start))
+            for target, (start, _) in zip(target_slices, box, strict=False)
+        ]
+
+    def write_stream_cache_attribute(self, cache_attribute: Attribute, source_spatial_shape: list[int]) -> None:
+        if "box" not in cache_attribute:
+            return
+        if not {"Origin", "Spacing", "Direction"} <= set(cache_attribute.keys()):
+            return
+        # The crop keeps the box's near corner, so the new origin is the physical point that corner
+        # already sat on: the old origin stepped along each axis by its own margin. A margin is in
+        # array order and the geometry is in (x, y, z), hence the reversed indexing.
+        box = Crop._parse_box(cache_attribute["box"])
+        origin = torch.tensor(cache_attribute.get_np_array("Origin"))
+        matrix = torch.tensor(cache_attribute.get_np_array("Direction").reshape((len(origin), len(origin))))
+        origin = torch.matmul(origin, matrix)
+        for dim in range(box.shape[0]):
+            origin[-dim - 1] += box[dim][0] * cache_attribute.get_np_array("Spacing")[-dim - 1]
+        cache_attribute["Origin"] = torch.matmul(origin, torch.inverse(matrix))
 
     def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
         # The crop box is content-dependent (foreground bounding box), so the output shape
@@ -1222,16 +1872,10 @@ class Crop(TransformInverse):
         if "box" not in cache_attribute:
             return tensor
         box = self._parse_box(cache_attribute["box"])
+        self.write_stream_cache_attribute(cache_attribute, list(tensor.shape[1:]))
+        # The box carries the FAR margin, so the stop it crops at is the one the extent in hand decides.
         for i, ((_, b), s) in enumerate(zip(box, tensor.shape[1:], strict=False)):
             box[i][1] = s - b
-        if "Origin" in cache_attribute and "Spacing" in cache_attribute and "Direction" in cache_attribute:
-            origin = torch.tensor(cache_attribute.get_np_array("Origin"))
-            matrix = torch.tensor(cache_attribute.get_np_array("Direction").reshape((len(origin), len(origin))))
-            origin = torch.matmul(origin, matrix)
-            for dim in range(box.shape[0]):
-                origin[-dim - 1] += box[dim][0] * cache_attribute.get_np_array("Spacing")[-dim - 1]
-            cache_attribute["Origin"] = torch.matmul(origin, torch.inverse(matrix))
-
         image = data_to_image(tensor, cache_attribute)
         result = crop_with_mask(image, box)
         data, _ = image_to_data(result)

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -21,10 +21,13 @@ from __future__ import annotations
 import ast
 import copy
 import csv
+import functools
 import glob
 import math
 import os
+import re
 import threading
+import warnings
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
@@ -122,6 +125,10 @@ class Attribute(dict[str, Any]):
         return key in self and self[key] == value
 
 
+# Elements held in memory at once while accumulating statistics chunk by chunk, whatever the backend.
+_STATISTICS_CHUNK_ELEMENTS = 8_000_000
+
+
 def _update_running_statistics(
     state: dict[str, float] | None,
     array: np.ndarray,
@@ -160,6 +167,30 @@ def _finalize_running_statistics(state: dict[str, float] | None) -> dict[str, fl
         "mean": state["mean"],
         "std": math.sqrt(max(variance, 0.0)),
     }
+
+
+# Formats already reported by _warn_unstreamed_region_read. Keyed by format, not by file: the remedy
+# is dataset-wide, so every case of a dataset would otherwise repeat the same warning.
+_unstreamed_formats_warned: set[str] = set()
+
+
+def _warn_unstreamed_region_read(path: str) -> None:
+    """Warn that `path`'s format decodes the whole volume for every patch region read from it.
+
+    `warnings.warn` dedups per call site, which here is one line in a loop over every patch of every
+    case: the seen-set is what makes this once per format rather than thousands of times.
+    """
+    suffix = Path(path).suffix
+    if suffix in _unstreamed_formats_warned:
+        return
+    _unstreamed_formats_warned.add(suffix)
+    warnings.warn(
+        f"Patch-streaming '{suffix}' files (e.g. '{path}'): this format cannot serve a disk region "
+        "(NRRD, or any compressed file), so every patch decodes the whole volume again -- 10-20x the "
+        "cost of one read. Convert the dataset to a chunked format (OME-Zarr or HDF5), which KonfAI "
+        "streams natively, or to an uncompressed .mha/.nii. Warned once per format.",
+        stacklevel=2,
+    )
 
 
 def is_an_image(attributes: Attribute) -> bool:
@@ -385,8 +416,7 @@ class Dataset:
 
             axis = 1 if dataset.ndim > 1 else 0
             trailing_size = int(np.prod(dataset.shape[axis + 1 :], dtype=np.int64)) if axis + 1 < dataset.ndim else 1
-            max_elements = 8_000_000
-            chunk_length = max(1, max_elements // max(1, trailing_size))
+            chunk_length = max(1, _STATISTICS_CHUNK_ELEMENTS // max(1, trailing_size))
             state: dict[str, float] | None = None
 
             for start in range(0, dataset.shape[axis], chunk_length):
@@ -535,6 +565,29 @@ class Dataset:
         def _supports_direct_slice(slices: tuple[slice, ...]) -> bool:
             return all(item.step in (None, 1) for item in slices)
 
+        @staticmethod
+        @functools.cache
+        def _supports_region_read(path: str) -> bool:
+            """Return whether ITK can serve a region of `path` without decoding the whole volume.
+
+            SimpleITK exposes no equivalent of ImageIOBase::CanStreamRead(), so the streaming IOs are
+            mirrored here: MetaImage and NIfTI stream while their pixel data is uncompressed. A compressed
+            stream is not seekable, and NrrdImageIO never streams, so both decode the whole volume for
+            every region asked of them. Getting this wrong only ever costs speed, never correctness.
+
+            Cached: the patch path asks this per read, and it opens the file to read a header.
+            """
+            image_io = sitk.ImageFileReader.GetImageIOFromFileName(path)
+            if image_io == "MetaImageIO":
+                # MetaImage announces compression in its ASCII header, ahead of ElementDataFile.
+                with open(path, "rb") as file:
+                    header = file.read(4096)
+                return re.search(rb"CompressedData\s*=\s*True", header, re.IGNORECASE) is None
+            if image_io == "NiftiImageIO":
+                with open(path, "rb") as file:
+                    return file.read(2) != b"\x1f\x8b"  # gzip magic: a .nii.gz stream
+            return False
+
         def _resolve_data_path(self, name: str) -> str | None:
             base = f"{self.filename}{name}"
             for suffix in (".itk.txt", ".fcsv", ".xml", ".vtk", ".npy"):
@@ -570,6 +623,9 @@ class Dataset:
                 data, attributes = self.file_to_data("", name)
                 return data[normalized], attributes
 
+            if not self._supports_region_read(path):
+                _warn_unstreamed_region_read(path)
+
             extract_index_xyz = [item.start for item in reversed(normalized[1:])]
             extract_size_xyz = [item.stop - item.start for item in reversed(normalized[1:])]
             reader.SetExtractIndex(extract_index_xyz)
@@ -582,6 +638,26 @@ class Dataset:
             direction = np.asarray(reader.GetDirection(), dtype=np.float64).reshape(len(spacing), len(spacing))
             attributes["Origin"] = origin + direction @ (np.asarray(extract_index_xyz, dtype=np.float64) * spacing)
             return data[normalized[:1] + tuple(slice(None) for _ in normalized[1:])], attributes
+
+        def _file_to_image_statistics(self, name: str, path: str, channels: list[int] | None) -> dict[str, float]:
+            reader = sitk.ImageFileReader()
+            reader.SetFileName(path)
+            reader.ReadImageInformation()
+            data_shape = [reader.GetNumberOfComponents(), *reversed(reader.GetSize())]
+
+            trailing_size = int(np.prod(data_shape[2:], dtype=np.int64))
+            slab_length = max(1, _STATISTICS_CHUNK_ELEMENTS // max(1, trailing_size))
+            state: dict[str, float] | None = None
+
+            for start in range(0, data_shape[1], slab_length):
+                slices: list[slice] = [slice(None)] * len(data_shape)
+                slices[1] = slice(start, min(data_shape[1], start + slab_length))
+                slab, _ = self._file_to_image_slice(name, path, tuple(slices))
+                if channels is not None:
+                    slab = slab[channels]
+                state = _update_running_statistics(state, slab)
+
+            return _finalize_running_statistics(state)
 
         def file_to_data(self, group: str, name: str) -> tuple[np.ndarray, Attribute]:
             attributes = Attribute()
@@ -699,6 +775,11 @@ class Dataset:
                     data = data[channels]
                 return _finalize_running_statistics(_update_running_statistics(None, data))
 
+            if self._supports_region_read(path):
+                return self._file_to_image_statistics(name, path, channels)
+
+            # The whole volume lands in memory here, which the streamed path above exists to avoid. Nothing
+            # better is left: a format that cannot serve a region would decode itself once per slab.
             image = sitk.ReadImage(path)
             data = sitk.GetArrayViewFromImage(image)
             if image.GetNumberOfComponentsPerPixel() == 1:

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -128,6 +128,54 @@ def get_memory() -> float:
     return psutil.virtual_memory().used / 2**30
 
 
+# psutil.virtual_memory() always reports the HOST, so inside a container or a SLURM cgroup that grants
+# far less than the node has, a memory budget derived from it would overshoot the real limit and get
+# OOM-killed. The cgroup ceiling is read directly instead. cgroup v2 exposes ``memory.max`` (the literal
+# ``"max"`` means unbounded); cgroup v1 exposes ``memory.limit_in_bytes`` with a page-aligned near
+# INT64_MAX sentinel that means the same. Only Linux has these files; every other host has no cgroup.
+_CGROUP_V2_MEMORY_MAX = "/sys/fs/cgroup/memory.max"
+_CGROUP_V1_MEMORY_LIMIT = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+_CGROUP_UNLIMITED = 1 << 62  # any v1 limit at or above this is the "no limit" sentinel
+
+
+def _read_cgroup_memory_limit() -> int | None:
+    """Return this process's cgroup memory ceiling in bytes, or ``None`` when unbounded or absent.
+
+    Tries cgroup v2 first, then v1. A missing file (non-Linux host, or cgroups disabled), the ``"max"``
+    keyword, the v1 sentinel, or an unparseable value all resolve to ``None`` -- "no cgroup limit".
+    """
+    try:
+        raw = Path(_CGROUP_V2_MEMORY_MAX).read_text().strip()
+    except OSError:
+        raw = ""
+    if raw:
+        if raw == "max":
+            return None
+        try:
+            return int(raw)
+        except ValueError:
+            pass
+    try:
+        limit = int(Path(_CGROUP_V1_MEMORY_LIMIT).read_text().strip())
+    except (OSError, ValueError):
+        return None
+    return None if limit >= _CGROUP_UNLIMITED else limit
+
+
+def available_memory_bytes() -> tuple[int, str]:
+    """Return ``(bytes a process may safely allocate, source label)``, honouring a cgroup limit.
+
+    ``psutil`` sees the host's free RAM, which overshoots a container/cgroup ceiling; the tighter of
+    the cgroup limit and the host figure wins, so the number is safe on a bare host and in a
+    memory-capped container alike. The label names which bound won, for the startup decision log.
+    """
+    host_available = int(psutil.virtual_memory().available)
+    limit = _read_cgroup_memory_limit()
+    if limit is not None and limit < host_available:
+        return limit, "cgroup limit"
+    return host_available, "host available RAM"
+
+
 def configure_workflow_environment(
     *,
     config_path: Path | str,

--- a/tests/unit/test_augmentation.py
+++ b/tests/unit/test_augmentation.py
@@ -34,6 +34,7 @@ from konfai.data.augmentation import (
     Rotate,
     Translate,
 )
+from konfai.data.transform import LocalityKind
 from konfai.utils.dataset import Attribute
 from konfai.utils.errors import AugmentationError
 
@@ -155,7 +156,7 @@ def test_flip_vector_field_round_trip_is_identity() -> None:
     flip = _flip_all_axes(vector_field=True)
     dvf = torch.randn(3, 4, 5, 6)
 
-    augmented = flip._compute("case", 0, [dvf.clone()])[0]
+    augmented = flip._compute("case", 0, 0, dvf.clone())
 
     assert torch.equal(flip._inverse(0, 0, augmented), dvf)
 
@@ -166,7 +167,7 @@ def test_flip_vector_field_negates_flipped_components() -> None:
     flip = _flip_all_axes(vector_field=True)
     dvf = torch.randn(3, 4, 5, 6)
 
-    augmented = flip._compute("case", 0, [dvf.clone()])[0]
+    augmented = flip._compute("case", 0, 0, dvf.clone())
 
     layout_only = torch.flip(dvf, dims=[1, 2, 3])
     assert torch.equal(augmented, -layout_only)
@@ -178,7 +179,7 @@ def test_flip_scalar_data_is_layout_only() -> None:
     flip = _flip_all_axes(vector_field=True)
     volume = torch.randn(1, 4, 5, 6)
 
-    augmented = flip._compute("case", 0, [volume.clone()])[0]
+    augmented = flip._compute("case", 0, 0, volume.clone())
 
     assert torch.equal(augmented, torch.flip(volume, dims=[1, 2, 3]))
     assert torch.equal(flip._inverse(0, 0, augmented), volume)
@@ -189,7 +190,7 @@ def test_flip_default_stays_layout_only_on_vector_data() -> None:
     flip = _flip_all_axes(vector_field=False)
     dvf = torch.randn(3, 4, 5, 6)
 
-    augmented = flip._compute("case", 0, [dvf.clone()])[0]
+    augmented = flip._compute("case", 0, 0, dvf.clone())
 
     assert torch.equal(augmented, torch.flip(dvf, dims=[1, 2, 3]))
 
@@ -240,11 +241,84 @@ def test_rotate_preserves_label_ids_with_nearest() -> None:
     labels[:, 12:20, 12:20] = 3
     rotate._state_init(0, [[32, 32]], [Attribute()])
 
-    out = rotate._compute("case", 0, [labels.clone()])[0]
+    out = rotate._compute("case", 0, 0, labels.clone())
 
     assert out.dtype == torch.uint8
     assert set(out.unique().tolist()).issubset({0, 1, 3})
     assert 2 not in out.unique().tolist()
+
+
+def _rotate_volume(spatial: tuple[int, ...]) -> torch.Tensor:
+    # Distinct values everywhere: a repeated one could survive a wrong remap by coincidence, and the
+    # multiset check below is only as strict as the volume is varied.
+    return torch.from_numpy((np.random.default_rng(0).standard_normal(spatial) * 500.0).astype(np.float32))[None]
+
+
+@pytest.mark.parametrize("seed", range(8))
+def test_rotate_quarter_is_an_exact_bijection_on_a_cubic_grid(seed: int) -> None:
+    # A multiple of 90 degrees about each axis composes to a signed permutation of the axes, so it only
+    # moves voxels: the sorted multiset of values must come back bit for bit. This is what
+    # LocalityKind.preserves_statistics lets a later stage trust, and it is strictly stronger than
+    # comparing statistics -- a sampled turn can leave one looking right while moving the values under it.
+    torch.manual_seed(seed)
+    volume = _rotate_volume((12, 12, 12))
+    rotate = Rotate(is_quarter=True)
+    rotate._state_init(0, [[12, 12, 12]], [Attribute()])
+
+    out = rotate._compute("case", 0, 0, volume)
+
+    assert out.shape == volume.shape
+    assert torch.equal(torch.sort(out.flatten())[0], torch.sort(volume.flatten())[0])
+    assert torch.min(out) == torch.min(volume)
+    assert torch.max(out) == torch.max(volume)
+    assert torch.std(out) == torch.std(volume)
+    # And it is the SAME turn the sampler describes, not merely some bijection: a different permutation
+    # would disagree by the data's own range, where interpolating this one disagrees by ~1e-3 of it.
+    sampled = rotate._sample(rotate._grid_matrix(0, 0, [12, 12, 12]), volume)
+    assert (out.double() - sampled.double()).abs().max() < 0.05
+
+
+@pytest.mark.parametrize("seed", range(8))
+def test_rotate_quarter_inverse_restores_the_volume_exactly(seed: int) -> None:
+    # An exact turn undone by a sampled one would put the interpolation error back at prediction time.
+    torch.manual_seed(seed)
+    volume = _rotate_volume((12, 12, 12))
+    rotate = Rotate(is_quarter=True)
+    rotate._state_init(0, [[12, 12, 12]], [Attribute()])
+
+    assert torch.equal(rotate._inverse(0, 0, rotate._compute("case", 0, 0, volume)), volume)
+
+
+@pytest.mark.parametrize("seed", range(12))
+def test_rotate_quarter_transposes_a_non_cubic_grid_exactly(seed: int) -> None:
+    # A 90 degree turn transposes the two extents it swaps, so the copy it draws is cut on the grid the
+    # turn lands on -- which _state_init announces and the patch grid is loaded from. The remap stays a
+    # bijection on the voxels whatever the extents: only where they sit changes.
+    torch.manual_seed(seed)
+    volume = _rotate_volume((9, 10, 11))
+    rotate = Rotate(is_quarter=True)
+
+    drawn = rotate._state_init(0, [[9, 10, 11]], [Attribute()])
+    out = rotate._compute("case", 0, 0, volume)
+
+    assert list(out.shape[1:]) == drawn[0], "the copy must be cut on the grid its draw announced"
+    assert sorted(drawn[0]) == [9, 10, 11], "a turn permutes the extents, it does not invent them"
+    assert torch.equal(torch.sort(out.flatten())[0], torch.sort(volume.flatten())[0])
+    # And the inverse brings back the source extent as well as the values.
+    assert torch.equal(rotate._inverse(0, 0, out), volume)
+
+
+def test_rotate_declares_orientation_from_the_draw_not_from_the_flag() -> None:
+    # The declaration is about the turn that was drawn, so a free range pinned to a right angle is just
+    # as exact as a quarter draw, and a free angle is not -- whatever the extents it was drawn for.
+    torch.manual_seed(0)
+    right_angle = Rotate(a_min=90.0, a_max=90.0)
+    right_angle._state_init(0, [[9, 10, 11]], [Attribute()])
+    assert right_angle._patch_locality(0, 0, Attribute()).kind is LocalityKind.ORIENTATION
+
+    free = Rotate(a_min=10.0, a_max=10.0)
+    free._state_init(0, [[12, 12, 12]], [Attribute()])
+    assert free._patch_locality(0, 0, Attribute()).kind is LocalityKind.WHOLE_VOLUME
 
 
 # --------------------------------------------------------------------------------------
@@ -261,7 +335,7 @@ def test_translate_scales_voxel_offset_to_normalized_grid():
     """
     aug = Translate(t_min=5.0, t_max=5.0, is_int=False)  # deterministic 5-voxel shift
     aug._state_init(0, [[4, 6, 10]], [Attribute()])  # spatial (z, y, x)
-    column = aug.matrix[0][0][0, :3, 3]  # affine order (x, y, z)
+    column = aug._grid_matrix(0, 0, [4, 6, 10])[0, :3, 3]  # affine order (x, y, z)
     expected = torch.tensor([5.0 * 2 / (10 - 1), 5.0 * 2 / (6 - 1), 5.0 * 2 / (4 - 1)])
     assert torch.allclose(column, expected, atol=1e-6)
 
@@ -270,7 +344,7 @@ def test_translate_is_int_rounds_to_whole_voxels():
     """``is_int`` must round to entire voxels, not to two decimals (0.01)."""
     aug = Translate(t_min=5.3, t_max=5.3, is_int=True)
     aug._state_init(0, [[9, 9, 9]], [Attribute()])
-    column = aug.matrix[0][0][0, :3, 3]
+    column = aug._grid_matrix(0, 0, [9, 9, 9])[0, :3, 3]
     expected = torch.full((3,), 5.0 * 2 / (9 - 1))  # round(5.3) == 5, then normalized
     assert torch.allclose(column, expected, atol=1e-6)
     # Neither the pre-fix 0.01 rounding (5.3) nor raw-voxel units survive.
@@ -311,6 +385,6 @@ def test_mask_reads_pixels_only_on_first_compute(tmp_path: Path, monkeypatch: py
     augmentation._state_init(0, [[2, 2]], [Attribute()])
 
     assert read_count == 0
-    augmentation._compute("case", 0, [torch.ones((1, 2, 2))])
-    augmentation._compute("case", 0, [torch.ones((1, 2, 2))])
+    augmentation._compute("case", 0, 0, torch.ones((1, 2, 2)))
+    augmentation._compute("case", 0, 0, torch.ones((1, 2, 2)))
     assert read_count == 1

--- a/tests/unit/test_data_manager.py
+++ b/tests/unit/test_data_manager.py
@@ -508,6 +508,27 @@ def test_windowed_sampler_keeps_a_bounded_set_of_cases_resident() -> None:
         assert _distinct_cases_per_slice(order, mapping, window * 5) <= window
 
 
+def test_windowed_sampler_epoch_length_is_equal_across_ddp_ranks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every rank must run the same number of batches, whatever cases its shard happens to hold.
+
+    ``Data._split`` pads the shards to equal length precisely because DDP(static_graph=True) hangs
+    when the ranks disagree on the batch count. A length read from the per-rank case-to-worker
+    partition undoes that: the shards carry the same NUMBER of patches but different cases, so the
+    partitions -- and the epoch -- come out different sizes.
+    """
+    monkeypatch.setenv("KONFAI_STATE", str(State.TRAIN))
+    # Cases of increasing size, as a real dataset's volumes are: the shards then carry the same
+    # patch COUNT but different cases, which is what makes the partitions -- and the length read
+    # from them -- differ. A symmetric distribution hides this.
+    mapping = [(case, 0, patch) for case, count in enumerate([1, 2, 3, 4, 5, 6, 7, 8]) for patch in range(count)]
+    shards = Data._split(mapping, 2)
+    assert len({len(shard) for shard in shards}) == 1, "precondition: _split equalises shard length"
+
+    lengths = {len(WindowedCaseSampler(shard, shuffle=True, window=2, batch_size=2, num_workers=2)) for shard in shards}
+
+    assert len(lengths) == 1, f"ranks disagree on the epoch length: {lengths}"
+
+
 def test_windowed_sampler_shards_cases_across_workers_without_overlap() -> None:
     # A map-style DataLoader sends batch j to worker j % num_workers, and each worker holds its own
     # buffer. The sampler must therefore give each batch only its worker-partition's cases so a case

--- a/tests/unit/test_data_manager.py
+++ b/tests/unit/test_data_manager.py
@@ -26,9 +26,19 @@ import numpy as np
 import pytest
 import torch
 from konfai.data.augmentation import DataAugmentation, DataAugmentationsList
-from konfai.data.data_manager import Data, DatasetIter, DataTrain, Group, GroupTransform, _cache_worker_count
+from konfai.data.data_manager import (
+    Data,
+    DatasetIter,
+    DataTrain,
+    Group,
+    GroupTransform,
+    PredictionSubset,
+    TrainSubset,
+    WindowedCaseSampler,
+    _cache_worker_count,
+)
 from konfai.data.patching import DatasetManager, DatasetPatch
-from konfai.data.transform import TensorCast
+from konfai.data.transform import TensorCast, Transform
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.runtime import State
 
@@ -233,6 +243,17 @@ def test_streaming_tensorcast_persists_source_dtype_for_inverse() -> None:
 # --------------------------------------------------------------------------------------
 
 
+class _WholeVolumeTransform(Transform):
+    """A spatial identity that declares nothing, so its chain can only run on a whole volume.
+
+    Cases here are about what happens once a volume is resident -- the FIFO buffer, the augmentation
+    draws -- so they need a chain the streamer refuses. Declaring it is how a chain says so.
+    """
+
+    def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
+        return tensor
+
+
 class _DummyDataset:
     def __init__(self, array: np.ndarray) -> None:
         self.array = array
@@ -257,14 +278,9 @@ class _CountingOffsetAugmentation(DataAugmentation):
     ) -> list[list[int]]:
         return shapes
 
-    def _compute(
-        self,
-        name: str,
-        index: int,
-        tensors: list[torch.Tensor],
-    ) -> list[torch.Tensor]:
+    def _compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
         self.compute_calls += 1
-        return [tensor + (offset + 1) for offset, tensor in enumerate(tensors)]
+        return tensor + (a + 1)
 
     def _inverse(self, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
         return tensor
@@ -278,7 +294,7 @@ def _make_manager(dataset: Dataset, augmentations: DataAugmentationsList, group_
         name="case_000",
         dataset=dataset,
         patch=None,
-        transforms=[],
+        transforms=[_WholeVolumeTransform()],
         data_augmentations_list=[augmentations],
     )
 
@@ -313,12 +329,13 @@ def test_inline_augmentations_are_loaded_on_demand() -> None:
     assert torch.equal(base_sample, torch.from_numpy(base))
 
     first_augmented_sample = dataset_iter[1]["dest"].tensor
-    assert augmentation.compute_calls == 1
+    # One call per copy: the group's two copies are drawn together, on first demand.
+    assert augmentation.compute_calls == 2
     assert manager.augmentationLoaded is True
     assert torch.equal(first_augmented_sample, torch.from_numpy(base) + 1)
 
     second_augmented_sample = dataset_iter[2]["dest"].tensor
-    assert augmentation.compute_calls == 1
+    assert augmentation.compute_calls == 2
     assert torch.equal(second_augmented_sample, torch.from_numpy(base) + 2)
 
 
@@ -372,8 +389,8 @@ class _DrawCountingAugmentation(DataAugmentation):
         new_shape = [2, 4] if self.draws == 1 else [4, 4]
         return [list(new_shape) for _ in shapes]
 
-    def _compute(self, name: str, index: int, tensors: list[torch.Tensor]) -> list[torch.Tensor]:
-        return tensors
+    def _compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
+        return tensor
 
     def _inverse(self, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
         return tensor
@@ -434,3 +451,180 @@ def test_reset_augmentation_shares_one_draw_across_destination_groups() -> None:
     assert augmentation.draws == 1
     # Both groups therefore rebuild their augmented patch grid from the same shape.
     assert manager_a.patch.get_size(1) == manager_b.patch.get_size(1)
+
+
+# --------------------------------------------------------------------------------------
+# WindowedCaseSampler - locality-aware training order, worker sharding, buffer hit rate
+# --------------------------------------------------------------------------------------
+
+
+def _case_major_mapping(n_cases: int, patches_per_case: int) -> list[tuple[int, int, int]]:
+    return [(x, 0, p) for x in range(n_cases) for p in range(patches_per_case)]
+
+
+def _distinct_cases_per_slice(order: list[int], mapping: list[tuple[int, int, int]], slice_len: int) -> int:
+    cases = [mapping[i][0] for i in order]
+    return max(len(set(cases[k : k + slice_len])) for k in range(0, len(order) - slice_len + 1, slice_len))
+
+
+def test_windowed_sampler_none_is_exact_global_shuffle() -> None:
+    # window=None is the default and MUST be byte-identical to the historical global randperm so it
+    # never silently changes training statistics.
+    mapping = _case_major_mapping(6, 4)
+    sampler = WindowedCaseSampler(mapping, shuffle=True, window=None, batch_size=2, num_workers=1)
+    torch.manual_seed(2024)
+    got = list(iter(sampler))
+    torch.manual_seed(2024)
+    expected = torch.randperm(len(mapping)).tolist()
+    assert got == expected
+    assert len(sampler) == len(mapping)
+
+
+def test_windowed_sampler_full_window_degenerates_to_global_shuffle() -> None:
+    # window == n_cases is the compat escape hatch: it degenerates EXACTLY to the global shuffle.
+    mapping = _case_major_mapping(6, 4)
+    n_cases = 6
+    sampler = WindowedCaseSampler(mapping, shuffle=True, window=n_cases, batch_size=2, num_workers=1)
+    torch.manual_seed(11)
+    got = list(iter(sampler))
+    torch.manual_seed(11)
+    expected = torch.randperm(len(mapping)).tolist()
+    assert got == expected
+    # An oversized window is also the global shuffle (no windowing).
+    sampler_big = WindowedCaseSampler(mapping, shuffle=True, window=n_cases + 5, batch_size=2, num_workers=1)
+    torch.manual_seed(11)
+    assert list(iter(sampler_big)) == expected
+
+
+def test_windowed_sampler_keeps_a_bounded_set_of_cases_resident() -> None:
+    mapping = _case_major_mapping(12, 5)
+    for window in (1, 2, 3):
+        sampler = WindowedCaseSampler(mapping, shuffle=True, window=window, batch_size=2, num_workers=1)
+        order = list(iter(sampler))
+        # Every original patch is represented and only bounded padding duplicates are added.
+        assert set(order) >= set(range(len(mapping)))
+        assert len(order) - len(set(order)) <= sampler.batch_size
+        # A window slice (window cases * patches_per_case) touches at most `window` distinct cases.
+        assert _distinct_cases_per_slice(order, mapping, window * 5) <= window
+
+
+def test_windowed_sampler_shards_cases_across_workers_without_overlap() -> None:
+    # A map-style DataLoader sends batch j to worker j % num_workers, and each worker holds its own
+    # buffer. The sampler must therefore give each batch only its worker-partition's cases so a case
+    # is never loaded by more than one worker (no num_workers-fold RAM/I/O blow-up).
+    mapping = _case_major_mapping(16, 4)
+    for num_workers in (2, 4):
+        sampler = WindowedCaseSampler(mapping, shuffle=True, window=2, batch_size=2, num_workers=num_workers)
+        order = list(iter(sampler))
+        batches = [order[i : i + 2] for i in range(0, len(order), 2)]
+        cases = list(sampler.case_entries.keys())
+        partition_of = {case: position % num_workers for position, case in enumerate(cases)}
+        worker_cases: dict[int, set[int]] = {w: set() for w in range(num_workers)}
+        for batch_index, batch in enumerate(batches):
+            for sample_index in batch:
+                case = mapping[sample_index][0]
+                # every sample in batch j belongs to partition j % num_workers
+                assert partition_of[case] == batch_index % num_workers
+                worker_cases[batch_index % num_workers].add(case)
+        for a in range(num_workers):
+            for b in range(a + 1, num_workers):
+                assert worker_cases[a].isdisjoint(worker_cases[b])
+
+
+class _WholeVolumeDataset:
+    """In-memory dataset whose patches are non-streamable (forces the FIFO case-load path)."""
+
+    def __init__(self, volume: np.ndarray) -> None:
+        self.volume = volume
+
+    def get_infos(self, group_src: str, name: str) -> tuple[list[int], Attribute]:
+        return list(self.volume.shape), Attribute({"name": name})
+
+    def read_data(self, group_src: str, name: str) -> tuple[np.ndarray, Attribute]:
+        return self.volume.copy(), Attribute({"name": name})
+
+
+def _reload_count(order: list[int], mapping: list[tuple[int, int, int]], n_cases: int, buffer_size: int) -> int:
+    dataset = cast(Dataset, _WholeVolumeDataset(np.zeros((1, 8, 8), dtype=np.float32)))
+    augmentations = DataAugmentationsList(nb=0, data_augmentations={})
+    augmentation = _CountingOffsetAugmentation()
+    augmentation.load(1.0)
+    augmentations.data_augmentations = [augmentation]
+    managers = [
+        DatasetManager(
+            index=i,
+            group_src="src",
+            group_dest="dest",
+            name=f"case_{i:03d}",
+            dataset=dataset,
+            patch=DatasetPatch([4, 4]),
+            transforms=[_WholeVolumeTransform()],
+            data_augmentations_list=[augmentations],
+        )
+        for i in range(n_cases)
+    ]
+    dataset_iter = DatasetIter(
+        rank=0,
+        data={"dest": managers},
+        mapping=mapping,
+        groups_src={"src": Group(groups_dest={"dest": GroupTransform(transforms=None, patch_transforms=None)})},
+        inline_augmentations=False,
+        data_augmentations_list=[augmentations],
+        patch_size=[4, 4],
+        overlap=None,
+        buffer_size=buffer_size,
+        use_cache=False,
+    )
+    reloads = {"n": 0}
+    original = dataset_iter._load_data
+
+    def counting_load(index: int, augmentation_index: int | None = None) -> bool:
+        loaded = original(index, augmentation_index)
+        if loaded:
+            reloads["n"] += 1
+        return loaded
+
+    dataset_iter._load_data = counting_load  # type: ignore[method-assign]
+    for sample_index in order:
+        dataset_iter[sample_index]
+    return reloads["n"]
+
+
+def test_windowed_sampler_reaches_one_read_per_case() -> None:
+    # The whole point: a windowed epoch loads each volume ~once, versus many times for global shuffle.
+    n_cases, patches_per_case = 10, 4
+    mapping = _case_major_mapping(n_cases, patches_per_case)
+
+    torch.manual_seed(0)
+    global_order = WindowedCaseSampler(mapping, shuffle=True, window=None, batch_size=2, num_workers=1)
+    global_reloads = _reload_count(list(iter(global_order)), mapping, n_cases, buffer_size=3)
+
+    windowed = WindowedCaseSampler(mapping, shuffle=True, window=2, batch_size=2, num_workers=1)
+    windowed_reloads = _reload_count(list(iter(windowed)), mapping, n_cases, buffer_size=max(3, 2))
+
+    # Global shuffle thrashes (well above one read per case); the window reads each case exactly once.
+    assert global_reloads > n_cases
+    assert windowed_reloads == n_cases
+
+
+def test_prediction_subset_order_stays_case_major_and_unwindowed() -> None:
+    # The prediction path uses shuffle=False. The sampler must emit the identity (case-major) order and
+    # ignore any window, so the prediction buffer keeps hitting ~100% and stays byte-identical.
+    mapping = _case_major_mapping(5, 3)
+    prediction = PredictionSubset()
+    assert prediction.shuffle is False
+    assert prediction.shuffle_window is None
+    sampler = WindowedCaseSampler(mapping, shuffle=prediction.shuffle, window=None, batch_size=1, num_workers=4)
+    assert list(iter(sampler)) == list(range(len(mapping)))
+    # A window is inert once shuffle is off: still the case-major identity order.
+    windowed = WindowedCaseSampler(mapping, shuffle=False, window=2, batch_size=1, num_workers=4)
+    assert list(iter(windowed)) == list(range(len(mapping)))
+
+
+def test_train_subset_exposes_shuffle_window_knob() -> None:
+    # The knob is a plain constructor argument so the reflection config engine can bind it.
+    default = TrainSubset()
+    assert default.shuffle_window is None
+    configured = TrainSubset(shuffle_window=4)
+    assert configured.shuffle_window == 4
+    assert configured.shuffle is True

--- a/tests/unit/test_dataset_streaming.py
+++ b/tests/unit/test_dataset_streaming.py
@@ -14,6 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
 from pathlib import Path
 from typing import cast
 
@@ -29,10 +30,33 @@ from konfai.data.data_manager import (
     Group,
     GroupTransform,
     PredictionSubset,
+    _check_patch_transform_invertible,
+    _check_patch_transform_locality,
+    _check_patch_transform_shape,
 )
 from konfai.data.patching import DatasetManager, DatasetPatch
-from konfai.data.transform import KonfAIInference, Mask, Normalize, Standardize, TransformLoader
+from konfai.data.transform import (
+    Clip,
+    Dilate,
+    Flip,
+    Gradient,
+    KonfAIInference,
+    LocalityKind,
+    Mask,
+    Normalize,
+    OneHot,
+    PatchLocality,
+    Permute,
+    ResampleToShape,
+    Softmax,
+    Standardize,
+    TensorCast,
+    Transform,
+    TransformLoader,
+)
+from konfai.utils import dataset as dataset_module
 from konfai.utils.dataset import Attribute, Dataset
+from konfai.utils.errors import ConfigError
 from konfai.utils.runtime import State
 
 SimpleITK = pytest.importorskip("SimpleITK")
@@ -89,23 +113,147 @@ def test_dataset_read_data_slice_sitk_reads_requested_patch_and_updates_origin(t
     )
 
 
+def _write_image(path: Path, compress: bool) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    writer = SimpleITK.ImageFileWriter()
+    writer.SetFileName(str(path))
+    writer.SetUseCompression(compress)
+    writer.Execute(SimpleITK.GetImageFromArray(np.arange(4 * 5 * 6, dtype=np.float32).reshape(4, 5, 6)))
+    return path
+
+
+def _reject_whole_volume_read(*args: object, **kwargs: object) -> None:
+    pytest.fail("statistics must be accumulated slab by slab, never by reading the whole volume")
+
+
+@pytest.mark.parametrize(
+    ("filename", "compress", "streams"),
+    [
+        ("volume.mha", False, True),
+        ("volume.mha", True, False),
+        ("volume.mhd", False, True),
+        ("volume.nii", False, True),
+        ("volume.nii.gz", True, False),
+        # NrrdImageIO serves no region at all, compressed or not: a slab loop would decode the whole
+        # volume once per slab, so it stays on the single whole-volume read.
+        ("volume.nrrd", False, False),
+        ("volume.nrrd", True, False),
+    ],
+)
+def test_sitk_supports_region_read_matches_itk_streaming_capability(
+    tmp_path: Path, filename: str, compress: bool, streams: bool
+) -> None:
+    path = _write_image(tmp_path / filename, compress)
+
+    assert Dataset.SitkFile._supports_region_read(str(path)) is streams
+
+
+@pytest.mark.parametrize(
+    ("file_format", "compress", "warns"),
+    [("nrrd", False, True), ("mha", True, True), ("mha", False, False)],
+)
+def test_patch_stream_warns_once_per_format_that_cannot_serve_a_disk_region(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, file_format: str, compress: bool, warns: bool
+) -> None:
+    """A format serving no region re-decodes the whole volume per patch: say so, once for the dataset.
+
+    Two cases x three patches: the warning is about the format, so it must survive neither the patch
+    loop nor the second case. Streaming an uncompressed .mha is a win and must stay silent.
+    """
+    monkeypatch.setattr(dataset_module, "_unstreamed_formats_warned", set())
+    dataset = Dataset(tmp_path / "Dataset", file_format)
+    volume = np.arange(1 * 4 * 5 * 6, dtype=np.float32).reshape(1, 4, 5, 6)
+    for name in ("CASE_000", "CASE_001"):
+        dataset.write("CT", name, volume, _image_attributes([10.0, 20.0, 30.0], [0.5, 1.5, 2.0]))
+        _write_image(tmp_path / "Dataset" / name / f"CT.{file_format}", compress)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        for name in ("CASE_000", "CASE_001"):
+            for plane in range(3):
+                patch, _ = dataset.read_data_slice(
+                    "CT",
+                    name,
+                    (slice(None), slice(plane, plane + 1), slice(None), slice(None)),
+                )
+                np.testing.assert_array_equal(patch, volume[:, plane : plane + 1])
+
+    messages = [str(w.message) for w in caught if "cannot serve a disk region" in str(w.message)]
+    assert len(messages) == (1 if warns else 0)
+    if warns:
+        assert f"'.{file_format}' files" in messages[0]
+        assert "OME-Zarr or HDF5" in messages[0]
+
+
+def test_dataset_read_data_statistics_sitk_accumulates_slabs_without_loading_full_volume(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dataset = Dataset(tmp_path / "Dataset", "mha")
+    volume = np.arange(1 * 4 * 5 * 6, dtype=np.float32).reshape(1, 4, 5, 6)
+    dataset.write("CT", "CASE_000", volume, _image_attributes([10.0, 20.0, 30.0], [0.5, 1.5, 2.0]))
+
+    # One slab per plane, so the running merge spans several reads on a volume this small.
+    monkeypatch.setattr(dataset_module, "_STATISTICS_CHUNK_ELEMENTS", 1)
+    monkeypatch.setattr(SimpleITK, "ReadImage", _reject_whole_volume_read)
+
+    stats = dataset.read_data_statistics("CT", "CASE_000")
+
+    assert stats["min"] == pytest.approx(float(volume.min()))
+    assert stats["max"] == pytest.approx(float(volume.max()))
+    assert stats["mean"] == pytest.approx(float(volume.mean()))
+    assert stats["std"] == pytest.approx(float(volume.std(ddof=1)))
+
+
+def test_dataset_read_data_statistics_sitk_selects_channels_while_streaming(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dataset = Dataset(tmp_path / "Dataset", "mha")
+    volume = np.arange(3 * 4 * 5 * 6, dtype=np.float32).reshape(3, 4, 5, 6)
+    dataset.write("CT", "CASE_000", volume, _image_attributes([10.0, 20.0, 30.0], [0.5, 1.5, 2.0]))
+
+    monkeypatch.setattr(dataset_module, "_STATISTICS_CHUNK_ELEMENTS", 1)
+    monkeypatch.setattr(SimpleITK, "ReadImage", _reject_whole_volume_read)
+
+    stats = dataset.read_data_statistics("CT", "CASE_000", [0, 2])
+
+    assert stats["mean"] == pytest.approx(float(volume[[0, 2]].mean()))
+    assert stats["std"] == pytest.approx(float(volume[[0, 2]].std(ddof=1)))
+
+
+def test_dataset_read_data_statistics_sitk_keeps_whole_read_for_compressed_volumes(tmp_path: Path) -> None:
+    dataset = Dataset(tmp_path / "Dataset", "mha")
+    volume = np.arange(1 * 4 * 5 * 6, dtype=np.float32).reshape(1, 4, 5, 6)
+    dataset.write("CT", "CASE_000", volume, _image_attributes([10.0, 20.0, 30.0], [0.5, 1.5, 2.0]))
+    _write_image(tmp_path / "Dataset" / "CASE_000" / "CT.mha", compress=True)
+
+    stats = dataset.read_data_statistics("CT", "CASE_000")
+
+    compressed = np.arange(4 * 5 * 6, dtype=np.float32)
+    assert stats["mean"] == pytest.approx(float(compressed.mean()))
+    assert stats["std"] == pytest.approx(float(compressed.std(ddof=1)))
+
+
 class StreamingDatasetStub:
     def __init__(self, volume: np.ndarray) -> None:
         self.volume = volume
         self.full_reads = 0
         self.patch_reads = 0
         self.stats_reads = 0
+        # Identity geometry with one origin/spacing entry per spatial axis (channel-first volume),
+        # so geometry-aware transforms (e.g. Resample) get a Spacing matching the volume's rank.
+        spatial = volume.ndim - 1
+        self._geometry = ([0.0] * spatial, [1.0] * spatial)
 
     def get_infos(self, group_src: str, name: str) -> tuple[list[int], Attribute]:
-        return list(self.volume.shape), _image_attributes([0.0, 0.0], [1.0, 1.0])
+        return list(self.volume.shape), _image_attributes(*self._geometry)
 
     def read_data(self, group_src: str, name: str) -> tuple[np.ndarray, Attribute]:
         self.full_reads += 1
-        return self.volume.copy(), _image_attributes([0.0, 0.0], [1.0, 1.0])
+        return self.volume.copy(), _image_attributes(*self._geometry)
 
     def read_data_slice(self, group_src: str, name: str, slices: tuple[slice, ...]) -> tuple[np.ndarray, Attribute]:
         self.patch_reads += 1
-        return self.volume[slices].copy(), _image_attributes([0.0, 0.0], [1.0, 1.0])
+        return self.volume[slices].copy(), _image_attributes(*self._geometry)
 
     def read_data_statistics(
         self,
@@ -631,3 +779,606 @@ def test_dataset_is_dataset_exist_benefits_from_cache(tmp_path: Path) -> None:
     assert dataset.is_dataset_exist("CT", "CASE_000")
     assert "CT" in dataset._names_cache
     assert not dataset.is_dataset_exist("CT", "CASE_999")
+
+
+def _build_streaming_manager(volume: np.ndarray, transforms: list[Transform], patch_size: list[int]) -> DatasetManager:
+    stub = StreamingDatasetStub(volume)
+    return DatasetManager(
+        index=0,
+        group_src="CT",
+        group_dest="CT",
+        name="CASE_000",
+        dataset=cast(Dataset, stub),
+        patch=DatasetPatch(patch_size),
+        transforms=transforms,
+        data_augmentations_list=[],
+    )
+
+
+def _assert_stream_matches_whole_volume(
+    volume: np.ndarray,
+    transforms: list[Transform],
+    patch_size: list[int],
+    *,
+    atol: float = 0.0,
+) -> DatasetManager:
+    """Every streamed patch must equal the whole-volume pass sliced on the same grid."""
+    manager = _build_streaming_manager(volume, transforms, patch_size)
+    assert manager.can_stream_patch(0)
+
+    size = manager.patch.get_size(0)
+    streamed = [manager._get_streamed_data(index, 0, True)[0] for index in range(size)]
+
+    reference_tensor = torch.from_numpy(volume.copy())
+    reference_attribute = Attribute()
+    for transform in transforms:
+        reference_tensor = transform("CASE_000", reference_tensor, reference_attribute)
+    reference = [manager.patch.get_data(reference_tensor, index, 0, True) for index in range(size)]
+
+    assert len(streamed) == len(reference) == size
+    for got, expected in zip(streamed, reference, strict=False):
+        assert got.shape == expected.shape
+        if atol == 0.0:
+            assert torch.equal(got, expected)
+        else:
+            np.testing.assert_allclose(got.numpy(), expected.numpy(), atol=atol)
+    return manager
+
+
+def test_stream_halo_dilate_seam_matches_whole_volume() -> None:
+    # Foreground straddling the patch boundary at column 4: a whole-volume dilation spreads across the
+    # seam, so a correct HALO read + crop must reproduce it patch-for-patch.
+    volume = np.zeros((1, 8, 8), dtype=np.float32)
+    volume[0, 3:5, 3:5] = 1.0
+    manager = _assert_stream_matches_whole_volume(volume, [Dilate(2)], [4, 4])
+    # The dispatcher must actually take the region (HALO) path, not fall back.
+    assert manager._resolve_patch_stream_source(0, True).region_index == 0
+
+
+def test_stream_halo_gradient_seam_matches_whole_volume() -> None:
+    rng = np.random.default_rng(0)
+    volume = rng.standard_normal((1, 8, 8)).astype(np.float32)
+    _assert_stream_matches_whole_volume(volume, [Gradient()], [4, 4], atol=1e-6)
+
+
+def test_stream_orientation_flip_remap_matches_whole_volume() -> None:
+    volume = np.arange(1 * 8 * 8, dtype=np.float32).reshape(1, 8, 8)
+    _assert_stream_matches_whole_volume(volume, [Flip("0|1")], [4, 4])
+
+
+def test_stream_orientation_permute_remap_matches_whole_volume() -> None:
+    volume = np.arange(1 * 8 * 8, dtype=np.float32).reshape(1, 8, 8)
+    manager = _assert_stream_matches_whole_volume(volume, [Permute("1|0")], [4, 4])
+    assert manager._resolve_patch_stream_source(0, True).region_index == 0
+
+
+def test_stream_orientation_permute_border_patch_uses_the_permuted_grid() -> None:
+    # Permute swaps the spatial axes, so the patch grid is cut on the PERMUTED extents (7x8, not 8x7).
+    # The last patch of the 7-long target axis is one voxel short of patch_size: the streamed patch must
+    # be padded against that target grid, not against the source shape, which would leave it short.
+    volume = np.arange(1 * 8 * 7, dtype=np.float32).reshape(1, 8, 7)
+    _assert_stream_matches_whole_volume(volume, [Permute("1|0")], [4, 4])
+
+
+def test_stream_pointwise_border_patch_pads_after_the_chain() -> None:
+    # A 9-long axis leaves the last patch one voxel short of patch_size, so the read plan pads it up.
+    # The whole-volume path transforms the volume and only then pads (with the min of the TRANSFORMED
+    # patch), so the streamed path must apply the read plan after its chain too -- padding the raw patch
+    # first pads in the source domain and then runs the transform over the padding.
+    volume = np.arange(3 * 8 * 9, dtype=np.float32).reshape(3, 8, 9)
+    _assert_stream_matches_whole_volume(volume, [Softmax(0)], [4, 4])
+
+
+def test_stream_global_stat_before_orientation_region_matches_whole_volume() -> None:
+    # GLOBAL_STAT (Normalize, seeded from disk stats) as a pre-pointwise stage in front of an
+    # ORIENTATION region transform: both the stat and the remap must compose byte-identically.
+    volume = np.arange(1 * 8 * 8, dtype=np.float32).reshape(1, 8, 8)
+    transforms: list[Transform] = [Normalize(), Flip("0")]
+    manager = _build_streaming_manager(volume, transforms, [4, 4])
+    assert manager.can_stream_patch(0)
+    region_index = manager._resolve_patch_stream_source(0, True).region_index
+    assert region_index == 1  # the Flip, not the Normalize
+
+    size = manager.patch.get_size(0)
+    streamed = [manager._get_streamed_data(index, 0, True)[0] for index in range(size)]
+
+    minimum = float(volume.min())
+    maximum = float(volume.max())
+    normalized = torch.from_numpy((2 * (volume - minimum) / (maximum - minimum) - 1).astype(np.float32)).flip(1)
+    reference = [manager.patch.get_data(normalized, index, 0, True) for index in range(size)]
+    for got, expected in zip(streamed, reference, strict=False):
+        np.testing.assert_allclose(got.numpy(), expected.numpy(), atol=1e-6)
+
+
+def test_stream_pointwise_chain_matches_whole_volume() -> None:
+    # A trailing chain of purely POINTWISE transforms streams the exact patch (region_index is None).
+    volume = np.arange(1 * 8 * 8, dtype=np.float32).reshape(1, 8, 8)
+    manager = _assert_stream_matches_whole_volume(volume, [TensorCast("float32"), Flip("0")], [4, 4])
+    assert manager._resolve_patch_stream_source(0, True).region_index == 1
+
+
+def test_softmax_channel_axis_is_pointwise_but_spatial_axis_falls_back() -> None:
+    # A channel-axis softmax (dim 0) is spatially pointwise and streams the exact patch. A softmax over
+    # a SPATIAL axis normalises across the whole extent, so a per-patch softmax would diverge: the
+    # contract must declare it WHOLE_VOLUME and the dispatcher must refuse to stream it.
+    assert Softmax(0).patch_locality(Attribute()).kind is LocalityKind.POINTWISE
+    assert Softmax(1).patch_locality(Attribute()).kind is LocalityKind.WHOLE_VOLUME
+    assert Softmax(-1).patch_locality(Attribute()).kind is LocalityKind.WHOLE_VOLUME
+
+    volume = np.arange(3 * 8 * 8, dtype=np.float32).reshape(3, 8, 8)
+    _assert_stream_matches_whole_volume(volume, [Softmax(0)], [4, 4], atol=1e-6)
+
+    spatial_manager = _build_streaming_manager(volume, [Softmax(1)], [4, 4])
+    assert spatial_manager.can_stream_patch(0) is False
+
+
+def test_stream_clip_fixed_bounds_is_pointwise_and_matches_whole_volume() -> None:
+    # Fixed float bounds clip each voxel independently: POINTWISE, exact patch, no region transform.
+    rng = np.random.default_rng(0)
+    volume = (rng.standard_normal((1, 8, 8)).astype(np.float32)) * 100.0
+    assert Clip(min_value=-50.0, max_value=50.0).patch_locality(Attribute()).kind is LocalityKind.POINTWISE
+    manager = _assert_stream_matches_whole_volume(volume, [Clip(min_value=-50.0, max_value=50.0)], [4, 4])
+    assert manager._resolve_patch_stream_source(0, True).region_index is None
+
+
+def test_stream_clip_min_max_is_global_stat_and_matches_whole_volume() -> None:
+    # 'min'/'max' bounds clip to the volume extremum -- a no-op on that bound -- so the streamed
+    # per-patch result is byte-identical to the whole-volume pass, and the dispatcher seeds the
+    # global stat from a single read_data_statistics call instead of loading the full volume.
+    rng = np.random.default_rng(1)
+    volume = (rng.standard_normal((1, 8, 8)).astype(np.float32)) * 100.0
+    assert Clip(min_value="min", max_value="max").patch_locality(Attribute()).kind is LocalityKind.GLOBAL_STAT
+
+    stub = StreamingDatasetStub(volume)
+    manager = DatasetManager(
+        index=0,
+        group_src="CT",
+        group_dest="CT",
+        name="CASE_000",
+        dataset=cast(Dataset, stub),
+        patch=DatasetPatch([4, 4]),
+        transforms=[Clip(min_value="min", max_value="max")],
+        data_augmentations_list=[],
+    )
+    assert manager.can_stream_patch(0)  # planning reads the stat once
+    size = manager.patch.get_size(0)
+    streamed = [manager._get_streamed_data(index, 0, True)[0] for index in range(size)]
+
+    reference_tensor = Clip(min_value="min", max_value="max")("CASE_000", torch.from_numpy(volume.copy()), Attribute())
+    reference = [manager.patch.get_data(reference_tensor, index, 0, True) for index in range(size)]
+    for got, expected in zip(streamed, reference, strict=False):
+        assert torch.equal(got, expected)
+
+    assert stub.stats_reads == 1  # global stat seeded once from disk, never a full-volume load
+    assert stub.full_reads == 0
+
+
+def test_clip_percentile_and_mask_bounds_fall_back_to_whole_volume() -> None:
+    # A percentile bound needs the whole histogram and a mask reads a second full volume: both
+    # genuinely require the whole volume, so the contract declares WHOLE_VOLUME and streaming is off.
+    assert (
+        Clip(min_value="percentile:1", max_value="percentile:99").patch_locality(Attribute()).kind
+        is LocalityKind.WHOLE_VOLUME
+    )
+    assert Clip(mask="SEG").patch_locality(Attribute()).kind is LocalityKind.WHOLE_VOLUME
+    volume = np.arange(1 * 8 * 8, dtype=np.float32).reshape(1, 8, 8)
+    manager = _build_streaming_manager(volume, [Clip(min_value="percentile:1", max_value="percentile:99")], [4, 4])
+    assert not manager.can_stream_patch(0)
+
+
+def test_stream_orientation_border_patch_is_padded_to_patch_size() -> None:
+    # A tiling whose last patch is narrower than patch_size (30 with patch 8 -> border width 6): the
+    # whole-volume Patch.get_data pads that border up to patch_size, so the region streamed path must
+    # too, otherwise the border patch comes out one-or-more voxels short and cannot batch/reassemble.
+    volume = np.arange(1 * 30 * 30, dtype=np.float32).reshape(1, 30, 30)
+    manager = _assert_stream_matches_whole_volume(volume, [Flip("0|1")], [8, 8])
+    assert manager._resolve_patch_stream_source(0, True).region_index == 0
+    # Every streamed patch is exactly patch_size, including the borders.
+    size = manager.patch.get_size(0)
+    for index in range(size):
+        assert tuple(manager._get_streamed_data(index, 0, True)[0].shape) == (1, 8, 8)
+
+
+def test_stream_resample_border_patch_matches_padded_whole_volume() -> None:
+    # RESCALE upsample to a grid that tiles unevenly (30 with patch 8 -> border width 6). The whole-
+    # volume path resamples the whole volume then pads border patches to patch_size; the streamed
+    # resample path must reproduce that padding so border patches are shape- and value-consistent.
+    rng = np.random.default_rng(3)
+    volume = (rng.standard_normal((1, 20, 20, 20)).astype(np.float32)) * 100.0
+    shape = [30, 30, 30]
+    patch = [8, 8, 8]
+
+    stream_manager = _build_streaming_manager(volume, [ResampleToShape(shape=shape)], patch)
+    assert stream_manager.can_stream_patch(0)
+    assert stream_manager._resolve_patch_stream_source(0, True).region_index == 0
+
+    reference_manager = _build_streaming_manager(volume, [ResampleToShape(shape=shape)], patch)
+    reference_manager.load(reference_manager.transforms, [], load_augmentations=False)
+
+    size = stream_manager.patch.get_size(0)
+    streamed = [stream_manager._get_streamed_data(index, 0, True)[0] for index in range(size)]
+    reference = [reference_manager.patch.get_data(reference_manager.data[0], index, 0, True) for index in range(size)]
+
+    assert len(streamed) == len(reference) == size
+    for got, expected in zip(streamed, reference, strict=False):
+        assert tuple(got.shape) == tuple(expected.shape) == (1, 8, 8, 8)
+        # Interior values match F.interpolate to float32 interpolation-rounding; the previously
+        # short border patch is now padded to patch_size and byte-consistent in shape.
+        np.testing.assert_allclose(got.numpy(), expected.numpy(), atol=1e-3)
+
+
+# --------------------------------------------------------------------------------------
+# patch_transforms — the per-patch opt-in, guarded by the patch-locality contract
+#
+# A patch transform only ever sees ONE patch, and that is what asking for it there means: a
+# GLOBAL_STAT transform handed a patch derives the PATCH's statistic, deliberately. The volume's
+# statistic is opted into explicitly, by capturing it case-level with `lazy` (which traverses the
+# volume, caches Mean/Std and applies nothing) and letting the patch transform find it. These cover
+# both routes, and that neither one leaks a patch's statistic onto the shared case attribute.
+# --------------------------------------------------------------------------------------
+
+
+def _structured_volume() -> np.ndarray:
+    """A spatially STRUCTURED signal: each patch has a very different local statistic.
+
+    A uniform-noise volume hides the bug (every patch shares the volume's statistic); a ramp
+    makes a patch-local statistic diverge from the volume-global one.
+    """
+    z, y, x = np.meshgrid(np.arange(16), np.arange(16), np.arange(16), indexing="ij")
+    return (100.0 * z + 10.0 * y + 1.0 * x).astype(np.float32)[None]
+
+
+def _patch_manager(volume: np.ndarray, transforms: list[Transform]) -> DatasetManager:
+    return DatasetManager(
+        index=0,
+        group_src="CT",
+        group_dest="CT",
+        name="CASE_000",
+        dataset=cast(Dataset, StreamingDatasetStub(volume)),
+        patch=DatasetPatch([8, 8, 8], overlap=4),
+        transforms=transforms,
+        data_augmentations_list=[],
+    )
+
+
+def test_patch_transform_standardize_applies_a_lazily_captured_volume_statistic() -> None:
+    """`Standardize(lazy=True)` case-level + `Standardize()` per patch == case-level Standardize.
+
+    This is the documented way to standardize per patch by the VOLUME's statistic: the lazy pass
+    caches Mean/Std without applying anything, and the patch transform finds them on the attribute.
+    """
+    volume = _structured_volume()
+    case_level = _patch_manager(volume, [Standardize()])
+    per_patch = _patch_manager(volume, [Standardize(lazy=True)])
+
+    size = case_level.patch.get_size(0)
+    assert size > 1
+    for index in range(size):
+        expected = case_level.get_data(index, 0, [], True)
+        got = per_patch.get_data(index, 0, [Standardize()], True)
+        assert torch.equal(got, expected)
+
+
+def test_patch_transform_standardize_uses_the_patch_own_statistic() -> None:
+    """Asked for per-patch, a GLOBAL_STAT transform standardizes the patch by ITS OWN statistic."""
+    volume = _structured_volume()
+    manager = _patch_manager(volume, [])
+
+    patch = manager.get_data(0, 0, [Standardize()], True)
+
+    source = torch.from_numpy(volume[:, 0:8, 0:8, 0:8])
+    expected = (source - source.mean()) / source.std()
+    assert torch.equal(patch, expected)
+    # The patch's own mean is a long way from the volume's, so this really is the local statistic.
+    assert abs(float(source.mean()) - float(torch.from_numpy(volume).mean())) > 100.0
+
+
+def test_patch_transform_statistic_never_leaks_onto_the_case_attribute() -> None:
+    """A patch-local statistic must not reach the attribute the whole case shares.
+
+    Left there, the first patch read would freeze its own Mean/Std for every later patch: neither
+    the volume's statistic nor the patch's, and dependent on the order the patches happen to be read.
+    """
+    volume = _structured_volume()
+    manager = _patch_manager(volume, [])
+
+    manager.get_data(0, 0, [Standardize()], True)
+
+    assert "Mean" not in manager.cache_attributes[0]
+    assert "Std" not in manager.cache_attributes[0]
+
+
+def test_patch_transform_standardize_is_independent_of_patch_order() -> None:
+    """A patch's own statistic is the patch's alone: reading others first cannot change it."""
+    volume = _structured_volume()
+    forward = _patch_manager(volume, [])
+    backward = _patch_manager(volume, [])
+
+    size = forward.patch.get_size(0)
+    first = forward.get_data(0, 0, [Standardize()], True)
+    for index in reversed(range(size)):
+        backward.get_data(index, 0, [Standardize()], True)
+    last = backward.get_data(0, 0, [Standardize()], True)
+
+    assert torch.equal(first, last)
+
+
+def test_patch_transform_is_identical_across_managers() -> None:
+    """A fresh manager per patch -- the per-DataLoader-worker case -- gives the same patch.
+
+    Each worker owns its own cache attribute, so anything a patch records on it makes the result
+    depend on which worker drew which patch. Every patch here must be reproducible on its own.
+    """
+    volume = _structured_volume()
+    shared = _patch_manager(volume, [])
+    size = shared.patch.get_size(0)
+
+    for index in range(size):
+        assert torch.equal(
+            _patch_manager(volume, []).get_data(index, 0, [Standardize()], True),
+            shared.get_data(index, 0, [Standardize()], True),
+        )
+
+
+def test_patch_transform_overlapping_patches_agree_on_shared_voxel() -> None:
+    """With the volume statistic captured lazily, two overlapping patches agree on a shared voxel.
+
+    A fresh manager per patch reproduces the per-DataLoader-worker case: the coefficients come from
+    the case-level lazy pass, so they are the same in every worker.
+    """
+    volume = _structured_volume()
+    size = _patch_manager(volume, []).patch.get_size(0)
+
+    values: dict[tuple[int, int, int], list[float]] = {}
+    for index in range(size):
+        manager = _patch_manager(volume, [Standardize(lazy=True)])
+        patch = manager.get_data(index, 0, [Standardize()], True)
+        slices = manager.patch.get_read_plan([1, 16, 16, 16], index, 0, True).data_slices
+        zs, ys, xs = slices[1], slices[2], slices[3]
+        for z in range(zs.start, zs.stop):
+            for y in range(ys.start, ys.stop):
+                for x in range(xs.start, xs.stop):
+                    voxel = float(patch[0, z - zs.start, y - ys.start, x - xs.start])
+                    values.setdefault((z, y, x), []).append(voxel)
+
+    shared = [v for v in values.values() if len(v) > 1]
+    assert shared, "the patch grid must overlap for this test to mean anything"
+    assert max(max(v) - min(v) for v in shared) == 0.0
+
+
+def test_patch_transform_normalize_applies_a_lazily_captured_volume_range() -> None:
+    volume = _structured_volume()
+    manager = _patch_manager(volume, [Normalize(lazy=True)])
+
+    patch = manager.get_data(0, 0, [Normalize(min_value=-1, max_value=1)], True)
+
+    # Mapped by the volume's range, so the first patch (low corner of the ramp) stays well
+    # below the top of the target interval instead of being stretched onto it.
+    assert float(manager.cache_attributes[0]["Min"]) == pytest.approx(float(volume.min()))
+    assert float(manager.cache_attributes[0]["Max"]) == pytest.approx(float(volume.max()))
+    assert float(patch.max()) < 0.0
+
+
+def test_lazy_capture_reads_volume_statistics_once_per_case() -> None:
+    """The whole-volume statistic is a full disk scan: read it once, not once per patch."""
+    volume = _structured_volume()
+    stub = StreamingDatasetStub(volume)
+    manager = DatasetManager(
+        index=0,
+        group_src="CT",
+        group_dest="CT",
+        name="CASE_000",
+        dataset=cast(Dataset, stub),
+        patch=DatasetPatch([8, 8, 8], overlap=4),
+        transforms=[Standardize(lazy=True)],
+        data_augmentations_list=[],
+    )
+
+    for index in range(manager.patch.get_size(0)):
+        manager.get_data(index, 0, [Standardize()], True)
+
+    assert stub.stats_reads == 1
+    assert stub.full_reads == 0
+
+
+def test_patch_transform_reads_no_disk_statistic_when_the_volume_is_loaded() -> None:
+    """A loaded volume already holds the answer: the patch path must not go back to disk for it.
+
+    The lazy pass computes Mean/Std from the tensor in hand -- free, and carrying whatever the
+    preceding chain did to it -- so a `read_data_statistics` scan here would be both wasted and a
+    statistic of the wrong (stored) version of the volume.
+    """
+    volume = _structured_volume()
+    stub = StreamingDatasetStub(volume)
+    lazy: list[Transform] = [Standardize(lazy=True)]
+    manager = DatasetManager(
+        index=0,
+        group_src="CT",
+        group_dest="CT",
+        name="CASE_000",
+        dataset=cast(Dataset, stub),
+        patch=DatasetPatch([8, 8, 8], overlap=4),
+        transforms=lazy,
+        data_augmentations_list=[],
+    )
+    manager.load(lazy, [], load_augmentations=False)
+    assert manager.loaded is True
+
+    case_level: list[Transform] = [Standardize()]
+    reference = _patch_manager(volume, case_level)
+    reference.load(case_level, [], load_augmentations=False)
+    for index in range(manager.patch.get_size(0)):
+        assert torch.equal(manager.get_data(index, 0, [Standardize()], True), reference.get_data(index, 0, [], True))
+    assert stub.stats_reads == 0
+
+
+# --------------------------------------------------------------------------------------
+# Seeding a GLOBAL_STAT from disk reads the statistics of the STORED volume, so it is only that
+# transform's own input when nothing before it touched the values.
+# --------------------------------------------------------------------------------------
+
+
+def test_streaming_is_refused_when_a_transform_modifies_values_before_a_global_stat() -> None:
+    """[Clip, Standardize] must not stream: on disk lie the PRE-Clip statistics.
+
+    Clipping moves Mean and Std, so seeding Standardize from `read_data_statistics` would standardize
+    every patch by a statistic of a volume that no longer exists. Refusing sends the case down the
+    whole-volume path, where Standardize computes Mean/Std from the clipped tensor it is handed.
+    """
+    volume = _structured_volume()
+    manager = _patch_manager(volume, [Clip(min_value=200.0, max_value=1000.0), Standardize()])
+
+    assert manager.can_stream_patch(0) is False
+    assert "Mean" not in manager.cache_attributes[0]
+
+
+def test_clip_then_standardize_equals_the_whole_volume_result() -> None:
+    """The value every patch must carry: standardized by the CLIPPED volume's statistic."""
+    volume = _structured_volume()
+    chain: list[Transform] = [Clip(min_value=200.0, max_value=1000.0), Standardize()]
+    manager = _patch_manager(volume, chain)
+    manager.load(chain, [], load_augmentations=False)
+
+    clipped = torch.from_numpy(volume).clip(200.0, 1000.0)
+    expected_volume = (clipped - clipped.mean()) / clipped.std()
+
+    size = manager.patch.get_size(0)
+    assert size > 1
+    for index in range(size):
+        patch = manager.get_data(index, 0, [], True)
+        slices = manager.patch.get_read_plan(list(volume.shape), index, 0, True).data_slices
+        assert torch.equal(patch, expected_volume[slices])
+    # The statistic the rejected seed would have used is a long way from the clipped volume's.
+    assert abs(float(torch.from_numpy(volume).mean()) - float(clipped.mean())) > 100.0
+
+
+def test_streaming_still_seeds_a_global_stat_behind_a_reorientation() -> None:
+    """A flip only moves voxels, so the stored statistics are still Standardize's own input."""
+    volume = _structured_volume()
+    manager = _patch_manager(volume, [Flip(dims="0"), Standardize()])
+
+    assert manager.can_stream_patch(0) is True
+    assert "Mean" in manager.cache_attributes[0]
+
+
+@pytest.mark.parametrize(
+    ("transform", "kind"),
+    [
+        (Standardize(mask="MASK"), LocalityKind.WHOLE_VOLUME),
+        (KonfAIInference(), LocalityKind.WHOLE_VOLUME),
+        (Gradient(), LocalityKind.HALO),
+        (Dilate(dilate=2), LocalityKind.HALO),
+        (Flip(), LocalityKind.ORIENTATION),
+        (Permute(), LocalityKind.ORIENTATION),
+    ],
+)
+def test_patch_transform_rejects_transforms_that_cannot_run_per_patch(
+    monkeypatch: pytest.MonkeyPatch, transform: Transform, kind: LocalityKind
+) -> None:
+    """A transform that cannot be correct per-patch must fail at config time, never silently."""
+    monkeypatch.setenv("KONFAI_ROOT", "Trainer")
+    assert transform.patch_locality(Attribute()).kind is kind
+
+    with pytest.raises(ConfigError) as excinfo:
+        _check_patch_transform_locality(transform, "CT", "CT")
+
+    message = str(excinfo.value)
+    assert type(transform).__name__ in message
+    assert "patch_transforms" in message
+    assert "transforms" in message
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [TensorCast(dtype="float32"), Standardize(mean=[0.0], std=[1.0]), Standardize(), Normalize()],
+)
+def test_patch_transform_accepts_pointwise_and_global_stat_transforms(
+    monkeypatch: pytest.MonkeyPatch, transform: Transform
+) -> None:
+    monkeypatch.setenv("KONFAI_ROOT", "Trainer")
+
+    _check_patch_transform_locality(transform, "CT", "CT")
+
+
+class _ShapeChangingPointwise(Transform):
+    """What the locality declaration cannot catch: a custom transform that declares POINTWISE and crops."""
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        return PatchLocality(LocalityKind.POINTWISE)
+
+    def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
+        return [size - 1 for size in shape]
+
+    def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
+        return tensor[..., :-1, :-1, :-1]
+
+
+def test_patch_transform_rejects_a_transform_that_changes_the_spatial_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A POINTWISE declaration buys a transform past the locality check; the shape it returns does not."""
+    monkeypatch.setenv("KONFAI_ROOT", "Trainer")
+    transform = _ShapeChangingPointwise()
+    _check_patch_transform_locality(transform, "CT", "CT")  # the declaration alone lets it through
+
+    with pytest.raises(ConfigError) as excinfo:
+        _check_patch_transform_shape(transform, "CT", "CT")
+
+    message = str(excinfo.value)
+    assert "_ShapeChangingPointwise" in message
+    assert "Trainer.Dataset.groups_src.CT.groups_dest.CT.patch_transforms" in message
+
+
+def test_patch_transform_shape_guard_is_spatial_not_channel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OneHot expands the CHANNEL axis and keeps the spatial one: the grid is spatial, so it is allowed."""
+    monkeypatch.setenv("KONFAI_ROOT", "Trainer")
+    one_hot = OneHot(num_classes=4)
+    labels = torch.zeros((1, 4, 5, 6), dtype=torch.int64)
+    assert list(one_hot("CASE_000", labels, Attribute()).shape) == [4, 4, 5, 6]  # 1 channel -> 4
+
+    _check_patch_transform_shape(one_hot, "CT", "CT")
+
+
+def test_group_transform_prepare_guards_the_shape_of_every_patch_transform(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The guard runs at config time, from prepare() -- not only when someone calls it directly."""
+    monkeypatch.setenv("KONFAI_ROOT", "Trainer")
+    monkeypatch.setattr(TransformLoader, "get_transform", lambda *_, **__: _ShapeChangingPointwise())
+    group = GroupTransform(transforms=None, patch_transforms={"_ShapeChangingPointwise": TransformLoader()})
+
+    with pytest.raises(ConfigError):
+        group.prepare("CT", "CT")
+
+
+@pytest.mark.parametrize("state", [State.TRAIN, State.RESUME])
+def test_per_patch_global_stat_is_allowed_when_training(monkeypatch: pytest.MonkeyPatch, state: State) -> None:
+    """Per-patch statistics are a valid, deliberate training use: no forward inverse runs to break."""
+    monkeypatch.setenv("KONFAI_ROOT", "Trainer")
+    monkeypatch.setenv("KONFAI_STATE", str(state))
+    _check_patch_transform_invertible(Standardize(), [], "CT", "CT")
+
+
+@pytest.mark.parametrize("transform", [Standardize(), Normalize()])
+def test_per_patch_global_stat_is_refused_at_prediction(monkeypatch: pytest.MonkeyPatch, transform: Transform) -> None:
+    """At prediction the finalize inverse pops a statistic the per-patch scope never left case-level."""
+    monkeypatch.setenv("KONFAI_ROOT", "Predictor")
+    monkeypatch.setenv("KONFAI_STATE", str(State.PREDICTION))
+
+    with pytest.raises(ConfigError) as excinfo:
+        _check_patch_transform_invertible(transform, [], "CT", "CT")
+
+    message = str(excinfo.value)
+    assert type(transform).__name__ in message
+    assert "Predictor.Dataset.groups_src.CT.groups_dest.CT.patch_transforms" in message
+    assert "lazy=True" in message
+
+
+def test_case_level_lazy_capture_makes_the_patch_statistic_invertible(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Standardize(lazy=True) in transforms caches Mean/Std case-level, so the patch consumer inverts."""
+    monkeypatch.setenv("KONFAI_ROOT", "Predictor")
+    monkeypatch.setenv("KONFAI_STATE", str(State.PREDICTION))
+    _check_patch_transform_invertible(Standardize(), [Standardize(lazy=True)], "CT", "CT")
+
+
+def test_per_patch_global_stat_without_inverse_is_allowed_at_prediction(monkeypatch: pytest.MonkeyPatch) -> None:
+    """inverse=False never pops the statistic, so there is nothing to reconstruct and nothing to refuse."""
+    monkeypatch.setenv("KONFAI_ROOT", "Predictor")
+    monkeypatch.setenv("KONFAI_STATE", str(State.PREDICTION))
+    _check_patch_transform_invertible(Standardize(inverse=False), [], "CT", "CT")

--- a/tests/unit/test_memory_budget.py
+++ b/tests/unit/test_memory_budget.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the B1 memory-budget chooser: it derives ``use_cache`` from a declared RAM budget,
+estimates the dataset size from headers alone, and -- for ``"auto"`` -- reads the cgroup limit rather
+than the host so a container/SLURM job is not OOM-killed."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from konfai.data import data_manager
+from konfai.data.data_manager import (
+    _AUTO_MEMORY_SAFETY_FRACTION,
+    DataPrediction,
+    DataTrain,
+    _parse_memory_budget_bytes,
+)
+from konfai.utils import runtime
+from konfai.utils.errors import ConfigError
+
+# --------------------------------------------------------------------------------------
+# Budget parsing -- a bare number is GiB, a string carries its own unit
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (24, 24 * 2**30),  # bare number => GiB
+        (24.0, 24 * 2**30),
+        ("24GB", 24 * 10**9),  # decimal
+        ("32GiB", 32 * 2**30),  # binary
+        ("512mb", 512 * 10**6),  # case-insensitive
+        ("32 GiB", 32 * 2**30),  # optional space
+        ("4096b", 4096),  # explicit bytes
+        ("24", 24 * 2**30),  # unitless string (YAML face of a bare number) is GiB
+    ],
+)
+def test_parse_memory_budget_bytes(value: str | float, expected: int) -> None:
+    assert _parse_memory_budget_bytes(value) == expected
+
+
+@pytest.mark.parametrize("value", ["twelve", "24 gigabytes", "GB", ""])
+def test_parse_memory_budget_bytes_rejects_garbage(value: str) -> None:
+    with pytest.raises(ConfigError):
+        _parse_memory_budget_bytes(value)
+
+
+# --------------------------------------------------------------------------------------
+# THE CGROUP TRAP -- "auto" must see the cgroup ceiling, not the host's RAM
+# --------------------------------------------------------------------------------------
+
+
+def _point_cgroup_at(monkeypatch: pytest.MonkeyPatch, *, v2: Path | None, v1: Path | None) -> None:
+    monkeypatch.setattr(runtime, "_CGROUP_V2_MEMORY_MAX", str(v2) if v2 else "/nonexistent/memory.max")
+    monkeypatch.setattr(runtime, "_CGROUP_V1_MEMORY_LIMIT", str(v1) if v1 else "/nonexistent/limit_in_bytes")
+
+
+def _fake_host_available(monkeypatch: pytest.MonkeyPatch, num_bytes: int) -> None:
+    monkeypatch.setattr(runtime.psutil, "virtual_memory", lambda: SimpleNamespace(available=num_bytes))
+
+
+def test_auto_respects_cgroup_limit_not_host(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # The headline: cgroup grants 8 GB while psutil sees a 512 GB host.
+    limit = tmp_path / "memory.max"
+    limit.write_text("8000000000")
+    _point_cgroup_at(monkeypatch, v2=limit, v1=None)
+    _fake_host_available(monkeypatch, 512 * 2**30)
+
+    assert runtime.available_memory_bytes() == (8_000_000_000, "cgroup limit")
+
+
+def test_cgroup_v2_max_falls_back_to_host(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    unlimited = tmp_path / "memory.max"
+    unlimited.write_text("max\n")
+    _point_cgroup_at(monkeypatch, v2=unlimited, v1=None)
+    _fake_host_available(monkeypatch, 64 * 2**30)
+
+    assert runtime.available_memory_bytes() == (64 * 2**30, "host available RAM")
+
+
+def test_cgroup_v1_limit_is_read_when_v2_absent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    v1 = tmp_path / "memory.limit_in_bytes"
+    v1.write_text("8000000000\n")
+    _point_cgroup_at(monkeypatch, v2=None, v1=v1)
+    _fake_host_available(monkeypatch, 512 * 2**30)
+
+    assert runtime.available_memory_bytes() == (8_000_000_000, "cgroup limit")
+
+
+def test_cgroup_v1_sentinel_reads_as_unlimited(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    v1 = tmp_path / "memory.limit_in_bytes"
+    v1.write_text(str(2**63))  # the near-INT64_MAX "no limit" sentinel
+    _point_cgroup_at(monkeypatch, v2=None, v1=v1)
+    _fake_host_available(monkeypatch, 64 * 2**30)
+
+    assert runtime.available_memory_bytes() == (64 * 2**30, "host available RAM")
+
+
+def test_no_cgroup_falls_back_to_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    _point_cgroup_at(monkeypatch, v2=None, v1=None)
+    _fake_host_available(monkeypatch, 42 * 2**30)
+
+    assert runtime.available_memory_bytes() == (42 * 2**30, "host available RAM")
+
+
+# --------------------------------------------------------------------------------------
+# The chooser -- derive use_cache from the budget vs the estimated dataset size
+# --------------------------------------------------------------------------------------
+
+# Two source groups, four cases each, a [1, 8, 8, 8] volume per case:
+#   8 volumes x 512 elements x 4 bytes = 16384 bytes.
+_GROUP_SHAPE = [1, 8, 8, 8]
+_CASES = ["case_a", "case_b", "case_c", "case_d"]
+_DATASET_BYTES = 2 * len(_CASES) * 512 * data_manager._CACHE_ELEMENT_BYTES
+
+
+def _make_train(memory_budget: str | float | None) -> DataTrain:
+    """A DataTrain with an injected, header-free prepared dataset (no disk, no config file)."""
+    data = DataTrain(augmentations=None, memory_budget=memory_budget)
+    managers = {group: [SimpleNamespace(base_shape=list(_GROUP_SHAPE)) for _ in _CASES] for group in ("CT", "SEG")}
+    data._prepared_data = managers  # type: ignore[assignment]
+    data._prepared_validation_data = {}
+    data._prepared_train_names = list(_CASES)
+    data._prepared_validation_names = []
+    return data
+
+
+def test_estimate_matches_known_fixture() -> None:
+    assert _make_train(None)._estimate_cached_bytes() == _DATASET_BYTES
+
+
+def test_budget_larger_than_dataset_caches() -> None:
+    data = _make_train(f"{_DATASET_BYTES + 1}b")
+    data._resolve_cache_regime(world_size=1)
+    assert data.use_cache is True
+    assert data.resolved_num_workers == 0  # caching preloads up front, so no loader workers
+
+
+def test_budget_smaller_than_dataset_does_not_cache() -> None:
+    data = _make_train(f"{_DATASET_BYTES - 1}b")
+    data._resolve_cache_regime(world_size=1)
+    assert data.use_cache is False
+    assert data.resolved_num_workers > 0  # the streaming/buffer path spins workers up
+
+
+def test_none_budget_leaves_declared_use_cache_untouched() -> None:
+    train = _make_train(None)
+    train.use_cache = True
+    train._resolve_cache_regime(world_size=1)
+    assert train.use_cache is True  # compat default: the declared regime is honoured verbatim
+
+    prediction = DataPrediction(augmentations=None)  # use_cache hardwired False, memory_budget None
+    prediction._prepared_data = {"CT": [SimpleNamespace(base_shape=[1, 2, 2, 2])]}  # type: ignore[assignment]
+    prediction._prepared_validation_data = {}
+    prediction._prepared_train_names = ["case_a"]
+    prediction._prepared_validation_names = []
+    prediction._resolve_cache_regime(world_size=1)
+    assert prediction.use_cache is False
+
+
+def test_budget_is_per_rank_so_world_size_flips_the_decision() -> None:
+    # A budget of half the dataset: it never fits on one rank, but does once sharded across four.
+    half = f"{_DATASET_BYTES // 2}b"
+
+    single = _make_train(half)
+    single._resolve_cache_regime(world_size=1)
+    assert single.use_cache is False
+
+    sharded = _make_train(half)
+    sharded._resolve_cache_regime(world_size=4)
+    assert sharded.use_cache is True
+
+
+def test_auto_budget_uses_detected_memory(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_available() -> tuple[int, str]:
+        return budget_source
+
+    monkeypatch.setattr(data_manager, "available_memory_bytes", fake_available)
+
+    # A cgroup so small that 80% of it cannot hold the dataset -> do not cache.
+    budget_source = (int(_DATASET_BYTES / _AUTO_MEMORY_SAFETY_FRACTION) - 1, "cgroup limit")
+    tight = _make_train("auto")
+    tight._resolve_cache_regime(world_size=1)
+    assert tight.use_cache is False
+
+    # A roomy node -> cache.
+    budget_source = (_DATASET_BYTES * 10, "host available RAM")
+    roomy = _make_train("auto")
+    roomy._resolve_cache_regime(world_size=1)
+    assert roomy.use_cache is True

--- a/tests/unit/test_memory_budget.py
+++ b/tests/unit/test_memory_budget.py
@@ -23,6 +23,7 @@ from types import SimpleNamespace
 
 import pytest
 from konfai.data import data_manager
+from konfai.data.augmentation import DataAugmentationsList
 from konfai.data.data_manager import (
     _AUTO_MEMORY_SAFETY_FRACTION,
     DataPrediction,
@@ -142,6 +143,27 @@ def _make_train(memory_budget: str | float | None) -> DataTrain:
 
 def test_estimate_matches_known_fixture() -> None:
     assert _make_train(None)._estimate_cached_bytes() == _DATASET_BYTES
+
+
+def test_estimate_counts_one_copy_per_augmentation_draw() -> None:
+    """A cached case holds its base tensor plus one per draw, so the estimate must multiply by them.
+
+    Counting the base tensor alone under-reports the cache by the augmentation count -- the budget
+    then picks CACHE for a dataset several times too big for it and the run is OOM-killed anyway.
+    """
+    data = DataTrain(
+        augmentations={"Aug_0": DataAugmentationsList(nb=4, data_augmentations={})},
+        memory_budget=None,
+        validation=None,
+    )
+    managers = {group: [SimpleNamespace(base_shape=list(_GROUP_SHAPE)) for _ in _CASES] for group in ("CT", "SEG")}
+    data._prepared_data = managers  # type: ignore[assignment]
+    data._prepared_validation_data = {}
+    data._prepared_train_names = list(_CASES)
+    data._prepared_validation_names = []
+
+    # 1 base copy + 4 draws.
+    assert data._estimate_cached_bytes() == 5 * _DATASET_BYTES
 
 
 def test_budget_larger_than_dataset_caches() -> None:

--- a/tests/unit/test_streaming_regressions.py
+++ b/tests/unit/test_streaming_regressions.py
@@ -1,0 +1,202 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Streamed-path regressions: each test encodes one reviewed failure and must keep failing loudly.
+
+Every scenario here was reproduced on the branch before the fix it pins down:
+- a GLOBAL_STAT after a value-preserving cast must still stream (parity with the released behaviour);
+- an augmented copy must consume the volume statistic, not each patch's own;
+- replanning after an epoch's re-draw must read the stored geometry, not the previous epoch's output;
+- two groups of one case must share one augmentation draw at construction;
+- the streamed resample must match the whole-volume one in 2D and for nearest at any size ratio.
+"""
+
+from typing import cast
+
+import numpy as np
+import pytest
+import torch
+from konfai.data.augmentation import DataAugmentationsList
+from konfai.data.augmentation import Flip as FlipAugmentation
+from konfai.data.augmentation import Rotate as RotateAugmentation
+from konfai.data.patching import DatasetManager, DatasetPatch
+from konfai.data.transform import Canonical, Normalize, ResampleToShape, TensorCast
+from konfai.utils.dataset import Attribute, Dataset
+
+
+class StreamingDatasetStub:
+    """In-memory dataset serving whole reads, region reads, and statistics, with full geometry."""
+
+    def __init__(self, volume: np.ndarray) -> None:
+        self.volume = volume
+        self.full_reads = 0
+        self.patch_reads = 0
+
+    def _attributes(self) -> Attribute:
+        attribute = Attribute()
+        spatial = self.volume.ndim - 1
+        attribute["Origin"] = np.zeros(spatial)
+        attribute["Spacing"] = np.ones(spatial)
+        attribute["Direction"] = np.eye(spatial).flatten()
+        return attribute
+
+    def get_infos(self, group_src: str, name: str) -> tuple[list[int], Attribute]:
+        return list(self.volume.shape), self._attributes()
+
+    def read_data(self, group_src: str, name: str) -> tuple[np.ndarray, Attribute]:
+        self.full_reads += 1
+        return self.volume.copy(), self._attributes()
+
+    def read_data_slice(self, group_src: str, name: str, slices: tuple[slice, ...]) -> tuple[np.ndarray, Attribute]:
+        self.patch_reads += 1
+        return self.volume[slices].copy(), self._attributes()
+
+    def read_data_statistics(self, group_src: str, name: str, channels: list[int] | None = None) -> dict[str, float]:
+        data = self.volume if channels is None else self.volume[channels]
+        return {
+            "min": float(data.min()),
+            "max": float(data.max()),
+            "mean": float(data.mean()),
+            "std": float(data.std(ddof=1)),
+        }
+
+
+_GeometryDatasetStub = StreamingDatasetStub
+
+
+def _manager(stub: StreamingDatasetStub, transforms, augmentations=(), patch=(4, 4, 4), group="CT") -> DatasetManager:
+    return DatasetManager(
+        index=0,
+        group_src=group,
+        group_dest=group,
+        name="CASE_000",
+        dataset=cast(Dataset, stub),
+        patch=DatasetPatch(list(patch)),
+        transforms=list(transforms),
+        data_augmentations_list=list(augmentations),
+    )
+
+
+def _flip_augmentations() -> list[DataAugmentationsList]:
+    augmentations = DataAugmentationsList(nb=1, data_augmentations={})
+    flip = FlipAugmentation(f_prob=[1.0, 1.0, 1.0])
+    flip.load(1.0)
+    augmentations.data_augmentations = [flip]
+    return [augmentations]
+
+
+def test_global_stat_after_float_cast_still_streams_and_matches() -> None:
+    """[TensorCast -> float, Normalize] streams (released behaviour) and equals the whole-volume path."""
+    volume = np.arange(1 * 8 * 8 * 8, dtype=np.uint8).reshape(1, 8, 8, 8)
+    transforms = [TensorCast("float32"), Normalize()]
+    streamed = _manager(StreamingDatasetStub(volume), transforms)
+    reference = _manager(StreamingDatasetStub(volume), transforms)
+    reference.load(transforms, [])
+
+    assert streamed.can_stream_patch(0)
+    for index in range(streamed.get_size(0)):
+        got = streamed.get_data(index, 0, [], True)
+        expected = reference.get_data(index, 0, [], True)
+        torch.testing.assert_close(got, expected, rtol=0, atol=0)
+
+
+def test_augmented_copy_consumes_the_volume_statistic() -> None:
+    """Copy a=1, requested before copy 0 ever streams, still normalizes by the VOLUME's Min/Max."""
+    torch.manual_seed(0)
+    volume = np.arange(1 * 8 * 8 * 8, dtype=np.float32).reshape(1, 8, 8, 8)
+    streamed = _manager(StreamingDatasetStub(volume), [Normalize()], _flip_augmentations())
+    reference = _manager(StreamingDatasetStub(volume), [Normalize()], streamed.data_augmentations_list)
+    reference.load([Normalize()], reference.data_augmentations_list)
+
+    assert streamed.can_stream_patch(1)
+    for index in range(streamed.get_size(1)):
+        got = streamed.get_data(index, 1, [], True)
+        expected = reference.get_data(index, 1, [], True)
+        torch.testing.assert_close(got, expected, rtol=0, atol=1e-6)
+
+
+@pytest.mark.parametrize("transform_case", ["resample", "canonical"])
+def test_replanning_after_epoch_redraw_keeps_the_stored_geometry(transform_case: str) -> None:
+    """Epoch 2 must stream the same bytes as epoch 1, with no attribute stack growth.
+
+    Replanning used to read the live case attribute -- already carrying epoch 1's target
+    Spacing/Direction -- so a streamed Resample degraded to identity and a streamed Canonical stopped
+    reorienting from the second epoch on, while the geometry keys stacked once more per epoch.
+    """
+    volume = np.arange(1 * 8 * 8 * 8, dtype=np.float32).reshape(1, 8, 8, 8)
+    transform = ResampleToShape(shape=[16, 16, 16]) if transform_case == "resample" else Canonical()
+    streamed = _manager(_GeometryDatasetStub(volume), [transform], _flip_augmentations())
+
+    assert streamed.can_stream_patch(0)
+    first_epoch = [streamed.get_data(index, 0, [], True) for index in range(streamed.get_size(0))]
+    keys_after_first = list(streamed.cache_attributes[0].keys())
+
+    streamed.reset_augmentation(reset_state=False)
+    assert streamed.can_stream_patch(0)
+    second_epoch = [streamed.get_data(index, 0, [], True) for index in range(streamed.get_size(0))]
+    keys_after_second = list(streamed.cache_attributes[0].keys())
+
+    for got, expected in zip(second_epoch, first_epoch, strict=True):
+        torch.testing.assert_close(got, expected, rtol=0, atol=0)
+    assert keys_after_second == keys_after_first
+
+
+def test_two_groups_share_one_construction_draw() -> None:
+    """Building the label group's manager must reuse the image group's draw, not redraw over it.
+
+    A quarter Rotate transposes per-copy extents, so a per-group redraw leaves the two groups with
+    different copy grids -- crashing the streamed read of the stale grid's last patch.
+    """
+    volume = np.zeros((1, 6, 8, 10), dtype=np.float32)
+    for seed in range(10):
+        torch.manual_seed(seed)
+        augmentations = DataAugmentationsList(nb=2, data_augmentations={})
+        rotate = RotateAugmentation(is_quarter=True)
+        rotate.load(1.0)
+        augmentations.data_augmentations = [rotate]
+        image_manager = _manager(StreamingDatasetStub(volume), [], [augmentations], group="CT")
+        label_manager = _manager(StreamingDatasetStub(volume), [], [augmentations], group="SEG")
+        assert image_manager.shapes == label_manager.shapes, f"seed {seed}"
+
+
+@pytest.mark.parametrize(("n_in", "n_out"), [(5, 3), (7, 3), (10, 7), (3, 7), (4, 6), (8, 8)])
+def test_streamed_nearest_resample_matches_whole_volume_at_any_ratio(n_in: int, n_out: int) -> None:
+    """The streamed nearest gather must pick the same source voxel as F.interpolate, per axis."""
+    volume = (torch.arange(n_in**3, dtype=torch.int32) % 251).to(torch.uint8).reshape(1, n_in, n_in, n_in)
+    resample = ResampleToShape(shape=[n_out, n_out, n_out], inverse=False)
+    attribute = Attribute()
+    attribute["Spacing"] = np.ones(3)
+    expected = resample("case", volume.clone(), Attribute(attribute))
+
+    target = tuple(slice(0, n_out) for _ in range(3))
+    slices, starts, scales, n_in_list, _ = resample.resample_source_region(target, [n_in] * 3, Attribute(attribute))
+    got = resample.resample_region(volume[(slice(None), *slices)], target, starts, scales, n_in_list)
+    torch.testing.assert_close(got, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.uint8])
+def test_streamed_resample_handles_2d(dtype: torch.dtype) -> None:
+    """resample_region must not assume three spatial axes."""
+    volume = (torch.arange(1 * 9 * 11, dtype=torch.float32).reshape(1, 9, 11) % 17).to(dtype)
+    resample = ResampleToShape(shape=[5, 6], inverse=False)
+    attribute = Attribute()
+    attribute["Spacing"] = np.ones(2)
+    expected = resample("case", volume.clone(), Attribute(attribute))
+
+    target = (slice(0, 5), slice(0, 6))
+    slices, starts, scales, n_in_list, _ = resample.resample_source_region(target, [9, 11], Attribute(attribute))
+    got = resample.resample_region(volume[(slice(None), *slices)], target, starts, scales, n_in_list)
+    torch.testing.assert_close(got, expected, rtol=0, atol=1e-5)

--- a/tests/unit/test_streaming_regressions.py
+++ b/tests/unit/test_streaming_regressions.py
@@ -220,7 +220,10 @@ class _RecordsOnlyInCall(Transform):
     def stream_region_source(
         self, target_slices: tuple[slice, ...], source_spatial_shape: list[int], cache_attribute: Attribute
     ) -> list[slice]:
-        return [slice(extent - t.stop, extent - t.start) for t, extent in zip(target_slices, source_spatial_shape)]
+        return [
+            slice(extent - t.stop, extent - t.start)
+            for t, extent in zip(target_slices, source_spatial_shape, strict=False)
+        ]
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         # Mirroring moves the near corner, and this is the only place it says so.

--- a/tests/unit/test_streaming_regressions.py
+++ b/tests/unit/test_streaming_regressions.py
@@ -33,8 +33,17 @@ from konfai.data.augmentation import DataAugmentationsList
 from konfai.data.augmentation import Flip as FlipAugmentation
 from konfai.data.augmentation import Rotate as RotateAugmentation
 from konfai.data.patching import DatasetManager, DatasetPatch
-from konfai.data.transform import Canonical, Normalize, ResampleToShape, TensorCast
+from konfai.data.transform import (
+    Canonical,
+    LocalityKind,
+    Normalize,
+    PatchLocality,
+    ResampleToShape,
+    TensorCast,
+    Transform,
+)
 from konfai.utils.dataset import Attribute, Dataset
+from konfai.utils.errors import PatchError
 
 
 class StreamingDatasetStub:
@@ -200,3 +209,30 @@ def test_streamed_resample_handles_2d(dtype: torch.dtype) -> None:
     slices, starts, scales, n_in_list, _ = resample.resample_source_region(target, [9, 11], Attribute(attribute))
     got = resample.resample_region(volume[(slice(None), *slices)], target, starts, scales, n_in_list)
     torch.testing.assert_close(got, expected, rtol=0, atol=1e-5)
+
+
+class _RecordsOnlyInCall(Transform):
+    """A region transform recording geometry where a streamed patch throws it away."""
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        return PatchLocality(LocalityKind.ORIENTATION)
+
+    def stream_region_source(
+        self, target_slices: tuple[slice, ...], source_spatial_shape: list[int], cache_attribute: Attribute
+    ) -> list[slice]:
+        return [slice(extent - t.stop, extent - t.start) for t, extent in zip(target_slices, source_spatial_shape)]
+
+    def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
+        # Mirroring moves the near corner, and this is the only place it says so.
+        cache_attribute["Origin"] = np.asarray([0.0, 0.0, 7.0])
+        return tensor.flip(tuple(range(1, tensor.dim())))
+
+
+def test_a_region_stage_recording_geometry_nowhere_the_case_reads_is_refused() -> None:
+    # A declaration this framework cannot honour must fail where it is made, not persist the geometry
+    # of the volume as stored and call the run correct.
+    stub = StreamingDatasetStub(np.arange(1 * 8 * 8 * 8, dtype=np.float32).reshape(1, 8, 8, 8))
+    manager = _manager(stub, [_RecordsOnlyInCall()])
+    with pytest.raises(PatchError) as error:
+        manager.get_data(0, 0, [], True)
+    assert "write_stream_cache_attribute" in str(error.value)

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -28,17 +28,20 @@ import torch.nn.functional as F
 from konfai.data.transform import (
     DEFAULT_INFERENCE_MODEL_NAME,
     DEFAULT_INFERENCE_REPO_ID,
+    Canonical,
     Clip,
     Crop,
     Dilate,
     InferenceStack,
     KonfAIInference,
+    LocalityKind,
     Norm,
     Normalize,
     OneHot,
     Padding,
     ResampleToResolution,
     ResampleToShape,
+    Squeeze,
     StandardDeviation,
     Standardize,
     Statistics,
@@ -187,6 +190,29 @@ def test_norm_reduces_trailing_component_axis_and_geometry() -> None:
 
 def test_norm_transform_shape_drops_trailing_axis() -> None:
     assert Norm().transform_shape("group", "case", [4, 5, 6, 3], Attribute()) == [4, 5, 6]
+
+
+# --------------------------------------------------------------------------------------
+# Squeeze — transform_shape must track which axis squeeze() drops, so the patch grid folds it
+# --------------------------------------------------------------------------------------
+
+
+def test_squeeze_channel_axis_leaves_spatial_shape_untouched() -> None:
+    # ``shape`` is the channel-stripped spatial shape, so the runtime tensor is [C, 4, 5, 6] and
+    # dim 0 squeezes the channel: the spatial grid the patches tile is unchanged.
+    assert Squeeze(0).transform_shape("group", "case", [4, 5, 6], Attribute()) == [4, 5, 6]
+
+
+def test_squeeze_singleton_spatial_axis_is_dropped_from_the_grid() -> None:
+    # Runtime tensor [C, 1, 5, 6]; dim 1 is the leading spatial axis (size 1), which squeeze() removes.
+    assert Squeeze(1).transform_shape("group", "case", [1, 5, 6], Attribute()) == [5, 6]
+    # A negative dim indexes from the back: -1 is the trailing spatial axis.
+    assert Squeeze(-1).transform_shape("group", "case", [4, 5, 1], Attribute()) == [4, 5]
+
+
+def test_squeeze_non_singleton_axis_is_a_no_op() -> None:
+    # squeeze() leaves a size>1 axis in place, so the grid must not drop it either.
+    assert Squeeze(1).transform_shape("group", "case", [4, 5, 6], Attribute()) == [4, 5, 6]
 
 
 # --------------------------------------------------------------------------------------
@@ -479,3 +505,211 @@ def test_clip_percentile_bounds_accept_a_cuda_resident_volume() -> None:
     assert out.device.type == "cuda"
     assert float(out.min()) == pytest.approx(9.9, abs=0.1)
     assert float(out.max()) == pytest.approx(89.1, abs=0.1)
+
+
+# --------------------------------------------------------------------------------------
+# Canonical. A reorientation between orthogonal direction cosines is a bijection on the
+# voxels, so the property to hold it to is not closeness but exactness.
+# --------------------------------------------------------------------------------------
+
+# Deliberately non-cubic on every axis: a cube hides an axis swap, and equal extents make a
+# wrong permutation look right.
+_CANONICAL_SPATIAL = (9, 10, 11)
+
+# LPS is what Canonical reorients ONTO, so it is the one direction that asks for no flip at all.
+_LPS = np.diag([-1.0, -1.0, 1.0])
+_RAS = np.eye(3)
+# Orthogonal, and neither the identity nor a mirroring: it swaps physical x and z.
+_PERMUTING = np.asarray([[0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]])
+_OBLIQUE = np.asarray(
+    [
+        [np.cos(np.deg2rad(20.0)), -np.sin(np.deg2rad(20.0)), 0.0],
+        [np.sin(np.deg2rad(20.0)), np.cos(np.deg2rad(20.0)), 0.0],
+        [0.0, 0.0, 1.0],
+    ]
+)
+# A direction is orthonormal by definition, not by construction. None of these is, so none of them
+# is a bijection on the voxels -- and each wears one half of a signed permutation's disguise.
+# Mixes two axes at unit weight: the column sums to 1 exactly as a permutation's does, and only its
+# flattened peak refuses it.
+_SHEARING = _LPS @ np.linalg.inv(np.asarray([[0.5, 0.0, 0.0], [0.5, 1.0, 0.0], [0.0, 0.0, 1.0]]))
+# Averages all three axes into each output. Its ROWS sum to unit weight too, so every sum a
+# permutation's matrix satisfies, this one satisfies: again only the peak is not there.
+_AVERAGING = _LPS @ np.linalg.inv(np.asarray([[0.5, 0.25, 0.25], [0.25, 0.5, 0.25], [0.25, 0.25, 0.5]]))
+# Reads a whole axis and a fraction of another on top: the peak IS a permutation's, and only the
+# weight the column carries besides it refuses it.
+_SUPERPOSING = _LPS @ np.linalg.inv(np.asarray([[1.0, 0.0, 0.0], [0.5, 1.0, 0.0], [0.0, 0.0, 1.0]]))
+
+
+def _canonical_attributes(direction: np.ndarray) -> Attribute:
+    # Deliberately anisotropic on every axis, for the reason the extents are non-cubic: a spacing an
+    # axis shares with another is a spacing a wrong permutation can carry onto it and look right.
+    attributes = Attribute()
+    attributes["Origin"] = np.asarray([-3.0, 5.0, 11.0])
+    attributes["Spacing"] = np.asarray([1.5, 1.75, 2.0])
+    attributes["Direction"] = direction.reshape(-1)
+    return attributes
+
+
+def _ct_like_volume() -> torch.Tensor:
+    # Distinct values everywhere: a repeated value could survive a wrong remap by coincidence, and
+    # the multiset check below is only as strict as the volume is varied.
+    rng = np.random.default_rng(0)
+    return torch.from_numpy(rng.standard_normal(_CANONICAL_SPATIAL).astype(np.float32) * 500.0)[None]
+
+
+@pytest.mark.parametrize(
+    "direction, expected",
+    [
+        # LPS is what Canonical reorients ONTO: the one direction that asks for nothing at all.
+        (_LPS, lambda volume: volume),
+        # RAS mirrors physical x and y, and physical axis k is array axis dim - 1 - k: array axes 3 and 2.
+        (_RAS, lambda volume: volume.flip((3, 2))),
+        # Swapping physical x and z transposes the array axes carrying them (3 and 1), and mirrors the
+        # two axes the canonical direction is negative on.
+        (_PERMUTING, lambda volume: volume.permute(0, 3, 2, 1).flip((2, 3))),
+    ],
+    ids=["LPS", "RAS", "permuting"],
+)
+def test_canonical_is_the_exact_index_remap_bit_for_bit(direction: np.ndarray, expected) -> None:
+    volume = _ct_like_volume()
+
+    out = Canonical()("case", volume, _canonical_attributes(direction))
+
+    assert torch.equal(out, expected(volume)), "an orthogonal reorientation must be the remap, not near it"
+
+
+@pytest.mark.parametrize("direction", [_RAS, _LPS, _PERMUTING], ids=["RAS", "LPS", "permuting"])
+def test_canonical_is_a_bijection_on_the_voxels(direction: np.ndarray) -> None:
+    # The whole claim, stated as strongly as it can be: reorienting only moves values, so the sorted
+    # multiset of them is bit-for-bit the input's. This is what LocalityKind.preserves_statistics lets a
+    # later GLOBAL_STAT trust, and it is strictly stronger than comparing statistics -- a sampled
+    # reorientation can leave a statistic looking right while having moved the values under it.
+    volume = _ct_like_volume()
+
+    out = Canonical()("case", volume, _canonical_attributes(direction))
+
+    assert torch.equal(torch.sort(out.flatten())[0], torch.sort(volume.flatten())[0])
+    # Reductions that do not depend on the order the voxels are visited in follow bit for bit.
+    assert torch.min(out) == torch.min(volume)
+    assert torch.max(out) == torch.max(volume)
+    assert torch.std(out) == torch.std(volume)
+    # A mean does depend on it: float addition is not associative, so summing the SAME multiset along a
+    # mirrored axis can land an ulp from summing it along the original one. That is the reduction's
+    # traversal, not the remap -- reduced in one order, or in a width the order cannot reach, it is 0.
+    assert torch.mean(out.double()) == torch.mean(volume.double())
+
+
+@pytest.mark.parametrize("direction", [_RAS, _LPS, _PERMUTING], ids=["RAS", "LPS", "permuting"])
+def test_canonical_round_trips_exactly(direction: np.ndarray) -> None:
+    # inverse() undoes a remap with a remap: an exact forward paired with a sampled inverse would put
+    # the interpolation error back at prediction time, where the inverse is what the user is handed.
+    # It restores the source EXTENT as well as the values -- a permutation transposed it on the way out.
+    volume = _ct_like_volume()
+    attributes = _canonical_attributes(direction)
+    transform = Canonical()
+
+    restored = transform.inverse("case", transform("case", volume, attributes), attributes)
+
+    assert restored.shape == volume.shape
+    assert torch.equal(restored, volume)
+    # And the geometry it popped is the source's, so a chain's stack comes back to the depth it started.
+    np.testing.assert_allclose(attributes.get_np_array("Origin"), [-3.0, 5.0, 11.0])
+    np.testing.assert_allclose(attributes.get_np_array("Spacing"), [1.5, 1.75, 2.0])
+    np.testing.assert_allclose(attributes.get_np_array("Direction"), direction.reshape(-1))
+
+
+def test_canonical_records_the_canonical_geometry_from_the_volume_extent() -> None:
+    # The new origin is the corner the reorientation mirrors onto, so it is the far end of the extent
+    # on each mirrored axis and untouched on the others. A mirroring moves no axis, so the spacing stays.
+    attributes = _canonical_attributes(_RAS)
+
+    Canonical()("case", _ct_like_volume(), attributes)
+
+    np.testing.assert_allclose(attributes.get_np_array("Direction"), np.diag([-1.0, -1.0, 1.0]).reshape(-1))
+    np.testing.assert_allclose(attributes.get_np_array("Spacing"), [1.5, 1.75, 2.0])
+    # Origin (x, y, z) = (-3, 5, 11); spacing (1.5, 1.75, 2.0); extents (x, y, z) = (11, 10, 9).
+    np.testing.assert_allclose(
+        attributes.get_np_array("Origin"),
+        [-3.0 + (11 - 1) * 1.5, 5.0 + (10 - 1) * 1.75, 11.0],
+    )
+
+
+def test_canonical_permuting_records_the_grid_the_remap_lands_on() -> None:
+    # An extent and a spacing travel with the axis they belong to, so swapping physical x and z carries
+    # the z spacing onto x. What the reorientation preserves is the physical extent -- the volume's
+    # centre is fixed -- so the origin is that centre stepped back by the TARGET half-extent.
+    attributes = _canonical_attributes(_PERMUTING)
+
+    Canonical()("case", _ct_like_volume(), attributes)
+
+    np.testing.assert_allclose(attributes.get_np_array("Direction"), np.diag([-1.0, -1.0, 1.0]).reshape(-1))
+    # Spacing (x, y, z) = (1.5, 1.75, 2.0) with x and z swapped.
+    np.testing.assert_allclose(attributes.get_np_array("Spacing"), [2.0, 1.75, 1.5])
+    # Centre = D @ half_extent_in + origin = (8, 7.875, 7.5) + (-3, 5, 11) = (5, 12.875, 18.5); target
+    # half-extent = (8, 7.875, 7.5); LPS steps back negatively on x and y, positively on z.
+    np.testing.assert_allclose(attributes.get_np_array("Origin"), [13.0, 20.75, 11.0])
+
+
+@pytest.mark.parametrize(
+    "direction, expected",
+    [
+        (_LPS, list(_CANONICAL_SPATIAL)),
+        (_RAS, list(_CANONICAL_SPATIAL)),
+        # Swapping physical x and z transposes the extents they carry: array (9, 10, 11) -> (11, 10, 9).
+        (_PERMUTING, [11, 10, 9]),
+        # An oblique direction is resampled onto the input's own grid, so it keeps its extent.
+        (_OBLIQUE, list(_CANONICAL_SPATIAL)),
+    ],
+    ids=["LPS", "RAS", "permuting", "oblique"],
+)
+def test_canonical_folds_the_patch_grid_onto_the_extent_it_produces(direction: np.ndarray, expected: list[int]) -> None:
+    # The patch grid is folded from transform_shape, so a permuting case's patches are cut on the grid
+    # this returns -- which is only the right grid if it is the extent __call__ actually produces.
+    transform = Canonical()
+    attributes = _canonical_attributes(direction)
+
+    folded = transform.transform_shape("Group", "case", list(_CANONICAL_SPATIAL), attributes)
+
+    assert folded == expected
+    assert list(transform("case", _ct_like_volume(), attributes).shape[1:]) == expected
+
+
+def test_canonical_shape_fold_leaves_the_case_metadata_alone() -> None:
+    # The attribute folded through transform_shape is the case's own, before a voxel has been read, and
+    # it is what the streamed chain is later seeded from: writing the target geometry here would hand
+    # every patch the reorientation's own result as the description of its input.
+    attributes = _canonical_attributes(_PERMUTING)
+    before = dict(attributes)
+
+    Canonical().transform_shape("Group", "case", list(_CANONICAL_SPATIAL), attributes)
+
+    assert dict(attributes) == before
+
+
+@pytest.mark.parametrize(
+    "direction, kind",
+    [
+        (_RAS, LocalityKind.ORIENTATION),
+        (_LPS, LocalityKind.ORIENTATION),
+        # Permuting is an exact remap too -- onto a grid of its own, which the patch grid is folded onto.
+        (_PERMUTING, LocalityKind.ORIENTATION),
+        # Genuinely mixes axes: no remap reproduces it, so it is resampled from the whole volume.
+        (_OBLIQUE, LocalityKind.WHOLE_VOLUME),
+        # Not orthonormal: no remap is a bijection on the voxels, whatever their columns attest.
+        (_SHEARING, LocalityKind.WHOLE_VOLUME),
+        (_AVERAGING, LocalityKind.WHOLE_VOLUME),
+        (_SUPERPOSING, LocalityKind.WHOLE_VOLUME),
+    ],
+    ids=["RAS", "LPS", "permuting", "oblique", "shearing", "averaging", "superposing"],
+)
+def test_canonical_declares_orientation_only_where_it_is_an_exact_index_remap(
+    direction: np.ndarray, kind: LocalityKind
+) -> None:
+    assert Canonical().patch_locality(_canonical_attributes(direction)).kind is kind
+
+
+def test_canonical_declaration_is_total_on_absent_metadata() -> None:
+    # The config-time checks probe with an empty Attribute, and a group carries only what its writer
+    # stored: a missing direction must fall to the safe kind rather than raise.
+    assert Canonical().patch_locality(Attribute()).kind is LocalityKind.WHOLE_VOLUME

--- a/tests/unit/test_transform_locality_contract.py
+++ b/tests/unit/test_transform_locality_contract.py
@@ -1,0 +1,607 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""A stage of a case's chain must behave as if it had seen the whole volume.
+
+Patch streaming is an optimisation, so it must be semantically invisible: a stage DECLARES how its
+output depends on its input (``patch_locality``) and the dispatcher reads only the source region that
+declaration allows. For every stage declaring a streamable kind, the streamed patch must therefore equal
+the whole-volume result cut on the same grid -- proven here for EVERY built-in transform AND every
+built-in augmentation, on a real on-disk dataset, over the full patch grid.
+
+Both are ENUMERATED from their module and selected by their own declaration, so a newly declared
+streamable stage is covered the day it lands. The case tables never decide coverage: they supply
+constructor arguments, and a fixture group, where a stage's defaults are not a meaningful streaming
+case, and -- for an augmentation, whose declaration is about a draw rather than a config -- the kind
+that draw must produce.
+
+The declaration is handed the case's metadata, so it is asked here exactly as the dispatcher asks it --
+per group, from what that group is stored with. The rules that argument comes with (read-only, total)
+are checked too, and a declaration that only the image can make is exercised end to end.
+"""
+
+import inspect
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+import torch
+from konfai.data import augmentation as augmentation_module
+from konfai.data import transform as transform_module
+from konfai.data.augmentation import DataAugmentation, DataAugmentationsList
+from konfai.data.augmentation import Flip as FlipAugmentation
+from konfai.data.patching import DatasetManager, DatasetPatch
+from konfai.data.transform import (
+    Argmax,
+    Canonical,
+    Clip,
+    Crop,
+    Dilate,
+    FlatLabel,
+    Flip,
+    Gradient,
+    HistogramMatching,
+    InferenceStack,
+    LocalityKind,
+    MergeLabels,
+    OneHot,
+    PatchLocality,
+    Percentage,
+    ResampleToResolution,
+    ResampleToShape,
+    ResampleTransform,
+    Save,
+    SegmentationDisagreement,
+    SelectLabel,
+    Softmax,
+    Squeeze,
+    StandardDeviation,
+    Sum,
+    Transform,
+    Variance,
+)
+from konfai.utils.dataset import Attribute, Dataset
+
+pytest.importorskip("SimpleITK")
+
+_CASE_NAME = "CASE_000"
+_SPATIAL = (9, 10, 11)
+_PATCH_SIZE = [4, 4, 4]
+_SPACING = [1.5, 1.5, 2.0]
+
+# No extent is a multiple of the patch size, so the last patch of every axis is a border patch the read
+# plan has to pad: the grid is 3x3x3 and 19 of its 27 patches touch a border.
+_PEAK = 450.0
+
+# Byte-identical is the norm: a streamable transform reads exactly the voxels the whole-volume pass
+# reads and does the same arithmetic on them. Two kinds legitimately round differently:
+#
+# - the seeded statistic: streaming seeds Mean/Std from `read_data_statistics` (a numpy pass over the
+#   stored volume) while the whole-volume path recomputes them with torch over the loaded tensor -- the
+#   same values summed in a different order, so a standardized (unit-scale) voxel may land a few
+#   float32 ulps away. Data-dependent: this fixture happens to agree exactly, a smooth field showed
+#   1.5e-8 (0.13 ulp), so the bound is stated rather than observed.
+_STAT_ATOL = 8 * float(np.finfo(np.float32).eps)
+# - the streamed resample (trilinear only): it gathers the same source samples, but computes the
+#   interpolation weights from coordinates expressed in the read sub-region's frame rather than the
+#   whole volume's. Both round to float32, so a weight lands ~ulp(coordinate) off and the interpolated
+#   voxel lands `neighbour gap * ulp(coordinate)` off -- the deviation scales with the local GRADIENT,
+#   not with the voxel's own magnitude. The fixture's gap is its 2*_PEAK bone/air step, which puts the
+#   bound at ulps of _PEAK; 64 of them is ~8x the measured max (2.3e-4, i.e. 7.5 ulp) and stays far
+#   below one part per million of the range. Nearest (uint8) uses no weights and stays exact.
+_RESCALE_ATOL = 64 * float(np.spacing(np.float32(_PEAK)))
+# An integer volume truncates the interpolation, so a sub-ulp disagreement that straddles an integer
+# boundary becomes a whole least-significant bit. 1 LSB is the tightest bound that can hold: the
+# alternative would be bit-exact agreement between two different float coordinate frames.
+_LSB_ATOL = 1.0
+
+
+@dataclass(frozen=True)
+class _Case:
+    """One representative configuration of a transform, and the fixture group it consumes."""
+
+    transform: Transform
+    group: str = "Intensity"
+    atol: float = 0.0
+
+
+# Only the transforms whose defaults are not a meaningful streaming case: a channel reduction needs a
+# multi-model input, a label op needs labels, and a required constructor argument has no default at all.
+_CASES: dict[str, list[_Case]] = {
+    "Argmax": [_Case(Argmax(0), group="Ensemble")],
+    # The defaults reorient the axis-aligned group, which is a mirroring. A PERMUTING direction is the
+    # other exact remap, and the only one that transposes extents: its patches are cut on a grid the
+    # source volume does not have, so its source region is a permuted slice tuple rather than the
+    # target's own. Both must stream, and a sagittal or coronal acquisition is the second.
+    "Canonical": [_Case(Canonical()), _Case(Canonical(), group="Permuting")],
+    "Clip": [
+        _Case(Clip(-200.0, 300.0)),  # fixed bounds: POINTWISE (the default range does not clip)
+        _Case(Clip("min", "max")),  # data-dependent bounds: GLOBAL_STAT
+    ],
+    # Only a case whose box is already stored is a translation; without one there is nothing to
+    # declare but the read that would find it.
+    "Crop": [_Case(Crop(), group="Boxed")],
+    "Dilate": [_Case(Dilate(2), group="Labels")],
+    "FlatLabel": [_Case(FlatLabel([1, 3]), group="Labels")],
+    "Gradient": [_Case(Gradient()), _Case(Gradient(per_dim=True))],
+    "HistogramMatching": [_Case(HistogramMatching("Intensity"))],
+    "InferenceStack": [_Case(InferenceStack("Dataset", "model"))],
+    "MergeLabels": [_Case(MergeLabels(), group="Ensemble")],
+    "OneHot": [_Case(OneHot(4), group="Labels")],
+    "Percentage": [_Case(Percentage(100.0))],
+    # The defaults ([1, 1, 1] mm / [100, 256, 256]) would be a no-op resample and a 6.5M-voxel upsample.
+    "ResampleToResolution": [
+        _Case(ResampleToResolution([2.0, 1.0, 3.0]), atol=_RESCALE_ATOL),
+        _Case(ResampleToResolution([2.0, 1.0, 3.0]), group="Int16", atol=_LSB_ATOL),
+        # uint8 resamples by nearest neighbour: no interpolation weights, so no rounding to disagree on.
+        _Case(ResampleToResolution([2.0, 1.0, 3.0]), group="Labels"),
+    ],
+    "ResampleToShape": [_Case(ResampleToShape([12, 8, 14]), atol=_RESCALE_ATOL)],
+    "ResampleTransform": [_Case(ResampleTransform({"transform": True}))],
+    "Save": [_Case(Save("Dataset"))],
+    "SegmentationDisagreement": [_Case(SegmentationDisagreement(), group="Ensemble")],
+    "SelectLabel": [_Case(SelectLabel(["(1,2)", "(3,1)"]), group="Labels")],
+    "Softmax": [_Case(Softmax(0), group="Ensemble")],
+    "Squeeze": [_Case(Squeeze(0))],
+    "Standardize": [_Case(transform_module.Standardize(), atol=_STAT_ATOL)],
+    "StandardDeviation": [_Case(StandardDeviation(), group="Ensemble")],
+    "Sum": [_Case(Sum(0), group="Ensemble")],
+    "Variance": [_Case(Variance(), group="Ensemble")],
+}
+
+
+# An axis-aligned direction, one that permutes physical x and z -- what a sagittal acquisition carries
+# -- and a rotated one; all orthonormal (a stored volume has no other kind). The first two make a
+# reorientation an exact index remap, which is what an image-dependent declaration keys on; the third
+# does not. The permuting one transposes the extents it swaps, so it also moves the patch grid.
+_AXIS_ALIGNED = np.eye(len(_SPATIAL))
+# A foreground box, as [start, after] margins per spatial axis: (9, 10, 11) is cropped to (6, 6, 6),
+# which still carries a patch grid to disagree over.
+_BOX = np.asarray([[2, 1], [1, 3], [3, 2]])
+_PERMUTING = np.asarray([[0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]])
+_OBLIQUE = np.asarray(
+    [
+        [np.cos(np.deg2rad(20.0)), -np.sin(np.deg2rad(20.0)), 0.0],
+        [np.sin(np.deg2rad(20.0)), np.cos(np.deg2rad(20.0)), 0.0],
+        [0.0, 0.0, 1.0],
+    ]
+)
+
+
+def _volumes() -> dict[str, np.ndarray]:
+    """One volume per input kind the built-in transforms consume, all on the same geometry."""
+    rng = np.random.default_rng(0)
+    axes = np.meshgrid(*[np.linspace(-1, 1, n) for n in _SPATIAL], indexing="ij")
+    # A CT-like phantom rather than a smooth field: the bone/air step is what makes an interpolation
+    # disagree at all (the deviation scales with the neighbour gap), so a smooth fixture would assert
+    # the resample tolerances against data that cannot exercise them.
+    radius = axes[0] ** 2 + axes[1] ** 2 + axes[2] ** 2
+    intensity = np.where(radius < 0.4, _PEAK, -_PEAK) + 30 * rng.standard_normal(_SPATIAL)
+    return {
+        "Intensity": intensity.astype(np.float32)[None],
+        # How a CT is actually stored, and the one dtype that quantizes an interpolation (see _LSB_ATOL).
+        "Int16": intensity.astype(np.int16)[None],
+        # Nested structures, not uniform noise: dilating scattered foreground saturates to all-ones,
+        # and an all-ones result is the same whether or not the halo was ever read. Compact labels
+        # keep a border for Dilate's halo to be wrong about.
+        "Labels": np.select([radius < 0.1, radius < 0.2, radius < 0.35], [1, 2, 3], 0).astype(np.uint8)[None],
+        "Ensemble": rng.integers(0, 3, (3, *_SPATIAL)).astype(np.float32),
+        # The same intensities stored on a rotated direction: the one group whose METADATA, not whose
+        # voxels, is the point (see test_a_declaration_reads_the_case_metadata).
+        "Oblique": intensity.astype(np.float32)[None],
+        # And on a direction that permutes axes, which reorienting transposes the extents of: the group
+        # whose metadata moves the patch grid the streamed patches are cut on.
+        "Permuting": intensity.astype(np.float32)[None],
+        # Stored with the foreground box already on it, which is how a crop is a translation rather
+        # than a question about the voxels.
+        "Boxed": intensity.astype(np.float32)[None],
+    }
+
+
+def _attributes(group: str) -> Attribute:
+    """The metadata a group is stored with -- and so what a declaration about it is handed."""
+    attributes = Attribute()
+    attributes["Origin"] = np.asarray([-3.0, 5.0, 11.0])
+    attributes["Spacing"] = np.asarray(_SPACING)
+    attributes["Direction"] = {"Oblique": _OBLIQUE, "Permuting": _PERMUTING}.get(group, _AXIS_ALIGNED).reshape(-1)
+    if group == "Ensemble":
+        # What a `combine: Concat` reduction writes: the per-model channel counts MergeLabels and
+        # Sum shift their label ranges by.
+        attributes["number_of_channels_per_model"] = np.asarray([3, 3, 3])
+    if group == "Boxed":
+        # What Crop.transform_shape leaves on the case: [start, after] margins per spatial axis.
+        # Both margins differ on every axis -- a box symmetric anywhere is one a wrong sign or a
+        # reversed axis order would still land on.
+        attributes["box"] = _BOX
+    return attributes
+
+
+@pytest.fixture(scope="session")
+def dataset(tmp_path_factory: pytest.TempPathFactory) -> Dataset:
+    """A real on-disk dataset, in the same format (mha) and channel-first layout a run reads."""
+    dataset = Dataset(tmp_path_factory.mktemp("workspace") / "Dataset", "mha")
+    for group, volume in _volumes().items():
+        dataset.write(group, _CASE_NAME, volume, _attributes(group))
+    return dataset
+
+
+def _builtin_transforms() -> list[type[Transform]]:
+    """Every concrete transform class KonfAI ships."""
+    return [
+        cls
+        for _, cls in inspect.getmembers(transform_module, inspect.isclass)
+        if issubclass(cls, Transform) and cls.__module__ == transform_module.__name__ and not inspect.isabstract(cls)
+    ]
+
+
+def _cases_of(cls: type[Transform]) -> list[_Case]:
+    """The configurations to exercise for one transform: the table's, else the transform's own defaults."""
+    if cls.__name__ in _CASES:
+        return _CASES[cls.__name__]
+    if any(parameter.default is parameter.empty for parameter in inspect.signature(cls).parameters.values()):
+        return []
+    return [_Case(cls())]
+
+
+def _kind_of(case: _Case) -> LocalityKind:
+    """What a case declares about the group it consumes -- asked exactly as the dispatcher asks it."""
+    return case.transform.patch_locality(_attributes(case.group)).kind
+
+
+def _streamable_cases() -> list[_Case]:
+    return [
+        case
+        for cls in _builtin_transforms()
+        for case in _cases_of(cls)
+        if _kind_of(case) is not LocalityKind.WHOLE_VOLUME
+    ]
+
+
+def _manager(dataset: Dataset, case: _Case) -> DatasetManager:
+    return DatasetManager(
+        index=0,
+        group_src=case.group,
+        group_dest=case.group,
+        name=_CASE_NAME,
+        dataset=dataset,
+        patch=DatasetPatch(list(_PATCH_SIZE)),
+        transforms=[case.transform],
+        data_augmentations_list=[],
+    )
+
+
+def test_every_builtin_transform_is_covered() -> None:
+    # A transform this file cannot construct is skipped silently -- and a skipped WHOLE_VOLUME
+    # declaration is exactly how a wrong one would hide. Give it a _CASES entry instead.
+    uncovered = [cls.__name__ for cls in _builtin_transforms() if not _cases_of(cls)]
+    assert uncovered == []
+
+
+def test_no_declaration_writes_to_the_case_metadata() -> None:
+    # READ-ONLY, checked. A declaration is made once for the whole case, so a value it wrote would be
+    # one patch's answer imposed on every other. The dispatcher hands over a copy, which contains the
+    # damage but also hides it -- so the rule is worth stating where it can actually be seen.
+    for cls in _builtin_transforms():
+        for case in _cases_of(cls):
+            attribute = _attributes(case.group)
+            before = dict(attribute)
+            case.transform.patch_locality(attribute)
+            assert dict(attribute) == before, f"{cls.__name__}.patch_locality() wrote to cache_attribute"
+
+
+def test_every_locality_kind_is_exercised() -> None:
+    # The property below is only as good as the kinds it reaches: every streamable kind must have at
+    # least one built-in standing for it, so a regression in one kind's dispatch cannot pass unseen.
+    kinds = {_kind_of(case) for case in _streamable_cases()}
+    assert kinds == set(LocalityKind) - {LocalityKind.WHOLE_VOLUME}
+
+
+@pytest.mark.parametrize(
+    "case",
+    _streamable_cases(),
+    ids=lambda case: f"{type(case.transform).__name__}-{_kind_of(case).value}-{case.group}",
+)
+def test_streamed_patch_equals_whole_volume(case: _Case, dataset: Dataset) -> None:
+    streamed = _manager(dataset, case)
+    reference = _manager(dataset, case)
+    # `load` runs the transform over the whole volume; `get_data` then cuts the patch out of the result.
+    # The other manager never loads, so the same `get_data` call streams instead -- same public entry
+    # point, same patch grid, and the declaration alone decides which path runs.
+    reference.load([case.transform], [])
+    assert reference.loaded
+    assert streamed.can_stream_patch(0)
+
+    for index in range(streamed.get_size(0)):
+        got = streamed.get_data(index, 0, [], True)
+        expected = reference.get_data(index, 0, [], True)
+        assert got.shape == expected.shape
+        assert got.dtype == expected.dtype
+        np.testing.assert_allclose(got.numpy(), expected.numpy(), rtol=0, atol=case.atol)
+
+
+class _FlipIfAxisAligned(Flip):
+    """A reorientation that is a flip only when the case says so -- the declaration no config can make.
+
+    Whether reorienting to canonical is a flip (streamable) or a resample (not) is decided by the
+    direction cosines the case was stored with, so it can only be answered from ``cache_attribute``.
+    ``Canonical`` makes exactly this declaration on a real chain; this stands in for it on the smallest
+    transform that can, so the mechanism is proven whatever any one built-in decides about its own case.
+    """
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        if "Direction" not in cache_attribute:
+            return PatchLocality(LocalityKind.WHOLE_VOLUME)
+        direction = cache_attribute.get_np_array("Direction")
+        # Axis-aligned iff exactly one non-zero per row and column, i.e. n non-zeros in an orthonormal
+        # matrix. Anything else mixes axes, and no flip reproduces it.
+        if np.count_nonzero(direction) != len(_SPATIAL):
+            return PatchLocality(LocalityKind.WHOLE_VOLUME)
+        return PatchLocality(LocalityKind.ORIENTATION)
+
+
+def test_a_declaration_reads_the_case_metadata() -> None:
+    """The argument carries the case: one transform, one config, two answers."""
+    transform = _FlipIfAxisAligned("0")
+    assert transform.patch_locality(_attributes("Intensity")).kind is LocalityKind.ORIENTATION
+    assert transform.patch_locality(_attributes("Oblique")).kind is LocalityKind.WHOLE_VOLUME
+
+
+def test_a_declaration_is_total_on_absent_metadata() -> None:
+    """A declaration must answer for any case, including one whose metadata it cannot find.
+
+    The config-time patch_transform checks probe with exactly this, and a group carries only what its
+    writer stored -- so the missing key has to fall to the safe kind rather than raise.
+    """
+    assert _FlipIfAxisAligned("0").patch_locality(Attribute()).kind is LocalityKind.WHOLE_VOLUME
+
+
+@pytest.mark.parametrize("group, streams", [("Intensity", True), ("Oblique", False)])
+def test_the_dispatcher_honours_an_image_dependent_declaration(dataset: Dataset, group: str, streams: bool) -> None:
+    """End to end: the same transform streams, or falls back, on the METADATA of the case it is given.
+
+    Both groups hold the same voxels and the same config, and differ only in the Direction they are
+    stored with -- so nothing but the declaration can decide the path, and the dispatcher must be
+    reading it from the case rather than from the transform.
+    """
+    assert _manager(dataset, _Case(_FlipIfAxisAligned("0"), group=group)).can_stream_patch(0) is streams
+
+
+def test_an_image_dependent_stream_equals_the_whole_volume(dataset: Dataset) -> None:
+    """And the case it does accept to stream is streamed correctly, border patches included."""
+    case = _Case(_FlipIfAxisAligned("0"), group="Intensity")
+    streamed, reference = _manager(dataset, case), _manager(dataset, case)
+    reference.load([case.transform], [])
+    for index in range(streamed.get_size(0)):
+        np.testing.assert_array_equal(
+            streamed.get_data(index, 0, [], True).numpy(), reference.get_data(index, 0, [], True).numpy()
+        )
+
+
+@pytest.mark.parametrize("group", ["Intensity", "Permuting"], ids=["mirroring", "permuting"])
+def test_a_streamed_region_records_the_whole_volume_geometry(dataset: Dataset, group: str) -> None:
+    """Streaming is invisible in the METADATA too, not only in the voxels.
+
+    A reorientation rewrites the case's geometry onto the grid it lands on -- a fact about the VOLUME's
+    extent, while a streamed stage is only ever handed a patch. The case must come out of the streamed
+    path with the geometry the whole-volume pass computes, never with the first patch's own corner
+    frozen onto it, and with the same stack depth so ``inverse()`` pops what was pushed.
+    """
+    case = _Case(Canonical(), group=group)
+    streamed, reference = _manager(dataset, case), _manager(dataset, case)
+    reference.load([case.transform], [])
+    streamed.get_data(0, 0, [], True)
+
+    for key in ("Origin", "Direction", "Spacing"):
+        np.testing.assert_array_equal(
+            streamed.cache_attributes[0].get_np_array(key), reference.cache_attributes[0].get_np_array(key)
+        )
+    assert sorted(streamed.cache_attributes[0].keys()) == sorted(reference.cache_attributes[0].keys())
+
+
+# --------------------------------------------------------------------------------------
+# The augmentations. Same contract, same property -- asked of a draw rather than a config.
+# --------------------------------------------------------------------------------------
+
+# A HALO draw is sampled by grid_sample from coordinates expressed in the halo'd read extent's frame
+# rather than the whole volume's: the same disagreement, for the same reason and with the same
+# gradient- and coordinate-scaling, that _RESCALE_ATOL bounds for the streamed resample. It is bitwise
+# on neither, and grows with the extent -- a 160^3 case at patch 64 lands at 2e-5 of its range.
+_AUGMENTATION_ATOL = _RESCALE_ATOL
+
+
+@dataclass(frozen=True)
+class _AugmentationCase:
+    """One representative draw, the kind it declares, and whether the dispatcher reads it.
+
+    Those are two questions, and keeping them apart is the contract's own split: a draw declares what
+    its output depends on, and the dispatcher decides whether reading that much is worth it. A wide
+    Translate declares a perfectly honest HALO and is refused all the same (see ``_affords_halo``).
+    """
+
+    augmentation: DataAugmentation
+    kind: LocalityKind
+    streams: bool
+    group: str = "Intensity"
+    atol: float = 0.0
+
+
+# Every augmentation KonfAI ships, at a draw that is a meaningful streaming case: probabilities are
+# pinned so the draw always fires (a copy no draw selected is the identity, which proves nothing), and
+# a required constructor argument is given a value. The kind is what THIS draw must declare -- so a
+# declaration silently retreating to WHOLE_VOLUME fails here rather than passing vacuously.
+_AUGMENTATION_CASES: dict[str, list[_AugmentationCase]] = {
+    "Brightness": [_AugmentationCase(augmentation_module.Brightness(0.5), LocalityKind.POINTWISE, True)],
+    "Contrast": [_AugmentationCase(augmentation_module.Contrast(0.5), LocalityKind.POINTWISE, True)],
+    "CutOUT": [_AugmentationCase(augmentation_module.CutOUT(1.0, 2, 0.0), LocalityKind.WHOLE_VOLUME, False)],
+    "Elastix": [_AugmentationCase(augmentation_module.Elastix(), LocalityKind.WHOLE_VOLUME, False)],
+    "Flip": [
+        _AugmentationCase(FlipAugmentation(f_prob=[1.0, 1.0, 1.0]), LocalityKind.ORIENTATION, True),
+        # A displacement field's flipped components are negated, which is not a bijection on values.
+        _AugmentationCase(
+            FlipAugmentation(f_prob=[1.0, 1.0, 1.0], vector_field=True), LocalityKind.WHOLE_VOLUME, False
+        ),
+    ],
+    "HUE": [_AugmentationCase(augmentation_module.HUE(1.0), LocalityKind.POINTWISE, True)],
+    "LumaFlip": [_AugmentationCase(augmentation_module.LumaFlip(), LocalityKind.POINTWISE, True)],
+    "Mask": [],  # a second on-disk volume that dictates the output grid; see its note.
+    "Noise": [_AugmentationCase(augmentation_module.Noise(1.0), LocalityKind.WHOLE_VOLUME, False)],
+    "Permute": [
+        _AugmentationCase(augmentation_module.Permute(prob_permute=[1.0, 1.0]), LocalityKind.ORIENTATION, True)
+    ],
+    "Rotate": [
+        _AugmentationCase(augmentation_module.Rotate(a_min=10.0, a_max=10.0), LocalityKind.WHOLE_VOLUME, False),
+        # A quarter draw is a signed permutation of the axes, so it is an exact remap whichever multiple
+        # of 90 degrees it lands on -- the declaration holds for every draw, not for the seed this
+        # happens to run on. The fixture is non-cubic, so 26 of its 27 draws transpose extents and cut
+        # the copy on a grid the stored volume does not have.
+        _AugmentationCase(augmentation_module.Rotate(is_quarter=True), LocalityKind.ORIENTATION, True),
+    ],
+    "Saturation": [_AugmentationCase(augmentation_module.Saturation(0.5), LocalityKind.POINTWISE, True)],
+    "Scale": [_AugmentationCase(augmentation_module.Scale(), LocalityKind.WHOLE_VOLUME, False)],
+    "Translate": [
+        # A halo of ceil(1) + 1 = 2 on a patch of 4: half the patch, the widest _affords_halo allows.
+        _AugmentationCase(
+            augmentation_module.Translate(t_min=-1.0, t_max=1.0), LocalityKind.HALO, True, atol=_AUGMENTATION_ATOL
+        ),
+        # The same declaration, a 10-voxel shift: an honest halo the dispatcher will not pay for.
+        _AugmentationCase(augmentation_module.Translate(t_min=10.0, t_max=10.0), LocalityKind.HALO, False),
+    ],
+}
+
+
+def _builtin_augmentations() -> list[type[DataAugmentation]]:
+    """Every concrete augmentation class KonfAI ships."""
+    return [
+        cls
+        for _, cls in inspect.getmembers(augmentation_module, inspect.isclass)
+        if issubclass(cls, DataAugmentation)
+        and cls.__module__ == augmentation_module.__name__
+        and not inspect.isabstract(cls)
+    ]
+
+
+def _augmentation_managers(dataset: Dataset, case: _AugmentationCase) -> tuple[DatasetManager, DatasetManager]:
+    """Two managers of the same case, on ONE draw: one that streams copy 1, one that loads it."""
+    case.augmentation.load(1.0)
+    augmentations = DataAugmentationsList(nb=1, data_augmentations={})
+    augmentations.data_augmentations = [case.augmentation]
+
+    def manager() -> DatasetManager:
+        return DatasetManager(
+            index=0,
+            group_src=case.group,
+            group_dest=case.group,
+            name=_CASE_NAME,
+            dataset=dataset,
+            patch=DatasetPatch(list(_PATCH_SIZE)),
+            transforms=[],
+            data_augmentations_list=[augmentations],
+        )
+
+    streamed, reference = manager(), manager()
+    # Constructing a manager re-draws (that is what an epoch reset does), so the two would otherwise
+    # compare different draws. Replaying the last one onto both is what makes them the same case.
+    for item in (streamed, reference):
+        item.reset_augmentation(reset_state=False)
+    return streamed, reference
+
+
+def _augmentation_cases() -> list[_AugmentationCase]:
+    return [case for cls in _builtin_augmentations() for case in _AUGMENTATION_CASES.get(cls.__name__, [])]
+
+
+def test_every_builtin_augmentation_is_covered() -> None:
+    # An augmentation absent from the table is never asked anything -- and an unasked declaration is
+    # exactly how a wrong one would hide. Give it an entry, empty only if no draw of it can stream.
+    uncovered = [cls.__name__ for cls in _builtin_augmentations() if cls.__name__ not in _AUGMENTATION_CASES]
+    assert uncovered == []
+
+
+@pytest.mark.parametrize(
+    "case",
+    _augmentation_cases(),
+    ids=lambda case: f"{type(case.augmentation).__name__}-{case.kind.value}-{case.streams}",
+)
+def test_an_augmentation_declares_the_kind_its_draw_makes_it(case: _AugmentationCase, dataset: Dataset) -> None:
+    streamed, _ = _augmentation_managers(dataset, case)
+    # Copy 1 carries the draw; the declaration is asked of it exactly as the dispatcher asks it.
+    assert case.augmentation.patch_locality(0, 0, _attributes(case.group)).kind is case.kind
+    assert streamed.can_stream_patch(1) is case.streams
+
+
+def test_no_augmentation_declaration_writes_to_the_case_metadata(dataset: Dataset) -> None:
+    # READ-ONLY, checked -- the same rule, and the same reason, as for a transform.
+    for case in _augmentation_cases():
+        _augmentation_managers(dataset, case)
+        attribute = _attributes(case.group)
+        before = dict(attribute)
+        case.augmentation.patch_locality(0, 0, attribute)
+        assert dict(attribute) == before, f"{type(case.augmentation).__name__}.patch_locality() wrote to it"
+
+
+@pytest.mark.parametrize(
+    "case",
+    [case for case in _augmentation_cases() if case.streams],
+    ids=lambda case: f"{type(case.augmentation).__name__}-{case.kind.value}",
+)
+def test_streamed_augmented_patch_equals_whole_volume(case: _AugmentationCase, dataset: Dataset) -> None:
+    streamed, reference = _augmentation_managers(dataset, case)
+    # `load` runs the draw over the whole volume; `get_data` then cuts the patch out of the result. The
+    # other manager never loads, so the same `get_data` call streams instead -- same public entry point,
+    # same patch grid, same draw, and the declaration alone decides which path runs.
+    reference.load([], reference.data_augmentations_list)
+    assert reference.loaded
+    assert streamed.can_stream_patch(1)
+
+    for index in range(streamed.get_size(1)):
+        got = streamed.get_data(index, 1, [], True)
+        expected = reference.get_data(index, 1, [], True)
+        assert got.shape == expected.shape
+        assert got.dtype == expected.dtype
+        np.testing.assert_allclose(got.numpy(), expected.numpy(), rtol=0, atol=case.atol)
+
+
+def test_a_pointwise_augmentation_streams_the_whole_grid_after_a_transform(dataset: Dataset) -> None:
+    """A copy is its transforms AND its draw: the dispatcher plans them as one chain.
+
+    A pointwise draw behind a region transform is still one region, so it streams; the same draw behind
+    a region transform AND a region draw would be two, which is what the plan refuses.
+    """
+    torch.manual_seed(0)
+    brightness = augmentation_module.Brightness(0.5)
+    brightness.load(1.0)
+    augmentations = DataAugmentationsList(nb=1, data_augmentations={})
+    augmentations.data_augmentations = [brightness]
+
+    def manager(transform: Transform) -> DatasetManager:
+        return DatasetManager(
+            index=0,
+            group_src="Intensity",
+            group_dest="Intensity",
+            name=_CASE_NAME,
+            dataset=dataset,
+            patch=DatasetPatch(list(_PATCH_SIZE)),
+            transforms=[transform],
+            data_augmentations_list=[augmentations],
+        )
+
+    resample = ResampleToResolution([2.0, 1.0, 3.0])
+    assert manager(resample).can_stream_patch(1) is True
+    # Two regions in one chain: the resample's, and the flip's.
+    flip = FlipAugmentation(f_prob=[1.0, 1.0, 1.0])
+    flip.load(1.0)
+    augmentations.data_augmentations = [flip]
+    assert manager(resample).can_stream_patch(1) is False


### PR DESCRIPTION
**Do not merge. Close this once the review is read.**

#41 was merged before CodeRabbit was installed, so it refuses it: *"Review failed — The pull request is closed."* A merged pull request has no diff left to comment on.

This carries the same diff on two throwaway branches so the review can happen:

| | |
|---|---|
| base | `review/before-41` — `main` as it stood before #41 (`d438c49`) |
| head | `review/after-41` — `main` as it stood after (`71a04ca`), pinned so other merges do not widen it |
| diff | 20 files, +5073 −435 — the same figures #41 reports |

Merging this would only fast-forward a throwaway branch, but there is nothing to gain from it: the code is already in `main`.

@coderabbitai full review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added patch-based volume streaming to reduce memory usage during preprocessing and dataset loading.
  - Added configurable memory budgets to automatically choose caching, streaming, or buffering.
  - Added windowed shuffling to limit in-memory training data while preserving consistent epochs.
  - Expanded support for streamed transforms, augmentations, resampling, orientation changes, and statistics.
  - Added safeguards and warnings when streaming is unsupported or unsafe.

- **Documentation**
  - Added comprehensive streaming guidance, configuration details, transform behavior, extension contracts, and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->