### PR TITLE
feat(predict): streamed prediction writes — bound RAM/VRAM by writing outputs slab by slab

### DIFF
--- a/docs/source/concepts/streaming.md
+++ b/docs/source/concepts/streaming.md
@@ -130,7 +130,7 @@ Five conditions reject streaming:
 
 ### Why `[Clip(-200, 400), Standardize()]` does not stream
 
-This is rule 4.
+This is rule 3.
 
 `Standardize` is `GLOBAL_STAT`: it needs the volume's `Mean` and `Std`, which
 KonfAI reads once from disk. The statistic on disk is the **stored** volume's,
@@ -158,16 +158,20 @@ as: `[TensorCast('float32'), Standardize()]` streams, while
 `[TensorCast('uint8'), Standardize()]` and `[TensorCast('float16'), Standardize()]`
 do not — a half cast moves 1500.3 onto 1500.0.
 
-### Why two region stages do not stream
+### How several region stages stream together
 
-A region stage is a rewrite of *which* source voxels a target patch needs. One
-such rewrite composes with the read: KonfAI maps the patch back through it and
-asks the file for the result. A second stage's region is expressed in the first
-stage's output space, which does not exist on disk. `[Dilate(1), Gradient()]` is
-two halos; `[Canonical(), Permute('2|1|0')]` is two reorientations. Both load the
-volume.
+A region stage is a rewrite of *which* source voxels a target patch needs, and
+these rewrites **compose**. The planner folds them back to front: the target
+patch maps through the last stage's rewrite, that region maps through the stage
+before it, and so on down to one region on disk. KonfAI reads that one region
+and runs the chain forward over it. `[Dilate(1), Gradient()]` is two halos that
+add, `[Canonical(), Permute('2|1|0')]` is two reorientations that pull through
+each other — both stream from a single bounded read, as does the whole
+`[Canonical, ResampleToResolution, Padding]` reorient-resample-pad pipeline. The
+one thing a region stage cannot do is read a statistic of its own input, because
+that input never exists whole on disk (rule 3).
 
-Rule 3 is about cost, not correctness. Every patch pays its halo on every side,
+Rule 2 is about cost, not correctness. Every patch pays its halo on every side,
 so streaming reads `prod(1 + 2·halo/extent)` times the case's bytes, where the
 extent is the patch or the volume, whichever is smaller. At half the extent that
 is 8× in 3D, against the single load streaming avoids. At patch 8, `Dilate(4)`

--- a/docs/source/concepts/streaming.md
+++ b/docs/source/concepts/streaming.md
@@ -112,25 +112,21 @@ which region of the file a patch needs.
 `WHOLE_VOLUME` is the default. A transform that declares nothing loads the
 volume and is correct.
 
-A chain streams when it has the shape
+A chain streams when every stage is pointwise or a region kind — `HALO`,
+`ORIENTATION`, `CROP`, `RESCALE` — where `GLOBAL_STAT` counts as pointwise.
+Region stages **compose** in any number: each stage's region pulls through the
+one before it, down to one bounded read of the stored volume. The chain planned
+is the group's `transforms` followed by the copy's own augmentation draw — one
+list, so a region transform and a region augmentation compose exactly like two
+region transforms.
 
-```text
-[pointwise*] [at most one region stage] [pointwise*]
-```
-
-where `GLOBAL_STAT` counts as pointwise, and the region stages are `HALO`,
-`ORIENTATION`, `CROP`, and `RESCALE`. The chain planned is the group's
-`transforms` followed by the copy's own augmentation draw — one list, so a
-region transform and a region augmentation are two regions.
-
-Six conditions reject streaming:
+Five conditions reject streaming:
 
 1. any `WHOLE_VOLUME` declaration;
-2. more than one region stage;
-3. a halo wider than half the read extent on any axis;
-4. a `GLOBAL_STAT` preceded by a stage that does not preserve statistics;
-5. a `GLOBAL_STAT` whose statistic cannot be read from disk;
-6. a `RESCALE` on a case with no `Spacing`.
+2. a halo wider than half the read extent on any axis;
+3. a `GLOBAL_STAT` preceded by a stage that does not preserve statistics;
+4. a `GLOBAL_STAT` whose statistic cannot be read from disk;
+5. a `RESCALE` on a case with no `Spacing`.
 
 ### Why `[Clip(-200, 400), Standardize()]` does not stream
 

--- a/docs/source/config_guide/prediction.md
+++ b/docs/source/config_guide/prediction.md
@@ -123,6 +123,15 @@ One `Prediction.yml` can be shared between different checkpoints as long as
 the exported output name stays consistent.
 ```
 
+```{note}
+**Streamed writes are automatic — there is no config key.** When an output can be finalized slab by slab
+byte-identically to the assembled volume (a voxel-local finalize chain, a single augmentation, and an
+`mha`/`h5`/`omezarr` destination), each slab is written to disk as its patches complete, bounding RAM at
+one patch window instead of the whole volume; otherwise the whole-volume path is used transparently. Set
+`KONFAI_STREAMED_WRITES=0` to force the whole-volume path globally (ops/debug or exact bit-reproducibility
+against a CPU run).
+```
+
 ## Examples
 
 See:

--- a/docs/source/config_guide/prediction.md
+++ b/docs/source/config_guide/prediction.md
@@ -125,11 +125,16 @@ the exported output name stays consistent.
 
 ```{note}
 **Streamed writes are automatic — there is no config key.** When an output can be finalized slab by slab
