### PR TITLE
refactor: readability pass on core workflow modules (no behavior change)

### DIFF
--- a/konfai/evaluator.py
+++ b/konfai/evaluator.py
@@ -357,7 +357,7 @@ class Evaluator(DistributedObject):
             dict[str, float]: Dictionary of computed metric values with keys in the format
                             'output_group:target_group:MetricName'.
         """
-        result = {}
+        result: dict[str, float] = {}
         for output_group in self.metrics:
             output_tensor = batch_sample[output_group].tensor
             metric_device = output_tensor.device
@@ -394,45 +394,56 @@ class Evaluator(DistributedObject):
                     if isinstance(loss, tuple):
                         true_loss = loss[1]
                         if len(loss) == 3:
-                            if metric.dataset:
-                                filename, _, file_format = split_path_spec(metric.dataset)
-                                map_dataset = Dataset(filename, file_format)
-                                group = metric.group if metric.group else output_group
-                                for dataset in self.dataset.datasets.values():
-                                    for g in dataset.get_group():
-                                        if dataset.is_dataset_exist(g, name):
-                                            _, cache_attribute = dataset.get_infos(g, name)
-                                            map_dataset.write(
-                                                group,
-                                                name,
-                                                loss[2].squeeze(0).numpy(),
-                                                cache_attribute,
-                                            )
-                                            break
+                            self._write_error_map(metric, loss[2], name, output_group)
                     else:
                         true_loss = loss.item()
 
                     direction = "max" if getattr(metric, "maximize", False) else "min"
-                    if isinstance(true_loss, dict):
-                        loss = 0
-                        c = 0
-                        for k, v in true_loss.items():
-                            component_key = f"{output_group}:{target_group}:{metric.get_name()}:{k}"
-                            result[component_key] = v
-                            statistics.directions[component_key] = direction
-                            if not np.isnan(v):
-                                loss += v
-                                c += 1
-                        base_key = f"{output_group}:{target_group}:{metric.get_name()}"
-                        result[base_key] = loss / c if c > 0 else np.nan
-                        statistics.directions[base_key] = direction
-                    else:
-                        base_key = f"{output_group}:{target_group}:{metric.get_name()}"
-                        result[base_key] = true_loss
-                        statistics.directions[base_key] = direction
+                    base_key = f"{output_group}:{target_group}:{metric.get_name()}"
+                    self._record_metric(result, statistics, base_key, true_loss, direction)
         if len(self.metrics) > 0:
             statistics.add(result, name)
         return result
+
+    def _write_error_map(self, metric: Any, error_map: torch.Tensor, name: str, output_group: str) -> None:
+        """Write a metric's per-voxel error map for ``name`` into its declared dataset, if it declares one."""
+        if not metric.dataset:
+            return
+        filename, _, file_format = split_path_spec(metric.dataset)
+        map_dataset = Dataset(filename, file_format)
+        group = metric.group if metric.group else output_group
+        for dataset in self.dataset.datasets.values():
+            for g in dataset.get_group():
+                if dataset.is_dataset_exist(g, name):
+                    _, cache_attribute = dataset.get_infos(g, name)
+                    map_dataset.write(group, name, error_map.squeeze(0).numpy(), cache_attribute)
+                    break
+
+    def _record_metric(
+        self,
+        result: dict[str, float],
+        statistics: Statistics,
+        base_key: str,
+        true_loss: float | dict[str, float],
+        direction: str,
+    ) -> None:
+        """Record one metric value under ``base_key``. A dict value records each component plus their
+        NaN-skipping mean under the base key; a scalar records straight through."""
+        if isinstance(true_loss, dict):
+            total = 0.0
+            count = 0
+            for k, v in true_loss.items():
+                component_key = f"{base_key}:{k}"
+                result[component_key] = v
+                statistics.directions[component_key] = direction
+                if not np.isnan(v):
+                    total += v
+                    count += 1
+            result[base_key] = total / count if count > 0 else np.nan
+            statistics.directions[base_key] = direction
+        else:
+            result[base_key] = true_loss
+            statistics.directions[base_key] = direction
 
     def run_process(self, world_size: int, global_rank: int, gpu: int, dataloaders: list[DataLoader]):
         """
@@ -457,60 +468,33 @@ class Evaluator(DistributedObject):
             - Only the main process (`global_rank == 0`) writes final results to disk.
         """
 
