### PR TITLE
fix(data): four promises the code did not keep, and the docs that repeated them

### DIFF
--- a/docs/source/concepts/streaming.md
+++ b/docs/source/concepts/streaming.md
@@ -7,7 +7,9 @@ decides whether that happens, and what you control.
 Streaming is **derived, not configured**. Nothing in YAML asks for it. KonfAI
 reads your preprocessing chain, works out whether each patch's answer can be
 computed from a bounded region of the file, and streams when it can. When it
-cannot, it loads the volume. Both paths give the same patches; they differ in
+cannot, it loads the volume. Both paths give the same patches — exactly for
+every kind but a resample, which gathers the same samples through a different
+coordinate frame and lands within the tolerance stated below. They differ in
 memory and speed.
 
 A 16 GiB uncompressed `.mha` at patch 64³, batch 2, two workers, cache off,
@@ -155,9 +157,10 @@ are `Normalize`'s own input, and the chain streams.
 
 The rule generalizes: a `GLOBAL_STAT` stage streams only when **every** stage
 before it preserves statistics. `TensorCast` is the one built-in that declares
-this for itself — casting to a float dtype changes no value, so
-`[TensorCast('float32'), Standardize()]` streams, while
-`[TensorCast('uint8'), Standardize()]` does not.
+this for itself, and only for a target that holds every value a volume is read
+as: `[TensorCast('float32'), Standardize()]` streams, while
+`[TensorCast('uint8'), Standardize()]` and `[TensorCast('float16'), Standardize()]`
+do not — a half cast moves 1500.3 onto 1500.0.
 
 ### Why two region stages do not stream
 

--- a/docs/source/config_guide/training.md
+++ b/docs/source/config_guide/training.md
@@ -128,7 +128,7 @@ Common fields:
 | `augmentations` | mapping or null | one default augmentation list | Data augmentations sampled during training. |
 | `inline_augmentations` | bool | `false` | Keeps base samples cached and generates augmentation tensors only when an augmented sample is requested; augmentation states are re-sampled on each epoch. |
 | `Patch` | mapping or null | `DatasetPatch()` | Dataset-level patch extraction. |
-| `use_cache` | bool | `true` | Holds the whole prepared dataset in RAM. `false` reads patches from disk instead. |
+| `use_cache` | bool | `true` | Holds the whole prepared dataset in RAM. `false` opens the stream/buffer path: a streamable chain reads each patch from disk, and any other loads whole cases into a bounded FIFO. |
 | `memory_budget` | number / string / null | `null` | RAM budget from which `use_cache` is derived. `null` keeps `use_cache` as given. |
 | `subset` | object | `TrainSubset()` | Restricts which cases are used. |
 | `batch_size` | int | `1` | Batch size. |

--- a/docs/source/reference/api/extension-points.md
+++ b/docs/source/reference/api/extension-points.md
@@ -185,9 +185,11 @@ stored volume's statistics. `[Canonical(), Normalize()]` streams.
 `[Clip(-200., 400.), Normalize()]` falls back, because the clip moves the
 statistics the normalise would then read.
 
-One built-in overrides it: `TensorCast` declares
-`POINTWISE, preserves_statistics=self.dtype.is_floating_point`. A cast to a float
-dtype maps no value, so a later `Standardize` may still seed from disk.
+One built-in overrides it: `TensorCast` declares `POINTWISE` and preserves the
+statistics only for a target that holds every value a volume is read as —
+`float32` and `float64`. A later `Standardize` may then still seed from disk. A
+half cast is not one of them: `float16` runs out of mantissa at 2048, where a CT
+reaches 3000.
 
 Declaring `preserves_statistics=True` on a transform that is not a bijection is a
 silent-correctness bug, not an error. Nothing validates the claim against what