-byte-identically to the assembled volume (a voxel-local finalize chain, a single augmentation, and an
+identically to the assembled volume (a single augmentation, a voxel-local reduction, and an
 `mha`/`h5`/`omezarr` destination), each slab is written to disk as its patches complete, bounding RAM at
-one patch window instead of the whole volume; otherwise the whole-volume path is used transparently. Set
-`KONFAI_STREAMED_WRITES=0` to force the whole-volume path globally (ops/debug or exact bit-reproducibility
-against a CPU run).
+one patch window instead of the whole volume. Geometry inverses stream too, composed in any number
+(`Canonical`/`Flip`/`Permute`, `Padding`, nearest-mode `ResampleToResolution`/`ResampleToShape`):
+each slab is remapped, cropped, or resampled through a sliding window straight to its written region.
+A chain streaming cannot honour streams its pointwise prefix into a light post-reduction buffer and
+runs the rest whole-volume on it. Streamed outputs match the assembled path voxel for voxel on a given
+device; only a transcendental-terminated float chain (Softmax/Sigmoid) can differ by ~1 ULP between a
+GPU window and a CPU whole-volume run. Set `KONFAI_STREAMED_WRITES=0` to force the whole-volume path
+globally (ops/debug or exact bit-reproducibility against a CPU run).
 ```
 
 ## Examples

--- a/docs/source/reference/api/extension-points.md
+++ b/docs/source/reference/api/extension-points.md
@@ -165,9 +165,10 @@ What a declaration costs you:
   `prod(1 + 2 * halo_k / patch_k)` times the case's bytes. A radius above half the
   patch — or half the case, whichever is smaller — on any axis is rejected, and
   the case falls back to a full load.
-- A chain streams only as `[pointwise*][at most one region][pointwise*]`, where
-  `GLOBAL_STAT` counts as pointwise. Two region stages, or any `WHOLE_VOLUME`,
-  falls back.
+- A chain streams when every stage is pointwise or a region kind, where
+  `GLOBAL_STAT` counts as pointwise. Region stages compose — each pulls through
+  the one before it — so their number is not limited; any `WHOLE_VOLUME` falls
+  back.
 
 `patch_transforms` is stricter than `transforms`: only `POINTWISE` and
 `GLOBAL_STAT` are accepted, and any other kind raises a `ConfigError` pointing at

--- a/docs/source/usage/large-images.md
+++ b/docs/source/usage/large-images.md
@@ -160,6 +160,14 @@ back to CPU accumulation when it does not. Mean/Cosinus overlap blending and
 Mean/Median/Concat model or TTA reductions have different memory costs. The
 canonical prediction fields are in {doc}`../config_guide/prediction`.
 
+When the reassembled output itself is the memory peak, streaming handles it
+automatically — there is no flag to set. Each output slab is finalized and
+written to disk as soon as its patches complete, so peak RAM is one patch window
+instead of the whole volume. It applies per case only when it is byte-identical
+to the assembled path (a voxel-local finalize chain, a single augmentation, an
+`mha`/`h5`/`omezarr` destination) and uses the whole-volume write transparently
+otherwise. `KONFAI_STREAMED_WRITES=0` forces the whole-volume path globally.
+
 ## Verify the behaviour you care about
 
 Do not infer streaming from a successful run alone—the fallback is designed to

--- a/docs/source/usage/large-images.md
+++ b/docs/source/usage/large-images.md
@@ -163,10 +163,22 @@ canonical prediction fields are in {doc}`../config_guide/prediction`.
 When the reassembled output itself is the memory peak, streaming handles it
 automatically — there is no flag to set. Each output slab is finalized and
 written to disk as soon as its patches complete, so peak RAM is one patch window
-instead of the whole volume. It applies per case only when it is byte-identical
-to the assembled path (a voxel-local finalize chain, a single augmentation, an
-`mha`/`h5`/`omezarr` destination) and uses the whole-volume write transparently
-otherwise. `KONFAI_STREAMED_WRITES=0` forces the whole-volume path globally.
+instead of the whole volume. Geometry inverses stream too, and they **compose**:
+a `Canonical`/`Flip`/`Permute` inverse remaps each slab to its written region, a
+`Padding` inverse crops it in flight, a `ResampleToResolution`/`ResampleToShape`
+inverse resamples back through a sliding window — chained in any number, each
+pulling through the next — so a huge output at ORIGINAL resolution is written
+slab by slab without ever being held whole. What streaming cannot honour (a
+whole-volume transform, a float resample — whose interpolation is only bit-equal
+whole-volume — or a destination without region writes) splits instead: the
+pointwise prefix still streams into a light post-reduction buffer and the
+remaining stages run once on it. Only several augmentations (TTA inverses apply
+to the assembled volume) or a non-voxel-local reduction keep the whole-volume
+path. Every streamed or split case is voxel-identical to the
+assembled path on a given device; as with the assembled path, only a
+transcendental-terminated float chain can differ by ~1 ULP between a GPU window
+and a CPU whole-volume run. `KONFAI_STREAMED_WRITES=0` forces the whole-volume
+path globally.
 
 ## Verify the behaviour you care about
 

--- a/konfai/data/augmentation.py
+++ b/konfai/data/augmentation.py
@@ -304,6 +304,15 @@ class DataAugmentation(NeedDevice, ABC):
         """Map a target patch's spatial slices to the source region copy *a* reads (region kinds)."""
         return self._stream_region_source(index, self.who_index[index].index(a), target_slices, source_spatial_shape)
 
+    def stream_shape(self, index: int, a: int, shape: list[int]) -> list[int]:
+        """The spatial shape copy *a*'s draw produces from ``shape`` (the shape-fold counterpart of
+        ``Transform.transform_shape``). The identity default covers every draw but a shape-changing
+        one, which restates here what its ``state_init`` did to the copy's grid."""
+        return self._stream_shape(index, self.who_index[index].index(a), shape)
+
+    def _stream_shape(self, index: int, a: int, shape: list[int]) -> list[int]:
+        return shape
+
     def _stream_region_source(
         self,
         index: int,
@@ -507,6 +516,10 @@ class Rotate(EulerTransform):
         if Rotate._index_remap(self.matrix[index][a]) is None:
             return PatchLocality(LocalityKind.WHOLE_VOLUME)
         return PatchLocality(LocalityKind.ORIENTATION)
+
+    def _stream_shape(self, index: int, a: int, shape: list[int]) -> list[int]:
+        # The same extent carry state_init applied to the copy's grid.
+        return Rotate._draw_shape(self.matrix[index][a], list(shape))
 
     def _stream_region_source(
         self,
@@ -1019,6 +1032,10 @@ class Permute(DataAugmentation):
         # Reordering axes moves every voxel and touches none, so the multiset of values is the input's:
         # a bijection, which is what ORIENTATION promises.
         return PatchLocality(LocalityKind.ORIENTATION)
+
+    def _stream_shape(self, index: int, a: int, shape: list[int]) -> list[int]:
+        # The same reorder state_init applied to the copy's grid.
+        return [shape[axis] for axis in self._source_axes(index, a)]
 
     def _stream_region_source(
         self,

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -20,6 +20,7 @@ import copy
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from dataclasses import dataclass
+from itertools import pairwise
 from typing import Protocol, cast
 
 import numpy as np
@@ -240,13 +241,13 @@ class Accumulator:
         self._weight_sum: torch.Tensor | None = None
         self._weight_patch: torch.Tensor | None = None
 
-    def add_layer(self, index: int, layer: torch.Tensor) -> None:
+    def add_layer(self, index: int, layer: torch.Tensor) -> list[tuple[slice, torch.Tensor]] | None:
         # Blend each patch straight into the running accumulator and drop the patch, rather than
         # storing all patches for a single assemble() at the end. The overlap blend is a weighted sum,
         # so accumulating incrementally is equivalent; re-adding an index is a no-op (last-write wins is
         # not possible once blended, and the prediction pipeline adds each patch exactly once).
         if self._done[index]:
-            return
+            return None
         n = self._n
         if self._result is None:
             # Allocate to the ACTUAL volume extent (self.shape), not the patch-size-extended grid. The
@@ -281,10 +282,17 @@ class Accumulator:
             self._result[slices_dest] = data[crop]
         self._done[index] = True
         self._filled += 1
+        return None
 
     def is_empty(self) -> bool:
         """True until the first patch has been blended in (no volume-sized buffer allocated yet)."""
         return self._result is None
+
+    @property
+    def footprint_shape(self) -> list[int]:
+        """Spatial shape held in memory at once — the whole volume for the base accumulator (overridden
+        by StreamingAccumulator, which keeps only a window). Used to size the blend device."""
+        return self.shape
 
     def is_full(self) -> bool:
         # O(1): a running counter avoids re-scanning every slot after each added patch
@@ -315,6 +323,132 @@ class Accumulator:
         self._filled = 0
         self._done = [False] * self._count
         return result
+
+
+class StreamingAccumulator(Accumulator):
+    """Accumulator holding only the active window along the first spatial axis; it yields each finalized
+    slab as its patches complete, so peak memory is one patch extent.
+
+    The patch-grid order (``get_patch_slices_from_shape`` iterates ``itertools.product`` with the first
+    spatial axis outermost) has patch starts along that axis never decreasing, so when a patch starting
+    at ``z`` arrives, every voxel before ``z`` has already received all of its patches and the region up
+    to ``z`` is final. ``add_layer`` returns those finalized slabs — ``assemble()``'s values, from the
+    same blend and weight arithmetic applied slab by slab — and ``finalize()`` flushes the tail.
+    """
+
+    def __init__(
+        self,
+        patch_slices: list[tuple[slice, ...]],
+        patch_size: list[int],
+        patch_combine: PathCombine | None = None,
+        batch: bool = True,
+    ) -> None:
+        super().__init__(patch_slices, patch_size, patch_combine, batch)
+        self._window = min(max(patch[0].stop - patch[0].start for patch in self.patch_slices), self.shape[0])
+        starts = [patch[0].start for patch in self.patch_slices]
+        if any(0 > current - previous or current - previous > self._window for previous, current in pairwise(starts)):
+            raise PatchError(
+                "StreamingAccumulator requires patches ordered by non-decreasing start on the first spatial axis,"
+                " advancing by at most one patch extent per step.",
+                "get_patch_slices_from_shape generates this order; a custom patch source must preserve it.",
+            )
+        self._flushed = 0
+
+    def add_layer(self, index: int, layer: torch.Tensor) -> list[tuple[slice, torch.Tensor]]:
+        if self._done[index]:
+            return []
+        n = self._n
+        patch_slice = self.patch_slices[index]
+        # Correctness rests on patches ARRIVING in non-decreasing axis-0-start order, not just on the
+        # slice list being sorted: a patch whose start is already flushed would write at a negative
+        # window offset (dest[0] below), which torch silently reads from the end -> misplaced data, no
+        # error. Fail loud instead. The prediction loop preserves per-case order (shuffle=False), so
+        # this only guards a future misuse (e.g. a shuffling sampler).
+        if patch_slice[0].start < self._flushed:
+            raise PatchError(
+                f"StreamingAccumulator received patch start {patch_slice[0].start} after flushing to "
+                f"{self._flushed}: patches must arrive in non-decreasing first-spatial-axis order.",
+                "Add patches in the order get_patch_slices_from_shape generates them (no shuffling).",
+            )
+        slabs = self._advance_to(patch_slice[0].start)
+        if self._result is None:
+            self._result = torch.zeros(
+                [*layer.shape[:n], self._window, *self.shape[1:]],
+                dtype=layer.dtype,
+                device=layer.device,
+            )
+            if self.patch_combine is not None:
+                self._weight_sum = torch.zeros(self._result.shape[n:], dtype=layer.dtype, device=layer.device)
+        data = layer
+        for dim, s in enumerate(patch_slice):
+            if s.stop - s.start == 1:
+                data = data.unsqueeze(dim=dim + n)
+        # Same blend as the parent (clamped destination, cropped patch, weighted overlap); the only
+        # difference is that the destination's first spatial index is relative to the window origin.
+        dest = [slice(s.start, min(s.stop, self.shape[dim])) for dim, s in enumerate(patch_slice)]
+        crop = tuple([slice(None)] * n + [slice(0, d.stop - d.start) for d in dest])
+        dest[0] = slice(dest[0].start - self._flushed, dest[0].stop - self._flushed)
+        slices_dest = tuple([slice(self._result.shape[i]) for i in range(n)] + dest)
+        if self.patch_combine is not None and self._weight_sum is not None:
+            self._result[slices_dest] += self.patch_combine(data)[crop]
+            if self._weight_patch is None:
+                self._weight_patch = self.patch_combine(torch.ones_like(data))[(0,) * n]
+            self._weight_sum[tuple(dest)] += self._weight_patch[crop[n:]]
+        else:
+            self._result[slices_dest] = data[crop]
+        self._done[index] = True
+        self._filled += 1
+        return slabs
+
+    def finalize(self) -> list[tuple[slice, torch.Tensor]]:
+        """Flush the remaining window and reset for reuse; call once ``is_full()``."""
+        slabs = self._advance_to(self.shape[0])
+        self._result = None
+        self._weight_sum = None
+        self._weight_patch = None
+        self._filled = 0
+        self._done = [False] * self._count
+        self._flushed = 0
+        return slabs
+
+    @property
+    def footprint_shape(self) -> list[int]:
+        # Only the window is resident, so the blend-device budget is the window's: a huge volume streams
+        # on the GPU within bounded VRAM. Blend and IEEE-correctly-rounded finalize ops (+, *, /, argmax,
+        # cast) are bit-identical CPU/CUDA; only a transcendental-terminated float output (Softmax/Sigmoid)
+        # can differ by ~1 ULP between a window on the GPU and a whole-volume reference on the CPU.
+        return [self._window, *self.shape[1:]]
+
+    def assemble(self) -> torch.Tensor:
+        raise PatchError(
+            "StreamingAccumulator does not assemble a whole volume.",
+            "Consume the slabs returned by add_layer() and finalize() instead.",
+        )
+
+    def _advance_to(self, z: int) -> list[tuple[slice, torch.Tensor]]:
+        """Finalize the window up to ``z`` (absolute) and shift the window origin there."""
+        z = min(z, self.shape[0])
+        if self._result is None or z <= self._flushed:
+            return []
+        n = self._n
+        length = z - self._flushed
+        lead = (slice(None),) * n
+        slab = self._result[(*lead, slice(0, length))]
+        if self.patch_combine is not None and self._weight_sum is not None:
+            # Same division and fp16 floor as Accumulator.assemble, applied to the finalized slab.
+            slab = slab / self._weight_sum[:length].clamp(min=torch.finfo(self._weight_sum.dtype).tiny)
+        else:
+            slab = slab.clone()
+        keep = self._window - length
+        # .clone(): source and destination views overlap when length < window.
+        self._result[(*lead, slice(0, keep))] = self._result[(*lead, slice(length, self._window))].clone()
+        self._result[(*lead, slice(keep, self._window))] = 0
+        if self._weight_sum is not None:
+            self._weight_sum[:keep] = self._weight_sum[length : self._window].clone()
+            self._weight_sum[keep:] = 0
+        region = slice(self._flushed, z)
+        self._flushed = z
+        return [(region, slab)]
 
 
 class Patch(ABC):

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -18,7 +18,7 @@
 
 import copy
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from itertools import pairwise
 from typing import Protocol, cast
@@ -94,23 +94,86 @@ class AugmentedStage:
     def write_stream_cache_attribute(self, cache_attribute: Attribute, source_spatial_shape: list[int]) -> None:
         """An augmentation draws a copy of the case rather than restating its geometry: nothing to record."""
 
+    def stream_shape(self, shape: list[int]) -> list[int]:
+        """The spatial shape this copy's draw produces from ``shape`` (its slot in the shape fold)."""
+        return self.augmentation.stream_shape(self.index, self.a, shape)
+
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         return self.augmentation.compute(name, self.index, self.a, tensor)
+
+
+# The region kinds a composed streamed read (or write) carries between its pointwise stages.
+_REGION_KINDS = (LocalityKind.HALO, LocalityKind.ORIENTATION, LocalityKind.CROP, LocalityKind.RESCALE)
+
+
+def _halo_pull(radii: list[int], shape: list[int]) -> Callable[[tuple[slice, ...]], list[slice]]:
+    """A halo stage's pull map: the region enlarged by the radius, clamped to the volume."""
+
+    def pull(target: tuple[slice, ...]) -> list[slice]:
+        return [
+            slice(max(0, t.start - radius), min(extent, t.stop + radius))
+            for t, radius, extent in zip(target, radii, shape, strict=False)
+        ]
+
+    return pull
+
+
+def _remap_pull(
+    remap: Callable[[tuple[slice, ...], list[int], Attribute], list[slice]],
+    shape: list[int],
+    attribute: Attribute,
+) -> Callable[[tuple[slice, ...]], list[slice]]:
+    """An index-remap stage's pull map, bound to the case state the stages before it left."""
+
+    def pull(target: tuple[slice, ...]) -> list[slice]:
+        return remap(target, list(shape), Attribute(attribute))
+
+    return pull
+
+
+def _scale_pull(scales: list[float], shape: list[int]) -> Callable[[tuple[slice, ...]], list[slice]]:
+    """A rescale stage's pull map: the source window of the scale mapping plus its interpolation halo."""
+
+    def pull(target: tuple[slice, ...]) -> list[slice]:
+        return Resample.source_window(target, scales, shape)
+
+    return pull
+
+
+@dataclass(frozen=True)
+class _ReadStagePlan:
+    """One chain stage as the composed streamed read runs it: its declared kind, the spatial shapes
+    on either side, and — for a region stage — the pull map from a region of its output to the region
+    of its input it is computed from, bound to the case state the stages before it left."""
+
+    kind: LocalityKind
+    in_shape: tuple[int, ...]
+    out_shape: tuple[int, ...]
+    pull: Callable[[tuple[slice, ...]], list[slice]] | None
 
 
 @dataclass(frozen=True)
 class _PatchStreamSource:
     """What a copy's patches are read from, and what runs on them once read.
 
-    ``region_index`` locates the single stage of ``stages`` that reads somewhere other than the target
-    patch, if there is one; the rest are pointwise, so they run wherever the region put them.
+    ``stage_plans`` mirrors ``stages`` one to one: the region plans locate every stage that reads
+    somewhere other than the target patch (they compose, each pulling through the one before it); the
+    rest are pointwise, so they run wherever the regions put them.
     """
 
     dataset: Dataset
     group: str
     shape: list[int]
     stages: list[Stage]
-    region_index: int | None
+    stage_plans: tuple[_ReadStagePlan, ...]
+
+    @property
+    def region_index(self) -> int | None:
+        """The first region stage, or ``None`` for an exact-patch chain."""
+        for index, plan in enumerate(self.stage_plans):
+            if plan.kind in _REGION_KINDS:
+                return index
+        return None
 
 
 @dataclass(frozen=True)
@@ -276,7 +339,11 @@ class Accumulator:
         if self.patch_combine is not None and self._weight_sum is not None:
             self._result[slices_dest] += self.patch_combine(data)[crop]
             if self._weight_patch is None:
-                self._weight_patch = self.patch_combine(torch.ones_like(data))[(0,) * n]
+                # Spatial-only ones: the weight is per-voxel, and deriving it from a channel-sized
+                # ones_like would allocate (and weight) C copies just to index one back out.
+                self._weight_patch = self.patch_combine(
+                    torch.ones(data.shape[n:], dtype=data.dtype, device=data.device)
+                )
             self._weight_sum[tuple(dest)] += self._weight_patch[crop[n:]]
         else:
             self._result[slices_dest] = data[crop]
@@ -392,7 +459,11 @@ class StreamingAccumulator(Accumulator):
         if self.patch_combine is not None and self._weight_sum is not None:
             self._result[slices_dest] += self.patch_combine(data)[crop]
             if self._weight_patch is None:
-                self._weight_patch = self.patch_combine(torch.ones_like(data))[(0,) * n]
+                # Spatial-only ones: the weight is per-voxel, and deriving it from a channel-sized
+                # ones_like would allocate (and weight) C copies just to index one back out.
+                self._weight_patch = self.patch_combine(
+                    torch.ones(data.shape[n:], dtype=data.dtype, device=data.device)
+                )
             self._weight_sum[tuple(dest)] += self._weight_patch[crop[n:]]
         else:
             self._result[slices_dest] = data[crop]
@@ -449,6 +520,149 @@ class StreamingAccumulator(Accumulator):
         region = slice(self._flushed, z)
         self._flushed = z
         return [(region, slab)]
+
+
+class SlabRegionStream:
+    """Slab in → slab out through one region stage, with bounded lookahead.
+
+    The write mirror of the read dispatcher's single-region rule: finalized slabs arrive in order along
+    the first spatial axis (the :class:`StreamingAccumulator`'s order), and each output region is
+    emitted as soon as the input region it pulls has arrived — so only a sliding window of the input is
+    ever resident. The stage itself is two injected callables, both pure region arithmetic + tensor
+    work, so no stage kind has streaming code of its own:
+
+    - ``pull(target_slices) -> source_slices`` — the clamped input region an output region is computed
+      from (a transform's ``stream_region_target``/``stream_region_source``, or a halo enlargement).
+    - ``produce(window, target_slices, source_slices) -> tensor`` — the output block for
+      ``target_slices``, given exactly the pulled window.
+
+    The schedule is derived from ``pull`` alone: a probe finds which output axis the input slab axis
+    feeds and in which direction (a mirrored or permuted axis streams too, through the sink's
+    random-access region writes), and emission advances along that axis as far as the arrived input
+    allows. Any per-axis monotone map works; nothing here names a stage.
+    """
+
+    def __init__(
+        self,
+        pull: Callable[[tuple[slice, ...]], list[slice]],
+        produce: Callable[[torch.Tensor, tuple[slice, ...], list[slice]], torch.Tensor],
+        in_spatial_shape: list[int],
+        out_spatial_shape: list[int],
+    ) -> None:
+        self._pull = pull
+        self._produce = produce
+        self._in_shape = [int(s) for s in in_spatial_shape]
+        self._out_shape = [int(s) for s in out_spatial_shape]
+        self._axis, self._ascending = self._probe_axis()
+        self._slabs: list[tuple[int, torch.Tensor]] = []
+        self._complete_to = 0
+        self._emitted = 0
+
+    def _probe_axis(self) -> tuple[int, bool]:
+        """Which output axis the input slab axis feeds, and whether in ascending order.
+
+        Probing one output row per axis against the full-region pull identifies the axis whose region
+        controls input axis 0; comparing the first and last rows' pulls gives the direction. A wrong
+        pick can never corrupt the output — emission is gated on the pull of the real regions — it only
+        buffers more, so a map no probe can tell apart falls back to axis 0 ascending.
+        """
+        full = tuple(slice(0, n) for n in self._out_shape)
+        baseline = self._pull(full)[0]
+        for axis, extent in enumerate(self._out_shape):
+            probe = list(full)
+            probe[axis] = slice(0, 1)
+            first = self._pull(tuple(probe))[0]
+            if (first.start, first.stop) == (baseline.start, baseline.stop):
+                continue
+            probe[axis] = slice(extent - 1, extent)
+            last = self._pull(tuple(probe))[0]
+            return axis, first.start <= last.start
+        return 0, True
+
+    def _prefix_slices(self, m: int) -> tuple[slice, ...]:
+        """The first ``m`` output rows in iteration order, as absolute region slices."""
+        extent = self._out_shape[self._axis]
+        rows = slice(0, m) if self._ascending else slice(extent - m, extent)
+        slices = [slice(0, n) for n in self._out_shape]
+        slices[self._axis] = rows
+        return tuple(slices)
+
+    def push(self, region: slice, slab: torch.Tensor) -> list[tuple[tuple[slice, ...], torch.Tensor]]:
+        """Take the next finalized slab (rows ``region`` of the input) and emit what it completes."""
+        if region.start != self._complete_to:
+            raise PatchError(
+                f"SlabRegionStream received rows [{region.start}, {region.stop}) after "
+                f"[0, {self._complete_to}): slabs must arrive contiguously from the first row.",
+                "Push the slabs exactly as the StreamingAccumulator yields them.",
+            )
+        self._slabs.append((region.start, slab))
+        self._complete_to = region.stop
+        return self._emit()
+
+    def finalize(self) -> list[tuple[tuple[slice, ...], torch.Tensor]]:
+        """Emit whatever the completed input still allows and verify nothing is left behind."""
+        emitted = self._emit()
+        if self._emitted != self._out_shape[self._axis]:
+            raise PatchError(
+                f"SlabRegionStream finalized with {self._emitted} of {self._out_shape[self._axis]} "
+                f"output rows emitted (input complete to {self._complete_to} of {self._in_shape[0]}).",
+                "Push every slab of the input before finalizing.",
+            )
+        self._slabs.clear()
+        return emitted
+
+    def _emit(self) -> list[tuple[tuple[slice, ...], torch.Tensor]]:
+        extent = self._out_shape[self._axis]
+        # The pull of an iteration prefix grows monotonically with it, so the furthest emittable row is
+        # a binary search — O(log rows) pull calls per push, and a pull may be more than slice
+        # arithmetic (a declaration may copy the attribute it reads).
+        low, high = self._emitted, extent
+        while low < high:
+            middle = (low + high + 1) // 2
+            if self._pull(self._prefix_slices(middle))[0].stop <= self._complete_to:
+                low = middle
+            else:
+                high = middle - 1
+        m = low
+        if m == self._emitted:
+            return []
+        rows = slice(self._emitted, m) if self._ascending else slice(extent - m, extent - self._emitted)
+        target = list(self._prefix_slices(m))
+        target[self._axis] = rows
+        source = self._pull(tuple(target))
+        window = self._window(source)
+        result = self._produce(window, tuple(target), source)
+        self._emitted = m
+        if m < extent:
+            remaining = [slice(0, n) for n in self._out_shape]
+            remaining[self._axis] = slice(m, extent) if self._ascending else slice(0, extent - m)
+            keep_from = self._pull(tuple(remaining))[0].start
+            self._slabs = [
+                (start, slab) for start, slab in self._slabs if start + slab.shape[-len(self._in_shape)] > keep_from
+            ]
+        else:
+            self._slabs.clear()
+        return [(tuple(target), result)]
+
+    def _window(self, source: list[slice]) -> torch.Tensor:
+        """The buffered input restricted to ``source`` — rows gathered from the arrived slabs, the
+        other axes sliced in place."""
+        axis0 = source[0]
+        n_lead = self._slabs[0][1].dim() - len(self._in_shape)
+        lead = (slice(None),) * n_lead
+        pieces = []
+        for start, slab in self._slabs:
+            stop = start + slab.shape[n_lead]
+            lo, hi = max(start, axis0.start), min(stop, axis0.stop)
+            if lo < hi:
+                pieces.append(slab[(*lead, slice(lo - start, hi - start))])
+        window = pieces[0] if len(pieces) == 1 else torch.cat(pieces, dim=n_lead)
+        if window.shape[n_lead] != axis0.stop - axis0.start:
+            raise PatchError(
+                f"SlabRegionStream window rows [{axis0.start}, {axis0.stop}) are not fully buffered.",
+                "The pull map must never reach below rows already pruned or above rows arrived.",
+            )
+        return window[(*lead, slice(None), *source[1:])]
 
 
 class Patch(ABC):
@@ -892,51 +1106,85 @@ class DatasetManager:
     def _plan_stream_region(
         self,
         a: int,
-        localities: list[PatchLocality],
+        stages: list[Stage],
         source_dataset: Dataset,
         source_group: str,
         cache_attribute: Attribute,
-    ) -> tuple[bool, int | None]:
-        """Validate a copy's locality declarations and locate the single region stage among them.
+        source_spatial_shape: list[int],
+    ) -> tuple[bool, tuple[_ReadStagePlan, ...]]:
+        """Validate a copy's locality declarations and plan its region stages, which compose.
 
-        Returns ``(streamable, region_index)``. The chain streams only when it is
-        ``[pre-pointwise*][at most one region: HALO|ORIENTATION|CROP|RESCALE][post-pointwise*]`` where
-        ``GLOBAL_STAT`` counts as pointwise (exact patch + a pre-populated stat). Any
-        ``WHOLE_VOLUME`` declaration, more than one region stage, an unreadable ``GLOBAL_STAT``, a
-        ``RESCALE`` without a known source ``Spacing``, or a halo too wide to be worth reading rejects
-        streaming. Nothing here names a stage: each declares its own contract, and this is where the
-        declarations are read -- which is why a transform and an augmentation are planned side by side.
+        Returns ``(streamable, stage_plans)``. The chain streams when every stage is pointwise, a
+        region kind (``HALO``/``ORIENTATION``/``CROP``/``RESCALE`` — any number, each pulling through
+        the one before it), or a ``GLOBAL_STAT`` with a pre-populated statistic. The plan walks the
+        chain once with one evolving case state, so each stage declares against — and remaps from —
+        the geometry the stages before it left, and folds the spatial shapes stage by stage; a fold
+        that does not land on the copy's own grid refuses (the safety net for a stage whose shape map
+        is not declared). Any ``WHOLE_VOLUME`` declaration, an unreadable ``GLOBAL_STAT``, a
+        ``RESCALE`` without a known ``Spacing`` (or that is not a :class:`Resample`), or a halo too
+        wide to be worth reading rejects streaming. Nothing here names a stage: each declares its own
+        contract, and this is where the declarations are read -- which is why a transform and an
+        augmentation are planned side by side.
         """
-        if any(loc.kind is LocalityKind.WHOLE_VOLUME for loc in localities):
-            return False, None
-        region_kinds = (LocalityKind.HALO, LocalityKind.ORIENTATION, LocalityKind.CROP, LocalityKind.RESCALE)
-        region_indices = [index for index, loc in enumerate(localities) if loc.kind in region_kinds]
-        if len(region_indices) > 1:
-            return False, None
-        if any(loc.kind is LocalityKind.HALO and not self._affords_halo(a, loc.halo) for loc in localities):
-            return False, None
-        for index, loc in enumerate(localities):
-            if loc.kind is not LocalityKind.GLOBAL_STAT:
-                continue
-            # The seed is the STORED volume's statistic, which is this transform's input only when
-            # every earlier stage preserves it; otherwise ([Clip(-200, 400), Standardize()]) every
-            # patch would be standardized by the pre-Clip statistic -- fall back to the whole volume.
-            if not all(previous.statistics_preserving for previous in localities[:index]):
-                return False, None
-            if not self._ensure_stream_stats(
-                source_dataset, source_group, cache_attribute, set(loc.stat_keys), loc.stat_channels
-            ):
-                return False, None
-        region_index = region_indices[0] if region_indices else None
-        if (
-            region_index is not None
-            and localities[region_index].kind is LocalityKind.RESCALE
-            and "Spacing" not in cache_attribute
-        ):
-            # A resample is patch-native only when the source geometry is known: the scale is read
-            # from cache_attribute['Spacing'] (a free geometry stat, no read_data_statistics).
-            return False, None
-        return True, region_index
+        evolved = Attribute(cache_attribute)
+        shape = [int(extent) for extent in source_spatial_shape]
+        localities: list[PatchLocality] = []
+        plans: list[_ReadStagePlan] = []
+        for stage in stages:
+            loc = stage.patch_locality(Attribute(evolved))
+            localities.append(loc)
+            if loc.kind is LocalityKind.WHOLE_VOLUME:
+                return False, ()
+            if loc.kind is LocalityKind.GLOBAL_STAT:
+                # The seed is the STORED volume's statistic, which is this transform's input only when
+                # every earlier stage preserves it; otherwise ([Clip(-200, 400), Standardize()]) every
+                # patch would be standardized by the pre-Clip statistic -- fall back to the whole volume.
+                if not all(previous.statistics_preserving for previous in localities[:-1]):
+                    return False, ()
+                if not self._ensure_stream_stats(
+                    source_dataset, source_group, cache_attribute, set(loc.stat_keys), loc.stat_channels
+                ):
+                    return False, ()
+            if loc.kind is LocalityKind.HALO and not self._affords_halo(a, loc.halo):
+                return False, ()
+            if loc.kind is LocalityKind.RESCALE and (not isinstance(stage, Resample) or "Spacing" not in evolved):
+                # A resample is patch-native only when the source geometry is known: the scale is read
+                # from the evolving 'Spacing' (a free geometry stat, no read_data_statistics).
+                return False, ()
+            plan = self._plan_read_stage(stage, loc, shape, evolved)
+            if plan is None:
+                return False, ()
+            plans.append(plan)
+            shape = list(plan.out_shape)
+        if shape != [int(extent) for extent in self.shapes[a]]:
+            return False, ()
+        return True, tuple(plans)
+
+    def _plan_read_stage(
+        self, stage: Stage, loc: PatchLocality, shape: list[int], evolved: Attribute
+    ) -> "_ReadStagePlan | None":
+        """One stage's slot in the composed plan: its shapes, its pull map, and — for a region stage —
+        the geometry it leaves for the stages after it (``write_stream_cache_attribute``)."""
+        if loc.kind not in _REGION_KINDS:
+            return _ReadStagePlan(loc.kind, tuple(shape), tuple(shape), None)
+        if loc.kind is LocalityKind.HALO:
+            return _ReadStagePlan(
+                loc.kind, tuple(shape), tuple(shape), _halo_pull(_halo_radii(loc.halo, len(shape)), list(shape))
+            )
+        if loc.kind is LocalityKind.RESCALE:
+            resample = cast(Resample, stage)
+            out = [int(e) for e in resample.transform_shape(self.group_src, self.name, list(shape), Attribute(evolved))]
+            scales = [shape[k] / out[k] for k in range(len(shape))]
+            resample.write_stream_cache_attribute(evolved, list(shape))
+            return _ReadStagePlan(loc.kind, tuple(shape), tuple(out), _scale_pull(scales, list(shape)))
+        # ORIENTATION / CROP: the stage's own remap, evaluated on the state the stages before it left.
+        pull = _remap_pull(stage.stream_region_source, list(shape), Attribute(evolved))
+        if isinstance(stage, Transform):
+            out = [int(e) for e in stage.transform_shape(self.group_src, self.name, list(shape), Attribute(evolved))]
+        else:
+            out = [int(e) for e in cast(AugmentedStage, stage).stream_shape(list(shape))]
+        stage.write_stream_cache_attribute(evolved, list(shape))
+        return _ReadStagePlan(loc.kind, tuple(shape), tuple(out), pull)
 
     @staticmethod
     def _dataset_from_spec(dataset_spec: str) -> Dataset:
@@ -986,15 +1234,14 @@ class DatasetManager:
             # cache-hit merges the cached header.
             for attribute_key, attribute_value in boundary_attributes.items():
                 stream_cache_attribute[attribute_key] = attribute_value
-        localities = [stage.patch_locality(Attribute(stream_cache_attribute)) for stage in stages]
-        streamable, region_index = self._plan_stream_region(
-            a, localities, source_dataset, source_group, stream_cache_attribute
+        streamable, stage_plans = self._plan_stream_region(
+            a, stages, source_dataset, source_group, stream_cache_attribute, list(source_shape[1:])
         )
         if streamable:
             self.cache_attributes[a] = Attribute(stream_cache_attribute)
             self.cache_attributes_bak[a] = Attribute(stream_cache_attribute)
             self._patch_stream_sources[key] = _PatchStreamSource(
-                source_dataset, source_group, list(source_shape), stages, region_index
+                source_dataset, source_group, list(source_shape), stages, stage_plans
             )
         else:
             self._patch_stream_sources[key] = None
@@ -1014,14 +1261,7 @@ class DatasetManager:
         if stream_source is None:
             raise RuntimeError("Patch streaming requested on a dataset manager without a streaming source.")
 
-        region_index = stream_source.region_index
-
-        # RESCALE keeps its dedicated body for its own scale/geometry maths (the attribute-persist
-        # stack is the same as the generic path below). The other region kinds go through that path.
-        if region_index is not None and isinstance(stream_source.stages[region_index], Resample):
-            return self._get_streamed_resample_data(index, a, stream_source, region_index, is_input)
-
-        if region_index is None:
+        if stream_source.region_index is None:
             # POINTWISE / GLOBAL_STAT only: read the exact patch and run the whole chain on it.
             plan = self.patch.get_read_plan(stream_source.shape, index, a, is_input)
             data, attributes = stream_source.dataset.read_data_slice(stream_source.group, self.name, plan.data_slices)
@@ -1039,7 +1279,7 @@ class DatasetManager:
                 self._persist_stream_attributes(a, cache_attribute, keys_before)
             return tensor, cache_attribute
 
-        return self._get_streamed_region_data(index, a, stream_source, region_index, is_input)
+        return self._get_streamed_region_data(index, a, stream_source, is_input)
 
     def _finalize_stream_patch(self, tensor: torch.Tensor, index: int, a: int, is_input: bool) -> torch.Tensor:
         """Pad/format a target-extent streamed patch to ``patch_size`` like the whole-volume path.
@@ -1071,48 +1311,34 @@ class DatasetManager:
         index: int,
         a: int,
         stream_source: _PatchStreamSource,
-        region_index: int,
         is_input: bool,
     ) -> tuple[torch.Tensor, Attribute]:
-        """Patch-native HALO/ORIENTATION: read the source region a target patch maps to.
+        """Patch-native region chain: read only the source region a target patch pulls, composed.
 
-        The chain is ``[pre-pointwise*][region][post-pointwise*]``. HALO reads the patch enlarged by the
-        declared per-axis radius (clamped to the volume) and crops the halo back after the stage; the
-        stage's own edge padding reproduces the whole-volume border once the clamp reaches the true
-        border, so seams agree. ORIENTATION reads the index-remapped source region
-        (``stream_region_source``) and applies the flip/permute -- same extent, no crop. Only the region
-        is requested; whether that avoids decoding the whole volume depends on the storage format --
-        compressed MetaImage and NRRD decode the full volume per read (see ``_supports_region_read``).
+        The region stages' pull maps fold backward from the target patch down to the stored volume —
+        each stage's region pulls through the one before it — so one bounded read serves any number of
+        them; the chain then runs forward over the sub-region, each stage on the region pair the same
+        fold computed for it. HALO reads the region enlarged by the declared radius (clamped to the
+        volume) and crops it back after the stage — the stage's own edge padding reproduces the
+        whole-volume border once the clamp reaches the true border, so seams agree. ORIENTATION
+        applies the index remap to what its region read; a CROP's remap IS its action, so the stage is
+        not re-applied; RESCALE interpolates the sub-region to its target extent. Only the composed
+        region is requested; whether that avoids decoding the whole volume depends on the storage
+        format -- compressed MetaImage and NRRD decode the full volume per read
+        (see ``_supports_region_read``).
         """
-        region_stage = stream_source.stages[region_index]
-        pre_stages = stream_source.stages[:region_index]
-        post_stages = stream_source.stages[region_index + 1 :]
-        region_loc = region_stage.patch_locality(Attribute(self.cache_attributes_bak[a]))
-
+        stages, plans = stream_source.stages, stream_source.stage_plans
         target_slices = tuple(self.patch.get_patch_slices(a)[index])
         n_prefix = len(stream_source.shape) - len(target_slices)
-        slices_pre = [slice(None) for _ in range(n_prefix)]
-        source_spatial = [int(s) for s in stream_source.shape[n_prefix:]]
 
-        crop_offsets: list[int] | None = None
-        if region_loc.kind is LocalityKind.HALO:
-            source_slices = []
-            crop_offsets = []
-            for k, (sl, radius) in enumerate(
-                zip(target_slices, _halo_radii(region_loc.halo, len(target_slices)), strict=False)
-            ):
-                start = max(0, sl.start - radius)
-                stop = min(source_spatial[k], sl.stop + radius)
-                source_slices.append(slice(start, stop))
-                crop_offsets.append(sl.start - start)
-        else:
-            source_slices = region_stage.stream_region_source(
-                target_slices, source_spatial, Attribute(self.cache_attributes_bak[a])
-            )
+        spans: list[list[slice]] = [list(target_slices)]
+        for plan in reversed(plans):
+            spans.append(plan.pull(tuple(spans[-1])) if plan.pull is not None else list(spans[-1]))
+        spans.reverse()
 
-        data_slices = tuple(slices_pre + source_slices)
+        data_slices = tuple([slice(None)] * n_prefix + spans[0])
         data, attributes = stream_source.dataset.read_data_slice(stream_source.group, self.name, data_slices)
-        sub = torch.from_numpy(data)
+        tensor = torch.from_numpy(data)
 
         # Each patch re-runs the chain from the state the whole-volume pass started from: the case as
         # stored (plus planned stats), never the live attribute -- that one carries the chain's own
@@ -1122,35 +1348,38 @@ class DatasetManager:
         persist = a not in self._stream_attributes_persisted
         keys_before = set(cache_attribute.keys()) if persist else set()
 
-        for stage in pre_stages:
-            sub = stage(self.name, sub, cache_attribute)
-        # The region stage's geometry writes describe the patch's extent, not the volume's: give it a
-        # throwaway scope, and write the case-level answer once from the FULL source shape below
-        # (write_stream_cache_attribute). A CROP's remap IS its action: the region read is already the
-        # target patch, so the stage is not re-applied.
-        scoped = Attribute(cache_attribute)
-        if region_loc.kind is LocalityKind.CROP:
-            tensor = sub
-        else:
-            tensor = region_stage(self.name, sub, scoped)
-        if crop_offsets is not None:
-            n_channel_axes = tensor.dim() - len(target_slices)
-            crop = tuple(
-                [slice(None)] * n_channel_axes
-                + [slice(off, off + (sl.stop - sl.start)) for off, sl in zip(crop_offsets, target_slices, strict=False)]
-            )
-            tensor = tensor[crop]
-        for stage in post_stages:
-            tensor = stage(self.name, tensor, cache_attribute)
+        for stage, plan, source, target in zip(stages, plans, spans[:-1], spans[1:], strict=True):
+            if plan.kind not in _REGION_KINDS:
+                tensor = stage(self.name, tensor, cache_attribute)
+                continue
+            # A region stage's geometry writes describe the patch's extent, not the volume's: give it
+            # a throwaway scope, and write the case-level answer once from the FULL shape below
+            # (write_stream_cache_attribute).
+            scoped = Attribute(cache_attribute)
+            if plan.kind is LocalityKind.RESCALE:
+                tensor = cast(Resample, stage).resample_region(
+                    tensor,
+                    tuple(target),
+                    [s.start for s in source],
+                    [plan.in_shape[k] / plan.out_shape[k] for k in range(len(plan.in_shape))],
+                    list(plan.in_shape),
+                )
+            elif plan.kind is not LocalityKind.CROP:
+                tensor = stage(self.name, tensor, scoped)
+                if plan.kind is LocalityKind.HALO:
+                    lead = tensor.dim() - len(target)
+                    crop = [slice(t.start - s.start, t.stop - s.start) for t, s in zip(target, source, strict=False)]
+                    tensor = tensor[(*[slice(None)] * lead, *crop)]
+            if persist:
+                # The stage's own geometry writes went to the patch-scoped copy above, so this is
+                # where the case gets them: computed once, from the FULL shape of the stage's input,
+                # against the attribute that still describes the whole volume.
+                stage.write_stream_cache_attribute(self.cache_attributes[a], list(plan.in_shape))
+                self._check_region_geometry_reaches_the_case(stage, scoped, cache_attribute)
 
         tensor = self._finalize_stream_patch(tensor, index, a, is_input)
 
         if persist:
-            # The region stage's own geometry writes went to the patch-scoped copy above, so this is
-            # where the case gets them: computed once, from the FULL source shape, against the attribute
-            # that still describes the whole volume.
-            region_stage.write_stream_cache_attribute(self.cache_attributes[a], source_spatial)
-            self._check_region_geometry_reaches_the_case(region_stage, scoped, cache_attribute)
             self._persist_stream_attributes(a, cache_attribute, keys_before)
         return tensor, cache_attribute
 
@@ -1176,69 +1405,6 @@ class DatasetManager:
             "Record the case's answer in write_stream_cache_attribute(): it is given the whole volume's"
             " shape, where a patch's extent cannot say it.",
         )
-
-    def _get_streamed_resample_data(
-        self,
-        index: int,
-        a: int,
-        stream_source: _PatchStreamSource,
-        resample_pos: int,
-        is_input: bool,
-    ) -> tuple[torch.Tensor, Attribute]:
-        """Patch-native resample: read ONLY the source region a target patch maps to.
-
-        The chain is ``[pre-pointwise][Resample][post-pointwise]``. The target-grid
-        patch slices (already on the post-resample shape) are mapped back to a
-        bounded source region via ``resample.resample_source_region``; only that region
-        is read (``read_data_slice``); pre-pointwise stages run on the sub-region,
-        then the gather kernel interpolates to the target extent, then post-pointwise
-        stages run on the patch. Only the source region is requested; whether that avoids decoding
-        the whole volume depends on the storage format -- compressed MetaImage and NRRD decode the
-        full volume per read (see ``_supports_region_read``).
-        """
-        source_shape = stream_source.shape
-        resample = cast(Resample, stream_source.stages[resample_pos])
-        pre_stages = stream_source.stages[:resample_pos]
-        post_stages = stream_source.stages[resample_pos + 1 :]
-
-        # Target-grid spatial slices for this patch (built on the post-resample shape).
-        target_slices = tuple(self.patch.get_patch_slices(a)[index])
-        source_spatial = list(source_shape[len(source_shape) - len(target_slices) :])
-
-        source_slices, region_starts, scales, n_in, _ = resample.resample_source_region(
-            target_slices, source_spatial, Attribute(self.cache_attributes_bak[a])
-        )
-
-        slices_pre = [slice(None) for _ in range(len(source_shape) - len(target_slices))]
-        data_slices = tuple(slices_pre + source_slices)
-        data, attributes = stream_source.dataset.read_data_slice(stream_source.group, self.name, data_slices)
-        sub = torch.from_numpy(data)
-
-        cache_attribute = Attribute(self.cache_attributes_bak[a])
-        cache_attribute.update(attributes)
-        persist = a not in self._stream_attributes_persisted
-        keys_before = set(cache_attribute.keys()) if persist else set()
-
-        for stage in pre_stages:
-            sub = stage(self.name, sub, cache_attribute)
-        tensor = resample.resample_region(sub, target_slices, region_starts, scales, n_in)
-        for stage in post_stages:
-            tensor = stage(self.name, tensor, cache_attribute)
-
-        tensor = self._finalize_stream_patch(tensor, index, a, is_input)
-
-        if persist:
-            persistent = self.cache_attributes[a]
-            persistent_keys = set(persistent.keys())
-            for key, value in cache_attribute.items():
-                if key not in keys_before and key not in persistent_keys:
-                    dict.__setitem__(persistent, key, value)
-            # Record the same Spacing/Size stack a whole-volume __call__ would, so
-            # inverse() at prediction time pops exactly what the non-streamed path
-            # pushed. Uses the FULL source shape, never the halo'd sub-region.
-            resample.write_stream_cache_attribute(persistent, source_spatial)
-            self._stream_attributes_persisted.add(a)
-        return tensor, cache_attribute
 
     def unload(self) -> None:
         self.data.clear()

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -202,6 +202,55 @@ class TransformInverse(Transform, ABC):
     def inverse(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         pass
 
+    def inverse_patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        """Declare how ``inverse``'s output depends on its input, for the streamed-write dispatcher.
+
+        The write mirror of :meth:`patch_locality`: a prediction's finalize chain applies transforms
+        INVERTED, so the streamed-write gate asks each one about its inverse. ``cache_attribute`` is the
+        finalize-time state — the case's attribute as ``inverse`` will receive it, with everything the
+        forward pass pushed still stacked on it — under the same three rules (read-only, no I/O, total).
+
+        The default derives from the forward contract where the derivation is safe for any subclass: a
+        per-voxel value map inverts to a per-voxel value map, and an index remap inverts to an index
+        remap. Every other kind falls to ``WHOLE_VOLUME`` — an inverse that is streamable anyway
+        (``Padding``'s crop, ``Resample``'s rescale) declares itself.
+        """
+        forward = self.patch_locality(cache_attribute)
+        if forward.kind in (LocalityKind.POINTWISE, LocalityKind.ORIENTATION):
+            return forward
+        return PatchLocality(LocalityKind.WHOLE_VOLUME)
+
+    def inverse_transform_shape(self, shape: list[int], cache_attribute: Attribute) -> list[int]:
+        """The spatial shape ``inverse`` produces from ``shape`` (write mirror of ``transform_shape``).
+
+        ``cache_attribute`` is the finalize-time state, as in :meth:`inverse_patch_locality`. The
+        default is the identity, exactly as (in)exact as ``transform_shape``'s: a shape-changing
+        inverse must override it, and the streamed-write dispatcher only trusts it for the kinds
+        :meth:`inverse_patch_locality` declared streamable.
+        """
+        return shape
+
+    def stream_region_target(
+        self,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+        cache_attribute: Attribute,
+    ) -> list[slice]:
+        """Map a region of ``inverse``'s OUTPUT to the region of its INPUT it is computed from.
+
+        The write mirror of :meth:`stream_region_source`, with the same direction of travel: the slices
+        are in the space being produced (here the written image), the shape is the space being consumed
+        (here the finalized accumulator), and the answer is the consumed region. The streamed-write
+        dispatcher holds a sliding window of finalized slabs and emits each output region once the
+        region this returns has arrived. ``cache_attribute`` is the finalize-time state; a transform
+        whose remap is read from what its own ``inverse`` pops accounts for those pops on a copy.
+        """
+        raise TransformError(
+            f"{type(self).__name__} declared a region inverse patch-locality but does not implement"
+            " stream_region_target().",
+            "Implement stream_region_target() or declare a non-region inverse_patch_locality().",
+        )
+
 
 class TransformLoader:
     """Resolve and instantiate transform classes from KonfAI configuration."""
@@ -441,6 +490,11 @@ class Normalize(TransformInverse):
 
         return tensor
 
+    def inverse_patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # The forward needs the volume's Min/Max (GLOBAL_STAT); the inverse only pops what the forward
+        # stacked, so on the finalize-time attribute it is a per-voxel affine map.
+        return PatchLocality(LocalityKind.POINTWISE)
+
     def inverse(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         if self.lazy:
             return tensor
@@ -539,6 +593,10 @@ class Standardize(TransformInverse):
             return stat.reshape(-1, *([1] * (tensor.dim() - 1)))
         return stat
 
+    def inverse_patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # Mask or not, the inverse only pops the Mean/Std the forward stacked: a per-voxel affine map.
+        return PatchLocality(LocalityKind.POINTWISE)
+
     def inverse(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         if self.lazy:
             return tensor
@@ -610,6 +668,29 @@ class Padding(TransformInverse):
         for dim in range(len(self.padding) // 2):
             shape[-dim - 1] += sum(self.padding[dim * 2 : dim * 2 + 2])
         return shape
+
+    def inverse_patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # The inverse drops the padded border and keeps a translated copy of what remains: a CROP.
+        return PatchLocality(LocalityKind.CROP)
+
+    def inverse_transform_shape(self, shape: list[int], cache_attribute: Attribute) -> list[int]:
+        shape = list(shape)
+        for dim in range(len(self.padding) // 2):
+            shape[-dim - 1] -= sum(self.padding[dim * 2 : dim * 2 + 2])
+        return shape
+
+    def stream_region_target(
+        self,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+        cache_attribute: Attribute,
+    ) -> list[slice]:
+        # Output index o holds input index o + pad_before: a written region pulls its own slices stepped
+        # forward by the leading pad (padding pairs are in reversed axis order, like F.pad).
+        before = [0] * len(target_slices)
+        for dim in range(min(len(self.padding) // 2, len(before))):
+            before[-dim - 1] = self.padding[dim * 2]
+        return [slice(t.start + b, t.stop + b) for t, b in zip(target_slices, before, strict=False)]
 
     def inverse(self, name: str, tensor: torch.Tensor, cache_attribute: dict[str, torch.Tensor]) -> torch.Tensor:
         if "Origin" in cache_attribute and "Spacing" in cache_attribute and "Direction" in cache_attribute:
@@ -684,12 +765,44 @@ class Resample(TransformInverse, ABC):
     def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
         pass
 
-    def inverse(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
+    def _inverse_geometry(self, cache_attribute: Attribute) -> list[int]:
+        """Pop the Size/Spacing stack the forward pushed and return the size the inverse restores."""
         cache_attribute.pop_np_array("Size")
         size_1 = cache_attribute.pop_np_array("Size")
         if "Spacing" in cache_attribute:
             cache_attribute.pop_np_array("Spacing")
-        return self._resample(tensor, [int(size) for size in size_1])
+        return [int(size) for size in size_1]
+
+    def inverse(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
+        return self._resample(tensor, self._inverse_geometry(cache_attribute))
+
+    def inverse_patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # The inverse rescales back to the size the forward stacked: patch-native (RESCALE) whenever
+        # that stack is on the finalize-time attribute, judged on a copy (a declaration never pops).
+        try:
+            self._inverse_geometry(Attribute(cache_attribute))
+        except NameError:
+            return PatchLocality(LocalityKind.WHOLE_VOLUME)
+        return PatchLocality(LocalityKind.RESCALE)
+
+    def inverse_transform_shape(self, shape: list[int], cache_attribute: Attribute) -> list[int]:
+        try:
+            return self._inverse_geometry(Attribute(cache_attribute))
+        except NameError:
+            return shape
+
+    def stream_region_target(
+        self,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+        cache_attribute: Attribute,
+    ) -> list[slice]:
+        # The inverse rescales the accumulator (n_in) back to the stored size: a written region pulls
+        # through the same coordinate formula as the forward read, with the roles swapped.
+        n_in = [int(s) for s in source_spatial_shape]
+        n_out = self.inverse_transform_shape(list(n_in), cache_attribute)
+        scales = [n_in[k] / n_out[k] for k in range(len(n_in))]
+        return Resample.source_window(target_slices, scales, n_in)
 
     # Every patch derives its source coordinates from the same global scale (n_in / n_out, from the
     # truncated integer sizes F.interpolate itself uses), which is what makes the streamed patches
@@ -715,17 +828,23 @@ class Resample(TransformInverse, ABC):
         n_in = [int(s) for s in source_spatial_shape]
         n_out = [int(s) for s in self.transform_shape("", "", list(n_in), cache_attribute)]
         scales = [n_in[k] / n_out[k] for k in range(len(n_in))]
+        source_slices = Resample.source_window(target_slices, scales, n_in, halo)
+        return source_slices, [s.start for s in source_slices], scales, n_in, n_out
+
+    @staticmethod
+    def source_window(
+        target_slices: tuple[slice, ...] | list[slice],
+        scales: list[float],
+        n_in: list[int],
+        halo: int = 1,
+    ) -> list[slice]:
+        """The clamped source region a target region interpolates from, per axis, given the scales."""
         source_slices: list[slice] = []
-        region_starts: list[int] = []
         for k, sl in enumerate(target_slices):
-            o0, o1 = sl.start, sl.stop
-            smin = int(np.floor(scales[k] * (o0 + 0.5) - 0.5))
-            smax = int(np.floor(scales[k] * ((o1 - 1) + 0.5) - 0.5))
-            a = max(0, smin - halo)
-            b = min(n_in[k], smax + 2 + halo)
-            source_slices.append(slice(a, b))
-            region_starts.append(a)
-        return source_slices, region_starts, scales, n_in, n_out
+            smin = int(np.floor(scales[k] * (sl.start + 0.5) - 0.5))
+            smax = int(np.floor(scales[k] * ((sl.stop - 1) + 0.5) - 0.5))
+            source_slices.append(slice(max(0, smin - halo), min(n_in[k], smax + 2 + halo)))
+        return source_slices
 
     def resample_region(
         self,
@@ -746,16 +865,17 @@ class Resample(TransformInverse, ABC):
         dev = sub_tensor.device
         ndim = len(target_slices)
         if mode == "nearest":
-            out = sub_tensor
+            indices = []
             for k in range(ndim):
                 # Take the axis's index map from F.interpolate itself, so streamed nearest picks the
                 # same source voxel as the whole-volume call for every size ratio.
                 src = torch.arange(n_in[k], device=dev, dtype=torch.float32).reshape(1, 1, -1)
                 n_out_k = round(n_in[k] / scales[k])
                 index = F.interpolate(src, size=n_out_k, mode="nearest").long().flatten()
-                index = index[target_slices[k].start : target_slices[k].stop] - region_starts[k]
-                out = out.index_select(k + 1, index)
-            return out
+                indices.append(index[target_slices[k].start : target_slices[k].stop] - region_starts[k])
+            # One gather over broadcast index views instead of one volume copy per axis (nearest is a
+            # pure coordinate gather, so composing the axes changes no value).
+            return sub_tensor[(slice(None), *torch.meshgrid(*indices, indexing="ij"))]
 
         if not sub_tensor.is_floating_point() or (
             sub_tensor.device.type == "cpu" and sub_tensor.dtype in (torch.float16, torch.bfloat16)
@@ -1258,6 +1378,22 @@ class Permute(TransformInverse):
             source_slices[self.dims[k + 1] - 1] = slice(sl.start, sl.stop)
         return source_slices
 
+    def inverse_transform_shape(self, shape: list[int], cache_attribute: Attribute) -> list[int]:
+        result = list(shape)
+        for k, d in enumerate(self.dims[1:]):
+            result[d - 1] = shape[k]
+        return result
+
+    def stream_region_target(
+        self,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+        cache_attribute: Attribute,
+    ) -> list[slice]:
+        # Input axis k carries output axis ``dims[k + 1] - 1``: a written region pulls, per input axis,
+        # the slice of the output axis it came from.
+        return [slice(target_slices[d - 1].start, target_slices[d - 1].stop) for d in self.dims[1:]]
+
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         return tensor.permute(tuple(self.dims))
 
@@ -1290,6 +1426,15 @@ class Flip(TransformInverse):
             else:
                 source_slices.append(slice(sl.start, sl.stop))
         return source_slices
+
+    def stream_region_target(
+        self,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+        cache_attribute: Attribute,
+    ) -> list[slice]:
+        # A flip is its own inverse: a written region pulls exactly the region the forward would read.
+        return self.stream_region_source(target_slices, source_spatial_shape, cache_attribute)
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         return tensor.flip(tuple(self.dims))
@@ -1475,6 +1620,60 @@ class Canonical(TransformInverse):
         # tensor's shape.
         center = initial_matrix @ half_extent + initial_origin
         cache_attribute["Origin"] = center - self.canonical_direction @ Canonical._carried(half_extent, remap)
+
+    def _inverse_remap(self, cache_attribute: Attribute) -> list[tuple[int, bool]] | None:
+        """The forward remap judged on the state ``inverse`` runs from: the popped-to source direction.
+
+        The inverse pops the canonical geometry and reorients back through the SOURCE direction under
+        it, so its streamability is the popped state's — evaluated on a copy, since a declaration
+        never mutates the case. A matrix and its inverse are signed permutations together, so the
+        forward remap answers for both; ``None`` where the case is oblique or carries no direction.
+        """
+        scoped = Attribute(cache_attribute)
+        if "Direction" not in scoped:
+            return None
+        scoped.pop("Direction")
+        return self._orthogonal_remap(scoped)
+
+    def inverse_patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        if self._inverse_remap(cache_attribute) is None:
+            return PatchLocality(LocalityKind.WHOLE_VOLUME)
+        return PatchLocality(LocalityKind.ORIENTATION)
+
+    def inverse_transform_shape(self, shape: list[int], cache_attribute: Attribute) -> list[int]:
+        # transform_shape reads target axis k's extent from source axis ``source``; the inverse puts
+        # each extent back on the axis it came from.
+        remap = self._inverse_remap(cache_attribute)
+        if remap is None:
+            return shape
+        result = list(shape)
+        for k, (source, _) in enumerate(remap):
+            result[source] = shape[k]
+        return result
+
+    def stream_region_target(
+        self,
+        target_slices: tuple[slice, ...],
+        source_spatial_shape: list[int],
+        cache_attribute: Attribute,
+    ) -> list[slice]:
+        # Canonical axis k holds source axis ``source``'s content: a written region pulls, per input
+        # axis, the slice of the output axis it carries — taken mirrored within the input extent where
+        # the remap reads that axis backwards (a flip restricted to a region is that region reversed).
+        remap = self._inverse_remap(cache_attribute)
+        if remap is None:
+            raise TransformError(
+                "Canonical declared a region inverse patch-locality for a direction it cannot remap exactly.",
+                "Report this: inverse_patch_locality() and stream_region_target() disagree about the case.",
+            )
+        source_slices: list[slice] = []
+        for k, (source, mirrored) in enumerate(remap):
+            target = target_slices[source]
+            extent = source_spatial_shape[k]
+            source_slices.append(
+                slice(extent - target.stop, extent - target.start) if mirrored else slice(target.start, target.stop)
+            )
+        return source_slices
 
     def _reorient(self, tensor: torch.Tensor, reorientation: torch.Tensor) -> torch.Tensor:
         """Apply a reorientation: an exact index remap where it is one, a resample where it is not.

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -838,12 +838,24 @@ class Resample(TransformInverse, ABC):
         n_in: list[int],
         halo: int = 1,
     ) -> list[slice]:
-        """The clamped source region a target region interpolates from, per axis, given the scales."""
+        """The clamped source region a target region reads from, per axis, given the scales.
+
+        Covers BOTH samplers, because the same window serves either mode: the linear taps around the
+        half-pixel source (``scale * (o + 0.5) - 0.5``, plus the ``+2``/``halo`` margin for the i1
+        neighbour) AND the voxel nearest picks (``floor(o * scale)`` -- F.interpolate's own nearest
+        index). Under strong downsampling the nearest voxel of the first output column falls BELOW the
+        linear window's start, so omitting it read one voxel short and the gather wrapped a negative
+        local index onto the far edge.
+        """
         source_slices: list[slice] = []
         for k, sl in enumerate(target_slices):
             smin = int(np.floor(scales[k] * (sl.start + 0.5) - 0.5))
             smax = int(np.floor(scales[k] * ((sl.stop - 1) + 0.5) - 0.5))
-            source_slices.append(slice(max(0, smin - halo), min(n_in[k], smax + 2 + halo)))
+            near_lo = int(np.floor(sl.start * scales[k]))
+            near_hi = int(np.floor((sl.stop - 1) * scales[k]))
+            start = min(smin - halo, near_lo)
+            stop = max(smax + 2 + halo, near_hi + 1)
+            source_slices.append(slice(max(0, start), min(n_in[k], stop)))
         return source_slices
 
     def resample_region(

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -37,11 +37,11 @@ except ImportError:
 
 from konfai import config_file, cuda_visible_devices, konfai_root, predictions_directory
 from konfai.data.data_manager import BatchSample, DataPrediction, DatasetIter
-from konfai.data.patching import Accumulator, PathCombine
-from konfai.data.transform import Transform, TransformInverse, TransformLoader
+from konfai.data.patching import Accumulator, PathCombine, StreamingAccumulator
+from konfai.data.transform import LocalityKind, Transform, TransformInverse, TransformLoader
 from konfai.network.network import Model, ModelLoader, NetState, Network
 from konfai.utils.config import apply_config, config
-from konfai.utils.dataset import Attribute, Dataset
+from konfai.utils.dataset import Attribute, Dataset, DataStream
 from konfai.utils.errors import ConfigError, PredictorError
 from konfai.utils.runtime import (
     DataLog,
@@ -58,7 +58,26 @@ from konfai.utils.utils import get_module, split_path_spec
 
 
 class Reduction(ABC):
-    """Abstract reduction applied across model ensemble or augmentation outputs."""
+    """Aggregate a list of predictions (one per model in an ensemble, or per TTA augmentation) into one.
+
+    A ``Reduction`` is a KonfAI extension point: subclass it and reference it by classpath in the
+    ``OutputDataset`` config. ``__call__`` receives the stacked predictions and returns the aggregate.
+    """
+
+    #: Streamed-write contract. ``True`` declares this reduction a **pure per-voxel** operation over the
+    #: model/TTA (stack) axis — every output voxel depends only on the SAME voxel of each input, never on
+    #: a spatial neighbour. The streamed-write gate reads this flag to decide whether the finalize chain
+    #: may run slab by slab.
+    #:
+    #: Rules for a custom reduction:
+    #: - **Default False.** Leave it False unless you are sure: an unknown reduction then takes the
+    #:   whole-volume path, costing the streaming optimisation but never correctness.
+    #: - **Set True only if voxel-local.** Reducing/stacking along the stack axis (dim 0) or the channel
+    #:   axis (dim 1) is fine — those are orthogonal to the spatial slab axis. Anything that reads across
+    #:   spatial positions (a spatial blur, a resample, a global-argmax over Z) must stay False.
+    #: - **A wrong True corrupts the streamed output** (each slab would be reduced with only its own data);
+    #:   the gate trusts this flag and checks nothing else.
+    voxel_local: bool = False
 
     @abstractmethod
     def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
@@ -67,6 +86,8 @@ class Reduction(ABC):
 
 class Mean(Reduction):
     """Average ensemble or augmentation predictions element-wise."""
+
+    voxel_local = True
 
     def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
         # A single element (no TTA / a lone model) is its own mean; skip the float32 clone + accumulate,
@@ -84,6 +105,8 @@ class Mean(Reduction):
 class Median(Reduction):
     """Compute the element-wise median across prediction tensors."""
 
+    voxel_local = True
+
     def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
         # A single element is its own median; skip the float32 stack (a large no-op for whole volumes).
         if len(tensors) == 1:
@@ -93,6 +116,9 @@ class Median(Reduction):
 
 class Concat(Reduction):
     """Concatenate prediction tensors along the channel dimension."""
+
+    # Cats along the channel axis, orthogonal to the spatial slab axis -- per-voxel, so slab-local.
+    voxel_local = True
 
     def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
         return torch.cat(tensors, dim=1)
@@ -274,11 +300,14 @@ class OutputDataset(Dataset, NeedDevice, ABC):
         layer: torch.Tensor,
         dataset: DatasetIter,
         attribute: Attribute | None = None,
+        number_of_channels_per_model: list[int] | None = None,
     ):
         raise NotImplementedError()
 
     def is_done(self, index: int) -> bool:
-        return len(self.output_layer_accumulator[index]) == self.nb_data_augmentation and all(
+        # ``.get``: a streamed case cleans itself up inside ``add_layer`` (its slabs are already on
+        # disk), so by the time the run loop asks, the index is gone and the answer is "nothing to do".
+        return len(self.output_layer_accumulator.get(index, {})) == self.nb_data_augmentation and all(
             acc.is_full() for acc in self.output_layer_accumulator[index].values()
         )
 
@@ -335,6 +364,15 @@ class OutSameAsGroupDataset(OutputDataset):
             reduction,
         )
         self.group_src, self.group_dest = same_as_group.split(":")
+        # Slab streaming has no config knob: it is applied automatically, per case, whenever it is
+        # byte-identical to the assembled path (``_stream_refusal is None`` -- pointwise finalize, single
+        # augmentation, region-writable backend), finalizing and writing each z-slab as its patches
+        # complete so RAM is bounded at one patch window; otherwise the whole-volume path is used
+        # transparently. ``KONFAI_STREAMED_WRITES=0`` is a global ops/debug kill-switch (also how a test
+        # gets the assembled reference), not a per-output option.
+        self._streaming_enabled = os.environ.get("KONFAI_STREAMED_WRITES", "1").lower() not in ("0", "false")
+        self._stream_active: dict[int, bool] = {}
+        self._stream_sinks: dict[int, DataStream] = {}
 
     def add_layer(
         self,
@@ -344,6 +382,7 @@ class OutSameAsGroupDataset(OutputDataset):
         layer: torch.Tensor,
         dataset: DatasetIter,
         attribute: Attribute | None = None,
+        number_of_channels_per_model: list[int] | None = None,
     ):
         if (
             index_dataset not in self.output_layer_accumulator
@@ -357,9 +396,16 @@ class OutSameAsGroupDataset(OutputDataset):
                 self.output_layer_accumulator[index_dataset] = {}
                 self.attributes[index_dataset] = {}
                 self.names[index_dataset] = input_dataset.name
+                # Stream this case iff enabled and byte-identical to the assembled path. No warning on a
+                # refusal: streaming is transparent, so the whole-volume path is a normal outcome, not a
+                # misconfiguration.
+                self._stream_active[index_dataset] = (
+                    self._streaming_enabled and self._stream_refusal(dataset, source_attribute) is None
+                )
             self.attributes[index_dataset][index_augmentation] = {}
 
-            self.output_layer_accumulator[index_dataset][index_augmentation] = Accumulator(
+            accumulator_type = StreamingAccumulator if self._stream_active[index_dataset] else Accumulator
+            self.output_layer_accumulator[index_dataset][index_augmentation] = accumulator_type(
                 input_dataset.patch.get_patch_slices(index_augmentation),
                 input_dataset.patch.patch_size,
                 self.patch_combine,
@@ -388,7 +434,7 @@ class OutSameAsGroupDataset(OutputDataset):
         elif str(layer.device) != str(target):
             layer = layer.to(target)
         try:
-            accumulator.add_layer(index_patch, layer)
+            slabs = accumulator.add_layer(index_patch, layer) or []
         except torch.cuda.OutOfMemoryError:
             # The gate samples free VRAM once per case: another process can reclaim it before this
             # volume-sized first allocation lands. Nothing is blended yet, so fall back to the
@@ -398,7 +444,131 @@ class OutSameAsGroupDataset(OutputDataset):
                 raise
             self._accum_device[index_dataset] = torch.device("cpu")
             torch.cuda.empty_cache()
-            accumulator.add_layer(index_patch, self._offload_to_cpu(layer))
+            slabs = accumulator.add_layer(index_patch, self._offload_to_cpu(layer)) or []
+        if not self._stream_active.get(index_dataset, False):
+            return
+        finished = accumulator.is_full()
+        if finished:
+            slabs = slabs + cast(StreamingAccumulator, accumulator).finalize()
+        try:
+            self._flush_slabs(index_dataset, slabs, number_of_channels_per_model, dataset)
+        except BaseException as error:
+            sink = self._stream_sinks.pop(index_dataset, None)
+            if sink is not None:
+                sink.__exit__(type(error), error, error.__traceback__)
+            raise
+        if finished:
+            self._close_stream(index_dataset)
+
+    def _stream_refusal(self, dataset: DatasetIter, attribute: Attribute) -> str | None:
+        """Why this case cannot be written slab by slab (``None`` = it can).
+
+        Streaming is only byte-identical to the assembled-volume path when every finalize stage is
+        voxel-local: single augmentation (TTA inverses apply to the assembled volume), a Mean/Median
+        reduction, and a POINTWISE ``patch_locality`` for every transform of the finalize chain — a
+        pointwise transform is a per-voxel value map, so its inverse is voxel-local too. Anything else
+        falls back to the proven whole-volume path.
+        """
+        if self.nb_data_augmentation != 1:
+            return "test-time augmentation inverses apply to the assembled volume"
+        # The reduction declares its own slab-locality (like a transform declares patch_locality) rather
+        # than the gate hardcoding a whitelist: any voxel-local reduction streams, an unknown one does not.
+        if not self.reduction.voxel_local:
+            return f"reduction '{type(self.reduction).__name__}' is not voxel-local"
+        chain: list[Transform] = [
+            *self.before_reduction_transforms,
+            *self.after_reduction_transforms,
+            *[
+                transform
+                for transform in dataset.groups_src[self.group_src][self.group_dest].transforms
+                if isinstance(transform, TransformInverse) and transform.apply_inverse
+            ],
+            *self.final_transforms,
+        ]
+        for transform in chain:
+            if transform.patch_locality(Attribute(attribute)).kind is not LocalityKind.POINTWISE:
+                return f"transform '{type(transform).__name__}' is not pointwise"
+        if not self.can_stream_data(attribute):
+            return f"write format '{self.file_format}' cannot serve region writes"
+        return None
+
+    def _flush_slabs(
+        self,
+        index: int,
+        slabs: list[tuple[slice, torch.Tensor]],
+        number_of_channels_per_model: list[int] | None,
+        dataset: DatasetIter,
+    ) -> None:
+        """Finalize each slab and write it into the case's sink (opened at the first slab, once the
+        finalize chain has fixed the output's channel count and dtype)."""
+        for region, slab in slabs:
+            result, attribute = self._finalize_slab(index, slab, number_of_channels_per_model, dataset)
+            array = result.detach().cpu().numpy()
+            if index not in self._stream_sinks:
+                spatial = self.output_layer_accumulator[index][0].shape
+                sink = self.open_data_stream(
+                    self.group, self.names[index], [array.shape[0], *spatial], array.dtype, attribute
+                )
+                if sink is None:
+                    raise PredictorError(
+                        f"Streamed write refused by the '{self.file_format}' backend for dtype"
+                        f" '{array.dtype}' on output '{self.group}': write it to an h5 or omezarr"
+                        f" dataset, or set KONFAI_STREAMED_WRITES=0 to force the whole-volume path."
+                    )
+                self._stream_sinks[index] = sink
+            self._stream_sinks[index].write_slice(
+                (slice(0, array.shape[0]), region, *(slice(0, extent) for extent in array.shape[2:])),
+                array,
+            )
+
+    def _finalize_slab(
+        self,
+        index: int,
+        layer: torch.Tensor,
+        number_of_channels_per_model: list[int] | None,
+        dataset: DatasetIter,
+    ) -> tuple[torch.Tensor, Attribute]:
+        """The single-augmentation finalize chain of ``_get_output``/``get_output``, on one z-slab.
+
+        Every stage passed ``_stream_refusal`` as voxel-local, so applying it slab by slab yields the
+        same voxels as applying it to the assembled volume. Each slab gets its own copy of the case
+        attribute (transform writes stay slab-local).
+        """
+        attribute = Attribute(self.attributes[index][0][0])
+        if number_of_channels_per_model and layer.shape[0] == sum(number_of_channels_per_model):
+            attribute["number_of_channels_per_model_0"] = torch.tensor(number_of_channels_per_model)
+            chunks = list(torch.split(layer, number_of_channels_per_model, dim=0))
+        else:
+            chunks = [layer]
+        results = []
+        for chunk in chunks:
+            for transform in self.before_reduction_transforms:
+                chunk = transform(self.names[index], chunk, Attribute(attribute))
+            results.append(chunk)
+        # Reduce, then drop the singleton stack axis; Mean/Median also drop the singleton model axis,
+        # while Concat keeps the [M, C, ...] model axis for after_reduction (Sum) to merge into labels.
+        result = self.reduction([torch.stack(results, dim=0).unsqueeze(0)]).squeeze(0)
+        if isinstance(self.reduction, Mean | Median):
+            result = result.squeeze(0)
+        for transform in self.after_reduction_transforms:
+            result = transform(self.names[index], result, attribute)
+        for transform in reversed(dataset.groups_src[self.group_src][self.group_dest].transforms):
+            if isinstance(transform, TransformInverse) and transform.apply_inverse:
+                result = transform.inverse(self.names[index], result, attribute)
+        for transform in self.final_transforms:
+            result = transform(self.names[index], result, attribute)
+        return result, attribute
+
+    def _close_stream(self, index: int) -> None:
+        """Finalize the case's sink and drop its bookkeeping (``is_done`` then reports nothing left)."""
+        sink = self._stream_sinks.pop(index, None)
+        if sink is not None:
+            sink.__exit__(None, None, None)
+        self._stream_active.pop(index, None)
+        self.output_layer_accumulator.pop(index, None)
+        self.attributes.pop(index, None)
+        self._accum_device.pop(index, None)
+        self._reduce_device.pop(index, None)
 
     def setup(self, datasets: list[Dataset], groups: dict[str, list[str]]):
         super().setup(datasets, groups)
@@ -434,20 +604,17 @@ class OutSameAsGroupDataset(OutputDataset):
             chunks = [layer]
 
         # The per-model channel reduction (softmax/argmax over the class dimension of a whole-volume
-        # multi-class output) is a strided reduction over billions of elements — slow on CPU, trivial on
-        # the GPU. If the accumulator blended on the GPU, the volume is already on-device: reduce there
-        # directly (no host round-trip, no ``empty_cache``). Otherwise it is on CPU; move the assembled
-        # chunk to the device only when it fits free VRAM, else keep the whole reduction on CPU.
-        if layer.device.type == "cuda":
-            reduce_device = layer.device
-        else:
-            # One decision per case (cached): deciding per augmentation would let free VRAM shrinking
-            # between augmentations flip the device mid-case and hand the reduction a mixed-device list.
-            if index not in self._reduce_device:
-                self._reduce_device[index] = (
-                    self._reduction_device(chunks[0], len(chunks)) if chunks else torch.device("cpu")
-                )
-            reduce_device = self._reduce_device[index]
+        # multi-class output) materialises a working volume on top of the resident accumulator. Decide
+        # once per case whether it fits free VRAM, with the accumulator already resident whatever device
+        # it sits on: if it fits, reduce on the GPU (a no-op move when the volume is already there); else
+        # move the finalize to the host. One decision per case -- deciding per augmentation would let free
+        # VRAM shrinking between augmentations flip the device mid-case and hand the reduction a
+        # mixed-device list.
+        if index not in self._reduce_device:
+            self._reduce_device[index] = (
+                self._reduction_device(chunks[0], len(chunks)) if chunks else torch.device("cpu")
+            )
+        reduce_device = self._reduce_device[index]
         results = []
         for i, layer in enumerate(chunks):
             attr = base_attr if (i == len(chunks) - 1) else Attribute(base_attr)
@@ -481,34 +648,38 @@ class OutSameAsGroupDataset(OutputDataset):
         needed = chunk.numel() * chunk.element_size() * (2 * max(1, nb_chunks) + 1)
         return device if needed < free else torch.device("cpu")
 
+    # A forward runs alongside the resident accumulator on every patch; the memory queries below happen
+    # before those allocations land, so keep ~10 % of free VRAM in reserve for fragmentation and a
+    # concurrent process.
+    _ACCUMULATE_MARGIN = 0.9
+
     def _accumulate_device(self, layer: torch.Tensor, accumulator: Accumulator) -> torch.device:
-        """Device on which to blend a case's patches. Keeping the accumulator on the GPU (nnU-Net style)
-        avoids the per-patch GPU->CPU offload and the CPU blend, and leaves the assembled volume on the
-        device for the reduction (no host round-trip, no ``empty_cache``). Only chosen when the full
-        combined volume of every augmentation, its weight map, and headroom for the ongoing forward
-        passes fit free VRAM; otherwise the memory-safe CPU accumulation is used."""
+        """Device on which to blend a case's patches. On the GPU the accumulator stays resident through
+        the case (no per-patch offload, no CPU blend, and the reduction runs where the volume already is).
+        Decided once per case, at the first patch, when the accumulator fits alongside the memory a
+        forward needs; else the accumulation runs on the CPU."""
         device = torch.device("cuda", self.device) if isinstance(self.device, int) else self.device
         if device.type != "cuda" or layer.device.type != "cuda":
             return torch.device("cpu")
         try:
-            # Release the forward pass's reserved-but-unused cache so ``mem_get_info`` reports the memory
-            # actually available (this runs once, on the first patch of the case).
+            # Return the reserved-but-unused cache so ``mem_get_info`` reports the memory actually free.
             torch.cuda.empty_cache()
             free, _ = torch.cuda.mem_get_info(device)
+            # A forward's transient footprint above the resident set, measured on the batch that just ran
+            # (its activations are already freed). ``max_memory_allocated`` is a high-water mark, so this
+            # bounds the next forward from above -- the gate errs toward the CPU, never toward an OOM.
+            transient = torch.cuda.max_memory_allocated(device) - torch.cuda.memory_allocated(device)
         except Exception:  # nosec B110 - any CUDA query failure keeps the blend on CPU
             return torch.device("cpu")
-        voxels = int(np.prod(accumulator.shape))
+        voxels = int(np.prod(accumulator.footprint_shape))
         # result [C, volume] + weight_sum [volume] at the patch dtype, for EVERY augmentation of the
         # case: ``is_done`` requires all augmentations complete before ``get_output``, so their
         # accumulators are resident simultaneously and the per-case device decision must budget them all.
-        needed = (layer.shape[0] + 1) * voxels * layer.element_size() * max(1, self.nb_data_augmentation)
-        # Keep the accumulator to a bit over a quarter of free VRAM (``needed * 2 < free * 0.56``): the
-        # ``* 2`` reserves a same-size reduction temp, and the rest leaves room for every remaining
-        # patch's forward while the accumulator stays resident. ``free`` is read after the first batch's
-        # forward, so a larger batch (which leaves less free) is rejected here -- exactly when the
-        # forward + resident accumulator would otherwise OOM mid-case. A many-channel volume whose
-        # accumulator dwarfs free (e.g. a 100+ class head) also falls back to the memory-safe CPU blend.
-        return device if needed * 2 < free * 0.56 else torch.device("cpu")
+        accumulator_bytes = (layer.shape[0] + 1) * voxels * layer.element_size() * max(1, self.nb_data_augmentation)
+        # During accumulation the resident accumulator and one forward coexist. The channel reduction's
+        # working volume is budgeted separately, at ``get_output`` time, by ``_reduction_device``.
+        needed = accumulator_bytes + transient
+        return device if needed < free * self._ACCUMULATE_MARGIN else torch.device("cpu")
 
     def get_output(self, index: int, number_of_channels_per_model: list[int], dataset: DatasetIter) -> torch.Tensor:
         results = [
@@ -732,6 +903,7 @@ class _Predictor:
                                     output[i],
                                     self.dataset,
                                     batch_sample[group].attribute[i],
+                                    number_of_channels_per_model,
                                 )
                                 if output_dataset.is_done(index):
                                     output_dataset.write_prediction(

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -22,6 +22,8 @@ import os
 import shutil
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
@@ -37,8 +39,24 @@ except ImportError:
 
 from konfai import config_file, cuda_visible_devices, konfai_root, predictions_directory
 from konfai.data.data_manager import BatchSample, DataPrediction, DatasetIter
-from konfai.data.patching import Accumulator, PathCombine, StreamingAccumulator
-from konfai.data.transform import LocalityKind, Transform, TransformInverse, TransformLoader
+from konfai.data.patching import (
+    Accumulator,
+    PathCombine,
+    SlabRegionStream,
+    StreamingAccumulator,
+    _halo_pull,
+    _halo_radii,
+    _remap_pull,
+    _scale_pull,
+)
+from konfai.data.transform import (
+    LocalityKind,
+    PatchLocality,
+    Resample,
+    Transform,
+    TransformInverse,
+    TransformLoader,
+)
 from konfai.network.network import Model, ModelLoader, NetState, Network
 from konfai.utils.config import apply_config, config
 from konfai.utils.dataset import Attribute, Dataset, DataStream
@@ -335,6 +353,77 @@ class OutputDataset(Dataset, NeedDevice, ABC):
         return str(self)
 
 
+# The write-side region kinds: what SlabRegionStream can carry inside a streamed finalize chain (the
+# same set the read dispatcher accepts as its region stages; on both sides they compose).
+_REGION_KINDS = (LocalityKind.HALO, LocalityKind.ORIENTATION, LocalityKind.CROP, LocalityKind.RESCALE)
+
+
+@dataclass(frozen=True)
+class _FinalizeStage:
+    """One step of the finalize chain, bound to how the chain applies it (forward or inverted)."""
+
+    transform: Transform
+    inverted: bool
+
+    def locality(self, attribute: Attribute) -> PatchLocality:
+        if self.inverted:
+            return cast(TransformInverse, self.transform).inverse_patch_locality(attribute)
+        return self.transform.patch_locality(attribute)
+
+    def __call__(self, name: str, tensor: torch.Tensor, attribute: Attribute) -> torch.Tensor:
+        if self.inverted:
+            return cast(TransformInverse, self.transform).inverse(name, tensor, attribute)
+        return self.transform(name, tensor, attribute)
+
+
+@dataclass(frozen=True)
+class _StreamPlan:
+    """How one case streams: the post-reduction stages, split into a per-slab pointwise prefix, a
+    streamed pipe of region and pointwise stages, and — past what streaming can honour — a
+    whole-volume tail.
+
+    ``to_sink`` streams straight into a region-write ``DataStream``; ``pipe_start`` is the first
+    region stage (``None`` when the chain is pointwise throughout), and the pipe runs from there to
+    the end — region stages compose, so their number is not limited. Without ``to_sink`` the prefix
+    streams into a post-reduction buffer and ``stages[tail_start:]`` runs once on it (the chain
+    split). The invariants: ``to_sink`` implies no tail, and a pipe implies ``to_sink`` — a tail
+    swallows the region stages, so the buffer always sits on the accumulator grid.
+    """
+
+    stages: list[_FinalizeStage]
+    pipe_start: int | None
+    tail_start: int
+    to_sink: bool
+
+    @property
+    def boundary(self) -> int:
+        """Where the per-slab pointwise prefix ends."""
+        return self.pipe_start if self.pipe_start is not None else self.tail_start
+
+    @property
+    def mode(self) -> str:
+        if not self.to_sink:
+            return "buffered"
+        return "region" if self.pipe_start is not None else "direct"
+
+
+@dataclass
+class _RegionState:
+    """One case's live streamed pipe: its slab scheduler and the geometry its closures share.
+
+    ``shapes[i]`` is the spatial shape between pipe stage ``i - 1`` and ``i`` (``shapes[0]`` the
+    accumulator's, ``shapes[-1]`` the written image's); a pointwise stage leaves it unchanged, so the
+    per-stage region bookkeeping folds through the same list the pull map composes over.
+    """
+
+    stages: list[_FinalizeStage]
+    kinds: list[LocalityKind]
+    shapes: list[list[int]]
+    stream: SlabRegionStream | None = None
+    # The attribute the latest emission ran the pipe on: what the sink opens with.
+    attribute: Attribute | None = None
+
+
 @config("OutputDataset")
 class OutSameAsGroupDataset(OutputDataset):
     """
@@ -365,14 +454,16 @@ class OutSameAsGroupDataset(OutputDataset):
         )
         self.group_src, self.group_dest = same_as_group.split(":")
         # Slab streaming has no config knob: it is applied automatically, per case, whenever it is
-        # byte-identical to the assembled path (``_stream_refusal is None`` -- pointwise finalize, single
-        # augmentation, region-writable backend), finalizing and writing each z-slab as its patches
-        # complete so RAM is bounded at one patch window; otherwise the whole-volume path is used
-        # transparently. ``KONFAI_STREAMED_WRITES=0`` is a global ops/debug kill-switch (also how a test
-        # gets the assembled reference), not a per-output option.
+        # byte-identical to the assembled path (see ``_plan_stream``), finalizing each z-slab as its
+        # patches complete so RAM is bounded at one patch window; otherwise the whole-volume path is
+        # used transparently. ``KONFAI_STREAMED_WRITES=0`` is a global ops/debug kill-switch (also how
+        # a test gets the assembled reference), not a per-output option.
         self._streaming_enabled = os.environ.get("KONFAI_STREAMED_WRITES", "1").lower() not in ("0", "false")
-        self._stream_active: dict[int, bool] = {}
+        self._stream_plans: dict[int, _StreamPlan | None] = {}
         self._stream_sinks: dict[int, DataStream] = {}
+        self._region_states: dict[int, _RegionState] = {}
+        self._stream_buffers: dict[int, torch.Tensor] = {}
+        self._post_prefix_attributes: dict[int, Attribute] = {}
 
     def add_layer(
         self,
@@ -396,15 +487,14 @@ class OutSameAsGroupDataset(OutputDataset):
                 self.output_layer_accumulator[index_dataset] = {}
                 self.attributes[index_dataset] = {}
                 self.names[index_dataset] = input_dataset.name
-                # Stream this case iff enabled and byte-identical to the assembled path. No warning on a
-                # refusal: streaming is transparent, so the whole-volume path is a normal outcome, not a
-                # misconfiguration.
-                self._stream_active[index_dataset] = (
-                    self._streaming_enabled and self._stream_refusal(dataset, source_attribute) is None
+                # Plan how (or whether) this case streams. No warning on a refusal: streaming is
+                # transparent, so the whole-volume path is a normal outcome, not a misconfiguration.
+                self._stream_plans[index_dataset] = (
+                    self._plan_stream(dataset, source_attribute) if self._streaming_enabled else None
                 )
             self.attributes[index_dataset][index_augmentation] = {}
 
-            accumulator_type = StreamingAccumulator if self._stream_active[index_dataset] else Accumulator
+            accumulator_type = StreamingAccumulator if self._stream_plans[index_dataset] else Accumulator
             self.output_layer_accumulator[index_dataset][index_augmentation] = accumulator_type(
                 input_dataset.patch.get_patch_slices(index_augmentation),
                 input_dataset.patch.patch_size,
@@ -445,13 +535,15 @@ class OutSameAsGroupDataset(OutputDataset):
             self._accum_device[index_dataset] = torch.device("cpu")
             torch.cuda.empty_cache()
             slabs = accumulator.add_layer(index_patch, self._offload_to_cpu(layer)) or []
-        if not self._stream_active.get(index_dataset, False):
+        if not self._stream_plans.get(index_dataset):
             return
         finished = accumulator.is_full()
         if finished:
             slabs = slabs + cast(StreamingAccumulator, accumulator).finalize()
         try:
-            self._flush_slabs(index_dataset, slabs, number_of_channels_per_model, dataset)
+            self._consume_slabs(index_dataset, slabs, number_of_channels_per_model)
+            if finished:
+                self._finish_stream(index_dataset)
         except BaseException as error:
             sink = self._stream_sinks.pop(index_dataset, None)
             if sink is not None:
@@ -460,79 +552,315 @@ class OutSameAsGroupDataset(OutputDataset):
         if finished:
             self._close_stream(index_dataset)
 
-    def _stream_refusal(self, dataset: DatasetIter, attribute: Attribute) -> str | None:
-        """Why this case cannot be written slab by slab (``None`` = it can).
+    @staticmethod
+    def _voxel_local(locality: PatchLocality, attribute: Attribute) -> bool:
+        """Whether a finalize stage is a per-voxel map here: POINTWISE, or GLOBAL_STAT whose statistic
+        the case already carries — the finalize attribute holds what the forward pass pushed, and there
+        is no stored volume left to derive a missing one from."""
+        if locality.kind is LocalityKind.POINTWISE:
+            return True
+        return locality.kind is LocalityKind.GLOBAL_STAT and all(key in attribute for key in locality.stat_keys)
 
-        Streaming is only byte-identical to the assembled-volume path when every finalize stage is
-        voxel-local: single augmentation (TTA inverses apply to the assembled volume), a Mean/Median
-        reduction, and a POINTWISE ``patch_locality`` for every transform of the finalize chain — a
-        pointwise transform is a per-voxel value map, so its inverse is voxel-local too. Anything else
-        falls back to the proven whole-volume path.
+    def _plan_stream(self, dataset: DatasetIter, attribute: Attribute) -> _StreamPlan | None:
+        """The streaming plan for this case, or ``None`` for the whole-volume path.
+
+        The streamed part of the finalize chain is ``[pointwise*][region and pointwise stages]``:
+        region stages compose — each pulls through the one before it — so any number of geometry
+        inverses streams to the write. What streaming cannot honour — a WHOLE_VOLUME stage, a
+        statistic nothing seeded — becomes a whole-volume TAIL: the prefix still streams slab by slab
+        into a light post-reduction buffer and the tail runs once on that buffer. A destination that
+        cannot serve region writes buffers too, and writes classically. Only a non-streamable start
+        refuses outright: several augmentations (TTA inverses apply to the assembled volume), a
+        reduction that is not voxel-local, or a non-voxel-local before-reduction transform (it runs
+        per model chunk inside the slab prefix).
         """
-        if self.nb_data_augmentation != 1:
-            return "test-time augmentation inverses apply to the assembled volume"
-        # The reduction declares its own slab-locality (like a transform declares patch_locality) rather
-        # than the gate hardcoding a whitelist: any voxel-local reduction streams, an unknown one does not.
-        if not self.reduction.voxel_local:
-            return f"reduction '{type(self.reduction).__name__}' is not voxel-local"
-        chain: list[Transform] = [
-            *self.before_reduction_transforms,
-            *self.after_reduction_transforms,
-            *[
-                transform
-                for transform in dataset.groups_src[self.group_src][self.group_dest].transforms
+        if self.nb_data_augmentation != 1 or not self.reduction.voxel_local:
+            return None
+        for transform in self.before_reduction_transforms:
+            if not self._voxel_local(transform.patch_locality(Attribute(attribute)), attribute):
+                return None
+        stages = [
+            *(_FinalizeStage(transform, False) for transform in self.after_reduction_transforms),
+            *(
+                _FinalizeStage(transform, True)
+                for transform in reversed(dataset.groups_src[self.group_src][self.group_dest].transforms)
                 if isinstance(transform, TransformInverse) and transform.apply_inverse
-            ],
-            *self.final_transforms,
+            ),
+            *(_FinalizeStage(transform, False) for transform in self.final_transforms),
         ]
-        for transform in chain:
-            if transform.patch_locality(Attribute(attribute)).kind is not LocalityKind.POINTWISE:
-                return f"transform '{type(transform).__name__}' is not pointwise"
-        if not self.can_stream_data(attribute):
-            return f"write format '{self.file_format}' cannot serve region writes"
-        return None
+        pipe_start: int | None = None
+        tail_start = len(stages)
+        for index, stage in enumerate(stages):
+            locality = stage.locality(Attribute(attribute))
+            if self._voxel_local(locality, attribute):
+                continue
+            if locality.kind in _REGION_KINDS:
+                if pipe_start is None:
+                    pipe_start = index
+                continue
+            tail_start = index
+            break
+        if tail_start < len(stages) or not self.can_stream_data(attribute):
+            # A whole-volume tail swallows the region stages too: the buffer sits on the accumulator
+            # grid, and the tail runs the true whole-volume operators on it — byte-identical for free.
+            if pipe_start is not None:
+                tail_start = min(tail_start, pipe_start)
+            return _StreamPlan(stages, None, tail_start, to_sink=False)
+        return _StreamPlan(stages, pipe_start, len(stages), to_sink=True)
 
-    def _flush_slabs(
+    def _consume_slabs(
         self,
         index: int,
         slabs: list[tuple[slice, torch.Tensor]],
         number_of_channels_per_model: list[int] | None,
-        dataset: DatasetIter,
     ) -> None:
-        """Finalize each slab and write it into the case's sink (opened at the first slab, once the
-        finalize chain has fixed the output's channel count and dtype)."""
+        """Run each finalized slab through the plan: prefix per slab, then sink, region stream, or
+        buffer. The first slab fixes the case's state (post-prefix attribute, region scheduler or
+        buffer) and may demote a RESCALE region to the buffered tail (see ``_init_stream_state``)."""
+        plan = cast(_StreamPlan, self._stream_plans[index])
         for region, slab in slabs:
-            result, attribute = self._finalize_slab(index, slab, number_of_channels_per_model, dataset)
-            array = result.detach().cpu().numpy()
-            if index not in self._stream_sinks:
-                spatial = self.output_layer_accumulator[index][0].shape
-                sink = self.open_data_stream(
-                    self.group, self.names[index], [array.shape[0], *spatial], array.dtype, attribute
-                )
-                if sink is None:
-                    raise PredictorError(
-                        f"Streamed write refused by the '{self.file_format}' backend for dtype"
-                        f" '{array.dtype}' on output '{self.group}': write it to an h5 or omezarr"
-                        f" dataset, or set KONFAI_STREAMED_WRITES=0 to force the whole-volume path."
-                    )
-                self._stream_sinks[index] = sink
-            self._stream_sinks[index].write_slice(
-                (slice(0, array.shape[0]), region, *(slice(0, extent) for extent in array.shape[2:])),
-                array,
+            block, attribute = self._finalize_slab(
+                index, slab, number_of_channels_per_model, plan.stages[: plan.boundary]
             )
+            if index not in self._post_prefix_attributes:
+                plan = self._init_stream_state(index, plan, block, attribute)
+            state = self._region_states.get(index)
+            if state is not None:
+                for target, emitted in cast(SlabRegionStream, state.stream).push(region, block):
+                    self._write_stream_block(index, target, emitted, cast(Attribute, state.attribute))
+            elif plan.to_sink:
+                spatial = self.output_layer_accumulator[index][0].shape
+                target = (region, *(slice(0, int(extent)) for extent in spatial[1:]))
+                self._write_stream_block(index, target, block, attribute)
+            else:
+                buffer = self._stream_buffers[index]
+                lead = (slice(None),) * (block.dim() - len(self.output_layer_accumulator[index][0].shape))
+                buffer[(*lead, region)] = block.to(buffer.device)
+
+    def _init_stream_state(
+        self, index: int, plan: _StreamPlan, block: torch.Tensor, attribute: Attribute
+    ) -> _StreamPlan:
+        """Fix the case's streaming state at its first slab, when the prefix output is known.
+
+        A RESCALE stage streams through ``resample_region``, which matches ``F.interpolate`` bit for
+        bit only in nearest mode (uint8): a pipe whose rescale would interpolate is demoted here to
+        the buffered tail, where the true inverse runs whole-volume — byte-identity is never traded
+        for streaming. The demotion leaves the prefix untouched (the pipe was never part of it).
+        """
+        self._post_prefix_attributes[index] = Attribute(attribute)
+        spatial = [int(extent) for extent in self.output_layer_accumulator[index][0].shape]
+        if plan.pipe_start is not None:
+            state = self._make_pipe_state(index, plan, spatial, block)
+            if state is None:
+                plan = _StreamPlan(plan.stages, None, plan.pipe_start, to_sink=False)
+                self._stream_plans[index] = plan
+            else:
+                self._region_states[index] = state
+        if not plan.to_sink:
+            lead = list(block.shape[: block.dim() - len(spatial)])
+            try:
+                buffer = torch.empty([*lead, *spatial], dtype=block.dtype, device=block.device)
+            except torch.cuda.OutOfMemoryError:
+                buffer = torch.empty([*lead, *spatial], dtype=block.dtype, device="cpu")
+            self._stream_buffers[index] = buffer
+        return plan
+
+    def _make_pipe_state(
+        self, index: int, plan: _StreamPlan, in_shape: list[int], block: torch.Tensor
+    ) -> _RegionState | None:
+        """Wire the case's streamed pipe into one :class:`SlabRegionStream` — or answer ``None`` for
+        the buffered tail where streaming would not be exact.
+
+        Region stages compose: the pull map folds each stage's own declaration backward — a written
+        region pulls through the last stage, whose region pulls through the one before it, down to
+        the accumulator — and ``produce`` walks the pipe forward over the pulled window, handing each
+        stage the region pair the same fold computed for it. Pointwise stages ride along unchanged.
+
+        The fold is planned by walking a one-voxel corner of the real first slab through the pipe
+        with one evolving attribute: each stage declares against, and remaps from, the state the
+        stages before it left — a second resample pops the Size stack the first one already popped,
+        a reorientation after a permute reads the moved axes — and the walk carries the dtype, so a
+        RESCALE that would interpolate (``resample_region`` matches ``F.interpolate`` bit for bit
+        only in nearest mode) answers ``None`` instead: byte-identity is never traded for streaming.
+        ``produce`` then replays the same transitions on a fresh copy per emission (the same
+        slab-local scoping as the prefix).
+        """
+        attr0 = self._post_prefix_attributes[index]
+        pipe = plan.stages[cast(int, plan.pipe_start) :]
+        name = self.names[index]
+
+        probe = block[(Ellipsis, *([slice(0, 1)] * len(in_shape)))].clone()
+        walking = Attribute(attr0)
+        shapes = [list(in_shape)]
+        kinds: list[LocalityKind] = []
+        pull_fns: list[Callable[[tuple[slice, ...]], list[slice]]] = []
+        try:
+            for stage in pipe:
+                shape = shapes[-1]
+                locality = stage.locality(Attribute(walking))
+                kinds.append(locality.kind)
+                snapshot = Attribute(walking)
+                if locality.kind is LocalityKind.HALO:
+                    pull_fns.append(_halo_pull(_halo_radii(locality.halo, len(shape)), shape))
+                    shapes.append(list(shape))
+                    probe = stage(name, probe, walking)
+                elif locality.kind is LocalityKind.RESCALE:
+                    if probe.dtype is not torch.uint8:
+                        return None
+                    resample = cast(Resample, stage.transform)
+                    if stage.inverted:
+                        pull_fns.append(_remap_pull(resample.stream_region_target, shape, snapshot))
+                        out = resample._inverse_geometry(walking)
+                    else:
+                        out = [
+                            int(extent)
+                            for extent in resample.transform_shape(
+                                self.group_src, name, list(shape), Attribute(walking)
+                            )
+                        ]
+                        scales = [shape[k] / out[k] for k in range(len(shape))]
+                        pull_fns.append(_scale_pull(scales, shape))
+                        resample.write_stream_cache_attribute(walking, shape)
+                    shapes.append([int(extent) for extent in out])
+                elif locality.kind in _REGION_KINDS:
+                    if stage.inverted:
+                        remapper = cast(TransformInverse, stage.transform)
+                        pull_fns.append(_remap_pull(remapper.stream_region_target, shape, snapshot))
+                        out = remapper.inverse_transform_shape(list(shape), Attribute(walking))
+                    else:
+                        pull_fns.append(_remap_pull(stage.transform.stream_region_source, shape, snapshot))
+                        out = stage.transform.transform_shape(self.group_src, name, list(shape), Attribute(walking))
+                    shapes.append([int(extent) for extent in out])
+                    # The stage's attribute transition, on a one-voxel corner: a crop's tensor answer
+                    # is meaningless there (the map is the action) but its pops are the case's.
+                    result = stage(name, probe, walking)
+                    if locality.kind is not LocalityKind.CROP:
+                        probe = result
+                else:
+                    pull_fns.append(lambda target: list(target))
+                    shapes.append(list(shape))
+                    probe = stage(name, probe, walking)
+        except Exception:  # nosec B110 - an unplannable pipe just keeps the case on the buffered path
+            return None
+
+        state = _RegionState(pipe, kinds, shapes)
+
+        def spans_for(target: tuple[slice, ...]) -> list[list[slice]]:
+            """The region of each inter-stage space behind ``target``, folded back to the accumulator."""
+            spans: list[list[slice]] = [list(target)]
+            for pull_stage in reversed(pull_fns):
+                spans.append(pull_stage(tuple(spans[-1])))
+            spans.reverse()
+            return spans
+
+        def pull(target: tuple[slice, ...]) -> list[slice]:
+            return spans_for(target)[0]
+
+        def produce(window: torch.Tensor, target: tuple[slice, ...], source: list[slice]) -> torch.Tensor:
+            attribute = Attribute(attr0)
+            spans = spans_for(target)
+            block = window
+            for i, (stage, kind) in enumerate(zip(pipe, kinds, strict=True)):
+                block = self._apply_pipe_stage(
+                    stage, kind, block, tuple(spans[i + 1]), spans[i], shapes[i], shapes[i + 1], attribute, name
+                )
+            state.attribute = attribute
+            return block
+
+        state.stream = SlabRegionStream(pull, produce, in_shape, shapes[-1])
+        return state
+
+    def _apply_pipe_stage(
+        self,
+        stage: _FinalizeStage,
+        kind: LocalityKind,
+        block: torch.Tensor,
+        target: tuple[slice, ...],
+        source: list[slice],
+        in_shape: list[int],
+        out_shape: list[int],
+        attribute: Attribute,
+        name: str,
+    ) -> torch.Tensor:
+        """Run one pipe stage on its pulled block, by declared kind — never by stage name."""
+        if kind is LocalityKind.CROP:
+            # The pull already translated the region, so the block IS the answer. The stage still runs
+            # for its attribute transition (a crop restores the origin it recorded); its tensor answer
+            # is one window's, dropped.
+            stage(name, block, attribute)
+            return block
+        if kind is LocalityKind.RESCALE:
+            resample = cast(Resample, stage.transform)
+            scales = [in_shape[k] / out_shape[k] for k in range(len(in_shape))]
+            result = resample.resample_region(block, target, [s.start for s in source], scales, in_shape)
+            if stage.inverted:
+                resample._inverse_geometry(attribute)
+            else:
+                resample.write_stream_cache_attribute(attribute, in_shape)
+            return result
+        result = stage(name, block, attribute)
+        if kind is LocalityKind.HALO:
+            lead = (slice(None),) * (result.dim() - len(target))
+            crop = tuple(slice(t.start - s.start, t.stop - s.start) for t, s in zip(target, source, strict=False))
+            result = result[(*lead, *crop)]
+        return result
+
+    def _write_stream_block(
+        self, index: int, target: tuple[slice, ...], block: torch.Tensor, attribute: Attribute
+    ) -> None:
+        """Write one finalized output block into the case's sink (opened at the first block, once the
+        chain has fixed the output's shape, channel count and dtype)."""
+        array = block.detach().cpu().numpy()
+        if index not in self._stream_sinks:
+            state = self._region_states.get(index)
+            spatial = (
+                state.shapes[-1]
+                if state is not None
+                else [int(extent) for extent in self.output_layer_accumulator[index][0].shape]
+            )
+            sink = self.open_data_stream(
+                self.group, self.names[index], [array.shape[0], *spatial], array.dtype, attribute
+            )
+            if sink is None:
+                raise PredictorError(
+                    f"Streamed write refused by the '{self.file_format}' backend for dtype"
+                    f" '{array.dtype}' on output '{self.group}': write it to an h5 or omezarr"
+                    f" dataset, or set KONFAI_STREAMED_WRITES=0 to force the whole-volume path."
+                )
+            self._stream_sinks[index] = sink
+        self._stream_sinks[index].write_slice((slice(0, array.shape[0]), *target), array)
+
+    def _finish_stream(self, index: int) -> None:
+        """Complete the case: flush the region scheduler, or run the whole-volume tail on the buffer
+        and write it classically."""
+        plan = cast(_StreamPlan, self._stream_plans[index])
+        state = self._region_states.get(index)
+        if state is not None:
+            for target, emitted in cast(SlabRegionStream, state.stream).finalize():
+                self._write_stream_block(index, target, emitted, cast(Attribute, state.attribute))
+            return
+        if plan.to_sink:
+            return
+        result = self._stream_buffers.pop(index)
+        attribute = Attribute(self._post_prefix_attributes[index])
+        name = self.names[index]
+        for stage in plan.stages[plan.tail_start :]:
+            result = stage(name, result, attribute)
+        super().write(self.group, name, result.detach().cpu().numpy(), attribute)
 
     def _finalize_slab(
         self,
         index: int,
         layer: torch.Tensor,
         number_of_channels_per_model: list[int] | None,
-        dataset: DatasetIter,
+        stages: list[_FinalizeStage],
     ) -> tuple[torch.Tensor, Attribute]:
-        """The single-augmentation finalize chain of ``_get_output``/``get_output``, on one z-slab.
+        """The single-augmentation finalize chain of ``_get_output``/``get_output``, on one z-slab, up
+        to the plan's prefix boundary.
 
-        Every stage passed ``_stream_refusal`` as voxel-local, so applying it slab by slab yields the
-        same voxels as applying it to the assembled volume. Each slab gets its own copy of the case
-        attribute (transform writes stay slab-local).
+        Every prefix stage passed the gate as voxel-local, so applying it slab by slab yields the same
+        voxels as applying it to the assembled volume. Each slab gets its own copy of the case
+        attribute (transform writes stay slab-local, and case-level pops repeat identically per slab).
         """
         attribute = Attribute(self.attributes[index][0][0])
         if number_of_channels_per_model and layer.shape[0] == sum(number_of_channels_per_model):
@@ -550,13 +878,8 @@ class OutSameAsGroupDataset(OutputDataset):
         result = self.reduction([torch.stack(results, dim=0).unsqueeze(0)]).squeeze(0)
         if isinstance(self.reduction, Mean | Median):
             result = result.squeeze(0)
-        for transform in self.after_reduction_transforms:
-            result = transform(self.names[index], result, attribute)
-        for transform in reversed(dataset.groups_src[self.group_src][self.group_dest].transforms):
-            if isinstance(transform, TransformInverse) and transform.apply_inverse:
-                result = transform.inverse(self.names[index], result, attribute)
-        for transform in self.final_transforms:
-            result = transform(self.names[index], result, attribute)
+        for stage in stages:
+            result = stage(self.names[index], result, attribute)
         return result, attribute
 
     def _close_stream(self, index: int) -> None:
@@ -564,7 +887,10 @@ class OutSameAsGroupDataset(OutputDataset):
         sink = self._stream_sinks.pop(index, None)
         if sink is not None:
             sink.__exit__(None, None, None)
-        self._stream_active.pop(index, None)
+        self._stream_plans.pop(index, None)
+        self._region_states.pop(index, None)
+        self._stream_buffers.pop(index, None)
+        self._post_prefix_attributes.pop(index, None)
         self.output_layer_accumulator.pop(index, None)
         self.attributes.pop(index, None)
         self._accum_device.pop(index, None)
@@ -679,6 +1005,10 @@ class OutSameAsGroupDataset(OutputDataset):
         # During accumulation the resident accumulator and one forward coexist. The channel reduction's
         # working volume is budgeted separately, at ``get_output`` time, by ``_reduction_device``.
         needed = accumulator_bytes + transient
+        if isinstance(accumulator, StreamingAccumulator):
+            # Flushing a slab divides it out-of-place and clones the shifted window: up to two
+            # window-sized transients coexist with the resident window while a slab finalizes.
+            needed += 2 * layer.shape[0] * voxels * layer.element_size()
         return device if needed < free * self._ACCUMULATE_MARGIN else torch.device("cpu")
 
     def get_output(self, index: int, number_of_channels_per_model: list[int], dataset: DatasetIter) -> torch.Tensor:

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -26,6 +26,7 @@ import glob
 import math
 import os
 import re
+import shutil
 import threading
 import warnings
 from abc import ABC, abstractmethod
@@ -217,6 +218,10 @@ def data_to_image(data: np.ndarray, attributes: Attribute) -> sitk.Image:
         data = data.detach().cpu().numpy()
     if not is_an_image(attributes):
         raise NameError("Data is not an image")
+    if data.dtype == np.float16:
+        # ITK has no half-float pixel type (GetImageFromArray rejects float16), so widen to float32 --
+        # exact and lossless. The streamed .mha writer widens the same way, so both write identical bytes.
+        data = data.astype(np.float32)
     if data.shape[0] == 1:
         image = sitk.GetImageFromArray(data[0])
     else:
@@ -303,6 +308,117 @@ def write_landmarks(data: np.ndarray, filename: Path) -> None:
         f.close()
 
 
+class DataStream(ABC):
+    """One dataset entry written incrementally, region by region. Obtained from
+    ``Dataset.open_data_stream``, which returns ``None`` when the write format cannot serve region writes
+    (the caller then assembles the volume and uses ``Dataset.write``). Use as a context manager: a clean
+    exit finalizes the entry, an exception removes the partial one so a reader never sees a half-written
+    volume."""
+
+    _file: Dataset.File | None = None
+
+    def __enter__(self) -> DataStream:
+        return self
+
+    @abstractmethod
+    def write_slice(self, slices: tuple[slice, ...], data: np.ndarray) -> None:
+        """Write ``data`` into the region ``slices`` (channel-first indices, step 1)."""
+
+    @abstractmethod
+    def _close(self, success: bool) -> None:
+        """Finalize the entry, or remove the partial one when ``success`` is False."""
+
+    def __exit__(self, exc_type, value, traceback) -> None:
+        try:
+            self._close(exc_type is None)
+        finally:
+            if self._file is not None:
+                self._file.__exit__(exc_type, value, traceback)
+
+
+class _H5DataStream(DataStream):
+    def __init__(self, dataset: h5py.Dataset) -> None:
+        self._dataset = dataset
+
+    def write_slice(self, slices: tuple[slice, ...], data: np.ndarray) -> None:
+        self._dataset[slices] = data
+
+    def _close(self, success: bool) -> None:
+        if not success:
+            del self._dataset.parent[self._dataset.name.rsplit("/", 1)[-1]]
+
+
+# MetaImage ElementType for each NumPy dtype a streamed .mha can hold.
+_MHA_ELEMENT_TYPES = {
+    "int8": "MET_CHAR",
+    "uint8": "MET_UCHAR",
+    "int16": "MET_SHORT",
+    "uint16": "MET_USHORT",
+    "int32": "MET_INT",
+    "uint32": "MET_UINT",
+    "int64": "MET_LONG_LONG",
+    "uint64": "MET_ULONG_LONG",
+    "float32": "MET_FLOAT",
+    "float64": "MET_DOUBLE",
+}
+
+
+class _MhaDataStream(DataStream):
+    """Uncompressed local-data MetaImage written region by region: a hand-written ASCII header, then a
+    memmap over the flat raw block. MetaIO stores vector pixels interleaved (channel fastest), so the
+    map is spatial-first ``[.., Y, X, C]`` and ``write_slice`` moves the channel axis last."""
+
+    def __init__(self, path: str, shape: list[int], dtype: np.dtype, attributes: Attribute) -> None:
+        self.path = path
+        spatial = list(shape[1:])
+        # The header declares BinaryDataByteOrderMSB=False, so the map must be explicitly little-endian.
+        self._dtype = np.dtype(dtype).newbyteorder("<")
+        fields: list[tuple[str, str]] = [
+            ("ObjectType", "Image"),
+            ("NDims", str(len(spatial))),
+            ("BinaryData", "True"),
+            ("BinaryDataByteOrderMSB", "False"),
+            ("CompressedData", "False"),
+            ("TransformMatrix", " ".join(str(v) for v in attributes.get_np_array("Direction"))),
+            ("Offset", " ".join(str(v) for v in attributes.get_np_array("Origin"))),
+            ("ElementSpacing", " ".join(str(v) for v in attributes.get_np_array("Spacing"))),
+            ("DimSize", " ".join(str(v) for v in reversed(spatial))),
+        ]
+        if shape[0] > 1:
+            fields.append(("ElementNumberOfChannels", str(shape[0])))
+        # Attribute entries ride along as MetaIO user fields, like WriteImage embeds image metadata.
+        fields += [(k, str(v)) for k, v in attributes.items() if str(v) and "\n" not in str(v) and " " not in k]
+        fields += [("ElementType", _MHA_ELEMENT_TYPES[self._dtype.name]), ("ElementDataFile", "LOCAL")]
+        header = "".join(f"{key} = {value}\n" for key, value in fields).encode("utf-8")
+        with open(path, "wb") as file:
+            file.write(header)
+            # Reserve the pixel block up front (sparse where the filesystem allows it).
+            file.truncate(len(header) + int(np.prod([*spatial, shape[0]], dtype=np.int64)) * self._dtype.itemsize)
+        self._memmap = np.memmap(path, dtype=self._dtype, mode="r+", offset=len(header), shape=(*spatial, shape[0]))
+
+    def write_slice(self, slices: tuple[slice, ...], data: np.ndarray) -> None:
+        self._memmap[(*slices[1:], slices[0])] = np.moveaxis(data, 0, -1)
+
+    def _close(self, success: bool) -> None:
+        self._memmap.flush()
+        del self._memmap
+        if not success:
+            os.remove(self.path)
+
+
+class _OmeZarrDataStream(DataStream):
+    def __init__(self, array: Any, store_path: Path) -> None:
+        self._array = array
+        self._store_path = store_path
+
+    def write_slice(self, slices: tuple[slice, ...], data: np.ndarray) -> None:
+        self._array[slices] = data
+
+    def _close(self, success: bool) -> None:
+        if not success:
+            shutil.rmtree(self._store_path, ignore_errors=True)
+
+
 class Dataset:
     """Filesystem or HDF5-backed dataset abstraction used across KonfAI."""
 
@@ -344,6 +460,16 @@ class Dataset:
             attributes: Attribute | None = None,
         ) -> None:
             pass
+
+        def open_data_stream(
+            self,
+            name: str,
+            shape: list[int],
+            dtype: np.dtype,
+            attributes: Attribute,
+        ) -> DataStream | None:
+            """Open ``name`` for incremental region writes; ``None`` when this backend cannot."""
+            return None
 
         @abstractmethod
         def get_names(self, group: str) -> list[str]:
@@ -489,6 +615,28 @@ class Dataset:
 
             dataset = h5_group.create_dataset(name, data=data, dtype=data.dtype, chunks=None)
             dataset.attrs.update({k: str(v) for k, v in attributes.items()})
+
+        def open_data_stream(
+            self,
+            name: str,
+            shape: list[int],
+            dtype: np.dtype,
+            attributes: Attribute,
+        ) -> DataStream | None:
+            if self.h5 is None:
+                return None
+            h5_group = self.h5
+            if len(name.split("/")) > 1:
+                group = "/".join(name.split("/")[:-1])
+                if group not in self.h5:
+                    self.h5.create_group(group)
+                h5_group = self.h5[group]
+            name = name.split("/")[-1]
+            if name in h5_group:
+                del h5_group[name]
+            dataset = h5_group.create_dataset(name, shape=tuple(shape), dtype=dtype, chunks=None)
+            dataset.attrs.update({k: str(v) for k, v in attributes.items()})
+            return _H5DataStream(dataset)
 
         def is_exist(self, group: str, name: str | None = None) -> bool:
             if self.h5 is not None:
@@ -869,6 +1017,31 @@ class Dataset:
             else:
                 np.save(f"{self.filename}{name}.npy", data)
 
+        def open_data_stream(
+            self,
+            name: str,
+            shape: list[int],
+            dtype: np.dtype,
+            attributes: Attribute,
+        ) -> DataStream | None:
+            # Only an uncompressed local-data MetaImage is region-writable (ASCII header + flat raw
+            # block); every other SimpleITK format writes the whole image in one WriteImage call.
+            if self.file_format != "mha" or not is_an_image(attributes) or len(shape) < 3:
+                return None
+            element_dtype = np.dtype(dtype)
+            if element_dtype == np.float16:
+                # MetaImage has no half-float type; widen float16 to float32 (exact), as data_to_image
+                # does, so streamed and whole-volume writes hold identical bytes.
+                element_dtype = np.dtype(np.float32)
+            if element_dtype.name not in _MHA_ELEMENT_TYPES:
+                return None
+            dimension = len(shape) - 1
+            geometry = (("Origin", dimension), ("Spacing", dimension), ("Direction", dimension * dimension))
+            if any(len(attributes.get_np_array(key)) != n for key, n in geometry):
+                return None
+            os.makedirs(self.filename, exist_ok=True)
+            return _MhaDataStream(f"{self.filename}{name}.{self.file_format}", shape, element_dtype, attributes)
+
         def is_exist(self, group: str, name: str | None = None) -> bool:
             base = f"{self.filename}{group}"
             return any(os.path.exists(base + "." + ext) for ext in SUPPORTED_EXTENSIONS)
@@ -1005,6 +1178,31 @@ class Dataset:
                 origin=origin,
                 attributes=dict(attributes),
             )
+
+        def open_data_stream(
+            self,
+            name: str,
+            shape: list[int],
+            dtype: np.dtype,
+            attributes: Attribute,
+        ) -> DataStream | None:
+            from konfai.utils.ome_zarr import create_ome_zarr_store
+
+            if len(shape) not in (3, 4):
+                return None
+            dimension = len(shape) - 1
+            spacing = attributes.get_np_array("Spacing") if "Spacing" in attributes else np.ones(dimension)
+            origin = attributes.get_np_array("Origin") if "Origin" in attributes else np.zeros(dimension)
+            store_path = self._path(name, writing=True)
+            array = create_ome_zarr_store(
+                store_path,
+                shape,
+                dtype,
+                spacing=spacing,
+                origin=origin,
+                attributes=dict(attributes),
+            )
+            return _OmeZarrDataStream(array, store_path)
 
         def get_names(self, group: str) -> list[str]:
             return self.get_group()
@@ -1275,6 +1473,57 @@ class Dataset:
         else:
             with Dataset.File(self.filename, False, self.file_format, self.level) as file:
                 file.data_to_file(f"{group}/{name}", data, attributes)
+
+    def can_stream_data(self, attributes: Attribute) -> bool:
+        """Whether ``open_data_stream`` can serve this dataset's write format.
+
+        H5 and OME-Zarr always can; MetaImage ``mha`` needs image geometry to write its header up
+        front; every other format only writes whole volumes (use ``write``).
+        """
+        if self.file_format in ("h5", "omezarr"):
+            return True
+        return self.file_format == "mha" and is_an_image(attributes)
+
+    def open_data_stream(
+        self,
+        group: str,
+        name: str,
+        shape: list[int],
+        dtype: np.dtype,
+        attributes: Attribute | None = None,
+    ) -> DataStream | None:
+        """Open one entry for incremental region writes.
+
+        Returns ``None`` when the write format cannot serve region writes; the caller then assembles
+        the volume and uses ``write``. The returned stream is a context manager: a clean exit
+        finalizes the entry, an exception removes the partial one.
+        """
+        self._names_cache.clear()
+        self._infos_cache.clear()
+        if attributes is None:
+            attributes = Attribute()
+        if self.is_directory:
+            os.makedirs(self.filename, exist_ok=True)
+            s_group = group.split("/")
+            if len(s_group) > 1:
+                name = f"{'/'.join(s_group[:-1])}/{name}"
+                group = s_group[-1]
+            file = Dataset.File(f"{self.filename}{name}", False, self.file_format, self.level)
+            entry = group
+        else:
+            file = Dataset.File(self.filename, False, self.file_format, self.level)
+            entry = f"{group}/{name}"
+        backend = file.__enter__()
+        try:
+            stream = backend.open_data_stream(entry, shape, dtype, attributes)
+        except BaseException:
+            file.__exit__(None, None, None)
+            raise
+        if stream is None:
+            file.__exit__(None, None, None)
+            return None
+        stream._file = file
+        return stream
 
     def read_data(self, groups: str, name: str) -> tuple[np.ndarray, Attribute]:
         if not self._exists_on_disk():

--- a/konfai/utils/ome_zarr.py
+++ b/konfai/utils/ome_zarr.py
@@ -210,6 +210,74 @@ def write_ome_zarr(
         group.attrs[_KONFAI_ATTR_KEY] = {"attributes": dict(attributes)}
 
 
+def create_ome_zarr_store(
+    store_path: str | Path,
+    shape: Sequence[int],
+    dtype: Any,
+    *,
+    spacing: Sequence[float] | None = None,
+    origin: Sequence[float] | None = None,
+    attributes: dict[str, Any] | None = None,
+    chunks: Sequence[int] | None = None,
+) -> Any:
+    """Create an empty single-level OME-NGFF store for region-by-region writes.
+
+    Returns the level-0 zarr array: chunks materialise as regions are assigned, and unwritten regions
+    read back as zeros. Metadata (the 0.4 multiscales entry plus the KonfAI attribute sidecar) is
+    complete from the start, so the store is readable at any point during the write.
+    """
+    _require_zarr()
+    if len(shape) not in {3, 4}:
+        raise DatasetManagerError(f"OME-Zarr writing expects a C-Y-X or C-Z-Y-X shape, got {list(shape)}.")
+
+    spatial_axes = ["y", "x"] if len(shape) == 3 else ["z", "y", "x"]
+    dimension = len(spatial_axes)
+    spacing_xyz = list(spacing if spacing is not None else [1.0] * dimension)
+    origin_xyz = list(origin if origin is not None else [0.0] * dimension)
+    if len(spacing_xyz) != dimension or len(origin_xyz) != dimension:
+        raise DatasetManagerError(
+            f"OME-Zarr geometry must contain {dimension} spacing and origin values for shape {list(shape)}."
+        )
+
+    coordinate = {"x": (spacing_xyz[0], origin_xyz[0]), "y": (spacing_xyz[1], origin_xyz[1])}
+    if dimension == 3:
+        coordinate["z"] = (spacing_xyz[2], origin_xyz[2])
+    scale = [1.0, *[float(coordinate[axis][0]) for axis in spatial_axes]]
+    translation = [0.0, *[float(coordinate[axis][1]) for axis in spatial_axes]]
+
+    if chunks is None:
+        spatial_chunks = [min(extent, 128) for extent in shape[1:]]
+        # Keep one chunk around 32 MiB: full 128-wide spatial tiles, channels split to fit the budget.
+        tile_bytes = int(np.prod(spatial_chunks, dtype=np.int64)) * np.dtype(dtype).itemsize
+        chunks = [min(shape[0], max(1, (32 << 20) // max(1, tile_bytes))), *spatial_chunks]
+
+    try:
+        group = zarr.open_group(str(store_path), mode="w", zarr_format=2)
+    except TypeError:  # zarr-python 2.x: the v2 layout is its only format
+        group = zarr.open_group(str(store_path), mode="w")
+    create_array = getattr(group, "create_array", None) or group.create_dataset
+    array = create_array("0", shape=tuple(shape), chunks=tuple(chunks), dtype=np.dtype(dtype), fill_value=0)
+    group.attrs["multiscales"] = [
+        {
+            "version": "0.4",
+            "name": "image",
+            "axes": [{"name": "c", "type": "channel"}, *[{"name": axis, "type": "space"} for axis in spatial_axes]],
+            "datasets": [
+                {
+                    "path": "0",
+                    "coordinateTransformations": [
+                        {"type": "scale", "scale": scale},
+                        {"type": "translation", "translation": translation},
+                    ],
+                }
+            ],
+        }
+    ]
+    if attributes:
+        group.attrs[_KONFAI_ATTR_KEY] = {"attributes": dict(attributes)}
+    return array
+
+
 def get_ome_zarr_info(store_path: str | Path, level: int = 0) -> dict[str, Any]:
     """Return OME-Zarr metadata (raw axis-order shape) without reading pixel data."""
     image = _load_image(store_path, level)

--- a/tests/integration/test_konfai_streamed_prediction.py
+++ b/tests/integration/test_konfai_streamed_prediction.py
@@ -17,8 +17,14 @@
 """Streamed prediction writes (automatic, no config knob): the slab-by-slab path must be voxel-identical
 to the assembled-volume path (obtained via the ``KONFAI_STREAMED_WRITES=0`` kill-switch), must actually
 take the streamed writer (its hand-written MetaImage header is observable), and must fall back safely
-when the gate refuses
-(here: TTA)."""
+when the gate refuses (here: TTA).
+
+The geometry variants exercise the write dispatcher end to end, one per region kind and then in
+composition: a ``Canonical`` inverse (ORIENTATION — in-slab mirrors), a ``Padding`` inverse (CROP), a
+``ResampleToResolution`` inverse on a uint8 chain (RESCALE, streamed through in nearest mode) and on a
+float chain (demoted to the buffered tail, since interpolation is only byte-identical whole-volume),
+a two-inverse pipe, and the full three-inverse stack (crop + rescale + reorient composed, streamed
+end to end). Every variant is compared voxel for voxel against its own kill-switch reference."""
 
 import subprocess
 import sys
@@ -75,9 +81,13 @@ def main() -> None:
         checkpoints_dir=root / "Checkpoints",
         statistics_dir=root / "Statistics",
     )
-    # Same Prediction.yml both ways -- only the kill-switch differs -- so the outputs must match bit for bit.
-    run_prediction(root / "Prediction.yml", root / "Predictions_reference", disable_streaming=True)
-    run_prediction(root / "Prediction.yml", root / "Predictions_streamed")
+    # Same config both ways -- only the kill-switch differs -- so the outputs must match bit for bit.
+    for variant in ["", "Canonical", "Padding", "ResampleLabel", "ResampleFloat", "GeometryPair", "GeometryStack"]:
+        run_prediction(
+            root / f"Prediction{variant}.yml", root / f"Predictions_{variant or 'base'}_reference",
+            disable_streaming=True,
+        )
+        run_prediction(root / f"Prediction{variant}.yml", root / f"Predictions_{variant or 'base'}_streamed")
     # TTA makes the finalize chain non-local, so streaming refuses and the run completes whole-volume.
     run_prediction(root / "PredictionTTA.yml", root / "Predictions_streamed_tta")
 
@@ -86,11 +96,84 @@ if __name__ == "__main__":
     main()
 """
 
+# One prediction config per write-dispatcher path: the transforms block goes on the INPUT group, so
+# the finalize chain carries its inverse. (YAML indentation matches tests/assets/Workflows/Prediction.yml.)
+_VARIANT_TRANSFORMS = {
+    # ORIENTATION: an identity-direction case reorients onto LPS by mirroring x and y — the inverse
+    # mirrors them back inside each slab while the slab axis maps identically.
+    "Canonical": """            transforms:
+              Canonical:
+                inverse: true""",
+    # CROP: the inverse drops the padded border and translates what remains.
+    "Padding": """            transforms:
+              Padding:
+                padding: [0, 0, 0, 0, 2, 1]
+                mode: constant
+                inverse: true""",
+    # RESCALE: the inverse resamples back to the stored grid.
+    "ResampleLabel": """            transforms:
+              ResampleToResolution:
+                spacing: [0.5, 0.5, -1.0]
+                inverse: true""",
+    "ResampleFloat": """            transforms:
+              ResampleToResolution:
+                spacing: [0.5, 0.5, -1.0]
+                inverse: true""",
+    # Several region stages compose into one streamed pipe: crop, then flip, straight to the sink.
+    "GeometryPair": """            transforms:
+              Padding:
+                padding: [0, 0, 0, 0, 2, 1]
+                mode: constant
+                inverse: true
+              Flip:
+                dims: '0'
+                inverse: true""",
+    # The full stack the composition exists for — reorient + resample + pad forward, so the finalize
+    # chain carries CROP + RESCALE + ORIENTATION in sequence on a uint8 labelmap, streamed end to end.
+    "GeometryStack": """            transforms:
+              Canonical:
+                inverse: true
+              ResampleToResolution:
+                spacing: [0.5, 0.5, -1.0]
+                inverse: true
+              Padding:
+                padding: [0, 0, 0, 0, 2, 1]
+                mode: constant
+                inverse: true""",
+}
+
+# ResampleLabel/GeometryStack cast to uint8 before the reduction, so the tensor reaching the RESCALE
+# stage resamples in nearest mode — the exactness the streamed resample requires. ResampleFloat keeps
+# the float chain: the dispatcher must demote it to the buffered tail and stay byte-identical.
+_UINT8_BEFORE_REDUCTION = """        before_reduction_transforms:
+          TensorCast:
+            dtype: uint8
+            inverse: false"""
+
+_UINT8_VARIANTS = ("ResampleLabel", "GeometryStack")
+
+# Whether the variant's output is written by the streamed region writer (hand-written MetaImage
+# header, no CenterOfRotation) or assembled in the buffer and written classically by SimpleITK.
+_VARIANT_USES_STREAMED_WRITER = {
+    "base": True,
+    "Canonical": True,
+    "Padding": True,
+    "ResampleLabel": True,
+    "ResampleFloat": False,
+    "GeometryPair": True,
+    "GeometryStack": True,
+}
+
 
 def _write_streamed_prediction_configs(experiment_dir: Path) -> None:
     base = (experiment_dir / "Prediction.yml").read_text(encoding="utf-8")
     tta = _replace_once(base, "    augmentations: None", TTA_AUGMENTATIONS_BLOCK)
     (experiment_dir / "PredictionTTA.yml").write_text(tta, encoding="utf-8")
+    for variant, transforms_block in _VARIANT_TRANSFORMS.items():
+        config = _replace_once(base, "            transforms: None", transforms_block)
+        if variant in _UINT8_VARIANTS:
+            config = _replace_once(config, "        before_reduction_transforms: None", _UINT8_BEFORE_REDUCTION)
+        (experiment_dir / f"Prediction{variant}.yml").write_text(config, encoding="utf-8")
 
 
 @pytest.fixture(scope="module")
@@ -111,8 +194,7 @@ def streamed_experiment(tmp_path_factory: pytest.TempPathFactory) -> dict[str, P
     )
     return {
         "dataset_dir": paths["dataset_dir"],
-        "reference": experiment_dir / "Predictions_reference",
-        "streamed": experiment_dir / "Predictions_streamed",
+        "experiment_dir": experiment_dir,
         "streamed_tta": experiment_dir / "Predictions_streamed_tta",
     }
 
@@ -129,27 +211,36 @@ def _prediction_path(predictions_dir: Path, case: str) -> Path:
     return path
 
 
-def test_streamed_prediction_is_voxel_identical_to_reference(streamed_experiment: dict[str, Path]) -> None:
+@pytest.mark.parametrize("variant", ["base", *_VARIANT_TRANSFORMS])
+def test_streamed_prediction_is_voxel_identical_to_reference(
+    streamed_experiment: dict[str, Path], variant: str
+) -> None:
+    experiment_dir = streamed_experiment["experiment_dir"]
     for case in _case_names(streamed_experiment["dataset_dir"]):
-        reference = SimpleITK.ReadImage(str(_prediction_path(streamed_experiment["reference"], case)))
-        streamed = SimpleITK.ReadImage(str(_prediction_path(streamed_experiment["streamed"], case)))
-        assert streamed.GetOrigin() == reference.GetOrigin(), case
-        assert streamed.GetSpacing() == reference.GetSpacing(), case
-        assert streamed.GetDirection() == reference.GetDirection(), case
+        reference = SimpleITK.ReadImage(
+            str(_prediction_path(experiment_dir / f"Predictions_{variant}_reference", case))
+        )
+        streamed = SimpleITK.ReadImage(str(_prediction_path(experiment_dir / f"Predictions_{variant}_streamed", case)))
+        assert streamed.GetOrigin() == reference.GetOrigin(), (variant, case)
+        assert streamed.GetSpacing() == reference.GetSpacing(), (variant, case)
+        assert streamed.GetDirection() == reference.GetDirection(), (variant, case)
         reference_array = SimpleITK.GetArrayFromImage(reference)
         streamed_array = SimpleITK.GetArrayFromImage(streamed)
-        assert streamed_array.dtype == reference_array.dtype, case
-        np.testing.assert_array_equal(streamed_array, reference_array, err_msg=case)
+        assert streamed_array.dtype == reference_array.dtype, (variant, case)
+        np.testing.assert_array_equal(streamed_array, reference_array, err_msg=f"{variant}/{case}")
 
 
-def test_streamed_prediction_used_the_streamed_writer(streamed_experiment: dict[str, Path]) -> None:
-    """SimpleITK always writes ``CenterOfRotation`` into a MetaImage header; the streamed writer never
-    does. Its absence proves the run streamed instead of silently falling back."""
+@pytest.mark.parametrize("variant", ["base", *_VARIANT_TRANSFORMS])
+def test_streamed_prediction_takes_the_expected_writer(streamed_experiment: dict[str, Path], variant: str) -> None:
+    """SimpleITK always writes ``CenterOfRotation`` into a MetaImage header; the streamed region writer
+    never does. Its absence proves the variant streamed to the sink; its presence proves the buffered
+    (chain-split / demoted) variants assembled and wrote classically."""
+    experiment_dir = streamed_experiment["experiment_dir"]
     case = _case_names(streamed_experiment["dataset_dir"])[0]
-    streamed_header = _prediction_path(streamed_experiment["streamed"], case).read_bytes()[:2048]
-    reference_header = _prediction_path(streamed_experiment["reference"], case).read_bytes()[:2048]
-    assert b"CenterOfRotation" not in streamed_header
-    assert b"CenterOfRotation" in reference_header
+    streamed_header = _prediction_path(experiment_dir / f"Predictions_{variant}_streamed", case).read_bytes()[:2048]
+    reference_header = _prediction_path(experiment_dir / f"Predictions_{variant}_reference", case).read_bytes()[:2048]
+    assert (b"CenterOfRotation" not in streamed_header) == _VARIANT_USES_STREAMED_WRITER[variant], variant
+    assert b"CenterOfRotation" in reference_header, variant
 
 
 def test_streamed_request_with_tta_falls_back_to_whole_volume_path(streamed_experiment: dict[str, Path]) -> None:

--- a/tests/integration/test_konfai_streamed_prediction.py
+++ b/tests/integration/test_konfai_streamed_prediction.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Streamed prediction writes (automatic, no config knob): the slab-by-slab path must be voxel-identical
+to the assembled-volume path (obtained via the ``KONFAI_STREAMED_WRITES=0`` kill-switch), must actually
+take the streamed writer (its hand-written MetaImage header is observable), and must fall back safely
+when the gate refuses
+(here: TTA)."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from test_konfai_core_workflows import _prepare_experiment_dir, _subprocess_env
+from test_konfai_ensemble_tta import TTA_AUGMENTATIONS_BLOCK, _replace_once
+
+pytestmark = pytest.mark.integration
+
+SimpleITK = pytest.importorskip("SimpleITK")
+
+TRAIN_NAME = "STREAMED"
+
+RUNNER_SOURCE = """
+import os
+from pathlib import Path
+
+from konfai.predictor import predict
+from konfai.trainer import train
+
+
+def run_prediction(prediction_file: Path, predictions_dir: Path, disable_streaming: bool = False) -> None:
+    # Streaming has no config knob -- it is automatic. The whole-volume reference is obtained through the
+    # global ops kill-switch KONFAI_STREAMED_WRITES=0; the streamed run just leaves it unset.
+    os.environ["KONFAI_STREAMED_WRITES"] = "0" if disable_streaming else "1"
+    root = Path.cwd()
+    checkpoints = sorted((root / "Checkpoints" / "__TRAIN_NAME__").glob("*.pt"))
+    if not checkpoints:
+        raise RuntimeError("no checkpoints produced")
+    predict(
+        models=[checkpoints[-1]],
+        overwrite=True,
+        gpu=[],
+        cpu=1,
+        quiet=True,
+        tensorboard=False,
+        prediction_file=prediction_file,
+        predictions_dir=predictions_dir,
+    )
+
+
+def main() -> None:
+    root = Path.cwd()
+    train(
+        overwrite=True,
+        gpu=[],
+        cpu=1,
+        quiet=True,
+        tensorboard=False,
+        config=root / "Config.yml",
+        checkpoints_dir=root / "Checkpoints",
+        statistics_dir=root / "Statistics",
+    )
+    # Same Prediction.yml both ways -- only the kill-switch differs -- so the outputs must match bit for bit.
+    run_prediction(root / "Prediction.yml", root / "Predictions_reference", disable_streaming=True)
+    run_prediction(root / "Prediction.yml", root / "Predictions_streamed")
+    # TTA makes the finalize chain non-local, so streaming refuses and the run completes whole-volume.
+    run_prediction(root / "PredictionTTA.yml", root / "Predictions_streamed_tta")
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+
+def _write_streamed_prediction_configs(experiment_dir: Path) -> None:
+    base = (experiment_dir / "Prediction.yml").read_text(encoding="utf-8")
+    tta = _replace_once(base, "    augmentations: None", TTA_AUGMENTATIONS_BLOCK)
+    (experiment_dir / "PredictionTTA.yml").write_text(tta, encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def streamed_experiment(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
+    """Train once, then predict the assembled reference (kill-switch), the automatic streamed run, and a
+    TTA run that must fall back to the whole-volume path."""
+    experiment_dir = tmp_path_factory.mktemp("streamed") / "experiment"
+    paths = _prepare_experiment_dir(experiment_dir, TRAIN_NAME)
+    _write_streamed_prediction_configs(experiment_dir)
+
+    runner_path = experiment_dir / "run_streamed_prediction.py"
+    runner_path.write_text(RUNNER_SOURCE.replace("__TRAIN_NAME__", TRAIN_NAME), encoding="utf-8")
+    subprocess.run(
+        [sys.executable, str(runner_path)],
+        cwd=experiment_dir,
+        env=_subprocess_env(),
+        check=True,
+    )
+    return {
+        "dataset_dir": paths["dataset_dir"],
+        "reference": experiment_dir / "Predictions_reference",
+        "streamed": experiment_dir / "Predictions_streamed",
+        "streamed_tta": experiment_dir / "Predictions_streamed_tta",
+    }
+
+
+def _case_names(dataset_dir: Path) -> list[str]:
+    names = sorted(path.name for path in dataset_dir.iterdir() if path.is_dir())
+    assert names, "synthetic dataset is empty"
+    return names
+
+
+def _prediction_path(predictions_dir: Path, case: str) -> Path:
+    path = predictions_dir / TRAIN_NAME / "Dataset" / case / "sCT.mha"
+    assert path.exists(), f"missing prediction output: {path}"
+    return path
+
+
+def test_streamed_prediction_is_voxel_identical_to_reference(streamed_experiment: dict[str, Path]) -> None:
+    for case in _case_names(streamed_experiment["dataset_dir"]):
+        reference = SimpleITK.ReadImage(str(_prediction_path(streamed_experiment["reference"], case)))
+        streamed = SimpleITK.ReadImage(str(_prediction_path(streamed_experiment["streamed"], case)))
+        assert streamed.GetOrigin() == reference.GetOrigin(), case
+        assert streamed.GetSpacing() == reference.GetSpacing(), case
+        assert streamed.GetDirection() == reference.GetDirection(), case
+        reference_array = SimpleITK.GetArrayFromImage(reference)
+        streamed_array = SimpleITK.GetArrayFromImage(streamed)
+        assert streamed_array.dtype == reference_array.dtype, case
+        np.testing.assert_array_equal(streamed_array, reference_array, err_msg=case)
+
+
+def test_streamed_prediction_used_the_streamed_writer(streamed_experiment: dict[str, Path]) -> None:
+    """SimpleITK always writes ``CenterOfRotation`` into a MetaImage header; the streamed writer never
+    does. Its absence proves the run streamed instead of silently falling back."""
+    case = _case_names(streamed_experiment["dataset_dir"])[0]
+    streamed_header = _prediction_path(streamed_experiment["streamed"], case).read_bytes()[:2048]
+    reference_header = _prediction_path(streamed_experiment["reference"], case).read_bytes()[:2048]
+    assert b"CenterOfRotation" not in streamed_header
+    assert b"CenterOfRotation" in reference_header
+
+
+def test_streamed_request_with_tta_falls_back_to_whole_volume_path(streamed_experiment: dict[str, Path]) -> None:
+    for case in _case_names(streamed_experiment["dataset_dir"]):
+        path = _prediction_path(streamed_experiment["streamed_tta"], case)
+        assert b"CenterOfRotation" in path.read_bytes()[:2048], "expected the whole-volume writer"
+        array = SimpleITK.GetArrayFromImage(SimpleITK.ReadImage(str(path)))
+        assert array.shape == (3, 16, 16), case
+        assert np.isfinite(array).all(), case

--- a/tests/unit/test_data_stream.py
+++ b/tests/unit/test_data_stream.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``Dataset.open_data_stream``: incremental region writes must produce entries
+indistinguishable from a whole-volume ``write``, remove partial entries on failure, and refuse formats
+that cannot serve region writes."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from konfai.utils.dataset import Attribute, Dataset
+
+pytest.importorskip("SimpleITK")
+
+
+def _image_attributes() -> Attribute:
+    attributes = Attribute()
+    attributes["Origin"] = np.asarray([10.0, 20.0, 30.0])
+    attributes["Spacing"] = np.asarray([0.5, 1.5, 2.0])
+    attributes["Direction"] = np.asarray([1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1.0, 0.0])
+    return attributes
+
+
+def _volume(channels: int = 2, dtype: type = np.float32) -> np.ndarray:
+    return (np.arange(channels * 6 * 5 * 4).reshape(channels, 6, 5, 4) - 30).astype(dtype)
+
+
+def _write_by_slabs(dataset: Dataset, volume: np.ndarray, attributes: Attribute, slab: int = 2) -> None:
+    stream = dataset.open_data_stream("CT", "CASE_001", list(volume.shape), volume.dtype, attributes)
+    assert stream is not None
+    with stream:
+        for start in range(0, volume.shape[1], slab):
+            region = slice(start, min(start + slab, volume.shape[1]))
+            slices = (slice(0, volume.shape[0]), region, *(slice(0, extent) for extent in volume.shape[2:]))
+            stream.write_slice(slices, volume[:, region])
+
+
+def _skip_unavailable(file_format: str) -> None:
+    if file_format == "omezarr":
+        pytest.importorskip("zarr")
+    if file_format == "h5":
+        pytest.importorskip("h5py")
+
+
+FORMATS = ["mha", "h5", "omezarr"]
+
+
+@pytest.mark.parametrize("file_format", FORMATS)
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_stream_matches_whole_volume_write(tmp_path: Path, file_format: str, dtype: type) -> None:
+    _skip_unavailable(file_format)
+    volume = _volume(dtype=dtype)
+    Dataset(tmp_path / "reference", file_format).write("CT", "CASE_001", volume, _image_attributes())
+    _write_by_slabs(Dataset(tmp_path / "streamed", file_format), volume, _image_attributes())
+
+    expected, expected_attributes = Dataset(tmp_path / "reference", file_format).read_data("CT", "CASE_001")
+    result, result_attributes = Dataset(tmp_path / "streamed", file_format).read_data("CT", "CASE_001")
+
+    assert result.dtype == expected.dtype
+    np.testing.assert_array_equal(result, expected)
+    for key in ("Origin", "Spacing", "Direction"):
+        np.testing.assert_allclose(result_attributes.get_np_array(key), expected_attributes.get_np_array(key))
+
+
+def test_mha_stream_single_channel_reads_back_as_scalar_image(tmp_path: Path) -> None:
+    volume = _volume(channels=1)
+    dataset = Dataset(tmp_path / "streamed", "mha")
+    _write_by_slabs(dataset, volume, _image_attributes())
+
+    import SimpleITK as sitk
+
+    image = sitk.ReadImage(str(tmp_path / "streamed" / "CASE_001" / "CT.mha"))
+    assert image.GetNumberOfComponentsPerPixel() == 1
+    assert image.GetSize() == (4, 5, 6)
+    np.testing.assert_allclose(image.GetOrigin(), [10.0, 20.0, 30.0])
+    np.testing.assert_array_equal(sitk.GetArrayFromImage(image), volume[0])
+
+
+def test_stream_partial_slab_regions_compose_exactly(tmp_path: Path) -> None:
+    """Uneven slab sizes and a non-zero channel offset must land where their slices say."""
+    volume = _volume(channels=3)
+    dataset = Dataset(tmp_path / "streamed", "mha")
+    stream = dataset.open_data_stream("CT", "CASE_001", list(volume.shape), volume.dtype, _image_attributes())
+    assert stream is not None
+    with stream:
+        stream.write_slice((slice(0, 3), slice(0, 5), slice(0, 5), slice(0, 4)), volume[:, 0:5])
+        stream.write_slice((slice(1, 3), slice(5, 6), slice(0, 5), slice(0, 4)), volume[1:3, 5:6])
+        stream.write_slice((slice(0, 1), slice(5, 6), slice(0, 5), slice(0, 4)), volume[0:1, 5:6])
+
+    result, _ = dataset.read_data("CT", "CASE_001")
+    np.testing.assert_array_equal(result, volume)
+
+
+@pytest.mark.parametrize("file_format", FORMATS)
+def test_stream_removes_partial_entry_on_error(tmp_path: Path, file_format: str) -> None:
+    _skip_unavailable(file_format)
+    volume = _volume()
+    dataset = Dataset(tmp_path / "streamed", file_format)
+    stream = dataset.open_data_stream("CT", "CASE_001", list(volume.shape), volume.dtype, _image_attributes())
+    assert stream is not None
+    with pytest.raises(RuntimeError, match="boom"):
+        with stream:
+            stream.write_slice(
+                (slice(0, volume.shape[0]), slice(0, 2), slice(0, 5), slice(0, 4)),
+                volume[:, 0:2],
+            )
+            raise RuntimeError("boom")
+
+    assert not dataset.is_dataset_exist("CT", "CASE_001")
+
+
+def test_unstreamable_formats_and_inputs_return_none(tmp_path: Path) -> None:
+    geometry = _image_attributes()
+    assert Dataset(tmp_path / "a", "nii.gz").open_data_stream("CT", "C", [1, 4, 4, 4], np.float32, geometry) is None
+    assert Dataset(tmp_path / "b", "mha").open_data_stream("CT", "C", [1, 4, 4, 4], np.float32, Attribute()) is None
+    assert Dataset(tmp_path / "c", "mha").open_data_stream("CT", "C", [1, 4, 4, 4], np.bool_, geometry) is None
+
+
+def test_mha_float16_is_stored_as_float32_matching_the_whole_volume_path(tmp_path: Path) -> None:
+    """MetaImage has no half-float type, so a float16 output streams as float32 -- the exact widening
+    the whole-volume writer does too, so streamed and assembled stay byte-identical (not a crash, which
+    is what a bare ``open_data_stream`` refusal would cause mid-run)."""
+    volume = _volume(channels=2, dtype=np.float16)
+    Dataset(tmp_path / "reference", "mha").write("CT", "CASE_001", volume, _image_attributes())
+    _write_by_slabs(Dataset(tmp_path / "streamed", "mha"), volume, _image_attributes())
+
+    expected, _ = Dataset(tmp_path / "reference", "mha").read_data("CT", "CASE_001")
+    result, _ = Dataset(tmp_path / "streamed", "mha").read_data("CT", "CASE_001")
+    assert expected.dtype == np.float32 and result.dtype == np.float32
+    np.testing.assert_array_equal(result, expected)
+    np.testing.assert_array_equal(result, volume.astype(np.float32))
+
+
+def test_can_stream_data_matches_open_support(tmp_path: Path) -> None:
+    geometry = _image_attributes()
+    assert Dataset(tmp_path / "a", "mha").can_stream_data(geometry)
+    assert not Dataset(tmp_path / "a", "mha").can_stream_data(Attribute())
+    assert not Dataset(tmp_path / "b", "nii.gz").can_stream_data(geometry)
+    assert Dataset(tmp_path / "c", "h5").can_stream_data(Attribute())
+    assert Dataset(tmp_path / "d", "omezarr").can_stream_data(Attribute())

--- a/tests/unit/test_dataset_streaming.py
+++ b/tests/unit/test_dataset_streaming.py
@@ -1054,6 +1054,29 @@ def test_stream_resample_border_patch_matches_padded_whole_volume() -> None:
         np.testing.assert_allclose(got.numpy(), expected.numpy(), atol=1e-3)
 
 
+def test_stream_resample_nearest_strong_downsampling_matches_whole_volume() -> None:
+    # Strong downsampling of a uint8 label map (nearest mode): the nearest voxel of the first output
+    # column (floor(o*scale)) falls BELOW the linear tap window's start, so the source read must widen
+    # to include it -- otherwise the gather indexed a negative local offset and wrapped onto the far
+    # edge, silently returning a wrong label. A regular ratio (a plain integer scale) hides the bug;
+    # 40 -> 6 (scale 6.67) exposes the sub-pixel offset that pushes the linear start past voxel 0.
+    volume = (np.arange(1 * 40 * 40).reshape(1, 40, 40) % 7).astype(np.uint8)
+    shape = [6, 6]
+    patch = [3, 3]
+    stream_manager = _build_streaming_manager(volume, [ResampleToShape(shape=shape)], patch)
+    assert stream_manager.can_stream_patch(0)
+
+    reference_manager = _build_streaming_manager(volume, [ResampleToShape(shape=shape)], patch)
+    reference_manager.load(reference_manager.transforms, [], load_augmentations=False)
+
+    size = stream_manager.patch.get_size(0)
+    for index in range(size):
+        got = stream_manager._get_streamed_data(index, 0, True)[0]
+        expected = reference_manager.patch.get_data(reference_manager.data[0], index, 0, True)
+        # Nearest is a pure gather: the streamed patch must equal the whole-volume pick bit for bit.
+        assert torch.equal(got, expected)
+
+
 # --------------------------------------------------------------------------------------
 # patch_transforms — the per-patch opt-in, guarded by the patch-locality contract
 #

--- a/tests/unit/test_dataset_streaming.py
+++ b/tests/unit/test_dataset_streaming.py
@@ -897,6 +897,41 @@ def test_stream_pointwise_chain_matches_whole_volume() -> None:
     assert manager._resolve_patch_stream_source(0, True).region_index == 1
 
 
+def test_stream_composed_orientation_and_halo_matches_whole_volume() -> None:
+    # Region stages compose: the dilation's halo pulls through the flip's mirror, so one bounded read
+    # serves both and the seam-spreading foreground must still agree bit for bit.
+    volume = np.zeros((1, 8, 8), dtype=np.float32)
+    volume[0, 3:5, 3:5] = 1.0
+    manager = _assert_stream_matches_whole_volume(volume, [Flip("0"), Dilate(1)], [4, 4])
+    plans = manager._resolve_patch_stream_source(0, True).stage_plans
+    assert [plan.kind.value for plan in plans] == ["orientation", "halo"]
+
+
+def test_stream_composed_rescale_and_orientation_matches_whole_volume() -> None:
+    # A resample followed by a flip: the flip's mirror region pulls through the resample's scale
+    # window, on the RESAMPLED grid the fold computed between them.
+    rng = np.random.default_rng(7)
+    volume = (rng.standard_normal((1, 8, 8)).astype(np.float32)) * 100.0
+    manager = _assert_stream_matches_whole_volume(
+        volume, [ResampleToShape(shape=[12, 12]), Flip("0")], [4, 4], atol=1e-3
+    )
+    plans = manager._resolve_patch_stream_source(0, True).stage_plans
+    assert [plan.kind.value for plan in plans] == ["rescale", "orientation"]
+    assert tuple(plans[1].in_shape) == (12, 12)
+
+
+def test_stream_composed_orientations_with_pointwise_between_match_whole_volume() -> None:
+    # Two orientations with a pointwise stage between them: the fold carries the permuted extents and
+    # the value map rides along where the regions put it.
+    volume = np.arange(1 * 8 * 6, dtype=np.float32).reshape(1, 8, 6)
+    manager = _assert_stream_matches_whole_volume(
+        volume, [Flip("0"), Clip(min_value=-10.0, max_value=10.0), Permute("1|0")], [4, 4]
+    )
+    plans = manager._resolve_patch_stream_source(0, True).stage_plans
+    assert [plan.kind.value for plan in plans] == ["orientation", "pointwise", "orientation"]
+    assert tuple(plans[2].out_shape) == (6, 8)
+
+
 def test_softmax_channel_axis_is_pointwise_but_spatial_axis_falls_back() -> None:
     # A channel-axis softmax (dim 0) is spatially pointwise and streams the exact patch. A softmax over
     # a SPATIAL axis normalises across the whole extent, so a per-patch softmax would diverge: the

--- a/tests/unit/test_dataset_streaming.py
+++ b/tests/unit/test_dataset_streaming.py
@@ -920,6 +920,18 @@ def test_stream_composed_rescale_and_orientation_matches_whole_volume() -> None:
     assert tuple(plans[1].in_shape) == (12, 12)
 
 
+def test_stream_composed_triple_region_chain_matches_whole_volume() -> None:
+    # Three region stages in one chain — flip, resample, permute — folded into one bounded read.
+    rng = np.random.default_rng(11)
+    volume = (rng.standard_normal((1, 8, 6)).astype(np.float32)) * 100.0
+    manager = _assert_stream_matches_whole_volume(
+        volume, [Flip("0"), ResampleToShape(shape=[12, 9]), Permute("1|0")], [4, 4], atol=1e-3
+    )
+    plans = manager._resolve_patch_stream_source(0, True).stage_plans
+    assert [plan.kind.value for plan in plans] == ["orientation", "rescale", "orientation"]
+    assert tuple(plans[2].out_shape) == (9, 12)
+
+
 def test_stream_composed_orientations_with_pointwise_between_match_whole_volume() -> None:
     # Two orientations with a pointwise stage between them: the fold carries the permuted extents and
     # the value map rides along where the regions put it.

--- a/tests/unit/test_patching.py
+++ b/tests/unit/test_patching.py
@@ -16,9 +16,11 @@
 
 """Unit tests for patch reconstruction and overlap-blending (``konfai.data.patching``)."""
 
+import itertools
+
 import pytest
 import torch
-from konfai.data.patching import Accumulator, Cosinus, Gaussian, Mean
+from konfai.data.patching import Accumulator, Cosinus, Gaussian, Mean, StreamingAccumulator
 from konfai.utils.errors import PatchError
 from konfai.utils.utils import get_patch_slices_from_shape
 
@@ -267,3 +269,102 @@ def test_gaussian_blend_in_fp16_has_no_nan_at_single_coverage_corners() -> None:
     assert not torch.isnan(out).any()
     # Single coverage: dividing by the accumulated weight must recover the raw value, corners included.
     torch.testing.assert_close(out.float(), torch.full((16, 16, 16), 3.0), rtol=0.02, atol=0.02)
+
+
+# --------------------------------------------------------------------------------------
+# StreamingAccumulator: slab-by-slab finalization must equal whole-volume assembly
+# --------------------------------------------------------------------------------------
+
+
+def _padded_patches(full: torch.Tensor, patch_slices, patch_size: list[int]) -> list[torch.Tensor]:
+    """Emit model-like patches: always full patch_size, garbage in the padded out-of-volume tail."""
+    patches = []
+    for sl in patch_slices:
+        patch = torch.randn(full.shape[0], *patch_size, dtype=full.dtype)
+        extents = [min(s.stop, full.shape[dim + 1]) - s.start for dim, s in enumerate(sl)]
+        source = (slice(None), *[slice(s.start, s.start + extent) for s, extent in zip(sl, extents, strict=True)])
+        patch[(slice(None), *[slice(0, extent) for extent in extents])] = full[source]
+        patches.append(patch)
+    return patches
+
+
+@pytest.mark.parametrize("combine_cls", [None, Mean, Cosinus, Gaussian])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+@pytest.mark.parametrize(
+    ("shape", "patch_size", "overlap"),
+    [
+        ((2, 13, 9, 11), [4, 4, 4], 2),
+        ((1, 7, 8), [3, 8], 1),
+        ((3, 16, 8, 8), [4, 8, 8], 0),
+        ((1, 5, 6, 7), [5, 6, 7], 0),
+    ],
+)
+def test_streaming_accumulator_slabs_match_assemble(combine_cls, dtype, shape, patch_size, overlap):
+    torch.manual_seed(0)
+    full = torch.randn(shape, dtype=dtype)
+    patch_slices, _ = get_patch_slices_from_shape(patch_size, list(shape[1:]), overlap)
+    patches = _padded_patches(full, patch_slices, patch_size)
+
+    def _combine():
+        if combine_cls is None:
+            return None
+        combine = combine_cls()
+        combine.set_patch_config(patch_size, overlap)
+        return combine
+
+    reference = Accumulator(patch_slices, patch_size, patch_combine=_combine(), batch=False)
+    streaming = StreamingAccumulator(patch_slices, patch_size, patch_combine=_combine(), batch=False)
+    slabs = []
+    for index, patch in enumerate(patches):
+        reference.add_layer(index, patch.clone())
+        slabs += streaming.add_layer(index, patch.clone())
+    assert streaming.is_full()
+    slabs += streaming.finalize()
+
+    expected = reference.assemble()
+    # The slab regions must tile the first spatial axis exactly, in order.
+    assert slabs[0][0].start == 0
+    assert slabs[-1][0].stop == shape[1]
+    assert all(a.stop == b.start for (a, _), (b, _) in itertools.pairwise(slabs))
+    assert all(tensor.shape[1] == region.stop - region.start for region, tensor in slabs)
+    result = torch.cat([tensor for _, tensor in slabs], dim=1)
+    assert torch.equal(result, expected), (result - expected).abs().max().item()
+
+
+def test_streaming_accumulator_rejects_unordered_patches():
+    with pytest.raises(PatchError, match="non-decreasing"):
+        StreamingAccumulator([(slice(4, 8),), (slice(0, 4),)], [4], patch_combine=None, batch=False)
+
+
+def test_streaming_accumulator_refuses_whole_volume_assemble():
+    streaming = StreamingAccumulator([(slice(0, 4),), (slice(4, 8),)], [4], patch_combine=None, batch=False)
+    streaming.add_layer(0, torch.ones(1, 4))
+    with pytest.raises(PatchError, match="assemble"):
+        streaming.assemble()
+
+
+def test_streaming_accumulator_is_reusable_after_finalize():
+    full = torch.arange(2 * 8, dtype=torch.float32).reshape(1, 2, 8)
+    patch_slices, _ = get_patch_slices_from_shape([1, 8], [2, 8], 0)
+    streaming = StreamingAccumulator(patch_slices, [1, 8], patch_combine=None, batch=False)
+    for _ in range(2):
+        slabs = []
+        for index, sl in enumerate(patch_slices):
+            slabs += streaming.add_layer(index, full[(slice(None), *sl)])
+        slabs += streaming.finalize()
+        assert torch.equal(torch.cat([tensor for _, tensor in slabs], dim=1), full)
+
+
+def test_streaming_accumulator_rejects_out_of_order_arrival():
+    # Correctness needs patches to ARRIVE in non-decreasing first-axis-start order, not just the slice
+    # list to be sorted. Arriving 0, 2, 3 then the skipped 1 flushes the window past start=2 before
+    # patch 1 (start=2) shows up; without the guard its window offset goes negative -> silent misplace.
+    patch_slices, _ = get_patch_slices_from_shape([4, 8], [10, 8], 2)  # starts 0, 2, 4, 6; window 4
+    starts = [sl[0].start for sl in patch_slices]
+    assert starts == [0, 2, 4, 6]
+    streaming = StreamingAccumulator(patch_slices, [4, 8], patch_combine=None, batch=False)
+    streaming.add_layer(0, torch.ones(1, 4, 8))
+    streaming.add_layer(1, torch.ones(1, 4, 8))
+    streaming.add_layer(3, torch.ones(1, 4, 8))  # start=6 flushes the window up to 6
+    with pytest.raises(PatchError, match="non-decreasing"):
+        streaming.add_layer(2, torch.ones(1, 4, 8))  # start=4 < flushed=6

--- a/tests/unit/test_predictor_reduction_device.py
+++ b/tests/unit/test_predictor_reduction_device.py
@@ -19,6 +19,7 @@ from typing import cast
 import pytest
 import torch
 from konfai.predictor import OutSameAsGroupDataset
+from konfai.utils.utils import get_patch_slices_from_shape
 
 
 def _dataset(device: torch.device | int, nb_data_augmentation: int = 1) -> OutSameAsGroupDataset:
@@ -65,6 +66,12 @@ class _FakeAccumulator:
     def __init__(self, shape: list[int]) -> None:
         self.shape = shape
 
+    @property
+    def footprint_shape(self) -> list[int]:
+        # A whole-volume accumulator's resident footprint IS its shape (StreamingAccumulator overrides
+        # this with its window); _accumulate_device budgets against the footprint.
+        return self.shape
+
 
 def test_accumulate_device_is_cpu_for_a_cpu_dataset() -> None:
     ds = _dataset(torch.device("cpu"))
@@ -78,8 +85,18 @@ def test_accumulate_device_is_cpu_when_the_patch_is_on_cpu() -> None:
     assert ds._accumulate_device(torch.zeros(4, 8, dtype=torch.float16), _FakeAccumulator([8])).type == "cpu"
 
 
+def _no_transient(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Pin the MEASURED forward transient to 0 (memory_allocated == max_memory_allocated) so a test
+    # exercises the accumulator budget alone, independent of any stale process-wide peak.
+    monkeypatch.setattr(torch.cuda, "memory_allocated", lambda *a, **k: 0)
+    monkeypatch.setattr(torch.cuda, "max_memory_allocated", lambda *a, **k: 0)
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU accumulation only applies on CUDA")
-def test_accumulate_device_uses_gpu_when_the_volume_fits_and_falls_back_when_it_does_not() -> None:
+def test_accumulate_device_uses_gpu_when_the_volume_fits_and_falls_back_when_it_does_not(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _no_transient(monkeypatch)
     ds = _dataset(0)
     patch = torch.zeros(4, 8, dtype=torch.float16, device="cuda")
     # a small combined volume comfortably fits free VRAM -> blend on the dataset's CUDA device
@@ -90,9 +107,9 @@ def test_accumulate_device_uses_gpu_when_the_volume_fits_and_falls_back_when_it_
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU accumulation only applies on CUDA")
 def test_accumulate_device_falls_back_when_free_vram_is_low(monkeypatch: pytest.MonkeyPatch) -> None:
-    # ``free`` is read after the first batch's forward, so a larger batch (which leaves little free
-    # VRAM) is rejected even for a tiny accumulator -- exactly when the resident accumulator plus the
-    # remaining forwards would otherwise OOM mid-case.
+    # ``free`` is read after the first batch's forward, so little free VRAM is rejected even for a tiny
+    # accumulator -- exactly when the resident accumulator plus the remaining forwards would OOM mid-case.
+    _no_transient(monkeypatch)
     ds = _dataset(0)
     patch = torch.zeros(4, 8, dtype=torch.float16, device="cuda")
     accumulator = _FakeAccumulator([8, 8, 8])  # a negligible combined volume
@@ -110,13 +127,38 @@ def test_accumulate_device_budgets_every_tta_augmentation(monkeypatch: pytest.Mo
     # augmentation complete before ``get_output``), so the per-case decision budgets accumulator x T:
     # a volume where one copy fits but T copies do not must take the CPU path for the WHOLE case —
     # a per-augmentation flip would hand the reduction a mixed CPU/CUDA list and crash it.
+    _no_transient(monkeypatch)
     monkeypatch.setattr(torch.cuda, "empty_cache", lambda *a, **k: None)
-    monkeypatch.setattr(torch.cuda, "mem_get_info", lambda *a, **k: (12 * 1024**3, 25 * 1024**3))
+    monkeypatch.setattr(torch.cuda, "mem_get_info", lambda *a, **k: (5 * 1024**3, 25 * 1024**3))
     patch = torch.zeros(1, 8, dtype=torch.float16, device="cuda")
     voxels = 512 * 1024**2  # (C+1)=2 x 2 bytes x voxels = 2 GiB per augmentation
-    # T=1: 2 GiB x 2 < 12 GiB x 0.56 -> GPU; T=3: 6 GiB x 2 >= 6.72 GiB -> whole case on CPU
+    # T=1: 2 GiB < 5 x 0.9 -> GPU ; T=3: 6 GiB >= 4.5 GiB -> whole case on CPU. The accumulation gate now
+    # budgets accumulator + measured forward (0 here); the reduction temp fit-checks itself at get_output.
     assert _dataset(0, nb_data_augmentation=1)._accumulate_device(patch, _FakeAccumulator([voxels])).type == "cuda"
     assert _dataset(0, nb_data_augmentation=3)._accumulate_device(patch, _FakeAccumulator([voxels])).type == "cpu"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU accumulation only applies on CUDA")
+def test_accumulate_device_budgets_the_streaming_window_not_the_whole_volume(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A StreamingAccumulator only ever holds its window, so _accumulate_device budgets that, not the
+    # full volume: a volume too big to assemble on the GPU still streams on the GPU when its window
+    # fits. This is what keeps a huge case both GPU-fast and VRAM-bounded.
+    from konfai.data.patching import Cosinus, StreamingAccumulator
+
+    _no_transient(monkeypatch)
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda *a, **k: None)
+    monkeypatch.setattr(torch.cuda, "mem_get_info", lambda *a, **k: (3 * 1024**3, 25 * 1024**3))
+    ds = _dataset(0)
+    patch = torch.zeros(64, 8, dtype=torch.float16, device="cuda")
+    # The whole volume's accumulator (~3.4 GiB) overflows 3 x 0.9; the window (one patch extent,
+    # ~0.13 GiB) fits easily.
+    patch_slices, _ = get_patch_slices_from_shape([16, 256, 256], [400, 256, 256], 0)
+    combine = Cosinus()
+    combine.set_patch_config([16, 256, 256], 0)
+    whole = _FakeAccumulator([400, 256, 256])
+    streaming = StreamingAccumulator(patch_slices, [16, 256, 256], patch_combine=combine, batch=False)
+    assert ds._accumulate_device(patch, whole).type == "cpu"
+    assert ds._accumulate_device(patch, streaming).type == "cuda"
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU reduction only applies on CUDA")
@@ -140,3 +182,20 @@ def test_reduction_device_budgets_every_parked_chunk() -> None:
     assert ds._reduction_device(cast(torch.Tensor, _Chunk(fits_alone)), 1).type == "cuda"
     # ...but (2*8+1) x chunk does not: eight parked chunks must fall back to the CPU reduction.
     assert ds._reduction_device(cast(torch.Tensor, _Chunk(fits_alone)), 8).type == "cpu"
+
+
+def test_reduction_declares_slab_locality_by_type() -> None:
+    # The streamed-write gate asks the reduction whether it is voxel-local (per-voxel over the model/TTA
+    # axis). Mean/Median/Concat all reduce orthogonally to the spatial slab axis; a bare custom reduction
+    # is unknown and must default to not-streamable, the way a transform defaults to WHOLE_VOLUME.
+    from konfai.predictor import Concat, Mean, Median, Reduction
+
+    assert Mean().voxel_local
+    assert Median().voxel_local
+    assert Concat().voxel_local
+
+    class _CustomReduction(Reduction):
+        def __call__(self, tensors):
+            return tensors[0]
+
+    assert _CustomReduction().voxel_local is False

--- a/tests/unit/test_streamed_write_dispatcher.py
+++ b/tests/unit/test_streamed_write_dispatcher.py
@@ -425,7 +425,7 @@ def test_plan_non_region_writable_format_buffers_and_writes_classically() -> Non
 # --------------------------------------------------------------------------------------
 
 
-def _drive_prediction(tmp_path, transforms, volume, monkeypatch, streamed=True, before=()):
+def _drive_prediction(tmp_path, transforms, volume, monkeypatch, streamed=True, before=(), final=()):
     """Push a whole case patch by patch through add_layer against an h5 sink and read the entry back.
 
     The forward ``transforms`` run once on ``volume`` (chained, stacking the attribute exactly as the
@@ -479,6 +479,7 @@ def _drive_prediction(tmp_path, transforms, volume, monkeypatch, streamed=True, 
     output_dataset.reduction = Mean()
     output_dataset.nb_data_augmentation = 1
     output_dataset.before_reduction_transforms = list(before)
+    output_dataset.final_transforms = list(final)
 
     for k in range(z):
         # Patch.get_data squeezes size-1 patch axes, so a [1, Y, X] patch reaches add_layer as [C, Y, X].
@@ -503,6 +504,28 @@ def test_add_layer_streams_a_flip_inverse_through_the_region_stage(tmp_path, mon
     reference = _drive_prediction(tmp_path / "reference", transforms, volume, monkeypatch, streamed=False)
     assert torch.equal(streamed, reference)
     assert torch.equal(streamed, volume)
+
+
+def test_add_layer_streams_a_stat_inverse_riding_the_pipe(tmp_path, monkeypatch) -> None:
+    # The common synthesis finalize: the forward Normalize stacked Min/Max, so its inverse is a
+    # per-voxel affine map riding the pipe behind the flip's region — the case the all-POINTWISE gate
+    # used to refuse outright.
+    volume = torch.from_numpy(np.random.default_rng(2).standard_normal((1, 6, 4, 3)).astype(np.float32))
+    transforms = [Normalize(inverse=True), Flip("0", inverse=True)]
+    streamed = _drive_prediction(tmp_path / "streamed", transforms, volume, monkeypatch, streamed=True)
+    reference = _drive_prediction(tmp_path / "reference", transforms, volume, monkeypatch, streamed=False)
+    assert torch.equal(streamed, reference)
+
+
+def test_add_layer_streams_a_forward_region_final_transform(tmp_path, monkeypatch) -> None:
+    # A region transform applied FORWARD in final_transforms (reorient the written output): the pull
+    # map is stream_region_source, the same declaration the read dispatcher uses.
+    volume = torch.from_numpy(np.random.default_rng(3).standard_normal((1, 6, 4, 3)).astype(np.float32))
+    final = [Flip("0", inverse=False)]
+    streamed = _drive_prediction(tmp_path / "streamed", [], volume, monkeypatch, streamed=True, final=final)
+    reference = _drive_prediction(tmp_path / "reference", [], volume, monkeypatch, streamed=False, final=final)
+    assert torch.equal(streamed, reference)
+    assert torch.equal(streamed, volume.flip(1))
 
 
 def test_add_layer_streams_a_full_geometry_stack_through_the_composed_pipe(tmp_path, monkeypatch) -> None:

--- a/tests/unit/test_streamed_write_dispatcher.py
+++ b/tests/unit/test_streamed_write_dispatcher.py
@@ -1,0 +1,526 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The write mirror of the read-side patch-streaming dispatcher.
+
+A finalize chain streams to the written image through its region stages — composed in any number,
+each pulling through the next — scheduled by :class:`SlabRegionStream` from the stages' own
+declarations (``inverse_patch_locality``, ``stream_region_target``), with the read side's promise:
+streaming is an optimisation, so every streamed output must equal the whole-volume result voxel for
+voxel. These tests prove that per region kind and in composition over random slab partitions, pin
+the window to its bound, and pin the planner's classification of chains onto the direct / region /
+buffered (chain-split) modes.
+"""
+
+from types import SimpleNamespace
+from typing import ClassVar, cast
+
+import numpy as np
+import pytest
+import torch
+from konfai.data.data_manager import DatasetIter
+from konfai.data.patching import SlabRegionStream, _halo_radii
+from konfai.data.transform import (
+    Canonical,
+    Dilate,
+    Flip,
+    LocalityKind,
+    Normalize,
+    Padding,
+    Permute,
+    ResampleToResolution,
+    Softmax,
+    Standardize,
+    TensorCast,
+    Transform,
+    TransformInverse,
+)
+from konfai.predictor import Mean, OutSameAsGroupDataset, Reduction
+from konfai.utils.dataset import Attribute
+from konfai.utils.errors import PatchError
+
+# --------------------------------------------------------------------------------------
+# SlabRegionStream: each region kind, streamed over random slab partitions, must equal the
+# whole-volume operator — and hold only a bounded window while doing it.
+# --------------------------------------------------------------------------------------
+
+C, Z, Y, X = 2, 8, 6, 5
+
+
+def _run_stream(pull, produce, in_shape, out_shape, volume, partitions):
+    """Push ``volume`` slab by slab and reassemble the emitted blocks into one output tensor."""
+    stream = SlabRegionStream(pull, produce, in_shape, out_shape)
+    out = torch.zeros([volume.shape[0], *out_shape], dtype=volume.dtype)
+    written = torch.zeros(out_shape, dtype=torch.bool)
+    emitted = []
+    start = 0
+    for stop in partitions:
+        emitted += stream.push(slice(start, stop), volume[:, start:stop].clone())
+        start = stop
+    emitted += stream.finalize()
+    for target, tensor in emitted:
+        assert not written[target].any(), "a region was emitted twice"
+        written[target] = True
+        out[(slice(None), *target)] = tensor
+    assert written.all(), "the emitted regions do not tile the output"
+    return out
+
+
+def _partitions(n: int, rng: np.random.Generator) -> list[int]:
+    cuts = rng.choice(range(1, n), size=int(rng.integers(0, min(4, n - 1))), replace=False)
+    return [*sorted(cuts.tolist()), n]
+
+
+@pytest.mark.parametrize("seed", range(4))
+def test_stream_orientation_mirrored_slab_axis_matches_whole_volume(seed: int) -> None:
+    # Flip on the slab axis: input slabs arrive ascending, output regions descend — the scheduler must
+    # discover the mirrored direction from the pull map alone and still tile the output exactly.
+    rng = np.random.default_rng(seed)
+    volume = torch.from_numpy(rng.standard_normal((C, Z, Y, X)).astype(np.float32))
+    flip = Flip("0")
+    reference = flip.inverse("case", volume, Attribute())
+    got = _run_stream(
+        lambda target: flip.stream_region_target(target, [Z, Y, X], Attribute()),
+        lambda window, target, source: flip.inverse("case", window, Attribute()),
+        [Z, Y, X],
+        [Z, Y, X],
+        volume,
+        _partitions(Z, rng),
+    )
+    assert torch.equal(got, reference)
+
+
+@pytest.mark.parametrize("seed", range(4))
+def test_stream_orientation_permuted_slab_axis_matches_whole_volume(seed: int) -> None:
+    # Permute z<->y: the input slab axis feeds output axis 1, so the emitted regions are slabs of a
+    # NON-first output axis, written by random access.
+    rng = np.random.default_rng(seed)
+    volume = torch.from_numpy(rng.standard_normal((C, Z, Y, X)).astype(np.float32))
+    permute = Permute("1|0|2")
+    permuted = permute("case", volume, Attribute())
+    reference = permute.inverse("case", permuted, Attribute())
+    in_shape = [Y, Z, X]
+    out_shape = permute.inverse_transform_shape(in_shape, Attribute())
+    assert out_shape == [Z, Y, X]
+    got = _run_stream(
+        lambda target: permute.stream_region_target(target, in_shape, Attribute()),
+        lambda window, target, source: permute.inverse("case", window, Attribute()),
+        in_shape,
+        out_shape,
+        permuted,
+        _partitions(Y, rng),
+    )
+    assert torch.equal(got, reference)
+
+
+@pytest.mark.parametrize("seed", range(4))
+def test_stream_orientation_canonical_inverse_matches_whole_volume(seed: int) -> None:
+    # An identity-direction case: Canonical's forward remap mirrors x and y, so the inverse mirrors
+    # them back INSIDE each slab while the slab axis maps identically.
+    rng = np.random.default_rng(seed)
+    volume = torch.from_numpy(rng.standard_normal((C, Z, Y, X)).astype(np.float32))
+    canonical = Canonical()
+    attribute = Attribute()
+    attribute["Direction"] = np.eye(3).flatten()
+    attribute["Spacing"] = np.ones(3)
+    attribute["Origin"] = np.zeros(3)
+    canonical_volume = canonical("case", volume, attribute)  # stacks the canonical geometry
+    assert canonical.inverse_patch_locality(attribute).kind is LocalityKind.ORIENTATION
+    reference = canonical.inverse("case", canonical_volume.clone(), Attribute(attribute))
+    got = _run_stream(
+        lambda target: canonical.stream_region_target(target, [Z, Y, X], Attribute(attribute)),
+        lambda window, target, source: canonical.inverse("case", window, Attribute(attribute)),
+        [Z, Y, X],
+        canonical.inverse_transform_shape([Z, Y, X], attribute),
+        canonical_volume,
+        _partitions(Z, rng),
+    )
+    assert torch.equal(got, reference)
+
+
+@pytest.mark.parametrize("seed", range(4))
+def test_stream_crop_padding_inverse_matches_whole_volume(seed: int) -> None:
+    # Padding's inverse is a translation that drops the padded border: the pulled window IS the block
+    # (the CROP contract), including slabs that lie entirely inside the dropped border.
+    rng = np.random.default_rng(seed)
+    volume = torch.from_numpy(rng.standard_normal((C, Z, Y, X)).astype(np.float32))
+    padding = Padding([0, 0, 1, 1, 2, 1])
+    padded = padding("case", volume, Attribute())
+    in_shape = [Z + 3, Y + 2, X]
+    out_shape = padding.inverse_transform_shape(in_shape, Attribute())
+    reference = padding.inverse("case", padded, Attribute())
+    assert list(reference.shape[1:]) == out_shape
+    got = _run_stream(
+        lambda target: padding.stream_region_target(target, in_shape, Attribute()),
+        lambda window, target, source: window,
+        in_shape,
+        out_shape,
+        padded,
+        _partitions(in_shape[0], rng),
+    )
+    assert torch.equal(got, reference)
+
+
+@pytest.mark.parametrize("seed", range(4))
+def test_stream_rescale_nearest_is_byte_identical_to_the_whole_volume_inverse(seed: int) -> None:
+    # The streamed resample takes its index map from F.interpolate itself, so nearest (uint8) is
+    # byte-identical to the whole-volume inverse — the exactness the RESCALE gate relies on.
+    rng = np.random.default_rng(seed)
+    volume = torch.from_numpy(rng.integers(0, 7, size=(C, Z, Y, X)).astype(np.uint8))
+    resample = ResampleToResolution([1.0, 1.0, 1.0])
+    attribute = Attribute()
+    attribute["Spacing"] = torch.tensor([1.0, 1.0, 1.0])
+    attribute["Size"] = np.asarray([12, 9, 7])  # the size the inverse restores
+    attribute["Size"] = np.asarray([Z, Y, X])
+    in_shape = [Z, Y, X]
+    out_shape = resample.inverse_transform_shape(in_shape, attribute)
+    assert out_shape == [12, 9, 7]
+    scales = [in_shape[k] / out_shape[k] for k in range(3)]
+    reference = resample.inverse("case", volume.clone(), Attribute(attribute))
+    got = _run_stream(
+        lambda target: resample.stream_region_target(target, in_shape, Attribute(attribute)),
+        lambda window, target, source: resample.resample_region(
+            window, target, [s.start for s in source], scales, in_shape
+        ),
+        in_shape,
+        out_shape,
+        volume,
+        _partitions(Z, rng),
+    )
+    assert torch.equal(got, reference)
+
+
+@pytest.mark.parametrize("seed", range(4))
+def test_stream_halo_dilate_matches_whole_volume(seed: int) -> None:
+    # A forward HALO stage (Dilate) rides the same window: the pull enlarges by the declared radius,
+    # the stage runs on the window, and the halo is cropped back — seams must agree bit for bit.
+    rng = np.random.default_rng(seed)
+    volume = (torch.from_numpy(rng.standard_normal((C, Z, Y, X)).astype(np.float32)) > 0.7).to(torch.float32)
+    dilate = Dilate(1)
+    radii = _halo_radii(dilate.patch_locality(Attribute()).halo, 3)
+    in_shape = [Z, Y, X]
+    reference = dilate("case", volume, Attribute())
+
+    def pull(target):
+        return [
+            slice(max(0, t.start - radius), min(extent, t.stop + radius))
+            for t, radius, extent in zip(target, radii, in_shape, strict=False)
+        ]
+
+    def produce(window, target, source):
+        result = dilate("case", window, Attribute())
+        crop = tuple(slice(t.start - s.start, t.stop - s.start) for t, s in zip(target, source, strict=False))
+        return result[(slice(None), *crop)]
+
+    got = _run_stream(pull, produce, in_shape, in_shape, volume, _partitions(Z, rng))
+    assert torch.equal(got, reference)
+
+
+def test_stream_window_is_bounded_by_the_pull_span() -> None:
+    # The whole point: the buffer holds the pull span of the pending output rows, never the volume.
+    tall = 64
+    volume = (torch.arange(1 * tall * Y * X).reshape(1, tall, Y, X) % 5).to(torch.uint8)
+    resample = ResampleToResolution([1.0, 1.0, 1.0])
+    attribute = Attribute()
+    attribute["Spacing"] = torch.tensor([1.0, 1.0, 1.0])
+    attribute["Size"] = np.asarray([96, Y, X])
+    attribute["Size"] = np.asarray([tall, Y, X])
+    in_shape = [tall, Y, X]
+    out_shape = [96, Y, X]
+    scales = [in_shape[k] / out_shape[k] for k in range(3)]
+    stream = SlabRegionStream(
+        lambda target: resample.stream_region_target(target, in_shape, Attribute(attribute)),
+        lambda window, target, source: resample.resample_region(
+            window, target, [s.start for s in source], scales, in_shape
+        ),
+        in_shape,
+        out_shape,
+    )
+    emitted = []
+    max_buffered = 0
+    for z in range(0, tall, 8):
+        emitted += stream.push(slice(z, z + 8), volume[:, z : z + 8].clone())
+        max_buffered = max(max_buffered, sum(slab.shape[1] for _, slab in stream._slabs))
+    emitted += stream.finalize()
+    assert max_buffered <= 16, f"window held {max_buffered} of {tall} rows"
+    reference = resample.inverse("case", volume.clone(), Attribute(attribute))
+    out = torch.zeros([1, *out_shape], dtype=torch.uint8)
+    for target, block in emitted:
+        out[(slice(None), *target)] = block
+    assert torch.equal(out, reference)
+
+
+def test_stream_rejects_non_contiguous_slabs_and_incomplete_finalize() -> None:
+    identity = SlabRegionStream(lambda t: list(t), lambda w, t, s: w, [4, 2], [4, 2])
+    identity.push(slice(0, 2), torch.zeros(1, 2, 2))
+    with pytest.raises(PatchError):
+        identity.push(slice(3, 4), torch.zeros(1, 1, 2))
+    with pytest.raises(PatchError):
+        identity.finalize()
+
+
+# --------------------------------------------------------------------------------------
+# The write-mirror declarations: how each inverse answers, and the safe defaults.
+# --------------------------------------------------------------------------------------
+
+
+def test_inverse_locality_defaults_and_overrides() -> None:
+    empty = Attribute()
+    # A per-voxel value map inverts to a per-voxel value map; an index remap to an index remap.
+    assert TensorCast().inverse_patch_locality(empty).kind is LocalityKind.POINTWISE
+    assert Flip("0").inverse_patch_locality(empty).kind is LocalityKind.ORIENTATION
+    assert Permute("1|0|2").inverse_patch_locality(empty).kind is LocalityKind.ORIENTATION
+    # Stat-based inverses only pop what the forward stacked: pointwise on the finalize-time attribute.
+    assert Normalize().inverse_patch_locality(empty).kind is LocalityKind.POINTWISE
+    assert Standardize().inverse_patch_locality(empty).kind is LocalityKind.POINTWISE
+    # Geometry inverses declare their own kind.
+    assert Padding().inverse_patch_locality(empty).kind is LocalityKind.CROP
+    # A resample inverse is patch-native only when the Size stack it pops is on the case.
+    assert ResampleToResolution().inverse_patch_locality(empty).kind is LocalityKind.WHOLE_VOLUME
+    seeded = Attribute()
+    seeded["Size"] = np.asarray([4, 4, 4])
+    seeded["Size"] = np.asarray([2, 2, 2])
+    assert ResampleToResolution().inverse_patch_locality(seeded).kind is LocalityKind.RESCALE
+    # Canonical judges the POPPED state: without a stacked direction there is nothing to invert onto.
+    assert Canonical().inverse_patch_locality(empty).kind is LocalityKind.WHOLE_VOLUME
+
+    # Any other kind falls to the safety net, exactly like the read side's default.
+    class _OpaqueInverse(TransformInverse):
+        def __call__(self, name, tensor, cache_attribute):
+            return tensor
+
+        def inverse(self, name, tensor, cache_attribute):
+            return tensor
+
+    assert _OpaqueInverse(True).inverse_patch_locality(empty).kind is LocalityKind.WHOLE_VOLUME
+
+
+def test_canonical_oblique_direction_refuses_the_inverse_remap() -> None:
+    attribute = Attribute()
+    theta = np.deg2rad(30.0)
+    rotation = np.array([[np.cos(theta), -np.sin(theta), 0.0], [np.sin(theta), np.cos(theta), 0.0], [0.0, 0.0, 1.0]])
+    attribute["Direction"] = rotation.flatten()
+    attribute["Direction"] = np.diag([-1.0, -1.0, 1.0]).flatten()  # what a forward pass stacked on top
+    assert Canonical().inverse_patch_locality(attribute).kind is LocalityKind.WHOLE_VOLUME
+
+
+# --------------------------------------------------------------------------------------
+# The planner: which chains stream, through which mode.
+# --------------------------------------------------------------------------------------
+
+
+def _output_dataset(
+    reduction: Reduction | None = None,
+    before: list[Transform] | None = None,
+    after: list[Transform] | None = None,
+    final: list[Transform] | None = None,
+    file_format: str = "h5",
+    nb_data_augmentation: int = 1,
+) -> OutSameAsGroupDataset:
+    ds = OutSameAsGroupDataset.__new__(OutSameAsGroupDataset)
+    ds.nb_data_augmentation = nb_data_augmentation
+    ds.reduction = reduction if reduction is not None else Mean()
+    ds.before_reduction_transforms = before or []
+    ds.after_reduction_transforms = after or []
+    ds.final_transforms = final or []
+    ds.group_src, ds.group_dest = "src", "dest"
+    ds.file_format = file_format
+    return ds
+
+
+def _dataset_iter(transforms: list[Transform]) -> DatasetIter:
+    return cast(
+        DatasetIter,
+        SimpleNamespace(groups_src={"src": {"dest": SimpleNamespace(transforms=list(transforms))}}),
+    )
+
+
+def _geometry_attribute() -> Attribute:
+    attribute = Attribute()
+    attribute["Origin"] = np.zeros(3)
+    attribute["Spacing"] = np.ones(3)
+    attribute["Direction"] = np.eye(3).flatten()
+    return attribute
+
+
+def test_plan_all_pointwise_streams_direct() -> None:
+    plan = _output_dataset(final=[TensorCast("float32", inverse=False)])._plan_stream(
+        _dataset_iter([]), _geometry_attribute()
+    )
+    assert plan is not None and plan.mode == "direct"
+
+
+def test_plan_one_geometry_inverse_streams_through_the_region_stage() -> None:
+    plan = _output_dataset()._plan_stream(_dataset_iter([Flip("0", inverse=True)]), _geometry_attribute())
+    assert plan is not None and plan.mode == "region"
+    assert plan.pipe_start == 0 and plan.stages[0].inverted
+
+
+def test_plan_several_region_stages_compose_into_one_streamed_pipe() -> None:
+    # Padding + Flip inverses: region stages compose (each pulls through the next), so a multi-inverse
+    # geometry chain still streams to the write — no chain is one region too many.
+    plan = _output_dataset()._plan_stream(
+        _dataset_iter([Flip("0", inverse=True), Padding([0, 0, 0, 0, 2, 1], inverse=True)]),
+        _geometry_attribute(),
+    )
+    assert plan is not None and plan.mode == "region"
+    assert plan.pipe_start == 0 and plan.tail_start == len(plan.stages)
+
+
+def test_plan_whole_volume_stage_falls_to_the_buffered_tail_and_swallows_the_region() -> None:
+    # [region, WHOLE_VOLUME]: the tail must start at the region stage, not after it — a buffered head
+    # is pointwise-only so the buffer sits on the accumulator grid.
+    plan = _output_dataset(final=[Softmax(1)])._plan_stream(
+        _dataset_iter([Flip("0", inverse=True)]), _geometry_attribute()
+    )
+    assert plan is not None and plan.mode == "buffered"
+    assert plan.pipe_start is None and plan.tail_start == 0
+
+
+def test_plan_seeded_global_stat_counts_as_pointwise_and_unseeded_does_not() -> None:
+    # Normalize forward in the finalize chain needs the volume's Min/Max: with the statistic already on
+    # the case it is a per-voxel map; without it each slab would derive its own — so it must be a tail.
+    seeded = _geometry_attribute()
+    seeded["Min"] = 0.0
+    seeded["Max"] = 1.0
+    plan = _output_dataset(final=[Normalize(inverse=False)])._plan_stream(_dataset_iter([]), seeded)
+    assert plan is not None and plan.mode == "direct"
+    plan = _output_dataset(final=[Normalize(inverse=False)])._plan_stream(_dataset_iter([]), _geometry_attribute())
+    assert plan is not None and plan.mode == "buffered" and plan.tail_start == 0
+
+
+def test_plan_refuses_tta_custom_reduction_and_non_pointwise_before_reduction() -> None:
+    class _CustomReduction(Reduction):
+        def __call__(self, tensors):
+            return tensors[0]
+
+    attribute = _geometry_attribute()
+    assert _output_dataset(nb_data_augmentation=2)._plan_stream(_dataset_iter([]), attribute) is None
+    assert _output_dataset(reduction=_CustomReduction())._plan_stream(_dataset_iter([]), attribute) is None
+    assert _output_dataset(before=[Softmax(1)])._plan_stream(_dataset_iter([]), attribute) is None
+
+
+def test_plan_non_region_writable_format_buffers_and_writes_classically() -> None:
+    # nrrd cannot serve region writes: the pointwise chain still streams the accumulator into a buffer
+    # (the windowed-accumulator win survives), and the volume is written through the classic writer.
+    plan = _output_dataset(file_format="nrrd")._plan_stream(_dataset_iter([]), _geometry_attribute())
+    assert plan is not None and plan.mode == "buffered" and plan.tail_start == len(plan.stages)
+
+
+# --------------------------------------------------------------------------------------
+# End to end at the unit level: a geometry inverse streamed through add_layer into a real sink.
+# --------------------------------------------------------------------------------------
+
+
+def _drive_prediction(tmp_path, transforms, volume, monkeypatch, streamed=True, before=()):
+    """Push a whole case patch by patch through add_layer against an h5 sink and read the entry back.
+
+    The forward ``transforms`` run once on ``volume`` (chained, stacking the attribute exactly as the
+    input pipeline would), and the transformed volume plays the model output: the finalize chain must
+    invert it back.
+    """
+    from konfai.utils.dataset import Dataset
+
+    monkeypatch.setenv("KONFAI_STREAMED_WRITES", "1" if streamed else "0")
+    monkeypatch.setenv("KONFAI_config_file", "unused.yml")
+    monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
+
+    attribute = _geometry_attribute()
+    model_volume = volume.clone()
+    for transform in transforms:
+        model_volume = transform("CASE_000", model_volume, attribute)
+    z = model_volume.shape[1]
+    patch_slices = [
+        (slice(k, k + 1), slice(0, model_volume.shape[2]), slice(0, model_volume.shape[3])) for k in range(z)
+    ]
+
+    class DummyPatch:
+        patch_size: ClassVar[list[int]] = [1, model_volume.shape[2], model_volume.shape[3]]
+
+        @staticmethod
+        def get_patch_slices(index_augmentation: int):
+            del index_augmentation
+            return patch_slices
+
+    class DummyManager:
+        name = "CASE_000"
+        patch = DummyPatch()
+        cache_attributes: ClassVar[list[Attribute]] = [Attribute()]
+
+    class DummyDatasetIter:
+        groups_src: ClassVar[dict] = {
+            "src": {"dest": SimpleNamespace(transforms=list(transforms), patch_transforms=[])}
+        }
+
+        @staticmethod
+        def get_dataset_from_index(group_dest: str, index: int):
+            return DummyManager()
+
+    output_dataset = OutSameAsGroupDataset(
+        same_as_group="src:dest",
+        dataset_filename=f"{tmp_path}/output.h5:h5",
+        group="out",
+        patch_combine=None,
+        reduction="Mean",
+    )
+    output_dataset.reduction = Mean()
+    output_dataset.nb_data_augmentation = 1
+    output_dataset.before_reduction_transforms = list(before)
+
+    for k in range(z):
+        # Patch.get_data squeezes size-1 patch axes, so a [1, Y, X] patch reaches add_layer as [C, Y, X].
+        output_dataset.add_layer(
+            0, 0, k, model_volume[:, k].clone(), cast(DatasetIter, DummyDatasetIter()), Attribute(attribute)
+        )
+        if output_dataset.is_done(0):
+            result = output_dataset.get_output(0, [volume.shape[0]], cast(DatasetIter, DummyDatasetIter()))
+            output_dataset.write_prediction(0, "CASE_000", result)
+
+    data, _ = Dataset(f"{tmp_path}/output.h5", "h5").read_data("out", "CASE_000")
+    return torch.from_numpy(data)
+
+
+def test_add_layer_streams_a_flip_inverse_through_the_region_stage(tmp_path, monkeypatch) -> None:
+    # The forward Flip was applied to the model input, so the accumulator holds the flipped volume and
+    # the finalize chain flips it back; the streamed sink entry must equal the original bit for bit —
+    # and equal what the whole-volume path (kill-switch) writes.
+    volume = torch.from_numpy(np.random.default_rng(0).standard_normal((1, 6, 4, 3)).astype(np.float32))
+    transforms = [Flip("0", inverse=True)]
+    streamed = _drive_prediction(tmp_path / "streamed", transforms, volume, monkeypatch, streamed=True)
+    reference = _drive_prediction(tmp_path / "reference", transforms, volume, monkeypatch, streamed=False)
+    assert torch.equal(streamed, reference)
+    assert torch.equal(streamed, volume)
+
+
+def test_add_layer_streams_a_full_geometry_stack_through_the_composed_pipe(tmp_path, monkeypatch) -> None:
+    # The general case the composition exists for: Canonical + ResampleToResolution + Padding forward,
+    # so the finalize chain carries CROP + RESCALE + ORIENTATION in sequence. With the labelmap cast
+    # to uint8 before the reduction, the whole stack streams to the sink and must match the
+    # whole-volume path bit for bit.
+    volume = (torch.arange(1 * 6 * 4 * 3).reshape(1, 6, 4, 3) % 5).to(torch.float32)
+    transforms = [
+        Canonical(inverse=True),
+        ResampleToResolution([0.5, 0.5, -1.0], inverse=True),
+        Padding([0, 0, 0, 0, 2, 1], inverse=True),
+    ]
+    before = [TensorCast("uint8", inverse=False)]
+    streamed = _drive_prediction(tmp_path / "streamed", transforms, volume, monkeypatch, streamed=True, before=before)
+    reference = _drive_prediction(
+        tmp_path / "reference", transforms, volume, monkeypatch, streamed=False, before=before
+    )
+    assert streamed.dtype == reference.dtype
+    assert torch.equal(streamed, reference)
+    assert list(streamed.shape) == list(volume.shape)

--- a/tests/unit/test_transform_locality_contract.py
+++ b/tests/unit/test_transform_locality_contract.py
@@ -588,8 +588,9 @@ def test_streamed_augmented_patch_equals_whole_volume(case: _AugmentationCase, d
 def test_a_pointwise_augmentation_streams_the_whole_grid_after_a_transform(dataset: Dataset) -> None:
     """A copy is its transforms AND its draw: the dispatcher plans them as one chain.
 
-    A pointwise draw behind a region transform is still one region, so it streams; the same draw behind
-    a region transform AND a region draw would be two, which is what the plan refuses.
+    A pointwise draw behind a region transform is still one region, so it streams; a region draw
+    behind a region transform makes two — and region stages compose, each pulling through the one
+    before it, so the pair streams too and must match the loaded copy patch for patch.
     """
     torch.manual_seed(0)
     brightness = augmentation_module.Brightness(0.5)
@@ -611,8 +612,19 @@ def test_a_pointwise_augmentation_streams_the_whole_grid_after_a_transform(datas
 
     resample = ResampleToResolution([2.0, 1.0, 3.0])
     assert manager(resample).can_stream_patch(1) is True
-    # Two regions in one chain: the resample's, and the flip's.
+    # Two regions in one chain — the resample's, then the flip draw's — composed into one pull.
     flip = FlipAugmentation(f_prob=[1.0, 1.0, 1.0])
     flip.load(1.0)
     augmentations.data_augmentations = [flip]
-    assert manager(resample).can_stream_patch(1) is False
+    streamed, reference = manager(resample), manager(resample)
+    for item in (streamed, reference):
+        item.reset_augmentation(reset_state=False)
+    assert streamed.can_stream_patch(1) is True
+    reference.load([resample], [augmentations], load_augmentations=True)
+    for index in range(streamed.get_size(1)):
+        got = streamed.get_data(index, 1, [], True)
+        expected = reference.get_data(index, 1, [], True)
+        assert got.shape == expected.shape
+        # The streamed resample matches F.interpolate to float32 interpolation rounding; the flip
+        # draw on top is an exact index remap of it.
+        np.testing.assert_allclose(got.numpy(), expected.numpy(), rtol=0, atol=1e-3)


### PR DESCRIPTION
**Base of the streaming stack** (`main..a56aa4d`). Bounds prediction RAM/VRAM by writing outputs slab by slab instead of assembling the whole volume.

- `Dataset.open_data_stream` / `DataStream` region-write backends (mha memmap, h5, OME-Zarr).
- `StreamingAccumulator` — window along the first spatial axis, yields finalized slabs as patches complete.
- Write dispatcher: direct / region (geometry inverses compose — Canonical/Flip/Permute/Padding/Resample stream to the sink) / buffered chain-split fallback. Read-side region composition mirrors it.
- GPU accumulation with a measured VRAM gate; host fallback when it does not fit.

Followed by #52 (auto-patching), #53 (loading-regime), #55 (TTA + perf + audit follow-up).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic streamed prediction writes to reduce peak memory for large outputs.
  * Added slab-by-slab output support for HDF5, uncompressed MetaImage, and OME-Zarr formats.
  * Expanded streaming support for composed geometry transforms, including orientation, padding, cropping, permutation, flipping, and resampling.
  * Added `KONFAI_STREAMED_WRITES=0` to force whole-volume output.

* **Bug Fixes**
  * Improved fallback to whole-volume processing when streaming is unsupported.
  * Ensured streamed results match assembled outputs, with only minor floating-point differences possible in specific chains.

* **Documentation**
  * Added guidance on streaming eligibility, memory behavior, supported formats, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->