-        def description(measure):
-            return (
-                f"Metric TRAIN : {' | '.join(f'{k}: {v:.4f}' for k, v in measure.items())}"
-                if measure is not None
-                else "Metric TRAIN : "
-            )
+        self._run_split(dataloaders[0], self.statistics_train, "TRAIN", world_size, gpu, global_rank)
+        if len(dataloaders) == 2:
+            self._run_split(dataloaders[1], self.statistics_validation, "VALIDATION", world_size, gpu, global_rank)
+
+    def _run_split(
+        self,
+        loader: DataLoader,
+        statistics: Statistics,
+        label: str,
+        world_size: int,
+        gpu: int,
+        global_rank: int,
+    ) -> None:
+        """Evaluate one split over its loader, then synchronise across ranks and write the JSON on rank 0."""
+
+        def description(measure: dict[str, float] | None) -> str:
+            body = " | ".join(f"{k}: {v:.4f}" for k, v in measure.items()) if measure is not None else ""
+            return f"Metric {label} : {body}"
 
         with tqdm.tqdm(
-            iterable=enumerate(dataloaders[0]),
-            leave=True,
-            desc=description(None),
-            total=len(dataloaders[0]),
-            ncols=0,
+            iterable=enumerate(loader), leave=True, desc=description(None), total=len(loader), ncols=0
         ) as batch_iter:
             for _, batch_sample in batch_iter:
-                batch_iter.set_description(
-                    description(
-                        self.update(
-                            batch_sample,
-                            self.statistics_train,
-                        )
-                    )
-                )
-        outputs = synchronize_data(world_size, gpu, self.statistics_train.measures)
+                batch_iter.set_description(description(self.update(batch_sample, statistics)))
+        outputs = synchronize_data(world_size, gpu, statistics.measures)
         if global_rank == 0:
-            self.statistics_train.write(outputs)
-        if len(dataloaders) == 2:
-
-            def description(measure):
-                return (
-                    f"Metric VALIDATION : {' | '.join(f'{k}: {v:.4f}' for k, v in measure.items())}"
-                    if measure is not None
-                    else "Metric VALIDATION : "
-                )
-
-            with tqdm.tqdm(
-                iterable=enumerate(dataloaders[1]),
-                leave=True,
-                desc=description(None),
-                total=len(dataloaders[1]),
-                ncols=0,
-            ) as batch_iter:
-                for _, batch_sample in batch_iter:
-                    batch_iter.set_description(
-                        description(
-                            self.update(
-                                batch_sample,
-                                self.statistics_validation,
-                            )
-                        )
-                    )
-            outputs = synchronize_data(world_size, gpu, self.statistics_validation.measures)
-            if global_rank == 0:
-                self.statistics_validation.write(outputs)
+            statistics.write(outputs)
 
 
 def build_evaluate(

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -74,7 +74,7 @@ class EarlyStoppingBase:
         return self.early_stop
 
     def get_score(self, values: dict[str, float]):
-        return sum(list(values.values()))
+        return sum(values.values())
 
     def is_better(self, score: float, reference: float) -> bool:
         """True if `score` is strictly better than `reference` under this monitor's direction."""
@@ -126,28 +126,22 @@ class EarlyStopping(EarlyStoppingBase):
         self.best_score: float | None = None
 
     def get_score(self, values: dict[str, float]):
-        if len(self.monitor) == 0:
+        if not self.monitor:
             return super().get_score(values)
         for v in self.monitor:
-            if v not in values.keys():
+            if v not in values:
                 raise TrainerError(
                     f"Metric '{v}' specified in EarlyStopping.monitor not found in logged values. "
                     f"Available keys: {sorted(values.keys())}. Please check your configuration."
                 )
-        return sum([i for v, i in values.items() if v in self.monitor])
+        return sum(i for v, i in values.items() if v in self.monitor)
 
     def __call__(self, current_score: float) -> bool:
         if self.best_score is None:
             self.best_score = current_score
             return False
 
-        if self.mode == "min":
-            improvement = self.best_score - current_score
-        elif self.mode == "max":
-            improvement = current_score - self.best_score
-        else:
-            raise TrainerError("Mode must be 'min' or 'max'.")
-
+        improvement = current_score - self.best_score if self.mode == "max" else self.best_score - current_score
         if improvement > self.min_delta:
             self.best_score = current_score
             self.counter = 0
@@ -226,12 +220,9 @@ class _Trainer:
         if self.global_rank == 0 and self.save_checkpoint_mode == "BEST":
             self._initialize_best_checkpoint_state()
         self.data_log: dict[str, tuple[DataLog, int]] = {}
-        if data_log is not None:
-            for data in data_log:
-                self.data_log[data.split("/")[0].replace(":", ".")] = (
-                    DataLog[data.split("/")[1]],
-                    int(data.split("/")[2]),
-                )
+        for data in data_log or []:
+            parts = data.split("/")
+            self.data_log[parts[0].replace(":", ".")] = (DataLog[parts[1]], int(parts[2]))
 
     def __enter__(self):
         return self
@@ -282,6 +273,21 @@ class _Trainer:
 
         checkpoint_path.unlink()
 
+    def _set_state(self, train: bool) -> None:
+        """Switch the model and its EMA companion between TRAIN and PREDICTION together.
+
+        The EMA copy always stays in eval mode; only its NetState follows the phase.
+        """
+        state = NetState.TRAIN if train else NetState.PREDICTION
+        if train:
+            self.model.train()
+        else:
+            self.model.eval()
+        self.model.module.set_state(state)
+        if self.model_ema is not None:
+            self.model_ema.eval()
+            self.model_ema.module.set_state(state)
+
     def run(self) -> None:
         """
         Launches the training loop, performing one epoch at a time.
@@ -315,11 +321,7 @@ class _Trainer:
         - loss logging and checkpoint saving
         - validation at configurable iteration interval
         """
-        self.model.train()
-        self.model.module.set_state(NetState.TRAIN)
-        if self.model_ema is not None:
-            self.model_ema.eval()
-            self.model_ema.module.set_state(NetState.TRAIN)
+        self._set_state(train=True)
 
         with tqdm.tqdm(
             iterable=enumerate(self.dataloader_training),
@@ -383,10 +385,7 @@ class _Trainer:
         """
         if self.dataloader_validation is None:
             return 0
-        self.model.eval()
-        self.model.module.set_state(NetState.PREDICTION)
-        if self.model_ema is not None:
-            self.model_ema.module.set_state(NetState.PREDICTION)
+        self._set_state(train=False)
 
         batch_sample: BatchSample = {}
         with tqdm.tqdm(
@@ -405,10 +404,7 @@ class _Trainer:
         self.dataloader_validation.dataset.reset_augmentation("Validation")
         if dist.is_initialized():
             dist.barrier()
-        self.model.train()
-        self.model.module.set_state(NetState.TRAIN)
-        if self.model_ema is not None:
-            self.model_ema.module.set_state(NetState.TRAIN)
+        self._set_state(train=True)
         return self._validation_log(batch_sample)
 
     def _broadcast_stop(self, stop: bool) -> bool:
@@ -459,27 +455,11 @@ class _Trainer:
             save_dict["Model_EMA"] = self.model_ema.module.state_dict()
             save_dict["Model_EMA_n_averaged"] = int(self.model_ema.n_averaged)
 
-        save_dict.update(
-            {
-                f"{name}_optimizer_state_dict": network.optimizer.state_dict()
-                for name, network in self.model.module.get_networks().items()
-                if network.optimizer is not None
-            }
-        )
-        save_dict.update(
-            {
-                f"{name}_it": network._it
-                for name, network in self.model.module.get_networks().items()
-                if network.optimizer is not None
-            }
-        )
-        save_dict.update(
-            {
-                f"{name}_nb_lr_update": network._nb_lr_update
-                for name, network in self.model.module.get_networks().items()
-                if network.optimizer is not None
-            }
-        )
+        for name, network in self.model.module.get_networks().items():
+            if network.optimizer is not None:
+                save_dict[f"{name}_optimizer_state_dict"] = network.optimizer.state_dict()
+                save_dict[f"{name}_it"] = network._it
+                save_dict[f"{name}_nb_lr_update"] = network._nb_lr_update
 
         torch.save(save_dict, save_path)
 
@@ -518,81 +498,71 @@ class _Trainer:
             ),
         )
 
-        if self.global_rank == 0:
-            images_log = []
-            if len(self.data_log):
-                for name, data_type in self.data_log.items():
-                    if name in batch_sample:
-                        data_type[0](
-                            self.tb,
-                            f"{type_log}/{name}",
-                            batch_sample[name].tensor[: self.data_log[name][1]].detach().cpu().numpy(),
-                            self.it,
-                        )
-                    else:
-                        images_log.append(name.replace(":", "."))
+        if self.global_rank != 0:
+            return None
 
-            for label, model in models.items():
-                for name, network in model.get_networks().items():
-                    if network.measure is not None:
-                        self.tb.add_scalars(
-                            f"{type_log}/{name}/Loss/{label}",
-                            {k.replace(":", "."): v[1] for k, v in measures[f"{name}{label}"][0].items()},
-                            self.it,
-                        )
-                        self.tb.add_scalars(
-                            f"{type_log}/{name}/Loss_weight/{label}",
-                            {k.replace(":", "."): v[0] for k, v in measures[f"{name}{label}"][0].items()},
-                            self.it,
-                        )
+        images_log = []
+        for name, (logger, count) in self.data_log.items():
+            if name in batch_sample:
+                logger(
+                    self.tb,
+                    f"{type_log}/{name}",
+                    batch_sample[name].tensor[:count].detach().cpu().numpy(),
+                    self.it,
+                )
+            else:
+                images_log.append(name.replace(":", "."))
 
-                        self.tb.add_scalars(
-                            f"{type_log}/{name}/Metric/{label}",
-                            {k.replace(":", "."): v[1] for k, v in measures[f"{name}{label}"][1].items()},
-                            self.it,
-                        )
-                        self.tb.add_scalars(
-                            f"{type_log}/{name}/Metric_weight/{label}",
-                            {k.replace(":", "."): v[0] for k, v in measures[f"{name}{label}"][1].items()},
-                            self.it,
-                        )
-
-                    if len(images_log):
-                        for name, layer, _ in model.get_layers(
-                            [v.tensor for v in batch_sample.values() if v.is_input],
-                            images_log,
-                        ):
-                            self.data_log[name][0](
-                                self.tb,
-                                f"{type_log}/{name}{label}",
-                                layer[: self.data_log[name][1]].detach().cpu().numpy(),
-                                self.it,
-                            )
-
-            if type_log == "Training":
-                for name, network in self.model.module.get_networks().items():
-                    if network.optimizer is not None:
-                        self.tb.add_scalar(
-                            f"{type_log}/{name}/Learning Rate",
-                            network.optimizer.param_groups[0]["lr"],
-                            self.it,
-                        )
-
-        if self.global_rank == 0:
-            loss = {}
-            loss_keys: set[str] = set()
-            for name, network in self.model.module.get_networks().items():
+        for label, model in models.items():
+            for name, network in model.get_networks().items():
                 if network.measure is not None:
-                    losses = {k: v[1] for k, v in measures[name][0].items()}
-                    loss_keys.update(losses)
-                    loss.update(losses)
-                    loss.update({k: v[1] for k, v in measures[name][1].items()})
-            # Remember which keys are losses (always minimise) vs metrics (direction varies), so
-            # default checkpoint/early-stop selection scores on the losses only -- summing a
-            # maximise-metric (e.g. Dice) into a minimised score would keep the worst model.
-            self._loss_keys = loss_keys
-            return loss
-        return None
+                    for kind, kind_measures in zip(("Loss", "Metric"), measures[f"{name}{label}"], strict=True):
+                        self.tb.add_scalars(
+                            f"{type_log}/{name}/{kind}/{label}",
+                            {k.replace(":", "."): v[1] for k, v in kind_measures.items()},
+                            self.it,
+                        )
+                        self.tb.add_scalars(
+                            f"{type_log}/{name}/{kind}_weight/{label}",
+                            {k.replace(":", "."): v[0] for k, v in kind_measures.items()},
+                            self.it,
+                        )
+
+                if images_log:
+                    for name, layer, _ in model.get_layers(
+                        [v.tensor for v in batch_sample.values() if v.is_input],
+                        images_log,
+                    ):
+                        logger, count = self.data_log[name]
+                        logger(
+                            self.tb,
+                            f"{type_log}/{name}{label}",
+                            layer[:count].detach().cpu().numpy(),
+                            self.it,
+                        )
+
+        if type_log == "Training":
+            for name, network in self.model.module.get_networks().items():
+                if network.optimizer is not None:
+                    self.tb.add_scalar(
+                        f"{type_log}/{name}/Learning Rate",
+                        network.optimizer.param_groups[0]["lr"],
+                        self.it,
+                    )
+
+        loss: dict[str, float] = {}
+        loss_keys: set[str] = set()
+        for name, network in self.model.module.get_networks().items():
+            if network.measure is not None:
+                losses = {k: v[1] for k, v in measures[name][0].items()}
+                loss_keys.update(losses)
+                loss.update(losses)
+                loss.update({k: v[1] for k, v in measures[name][1].items()})
+        # Remember which keys are losses (always minimise) vs metrics (direction varies), so
+        # default checkpoint/early-stop selection scores on the losses only -- summing a
+        # maximise-metric (e.g. Dice) into a minimised score would keep the worst model.
+        self._loss_keys = loss_keys
+        return loss
 
     @torch.no_grad()
     def _train_log(self, batch_sample: BatchSample) -> dict[str, float]:
@@ -728,12 +698,9 @@ class Trainer(DistributedObject):
         shutil.copyfile(self.config_path_src, self.config_namefile)
 
         self.dataloader, train_names, validation_names = self.dataset.get_data(world_size // self.size)
-        with open(statistics_directory() / self.name / f"Train_{self.it}.txt", "w") as f:
-            for name in train_names:
-                f.write(name + "\n")
-        with open(statistics_directory() / self.name / f"Validation_{self.it}.txt", "w") as f:
-            for name in validation_names:
-                f.write(name + "\n")
+        for split, names in (("Train", train_names), ("Validation", validation_names)):
+            path = statistics_directory() / self.name / f"{split}_{self.it}.txt"
+            path.write_text("".join(f"{name}\n" for name in names))
 
     def set_model(self, path_to_model: str | Path) -> None:
         self.path_to_model = str(path_to_model)

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -30,6 +30,7 @@ import shutil
 import threading
 import warnings
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -178,6 +179,33 @@ def _finalize_running_statistics(state: dict[str, float] | None) -> dict[str, fl
         "mean": state["mean"],
         "std": math.sqrt(max(variance, 0.0)),
     }
+
+
+def _accumulate_statistics(
+    shape: list[int] | tuple[int, ...],
+    axis: int,
+    read_slab: Callable[[tuple[slice, ...]], np.ndarray],
+    channels: list[int] | None,
+) -> dict[str, float]:
+    """Running min/max/mean/std over an array read chunk by chunk along ``axis``, so no backend ever
+    holds the whole volume. ``read_slab(slices)`` returns the NumPy chunk for one slice tuple."""
+    chunk_length = _statistics_chunk_length(shape, axis)
+    state: dict[str, float] | None = None
+    for start in range(0, shape[axis], chunk_length):
+        slices: list[slice] = [slice(None)] * len(shape)
+        slices[axis] = slice(start, min(shape[axis], start + chunk_length))
+        chunk = read_slab(tuple(slices))
+        if channels is not None:
+            chunk = chunk[channels]
+        state = _update_running_statistics(state, chunk)
+    return _finalize_running_statistics(state)
+
+
+def _flatten_transform(transform: sitk.Transform) -> list[sitk.Transform]:
+    """Expand a (possibly composite) transform into its ordered leaf transforms."""
+    if isinstance(transform, sitk.CompositeTransform):
+        return [transform.GetNthTransform(i) for i in range(transform.GetNumberOfTransforms())]
+    return [transform]
 
 
 # Formats already reported by _warn_unstreamed_region_read. Keyed by format, not by file: the remedy
@@ -551,18 +579,7 @@ class Dataset:
                 raise NameError(f"Dataset '{groups}/{name}' not found in '{self.filename}'.")
 
             axis = 1 if dataset.ndim > 1 else 0
-            chunk_length = _statistics_chunk_length(dataset.shape, axis)
-            state: dict[str, float] | None = None
-
-            for start in range(0, dataset.shape[axis], chunk_length):
-                slices = [slice(None)] * dataset.ndim
-                slices[axis] = slice(start, min(dataset.shape[axis], start + chunk_length))
-                chunk = np.asarray(dataset[tuple(slices)])
-                if channels is not None:
-                    chunk = chunk[channels]
-                state = _update_running_statistics(state, chunk)
-
-            return _finalize_running_statistics(state)
+            return _accumulate_statistics(dataset.shape, axis, lambda s: np.asarray(dataset[s]), channels)
 
         def data_to_file(
             self,
@@ -578,12 +595,7 @@ class Dataset:
                 data, attributes_tmp = image_to_data(data)
                 attributes.update(attributes_tmp)
             elif isinstance(data, sitk.Transform):
-                transforms = []
-                if isinstance(data, sitk.CompositeTransform):
-                    for i in range(data.GetNumberOfTransforms()):
-                        transforms.append(data.GetNthTransform(i))
-                else:
-                    transforms.append(data)
+                transforms = _flatten_transform(data)
                 datas = []
                 for i, transform in enumerate(transforms):
                     if isinstance(transform, sitk.Euler3DTransform):
@@ -802,29 +814,15 @@ class Dataset:
             reader.ReadImageInformation()
             data_shape = [reader.GetNumberOfComponents(), *reversed(reader.GetSize())]
 
-            slab_length = _statistics_chunk_length(data_shape, 1)
-            state: dict[str, float] | None = None
-
-            for start in range(0, data_shape[1], slab_length):
-                slices: list[slice] = [slice(None)] * len(data_shape)
-                slices[1] = slice(start, min(data_shape[1], start + slab_length))
-                slab, _ = self._file_to_image_slice(name, path, tuple(slices))
-                if channels is not None:
-                    slab = slab[channels]
-                state = _update_running_statistics(state, slab)
-
-            return _finalize_running_statistics(state)
+            return _accumulate_statistics(
+                data_shape, 1, lambda s: self._file_to_image_slice(name, path, s)[0], channels
+            )
 
         def file_to_data(self, group: str, name: str) -> tuple[np.ndarray, Attribute]:
             attributes = Attribute()
             if os.path.exists(f"{self.filename}{name}.itk.txt"):
                 data = sitk.ReadTransform(f"{self.filename}{name}.itk.txt")
-                transforms = []
-                if isinstance(data, sitk.CompositeTransform):
-                    for i in range(data.GetNumberOfTransforms()):
-                        transforms.append(data.GetNthTransform(i))
-                else:
-                    transforms.append(data)
+                transforms = _flatten_transform(data)
                 datas = []
                 for i, transform in enumerate(transforms):
                     if isinstance(transform, sitk.Euler3DTransform):

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -229,40 +229,30 @@ def gpu_info() -> str:
     return f"{node_name}GPU({devices}) Memory GPU ({memory.used / 1e9:.2f}G ({memory.used / memory.total * 100:.2f} %))"
 
 
+def _nvml_device_memory(device: int | torch.device) -> Any | None:
+    """Return the NVML memory info for one visible device, or ``None`` on CPU / without NVML."""
+    if not _PYNVML_AVAILABLE:
+        return None
+    if isinstance(device, torch.device):
+        if not str(device).startswith("cuda:"):
+            return None
+        device = int(str(device).replace("cuda:", ""))
+    device = cuda_visible_devices()[device]
+    if device >= pynvml.nvmlDeviceGetCount():
+        return None
+    return pynvml.nvmlDeviceGetMemoryInfo(pynvml.nvmlDeviceGetHandleByIndex(device))
+
+
 def get_max_gpu_memory(device: int | torch.device) -> float:
     """Return the total VRAM in GB for one device, or ``0`` on CPU."""
-    if not _PYNVML_AVAILABLE:
-        return 0
-    if isinstance(device, torch.device):
-        if str(device).startswith("cuda:"):
-            device = int(str(device).replace("cuda:", ""))
-        else:
-            return 0
-    device = cuda_visible_devices()[device]
-    if device < pynvml.nvmlDeviceGetCount():
-        handle = pynvml.nvmlDeviceGetHandleByIndex(device)
-        memory = pynvml.nvmlDeviceGetMemoryInfo(handle)
-    else:
-        return 0
-    return float(memory.total) / (10**9)
+    memory = _nvml_device_memory(device)
+    return float(memory.total) / (10**9) if memory is not None else 0
 
 
 def get_gpu_memory(device: int | torch.device) -> float:
     """Return current VRAM usage in GB for one device, or ``0`` on CPU."""
-    if not _PYNVML_AVAILABLE:
-        return 0
-    if isinstance(device, torch.device):
-        if str(device).startswith("cuda:"):
-            device = int(str(device).replace("cuda:", ""))
-        else:
-            return 0
-    device = cuda_visible_devices()[device]
-    if device < pynvml.nvmlDeviceGetCount():
-        handle = pynvml.nvmlDeviceGetHandleByIndex(device)
-        memory = pynvml.nvmlDeviceGetMemoryInfo(handle)
-    else:
-        return 0
-    return float(memory.used) / (10**9)
+    memory = _nvml_device_memory(device)
+    return float(memory.used) / (10**9) if memory is not None else 0
 
 
 class NeedDevice:
@@ -385,11 +375,7 @@ def _log_image_format(array: np.ndarray) -> np.ndarray:
 
 
 def _log_images_format(array: np.ndarray) -> np.ndarray:
-    result = []
-    for n in range(array.shape[0]):
-        result.append(_log_image_format(array[n]))
-    result = np.stack(result, axis=0)
-    return result
+    return np.stack([_log_image_format(image) for image in array], axis=0)
 
 
 def _log_video_format(array: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
Pure readability refactor — **strictly no behavior change**. Four modules, one commit each, every commit verified green (ruff, mypy, unit + integration suites) including the end-to-end train→predict→evaluate workflow test that exercises all four modules together.

### `refactor(dataset)` — dedupe the chunked-statistics loop and composite-transform flatten
- The per-backend chunked min/max/mean statistics loops shared the same skeleton — extracted once.
- The nested composite-transform flattening was written twice — single helper.

### `refactor(evaluator)` — extract `_run_split`, `_write_error_map` and `_record_metric`
- The evaluation loop inlined three concerns (split iteration, error-map output, metric recording with dict/scalar branching); each is now a named method with one job.

### `refactor(trainer)` — dedupe state switching, checkpointing and TensorBoard logging
- `_set_state(train: bool)`: the model/EMA `train()/eval()` + `NetState` switch was copied at 3 sites (start of the epoch loop, entering and leaving validation).
- `checkpoint_save`: three passes over `get_networks()` building `save_dict` collapsed into one.
- `_log`: the two consecutive `if global_rank == 0` blocks merged; the four copy-pasted `add_scalars` calls (Loss / Loss_weight / Metric / Metric_weight) folded into a loop that preserves the exact emission order; `data_log` tuples unpacked at use sites.
- `EarlyStopping`: dead `mode` re-validation removed from `__call__` (already validated in `__init__`).

### `refactor(runtime)` — share the NVML device-memory lookup
- `get_max_gpu_memory` / `get_gpu_memory` were identical except for `total` vs `used`; the NVML resolution (device normalisation, visibility mapping, availability guards) now lives in `_nvml_device_memory`, each getter a two-liner.

### Out of scope, on purpose
- `predictor.py` — just reshaped by `feat/streamed-prediction-writes` and the target of the upcoming auto-patching work; refactoring it now would only create rebase noise.
- `measure.py` / `transform.py` — reviewed, no dedup worth the churn.

### Verification
Each commit: `ruff check` + `ruff format --check` clean, `mypy` clean (45 files), full unit suite + `test_konfai_core_workflows` e2e green. No public API touched.

> Stacked on `feat/streamed-prediction-writes`; retarget to `main` once that branch merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Evaluation**
  * Improved metric post-processing for both scalar and multi-component outputs, including NaN-safe aggregation.
  * Standardized per-voxel error-map generation and JSON reporting during distributed runs.
  * Refined train/validation evaluation flow to reduce duplicated work and limit report writing to the primary process.

* **Training**
  * Improved early-stopping score handling.
  * Refined model phase switching, checkpoint save contents, and TensorBoard logging.
  * Streamlined writing of train/validation progress files.

* **Data Processing**
  * Improved dataset/image statistics computation for large inputs.
  * Improved serialization of composite image transforms.

* **Bug Fixes**
  * GPU memory queries now safely handle unavailable/invalid device information (returning 0 instead of failing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->