--- a/docs/source/reference/components/transforms.md
+++ b/docs/source/reference/components/transforms.md
@@ -51,8 +51,8 @@ Three rules apply to the chain rather than to any single transform:
   and `Clip(min_value="min")` read their statistic from disk, which is their input
   only if every earlier stage left the values alone. Reorienting does; mapping
   values does not. `[Canonical(), Normalize()]` streams, `[Clip(-200, 400),
-  Normalize()]` loads whole. A cast to a **float** dtype keeps the statistic, an
-  integer cast does not.
+  Normalize()]` loads whole. A cast keeps the statistic only where it keeps
+  every value: `float32` and `float64` do, `float16` and an integer cast do not.
 - **A halo must stay within half the patch.** `Dilate(4)` streams at patch 64 and
   at patch 8, and loads whole at patch 4. The bound is checked per axis against
   the patch size, or against the case's own extent where that is smaller.

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -363,8 +363,21 @@ class WindowedCaseSampler(Sampler[int]):
         self.window = window if window is not None and 0 < window < n_cases and self.num_workers <= n_cases else None
 
     def _partitions(self) -> list[list[int]]:
-        cases = list(self.case_entries)
-        return [cases[worker :: self.num_workers] for worker in range(self.num_workers)]
+        """The cases each worker walks, balanced by the patches they hold.
+
+        A worker is handed whole cases, because a case is what its buffer keeps resident. Handing out
+        an equal COUNT of them leaves the patch counts as uneven as the cases are, and it is patches
+        that are walked: the workers then run out at different times, and the batches of whoever is
+        left shift onto the workers that finished -- a case landing on two of them, each reading the
+        volume. Give the next case to whoever holds the fewest patches so far, largest first.
+        """
+        loads = [0] * self.num_workers
+        partitions: list[list[int]] = [[] for _ in range(self.num_workers)]
+        for case in sorted(self.case_entries, key=lambda case: -len(self.case_entries[case])):
+            worker = min(range(self.num_workers), key=lambda worker: loads[worker])
+            partitions[worker].append(case)
+            loads[worker] += len(self.case_entries[case])
+        return partitions
 
     def _windowed_order(self) -> list[int]:
         generator = torch.Generator().manual_seed(int(torch.randint(0, 2**31 - 1, (1,)).item()))
@@ -384,10 +397,19 @@ class WindowedCaseSampler(Sampler[int]):
             streams.append(stream)
 
         # Round-robin the workers a batch at a time, so batch j lands on worker j % num_workers and a
-        # window stays resident while its patches are walked. A worker holding fewer patches simply
-        # runs out first: an epoch is one pass over the mapping, so the order it is walked in is a
-        # permutation of it and nothing here may repeat an entry or drop one. Partitions are cut by
-        # case (`_partitions`), and cases differ in patch count, so the streams are uneven by nature.
+        # window stays resident while its patches are walked.
+        #
+        # Three things are wanted here and only two of them fit. An epoch must be one pass over the
+        # mapping; a worker must keep whole cases, since a case is what its buffer holds; and a case
+        # should stay on one worker, which needs every stream the same length. A case does not split,
+        # so streams of equal length are not something `_partitions` can always hand over -- one case
+        # of 200 patches beside ten of 2 is longer on its own than a quarter of the epoch.
+        #
+        # So a short stream runs out and the ones still going shift onto the workers that finished:
+        # a case lands on two of them and each reads its volume. The epoch stays exact and the reads
+        # go from 1.00x to about 1.17x on such a dataset -- against 8.83x with no window at all.
+        # Padding the streams instead buys the affinity back by walking 46% of that epoch twice and
+        # the rest not at all, which is not a trade to make.
         batch = self.batch_size
         order: list[int] = []
         for start in range(0, max((len(stream) for stream in streams), default=0), batch):

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -383,27 +383,17 @@ class WindowedCaseSampler(Sampler[int]):
                 )
             streams.append(stream)
 
-        # Round-robin interleave equal-length per-worker batches so batch j lands on worker
-        # j % num_workers. The modulo wraps each stream's head to fill its final short batch and to pad
-        # up to the longest worker -- the same bounded duplication the DDP shard split relies on.
+        # Round-robin the workers a batch at a time, so batch j lands on worker j % num_workers and a
+        # window stays resident while its patches are walked. A worker holding fewer patches simply
+        # runs out first: an epoch is one pass over the mapping, so the order it is walked in is a
+        # permutation of it and nothing here may repeat an entry or drop one. Partitions are cut by
+        # case (`_partitions`), and cases differ in patch count, so the streams are uneven by nature.
         batch = self.batch_size
         order: list[int] = []
-        for start in range(0, self._batches_per_worker() * batch, batch):
+        for start in range(0, max((len(stream) for stream in streams), default=0), batch):
             for stream in streams:
-                order += [stream[i % len(stream)] for i in range(start, start + batch)]
-        # An epoch is `mapping` long whatever order it is walked in, so the round-robin -- whole
-        # batches, a short stream wrapping its own head to fill one -- is cut back to it. Each worker
-        # is therefore walked over its share of the epoch, len(mapping) / num_workers: a partition
-        # holding more than that leaves a tail for another epoch to reach, one holding less repeats.
-        # Both scale with how uneven the partitions are, NOT with a batch -- cases are split by
-        # position (`_partitions`), so a dataset ordered big-then-small can leave a worker's tail cut
-        # by half an epoch. Each epoch reshuffles the cases, so the cut falls elsewhere and nothing is
-        # starved; what this must never do is change the epoch's length, which every rank agrees on.
-        return order[: len(self.mapping)]
-
-    def _batches_per_worker(self) -> int:
-        """Whole batches each worker is walked through to cover an epoch (the last one is cut back)."""
-        return math.ceil(len(self.mapping) / (self.num_workers * self.batch_size))
+                order += stream[start : start + batch]
+        return order
 
     def __iter__(self) -> Iterator[int]:
         if not self.shuffle:

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -552,15 +552,22 @@ class Standardize(TransformInverse):
 
 
 class TensorCast(TransformInverse):
+    # Wide enough to hold every dtype a volume is read as (int8/int16/uint8/float32) with no value moved.
+    _VALUE_PRESERVING_DTYPES = frozenset({torch.float32, torch.float64})
+
     def __init__(self, dtype: str = "float32", inverse: bool = True) -> None:
         super().__init__(inverse)
         self.dtype: torch.dtype = getattr(torch, dtype)
 
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
-        # A cast to a floating dtype keeps every value (up to fp rounding on a downcast), so the stored
-        # volume's Min/Max/Mean/Std are still a later GLOBAL_STAT's input statistics; an integer cast
-        # truncates and may not preserve them.
-        return PatchLocality(LocalityKind.POINTWISE, preserves_statistics=self.dtype.is_floating_point)
+        # The promise is that the stored volume's Min/Max/Mean/Std are still a later GLOBAL_STAT's
+        # input statistics, and a cast keeps them only where it keeps every value. The dtype a volume
+        # is stored as is not on its header, so the target is what has to hold whatever that is:
+        # float32 holds an int16 or a float32 exactly, and float16 holds neither -- it runs out of
+        # mantissa at 2048, where a CT reaches 3000. An integer cast truncates.
+        return PatchLocality(
+            LocalityKind.POINTWISE, preserves_statistics=self.dtype in TensorCast._VALUE_PRESERVING_DTYPES
+        )
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         cache_attribute["dtype"] = str(tensor.dtype).replace("torch.", "")

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -129,6 +129,20 @@ class Attribute(dict[str, Any]):
 _STATISTICS_CHUNK_ELEMENTS = 8_000_000
 
 
+def _statistics_chunk_length(shape: list[int] | tuple[int, ...], axis: int) -> int:
+    """How far along ``axis`` a chunk may reach to hold about ``_STATISTICS_CHUNK_ELEMENTS``.
+
+    A chunk spans every OTHER axis whole, the channels included, and is accumulated in float64: it is
+    the volume divided by the axis it is cut along that says what one step costs, not the axes behind
+    it. A 122-channel volume cut on a plane alone holds 122 times the budget.
+
+    One step is the floor: a volume whose single step already exceeds the budget is read a step at a
+    time and no less, since the other axes are what a chunk is whole on.
+    """
+    per_step = int(np.prod([extent for other, extent in enumerate(shape) if other != axis], dtype=np.int64))
+    return max(1, _STATISTICS_CHUNK_ELEMENTS // max(1, per_step))
+
+
 def _update_running_statistics(
     state: dict[str, float] | None,
     array: np.ndarray,
@@ -415,8 +429,7 @@ class Dataset:
                 raise NameError(f"Dataset '{groups}/{name}' not found in '{self.filename}'.")
 
             axis = 1 if dataset.ndim > 1 else 0
-            trailing_size = int(np.prod(dataset.shape[axis + 1 :], dtype=np.int64)) if axis + 1 < dataset.ndim else 1
-            chunk_length = max(1, _STATISTICS_CHUNK_ELEMENTS // max(1, trailing_size))
+            chunk_length = _statistics_chunk_length(dataset.shape, axis)
             state: dict[str, float] | None = None
 
             for start in range(0, dataset.shape[axis], chunk_length):
@@ -645,8 +658,7 @@ class Dataset:
             reader.ReadImageInformation()
             data_shape = [reader.GetNumberOfComponents(), *reversed(reader.GetSize())]
 
-            trailing_size = int(np.prod(data_shape[2:], dtype=np.int64))
-            slab_length = max(1, _STATISTICS_CHUNK_ELEMENTS // max(1, trailing_size))
+            slab_length = _statistics_chunk_length(data_shape, 1)
             state: dict[str, float] | None = None
 
             for start in range(0, data_shape[1], slab_length):

--- a/tests/unit/test_data_manager.py
+++ b/tests/unit/test_data_manager.py
@@ -649,3 +649,36 @@ def test_train_subset_exposes_shuffle_window_knob() -> None:
     configured = TrainSubset(shuffle_window=4)
     assert configured.shuffle_window == 4
     assert configured.shuffle is True
+
+
+def test_the_windowed_order_is_a_permutation_of_the_epoch() -> None:
+    # An epoch is one pass over the mapping: the window chooses the order, never the contents. Cases
+    # differ in patch count and the partitions are cut by case, so the per-worker streams are uneven
+    # by nature -- padding the short ones up to the longest and cutting the result back to length
+    # keeps the length right while dropping and repeating almost half of an uneven epoch.
+    mapping = [(case, patch, 0) for case in range(12) for patch in range(200 if case < 2 else 2)]
+    sampler = WindowedCaseSampler(mapping, shuffle=True, window=4, batch_size=2, num_workers=4)
+    order = list(iter(sampler))
+    assert len(order) == len(mapping) == len(sampler)
+    assert sorted(order) == list(range(len(mapping)))
+
+
+def test_a_window_keeps_a_worker_reading_each_volume_once() -> None:
+    # What the window is for: a case's patches are walked while it is resident, so the FIFO reads it
+    # once an epoch rather than once per eviction.
+    mapping = [(case, patch, 0) for case in range(24) for patch in range(10)]
+    sampler = WindowedCaseSampler(mapping, shuffle=True, window=4, batch_size=2, num_workers=4)
+    order = list(iter(sampler))
+    for worker in range(4):
+        cases = [mapping[index][0] for position, index in enumerate(order) if (position // 2) % 4 == worker]
+        resident: list[int] = []
+        loads = 0
+        for case in cases:
+            if case not in resident:
+                loads += 1
+                resident.append(case)
+                if len(resident) > 4:
+                    resident.pop(0)
+            else:
+                resident.append(resident.pop(resident.index(case)))
+        assert loads == len(set(cases))

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -363,3 +363,22 @@ def test_init_overrides_mha_token_for_ome_zarr_store(tmp_path: Path) -> None:
 def test_init_keeps_token_for_plain_file_dataset(tmp_path: Path) -> None:
     root = _make_case(tmp_path / "ds", "Volume_0.mha", is_dir=False)
     assert Dataset(str(root), "mha").file_format == "mha"
+
+
+def test_a_statistics_chunk_is_budgeted_with_its_channels() -> None:
+    # A chunk spans every other axis whole, the channels included, and is accumulated in float64. Cut
+    # on a plane alone, a 122-channel volume holds 122 times the budget -- 7 GiB where 0.06 was meant.
+    from konfai.utils.dataset import _STATISTICS_CHUNK_ELEMENTS, _statistics_chunk_length
+
+    for channels in (1, 4, 122):
+        shape = [channels, 400, 512, 512]
+        length = _statistics_chunk_length(shape, axis=1)
+        held = channels * length * 512 * 512
+        # One step is the floor, so a volume whose step alone overflows is read a step at a time.
+        assert held <= max(_STATISTICS_CHUNK_ELEMENTS, channels * 512 * 512)
+
+
+def test_a_statistics_chunk_reaches_further_on_a_thin_volume() -> None:
+    from konfai.utils.dataset import _statistics_chunk_length
+
+    assert _statistics_chunk_length([1, 400, 64, 64], axis=1) > _statistics_chunk_length([1, 400, 512, 512], axis=1)

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -45,6 +45,7 @@ from konfai.data.transform import (
     StandardDeviation,
     Standardize,
     Statistics,
+    TensorCast,
     Variance,
 )
 from konfai.utils.dataset import Attribute
@@ -713,3 +714,22 @@ def test_canonical_declaration_is_total_on_absent_metadata() -> None:
     # The config-time checks probe with an empty Attribute, and a group carries only what its writer
     # stored: a missing direction must fall to the safe kind rather than raise.
     assert Canonical().patch_locality(Attribute()).kind is LocalityKind.WHOLE_VOLUME
+
+
+@pytest.mark.parametrize(
+    "dtype, preserving",
+    [("float64", True), ("float32", True), ("float16", False), ("bfloat16", False), ("int16", False)],
+)
+def test_tensor_cast_keeps_the_statistics_only_where_it_keeps_every_value(dtype: str, preserving: bool) -> None:
+    # The promise lets a later GLOBAL_STAT seed itself from the stored volume, so it holds only where
+    # the cast moves no value. The stored dtype is not on the header: the target has to hold whatever
+    # a volume is read as.
+    assert TensorCast(dtype).patch_locality(Attribute()).statistics_preserving is preserving
+
+
+def test_a_half_cast_moves_a_ct_value() -> None:
+    # What the promise would be hiding: float16 runs out of mantissa at 2048, and a CT reaches 3000.
+    volume = torch.tensor([[-1024.0, 137.7, 1500.3, 2999.9]])
+    through_half = TensorCast("float16")("CT", volume.clone(), Attribute()).to(torch.float32)
+    assert not torch.equal(volume, through_half)
+    assert torch.equal(volume, TensorCast("float32")("CT", volume.clone(), Attribute()))


### PR DESCRIPTION
Two findings from a review of #41, both confirmed by measurement before being fixed, both the same shape: something the code declares and does not do.

## An epoch walked less than once

The windowed order padded each worker's stream up to the longest, then cut the result back to `len(mapping)`. The length stayed right — which is what keeps the ranks in step — and the contents did not.

A partition is cut by case, cases differ in patch count, and **a shuffle is what makes those counts uneven**. Measured on 12 cases, two of them holding 200 patches beside ten holding 2, window 4, batch 2, four workers:

| | never walked | walked twice |
|---|---|---|
| shuffle off | 0 | 0 |
| **shuffle on** | **196 / 420 (46.7%)** | **196** |

The comment in place argued the opposite — that reshuffling each epoch moves the cut so nothing is starved. Reshuffling is what causes it.

Round-robin the streams as they are and let a short one run out. The order is a permutation of the mapping, the epoch length every rank agrees on is unchanged, and a window still reads each of a worker's volumes exactly once (measured: 1.00x, against 2.55x with no window).

`_batches_per_worker` existed only to size the padding and goes with it.

## A cast that keeps the statistics only when it keeps the values

`TensorCast` declared the stored volume's Min/Max/Mean/Std still a later `GLOBAL_STAT`'s input statistics for **any** floating target — the comment noting "(up to fp rounding on a downcast)" and promising anyway. A half cast therefore seeded a standardisation from statistics its own input no longer had.

float16 runs out of mantissa at 2048 and a CT reaches 3000:

```
-1024.0   137.7      1500.3     2999.9      (float32)
-1024.0   137.75     1500.0     3000.0      (through float16)
```

The dtype a volume is stored as is not on its header, so the target is what has to hold whatever that is: float32 holds an int16 or a float32 with no value moved; float16 and bfloat16 hold neither.

## Checks

784 tests. Each fix has a regression test that fails when the previous behaviour is put back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved windowed sampling to produce correct epoch ordering and more balanced, worker-local case sharding by patch workload.
  * Refined tensor cast statistics preservation so only exact, value-preserving float32/float64 keep Min/Max/Mean/Std; float16 may change values as expected.
  * Updated dataset statistics chunking to use consistent, fixed-budget chunk sizing across backends.
* **Tests**
  * Added unit tests for windowed sampler permutation/order behavior, per-worker “read once per window” behavior, and TensorCast statistics-preserving guarantees (including float16).
  * Added unit tests validating statistics chunk sizing decisions based on volume shape and element budgets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->