### PR TITLE
feat: automatic memory-bounded patching — free patch axes sized by measurement

### DIFF
--- a/docs/source/config_guide/evaluation.md
+++ b/docs/source/config_guide/evaluation.md
@@ -73,6 +73,20 @@ Common fields:
 | `subset` | object | Restricts evaluated cases. |
 | `validation` | string / list / null | Optional validation selector for a separate JSON report. Supports a case-list file, a list of case names, or a list of case-list files. |
 
+### `memory_budget`: memory-bounded evaluation
+
+With a `memory_budget` (a bare number in GiB, `"24GB"`, `"auto"`), each run
+sizes itself from image headers alone: a case that fits the budget is evaluated
+whole, and a case that does not is cut into the largest
+DISJOINT patches that fit. Metrics accumulate running partial sums per patch and
+combine them into the exact whole-case value (never a mean of per-patch values).
+MAE, MSE, ME, PSNR and Dice — masked or not — support this, and the SaveMap
+error maps stream region by region into their `dataset` (mha, h5 or omezarr).
+One metric that cannot recombine (SSIM, LPIPS, or any custom metric that does
+not declare `reducible`) keeps the whole-volume path for the entire run: correct
+beats bounded. The same budget also decides the loading regime, as in every
+workflow.
+
 ## Output files
 
 Evaluation writes JSON files, not CSV files. The main outputs are:

--- a/docs/source/config_guide/prediction.md
+++ b/docs/source/config_guide/prediction.md
@@ -89,6 +89,28 @@ Use `Dataset.Patch` when:
 - you want slice-wise or sliding-window inference
 - you need the same spatial strategy as training
 
+### Free patch axes: sizing by measurement
+
+A `patch_size` entry of `0` declares a FREE axis the framework sizes itself. The
+patch starts at the axis's full extent — the whole volume when every axis is
+free — and shrinks only if the device actually runs out of memory:
+
+```yaml
+Patch:
+  patch_size: [0, 0, 0]   # whole volume when it fits; [1, 0, 0] = full 2D slices
+  overlap: 0
+```
+
+There is no budget key: the budget is the GPU's measured free VRAM. On a CUDA
+out-of-memory the run reads what the failed forward cost (the measurement is
+free — it already ran), shrinks the free axes by that ratio (pinned axes never
+move), re-plans the patch grid and re-runs the rank's cases — typically one
+restart. The chosen size also reserves room for the accumulation, so the blend
+stays on the GPU. `overlap` accepts voxels, a fraction (`0.2`), a percent string
+(`"20%"`) or a per-axis list, resolved after the size; an axis a single patch
+spans gets none. A `patch_size` without a `0` is never resized: the OOM
+propagates.
+
 ## `outputs_dataset`
 
 `outputs_dataset` defines how selected model outputs become files on disk.

--- a/docs/source/config_guide/training.md
+++ b/docs/source/config_guide/training.md
@@ -233,6 +233,19 @@ so the ranks can disagree on the number of batches in an epoch and the collectiv
 will hang. Leave it `null` for multi-GPU runs.
 ```
 
+### Free patch axes: sizing by measurement
+
+`Patch.patch_size` accepts the same free-axis convention as prediction: `0`
+entries are sized by the framework, starting at the full extent and shrinking
+only on a CUDA out-of-memory — the failed step (forward, backward and optimizer)
+already measured its cost, so the shrink lands near the target and the run
+restarts on the re-planned grid. Training runs out of memory at the first step
+when it does at all (its memory is maximal from step one), so a restart loses no
+meaningful work. Under DDP the failing ranks agree on the per-axis minimum
+before restarting, so every rank trains the same grid; a single rank failing
+alone dies at the collective timeout, exactly as an unhandled OOM does. A
+`patch_size` without a `0` is never resized: the OOM propagates.
+
 ### `groups_src`
 
 Each source group contains one or more destination groups:

--- a/docs/source/usage/large-images.md
+++ b/docs/source/usage/large-images.md
@@ -145,7 +145,9 @@ memory or dimensionality requirement. See {doc}`../concepts/model-graph`.
 
 1. Set `use_cache: false` to force the stream/buffer path, or set a
    `memory_budget` when dataset size should decide.
-2. Choose the largest `patch_size` that fits the model and required context.
+2. Leave `patch_size` axes at `0` so the framework sizes them (the whole volume
+   when it fits, a measured shrink on OOM), or pin the largest size that fits
+   the model and required context.
 3. Start with `batch_size: 1`; increase it while measuring throughput and VRAM.
 4. Add overlap only when border quality requires it. More overlap means more
    reads and forward passes.

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -51,7 +51,7 @@ from konfai.utils.runtime import (
     get_memory_info,
     memory_forecast,
 )
-from konfai.utils.utils import SUPPORTED_EXTENSIONS, OverlapSpec, split_path_spec
+from konfai.utils.utils import SUPPORTED_EXTENSIONS, OverlapSpec, resolve_patch, split_path_spec
 
 # A cached case is a float32 tensor (torch's default dtype, and the default TensorCast's target), so
 # bytes are counted at 4/element from the header shape alone -- not the on-disk dtype, and without
@@ -852,6 +852,9 @@ class Data(ABC):
         self.batch_size = batch_size
         self.inline_augmentations = inline_augmentations
         self.memory_budget = memory_budget
+        # The evaluation workflow may veto budget-driven auto-patching (a non-reducible metric
+        # needs whole volumes); harmless default for every other workflow.
+        self.auto_patch_allowed = True
         self.requires_single_process_loading = self._groups_require_single_process_loading(groups_src)
 
         # A window keeps ``shuffle_window`` cases resident, so the FIFO buffer must be at least that
@@ -1558,7 +1561,72 @@ class DataPrediction(Data):
 
 @config("Dataset")
 class DataMetric(Data):
-    """Dataset configuration used by the evaluation workflow."""
+    """Dataset configuration used by the evaluation workflow.
+
+    Evaluation never exposes a patch: with a ``memory_budget`` set, each run sizes its own -- a case
+    that fits the budget is evaluated whole (exact); one that does not is cut into the
+    largest DISJOINT patches that fit (overlap 0, no padding) and the reducible metrics combine their
+    running partials into the exact whole-case value. The evaluator disables this sizing when any of
+    its metrics is not reducible, so a metric that needs the whole volume always gets it.
+    """
+
+    #: Working copies a metric makes of the patch pair (float casts, the difference, a masked select):
+    #: measured ~<= 2x the resident tensors; the sizing keeps this conservative and the 0.8 safety
+    #: fraction absorbs the rest.
+    _METRIC_INTERMEDIATE_FACTOR = 2.0
+
+    def _maybe_auto_patch(self) -> None:
+        if self.memory_budget is None or self.patch is not None or not getattr(self, "auto_patch_allowed", True):
+            return
+        sources = self._resolve_dataset_sources()
+        # Header-only scan: for each case, its resident bytes per spatial voxel is the sum of its
+        # groups' channels (output + targets + masks all arrive as groups); the WORST case sizes the
+        # one patch every case then shares (a smaller case simply yields fewer patches).
+        channels_by_name: dict[str, int] = {}
+        spatial_by_name: dict[str, list[int]] = {}
+        for group, entries in sources.items():
+            for filename, _append in entries:
+                dataset = self.datasets[filename]
+                for name in dataset.get_names(group):
+                    shape, _ = dataset.get_infos(group, name)
+                    channels_by_name[name] = channels_by_name.get(name, 0) + int(shape[0])
+                    spatial = [int(s) for s in shape[1:]]
+                    known = spatial_by_name.setdefault(name, spatial)
+                    spatial_by_name[name] = [max(a, b) for a, b in zip(known, spatial, strict=False)]
+        if not spatial_by_name:
+            return
+        worst = max(
+            spatial_by_name,
+            key=lambda name: channels_by_name[name] * int(np.prod(spatial_by_name[name], dtype=np.int64)),
+        )
+        if isinstance(self.memory_budget, str) and self.memory_budget.strip().lower() == "auto":
+            node_bytes, _source = available_memory_bytes()
+            budget = node_bytes * _AUTO_MEMORY_SAFETY_FRACTION
+        else:
+            budget = float(_parse_memory_budget_bytes(self.memory_budget))
+        sized = resolve_patch(
+            [0] * len(spatial_by_name[worst]),
+            spatial_by_name[worst],
+            channels_by_name[worst],
+            _CACHE_ELEMENT_BYTES,
+            budget,
+            resident_images=1,
+            intermediate_factor=DataMetric._METRIC_INTERMEDIATE_FACTOR,
+        )
+        if sized == spatial_by_name[worst]:
+            return  # every case fits whole: the exact whole-volume path
+        patch = DatasetPatch(patch_size=sized, overlap=0)
+        patch.pad_to_patch = False  # reduced, not modelled: only in-volume voxels may reach the sums
+        self.patch = patch
+        print(
+            f"[KonfAI] memory_budget: worst case '{worst}' "
+            f"({channels_by_name[worst]}ch x {spatial_by_name[worst]}) exceeds the budget -> "
+            f"evaluating in disjoint patches of {sized} (overlap 0), metrics combined exactly."
+        )
+
+    def prepare(self) -> None:
+        self._maybe_auto_patch()
+        super().prepare()
 
     def __init__(
         self,

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -51,7 +51,7 @@ from konfai.utils.runtime import (
     get_memory_info,
     memory_forecast,
 )
-from konfai.utils.utils import SUPPORTED_EXTENSIONS, split_path_spec
+from konfai.utils.utils import SUPPORTED_EXTENSIONS, OverlapSpec, split_path_spec
 
 # A cached case is a float32 tensor (torch's default dtype, and the default TensorCast's target), so
 # bytes are counted at 4/element from the header shape alone -- not the on-disk dtype, and without
@@ -491,7 +491,7 @@ class DatasetIter(data.Dataset):
         inline_augmentations: bool,
         data_augmentations_list: list[DataAugmentationsList],
         patch_size: list[int] | None,
-        overlap: int | None,
+        overlap: OverlapSpec,
         buffer_size: int,
         apply_augmentations: bool = True,
         use_cache=True,
@@ -512,7 +512,7 @@ class DatasetIter(data.Dataset):
         self.inline_augmentations = inline_augmentations
         self.has_augmented_samples = self.apply_augmentations and any(a > 0 for _, a, _ in mapping)
 
-    def get_patch_config(self) -> tuple[list[int] | None, int | None]:
+    def get_patch_config(self) -> tuple[list[int] | None, OverlapSpec]:
         return self.patch_size, self.overlap
 
     def to(self, device: int):

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -1016,6 +1016,51 @@ class Data(ABC):
                 data_augmentations.prepare(key)
         self._prepare_datasets()
 
+    def worst_case_shape(self) -> list[int] | None:
+        """Per-axis maximum spatial extent over every prepared case and augmentation copy.
+
+        A provisional auto-patch grid starts from this worst case at full extent: one GLOBAL patch
+        size, which smaller cases clamp to fewer (or single whole-volume) patches for free.
+        """
+        shapes = [
+            shape
+            for prepared in (self._prepared_data, self._prepared_validation_data)
+            for managers in (prepared or {}).values()
+            for manager in managers
+            for shape in manager.shapes
+        ]
+        if not shapes:
+            return None
+        return [max(int(shape[axis]) for shape in shapes) for axis in range(len(shapes[0]))]
+
+    def replan_patch(self, patch_size: list[int]) -> None:
+        """Re-cut every prepared grid for a new GLOBAL patch size (the OOM-restart path).
+
+        The managers are rebuilt against the already-resolved sources and the SAME case lists --
+        NOT through ``prepare()`` (its idempotence guard would skip the rebuild) -- so a later
+        ``get_data`` shards cases identically across the restart: only the grids and the patch mapping change.
+        Each manager copies the shared ``DatasetPatch`` (with ``pad_to_patch``) at construction,
+        which is why the new sizes are written into that shared list IN PLACE -- the loader factory
+        holds a reference to it too.
+        """
+        if self.patch is None or self._prepared_data is None or self._prepared_validation_data is None:
+            raise DatasetManagerError(
+                "replan_patch requires a prepared dataset with a patch definition.",
+                "Call prepare() first; a dataset without 'patch' has no grid to re-cut.",
+            )
+        self.patch.patch_size[:] = [int(size) for size in patch_size]
+        datasets = self._resolve_dataset_sources()
+        dataset_name = {
+            group: {filename: self.datasets[filename].get_names(group) for filename, _ in entries}
+            for group, entries in datasets.items()
+        }
+        self._prepared_data, self._prepared_mapping = self._get_datasets(
+            self._prepared_train_names, dataset_name, self._get_data_augmentations(True)
+        )
+        self._prepared_validation_data, self._prepared_validation_mapping = self._get_datasets(
+            self._prepared_validation_names, dataset_name, self._get_data_augmentations(self.validation_augmentations)
+        )
+
     def _resolve_dataset_sources(self) -> dict[str, list[tuple[str, bool]]]:
         datasets: dict[str, list[tuple[str, bool]]] = {}
         if self.dataset_filenames is None or len(self.dataset_filenames) == 0:

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -32,7 +32,14 @@ from konfai.data.transform import LocalityKind, PatchLocality, Resample, Save, T
 from konfai.utils.config import apply_config, config
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import PatchError
-from konfai.utils.utils import SUPPORTED_EXTENSIONS, get_module, get_patch_slices_from_shape, split_path_spec
+from konfai.utils.utils import (
+    SUPPORTED_EXTENSIONS,
+    OverlapSpec,
+    get_module,
+    get_patch_slices_from_shape,
+    resolve_overlap,
+    split_path_spec,
+)
 
 # How far a halo may reach, as a fraction of the patch it surrounds. See DatasetManager._affords_halo.
 _MAX_HALO_FRACTION = 0.5
@@ -194,19 +201,22 @@ class PathCombine(ABC):
         self.overlap: int
         self._data_per_device: dict[tuple[torch.device, torch.dtype], torch.Tensor] = {}
 
-    def set_patch_config(self, patch_size: list[int], overlap: int) -> None:
+    def set_patch_config(self, patch_size: list[int], overlap: int | list[int]) -> None:
         self._data_per_device.clear()
-        self.overlap = overlap
-        if overlap <= 0:
+        overlaps = [overlap] * len(patch_size) if isinstance(overlap, int) else list(overlap)
+        self.overlap = max(overlaps)
+        if all(o <= 0 for o in overlaps):
             self.data = torch.ones(patch_size)
             return
         # The per-patch weight is the outer product of one 1-D window per axis. It is separable by
         # construction, so a per-axis partition of unity stays a partition of unity in N-D and overlapping
         # patches blend without darkening — no distance map or explicit renormalisation loop is needed, and
         # the trailing ``result / weight_sum`` in Accumulator.assemble stays exact at the volume borders.
-        data = self._window_1d(patch_size[0], overlap)
-        for size in patch_size[1:]:
-            data = data.unsqueeze(-1) * self._window_1d(size, overlap)
+        # Each axis tapers over its own overlap, so anisotropic overlaps blend correctly per axis.
+        data = self._window_1d(patch_size[0], overlaps[0]) if overlaps[0] > 0 else torch.ones(patch_size[0])
+        for size, axis_overlap in zip(patch_size[1:], overlaps[1:], strict=True):
+            window = self._window_1d(size, axis_overlap) if axis_overlap > 0 else torch.ones(size)
+            data = data.unsqueeze(-1) * window
         self.data = data
 
     def __call__(self, tensor: torch.Tensor) -> torch.Tensor:
@@ -226,6 +236,18 @@ class PathCombine(ABC):
     @abstractmethod
     def _window_1d(self, size: int, overlap: int) -> torch.Tensor:
         """Return the 1-D blend weight along one axis (length ``size``, ``overlap`` voxels tapered per side)."""
+
+
+def blend_overlap(overlap: "int | float | str | list[int | float | str]", patch_size: list[int]) -> list[int]:
+    """Per-axis blend overlap for a concrete ``patch_size`` (int broadcast, ``%``/fraction resolved).
+
+    The blend has no volume extent: every axis whose patch is longer than one voxel is treated as tiled
+    (the untiled-axis-0 rule is already applied by the slicing plan), so an int is the same voxel
+    overlap on every such axis.
+    """
+    if isinstance(overlap, int):
+        return [overlap if size > 1 else 0 for size in patch_size]
+    return resolve_overlap(overlap, patch_size, [size + 1 for size in patch_size])
 
 
 class Mean(PathCombine):
@@ -672,7 +694,7 @@ class Patch(ABC):
     def __init__(
         self,
         patch_size: list[int],
-        overlap: int | None,
+        overlap: OverlapSpec = None,
         pad_value: float | None = 0,
         extend_slice: int = 0,
     ) -> None:
@@ -789,7 +811,7 @@ class DatasetPatch(Patch):
     def __init__(
         self,
         patch_size: list[int] = [128, 128, 128],
-        overlap: int | None = None,
+        overlap: OverlapSpec = None,
         pad_value: float | None = None,
         extend_slice: int = 0,
     ) -> None:
@@ -806,7 +828,7 @@ class ModelPatch(Patch):
     def __init__(
         self,
         patch_size: list[int] = [128, 128, 128],
-        overlap: int | None = None,
+        overlap: OverlapSpec = None,
         patch_combine: str | None = None,
         pad_value: float | None = None,
         extend_slice: int = 0,
@@ -821,7 +843,8 @@ class ModelPatch(Patch):
             self.patch_combine = apply_config(key)(getattr(module, name))()
         if self.patch_size is not None and self.overlap is not None:
             if self.patch_combine is not None:
-                self.patch_combine.set_patch_config([i for i in self.patch_size if i > 1], self.overlap)
+                kept = [i for i in self.patch_size if i > 1]
+                self.patch_combine.set_patch_config(kept, blend_overlap(self.overlap, kept))
         else:
             self.patch_combine = None
 

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -712,6 +712,10 @@ class Patch(ABC):
         self._nb_patch_per_dim: dict[int, list[tuple[int, bool]]] = {}
         self.pad_value = pad_value
         self.extend_slice = extend_slice
+        # Models need every patch at the declared size, so the last patch of an axis is padded up to it.
+        # A consumer that REDUCES patches instead (streamed evaluation) must see only in-volume voxels:
+        # padded ones would pollute its running sums, so it turns this off and takes the cropped patch.
+        self.pad_to_patch = True
 
     def load(self, shape: list[int], a: int = 0) -> None:
         self._patch_slices[a], self._nb_patch_per_dim[a] = get_patch_slices_from_shape(
@@ -754,7 +758,7 @@ class Patch(ABC):
                 reflect_padding[-1] = self._patch_slices[a][index][0].stop + top - data_shape[len(slices_pre)]
 
         constant_padding = []
-        if self.patch_size is not None and not all(p == 0 for p in self.patch_size):
+        if self.pad_to_patch and self.patch_size is not None and not all(p == 0 for p in self.patch_size):
             for dim_it, _slice in enumerate(reversed(slices)):
                 p = (
                     0
@@ -898,6 +902,10 @@ class DatasetManager:
             if patch
             else DatasetPatch(_shape)
         )
+        if patch is not None:
+            # The manager works on its own copy (per-case grids); carry the reduction-vs-model contract
+            # with it, or a streamed evaluation would silently get padded border patches back.
+            self.patch.pad_to_patch = patch.pad_to_patch
         self.patch.load(_shape, 0)
         # The spatial grid each copy's patches are cut on: the un-augmented copy's is the source shape
         # folded by the transforms, and a copy whose draw changes shape (Permute, Mask) has its own.

--- a/konfai/evaluator.py
+++ b/konfai/evaluator.py
@@ -296,7 +296,22 @@ class Evaluator(DistributedObject):
         self.metrics = {k: v.get_targets_criterions(k) for k, v in self.metricsLoader.items()}
         self.statistics_train = Statistics(self.metric_path / "Metric_TRAIN.json")
         self.statistics_validation = Statistics(self.metric_path / "Metric_VALIDATION.json")
+        # A memory budget may patch the evaluation, but only when EVERY metric can rebuild its
+        # whole-case value from partial states; one non-reducible metric keeps the whole-volume path
+        # for everything (correct beats bounded).
+        self.dataset.auto_patch_allowed = all(
+            getattr(metric, "reducible", False)
+            for targets in self.metrics.values()
+            for criterions in targets.values()
+            for metric in criterions
+        )
         self.dataset.prepare()
+        # Set iff the budget actually patched: batches then carry one disjoint patch of a case, and
+        # update() accumulates partial states until the case's last patch before recording it.
+        self._streamed = self.dataset.patch is not None
+        self._pending: dict[tuple[str, str, int], tuple] = {}
+        self._pending_name: str | None = None
+        self._last_result: dict[str, float] = {}
         self._validate_metric_groups()
 
     def _validate_metric_groups(self) -> None:
@@ -357,7 +372,9 @@ class Evaluator(DistributedObject):
             dict[str, float]: Dictionary of computed metric values with keys in the format
                             'output_group:target_group:MetricName'.
         """
-        result = {}
+        if self._streamed:
+            return self._update_streamed(batch_sample, statistics)
+        result: dict[str, float] = {}
         for output_group in self.metrics:
             output_tensor = batch_sample[output_group].tensor
             metric_device = output_tensor.device
@@ -413,26 +430,86 @@ class Evaluator(DistributedObject):
                         true_loss = loss.item()
 
                     direction = "max" if getattr(metric, "maximize", False) else "min"
-                    if isinstance(true_loss, dict):
-                        loss = 0
-                        c = 0
-                        for k, v in true_loss.items():
-                            component_key = f"{output_group}:{target_group}:{metric.get_name()}:{k}"
-                            result[component_key] = v
-                            statistics.directions[component_key] = direction
-                            if not np.isnan(v):
-                                loss += v
-                                c += 1
-                        base_key = f"{output_group}:{target_group}:{metric.get_name()}"
-                        result[base_key] = loss / c if c > 0 else np.nan
-                        statistics.directions[base_key] = direction
-                    else:
-                        base_key = f"{output_group}:{target_group}:{metric.get_name()}"
-                        result[base_key] = true_loss
-                        statistics.directions[base_key] = direction
+                    base_key = f"{output_group}:{target_group}:{metric.get_name()}"
+                    Evaluator._record_value(result, statistics, base_key, true_loss, direction)
         if len(self.metrics) > 0:
             statistics.add(result, name)
         return result
+
+    @staticmethod
+    def _record_value(
+        result: dict[str, float],
+        statistics: Statistics,
+        base_key: str,
+        true_loss: float | dict,
+        direction: str,
+    ) -> None:
+        """Record one metric value: a dict records each component plus their NaN-skipping mean."""
+        if isinstance(true_loss, dict):
+            total = 0.0
+            count = 0
+            for k, v in true_loss.items():
+                component_key = f"{base_key}:{k}"
+                result[component_key] = v
+                statistics.directions[component_key] = direction
+                if not np.isnan(v):
+                    total += v
+                    count += 1
+            result[base_key] = total / count if count > 0 else np.nan
+            statistics.directions[base_key] = direction
+        else:
+            result[base_key] = true_loss
+            statistics.directions[base_key] = direction
+
+    def _update_streamed(self, batch_sample: BatchSample, statistics: Statistics) -> dict[str, float]:
+        """Accumulate one PATCH's partial states; record the case when its next sibling arrives.
+
+        The evaluation loader walks a case's disjoint patches contiguously (cases shard whole per
+        rank), so a change of case name marks the previous case complete -- ``_flush_pending`` at the
+        end of the split closes the last one.
+        """
+        name = next(batch_sample[output_group].name[0] for output_group in self.metrics)
+        if self._pending_name is not None and name != self._pending_name:
+            self._flush_pending(statistics)
+        self._pending_name = name
+        for output_group in self.metrics:
+            output_tensor = batch_sample[output_group].tensor
+            metric_device = output_tensor.device
+            for target_group in self.metrics[output_group]:
+                targets = [
+                    (
+                        batch_sample[group].tensor.to(
+                            metric_device, non_blocking=batch_sample[group].tensor.device.type == "cpu"
+                        )
+                        if batch_sample[group].tensor.device != metric_device
+                        else batch_sample[group].tensor
+                    )
+                    for group in target_group.split(";")
+                    if group in batch_sample
+                ]
+                for index, metric in enumerate(self.metrics[output_group][target_group]):
+                    with torch.no_grad():
+                        state = metric.partial_metric(output_tensor, *targets)
+                    entry = self._pending.setdefault((output_group, target_group, index), (metric, []))
+                    entry[1].append(state)
+        return self._last_result
+
+    def _flush_pending(self, statistics: Statistics) -> None:
+        """Combine the pending case's partial states into its exact values and record them."""
+        if self._pending_name is None:
+            return
+        result: dict[str, float] = {}
+        for (output_group, target_group, _index), (metric, states) in self._pending.items():
+            loss = metric.combine_metric(states)
+            true_loss = loss[1] if isinstance(loss, tuple) else float(loss.item())
+            direction = "max" if getattr(metric, "maximize", False) else "min"
+            base_key = f"{output_group}:{target_group}:{metric.get_name()}"
+            Evaluator._record_value(result, statistics, base_key, true_loss, direction)
+        if len(self.metrics) > 0:
+            statistics.add(result, self._pending_name)
+        self._pending = {}
+        self._pending_name = None
+        self._last_result = result
 
     def run_process(self, world_size: int, global_rank: int, gpu: int, dataloaders: list[DataLoader]):
         """
@@ -480,6 +557,7 @@ class Evaluator(DistributedObject):
                         )
                     )
                 )
+        self._flush_pending(self.statistics_train)  # close the split's last case
         outputs = synchronize_data(world_size, gpu, self.statistics_train.measures)
         if global_rank == 0:
             self.statistics_train.write(outputs)
@@ -508,6 +586,7 @@ class Evaluator(DistributedObject):
                             )
                         )
                     )
+            self._flush_pending(self.statistics_validation)  # close the split's last case
             outputs = synchronize_data(world_size, gpu, self.statistics_validation.measures)
             if global_rank == 0:
                 self.statistics_validation.write(outputs)

--- a/konfai/evaluator.py
+++ b/konfai/evaluator.py
@@ -28,10 +28,10 @@ import tqdm
 from torch.utils.data import DataLoader
 
 from konfai import config_file, cuda_visible_devices, evaluations_directory, konfai_root
-from konfai.data.data_manager import BatchSample, DataMetric
+from konfai.data.data_manager import BatchDataItem, BatchSample, DataMetric, DatasetIter
 from konfai.network.network import build_configured_criterions
 from konfai.utils.config import apply_config, config
-from konfai.utils.dataset import Dataset
+from konfai.utils.dataset import Attribute, Dataset, DataStream
 from konfai.utils.errors import ConfigError, EvaluatorError
 from konfai.utils.runtime import (
     DistributedObject,
@@ -312,6 +312,11 @@ class Evaluator(DistributedObject):
         self._pending: dict[tuple[str, str, int], tuple] = {}
         self._pending_name: str | None = None
         self._last_result: dict[str, float] = {}
+        # Per-voxel error maps under the patched path: one region-write sink per (metric, case),
+        # opened at the case's first patch, closed when the case flushes. Disjoint unpadded patches
+        # mean every voxel is written exactly once -- the streamed map equals the whole-volume one.
+        self._map_sinks: dict[tuple[str, str, int], DataStream] = {}
+        self._iter_dataset: DatasetIter | None = None
         self._validate_metric_groups()
 
     def _validate_metric_groups(self) -> None:
@@ -492,7 +497,62 @@ class Evaluator(DistributedObject):
                         state = metric.partial_metric(output_tensor, *targets)
                     entry = self._pending.setdefault((output_group, target_group, index), (metric, []))
                     entry[1].append(state)
+                    if getattr(metric, "dataset", None) and hasattr(metric, "partial_map"):
+                        with torch.no_grad():
+                            patch_map = metric.partial_map(output_tensor, *targets).squeeze(0)
+                        self._write_map_patch(
+                            (output_group, target_group, index),
+                            metric,
+                            batch_sample[output_group],
+                            output_group,
+                            patch_map,
+                        )
         return self._last_result
+
+    def _write_map_patch(
+        self,
+        key: tuple[str, str, int],
+        metric: Any,
+        item: BatchDataItem,
+        output_group: str,
+        patch_map: torch.Tensor,
+    ) -> None:
+        """Write one patch's per-voxel map into its case's region-write sink.
+
+        ``partial_map`` is voxel-local, so the patch's map is exactly the region of the whole-case
+        map; the disjoint unpadded evaluation grid writes every voxel once, never twice.
+        """
+        if self._iter_dataset is None:
+            raise EvaluatorError("Internal error: the streamed evaluation loop has no dataset iterator.")
+        manager = self._iter_dataset.get_dataset_from_index(output_group, int(item.x[0]))
+        array = patch_map.numpy()
+        sink = self._map_sinks.get(key)
+        if sink is None:
+            filename, _, file_format = split_path_spec(metric.dataset)
+            group = metric.group if metric.group else output_group
+            sink = Dataset(filename, file_format).open_data_stream(
+                group,
+                manager.name,
+                [array.shape[0], *manager.shapes[0]],
+                array.dtype,
+                Attribute(manager.cache_attributes[0]),
+            )
+            if sink is None:
+                raise EvaluatorError(
+                    f"The '{file_format}' backend cannot serve region writes for the "
+                    f"'{metric.get_name()}' error map under a memory_budget.",
+                    "Write the map to an mha, h5 or omezarr dataset, or drop 'memory_budget' to "
+                    "evaluate whole volumes.",
+                )
+            self._map_sinks[key] = sink
+        region = manager.patch.get_patch_slices(int(item.a[0]))[int(item.p[0])]
+        sink.write_slice((slice(0, array.shape[0]), *region), array)
+
+    def _abort_map_sinks(self, error: BaseException) -> None:
+        """Close open map sinks WITH the error so the backends remove their partial entries."""
+        for sink in self._map_sinks.values():
+            sink.__exit__(type(error), error, error.__traceback__)
+        self._map_sinks = {}
 
     def _flush_pending(self, statistics: Statistics) -> None:
         """Combine the pending case's partial states into its exact values and record them."""
@@ -505,6 +565,9 @@ class Evaluator(DistributedObject):
             direction = "max" if getattr(metric, "maximize", False) else "min"
             base_key = f"{output_group}:{target_group}:{metric.get_name()}"
             Evaluator._record_value(result, statistics, base_key, true_loss, direction)
+        for sink in self._map_sinks.values():
+            sink.__exit__(None, None, None)
+        self._map_sinks = {}
         if len(self.metrics) > 0:
             statistics.add(result, self._pending_name)
         self._pending = {}
@@ -541,23 +604,30 @@ class Evaluator(DistributedObject):
                 else "Metric TRAIN : "
             )
 
-        with tqdm.tqdm(
-            iterable=enumerate(dataloaders[0]),
-            leave=True,
-            desc=description(None),
-            total=len(dataloaders[0]),
-            ncols=0,
-        ) as batch_iter:
-            for _, batch_sample in batch_iter:
-                batch_iter.set_description(
-                    description(
-                        self.update(
-                            batch_sample,
-                            self.statistics_train,
+        self._iter_dataset = dataloaders[0].dataset
+        try:
+            with tqdm.tqdm(
+                iterable=enumerate(dataloaders[0]),
+                leave=True,
+                desc=description(None),
+                total=len(dataloaders[0]),
+                ncols=0,
+            ) as batch_iter:
+                for _, batch_sample in batch_iter:
+                    batch_iter.set_description(
+                        description(
+                            self.update(
+                                batch_sample,
+                                self.statistics_train,
+                            )
                         )
                     )
-                )
-        self._flush_pending(self.statistics_train)  # close the split's last case
+            self._flush_pending(self.statistics_train)  # close the split's last case
+        except BaseException as error:
+            # A half-written error map must not survive as a valid-looking file: abort the open
+            # region-write sinks so their backends remove the partial entries, then re-raise.
+            self._abort_map_sinks(error)
+            raise
         outputs = synchronize_data(world_size, gpu, self.statistics_train.measures)
         if global_rank == 0:
             self.statistics_train.write(outputs)
@@ -570,23 +640,28 @@ class Evaluator(DistributedObject):
                     else "Metric VALIDATION : "
                 )
 
-            with tqdm.tqdm(
-                iterable=enumerate(dataloaders[1]),
-                leave=True,
-                desc=description(None),
-                total=len(dataloaders[1]),
-                ncols=0,
-            ) as batch_iter:
-                for _, batch_sample in batch_iter:
-                    batch_iter.set_description(
-                        description(
-                            self.update(
-                                batch_sample,
-                                self.statistics_validation,
+            self._iter_dataset = dataloaders[1].dataset
+            try:
+                with tqdm.tqdm(
+                    iterable=enumerate(dataloaders[1]),
+                    leave=True,
+                    desc=description(None),
+                    total=len(dataloaders[1]),
+                    ncols=0,
+                ) as batch_iter:
+                    for _, batch_sample in batch_iter:
+                        batch_iter.set_description(
+                            description(
+                                self.update(
+                                    batch_sample,
+                                    self.statistics_validation,
+                                )
                             )
                         )
-                    )
-            self._flush_pending(self.statistics_validation)  # close the split's last case
+                self._flush_pending(self.statistics_validation)  # close the split's last case
+            except BaseException as error:
+                self._abort_map_sinks(error)
+                raise
             outputs = synchronize_data(world_size, gpu, self.statistics_validation.measures)
             if global_rank == 0:
                 self.statistics_validation.write(outputs)

--- a/konfai/metric/measure.py
+++ b/konfai/metric/measure.py
@@ -315,14 +315,13 @@ class MAESaveMap(MAE):
         super().__init__(reduction)
         self.dataset = dataset
         self.group = group
-        # The per-voxel error map is a whole-volume output; until it streams through a region write,
-        # this metric needs the whole case.
-        self.reducible = False
 
-    def forward(self, output: torch.Tensor, *targets: torch.Tensor):  # type: ignore[override]
-        loss, true_loss = super().forward(output, *targets)
+    def partial_map(self, output: torch.Tensor, *targets: torch.Tensor) -> torch.Tensor:
+        """Per-voxel |output - target| (masked where a mask is given). VOXEL-LOCAL by construction:
+        a patch's map equals the same region of the whole-case map, which is what lets the streamed
+        evaluation write it region by region instead of needing the whole case."""
         if len(targets) == 2:
-            error_map = (
+            return (
                 torch.nn.L1Loss(reduction="none")(
                     output.float() * torch.where(targets[1] == 1, 1, 0),
                     targets[0].float() * torch.where(targets[1] == 1, 1, 0),
@@ -330,9 +329,11 @@ class MAESaveMap(MAE):
                 .to(output.dtype)
                 .cpu()
             )
-        else:
-            error_map = torch.nn.L1Loss(reduction="none")(output.float(), targets[0].float()).to(output.dtype).cpu()
-        return loss, true_loss, error_map
+        return torch.nn.L1Loss(reduction="none")(output.float(), targets[0].float()).to(output.dtype).cpu()
+
+    def forward(self, output: torch.Tensor, *targets: torch.Tensor):  # type: ignore[override]
+        loss, true_loss = super().forward(output, *targets)
+        return loss, true_loss, self.partial_map(output, *targets)
 
     def get_name(self) -> str:
         return "MAE"
@@ -544,23 +545,24 @@ class DiceSaveMap(Dice):
         super().__init__(labels)
         self.dataset = dataset
         self.group = group
-        # The per-voxel error map is a whole-volume output; until it streams through a region write,
-        # this metric needs the whole case.
-        self.reducible = False
 
-    def forward(self, output: torch.Tensor, *targets: torch.Tensor):  # type: ignore[override]
-        loss, true_loss = super().forward(output, *targets)
+    def partial_map(self, output: torch.Tensor, *targets: torch.Tensor) -> torch.Tensor:
+        """Per-voxel label disagreement (masked where a mask is given). VOXEL-LOCAL by construction:
+        a patch's map equals the same region of the whole-case map, which is what lets the streamed
+        evaluation write it region by region instead of needing the whole case."""
         if len(targets) == 2:
-            error_map = (
+            return (
                 torch.nn.L1Loss(reduction="none")(
                     output * torch.where(targets[1] == 1, 1, 0), targets[0] * torch.where(targets[1] == 1, 1, 0)
                 )
                 .to(torch.uint8)
                 .cpu()
             )
-        else:
-            error_map = torch.nn.L1Loss(reduction="none")(output, targets[0]).to(torch.uint8).cpu()
-        return loss, true_loss, error_map
+        return torch.nn.L1Loss(reduction="none")(output, targets[0]).to(torch.uint8).cpu()
+
+    def forward(self, output: torch.Tensor, *targets: torch.Tensor):  # type: ignore[override]
+        loss, true_loss = super().forward(output, *targets)
+        return loss, true_loss, self.partial_map(output, *targets)
 
     def get_name(self) -> str:
         return "Dice"

--- a/konfai/metric/measure.py
+++ b/konfai/metric/measure.py
@@ -23,7 +23,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from functools import partial
 from types import ModuleType
-from typing import cast
+from typing import Any, cast
 
 import numpy as np
 import torch
@@ -67,11 +67,27 @@ class Criterion(torch.nn.Module, ABC):
     # selection) read it via getattr instead of guessing the direction from the metric's name.
     maximize: bool = False
 
+    # Streamed-evaluation contract, the metric mirror of ``Reduction.voxel_local``: ``True`` declares
+    # that this metric's whole-case value can be rebuilt from per-patch PARTIAL states (running sums,
+    # never per-patch final values), so evaluation may feed it disjoint patches instead of the whole
+    # volume. Default ``False``: an unknown metric evaluates whole -- a wrong ``True`` would corrupt
+    # the reported value, so only a metric whose ``partial_metric``/``combine_metric`` reproduce
+    # ``forward`` exactly may set it.
+    reducible: bool = False
+
     def __init__(self) -> None:
         super().__init__()
 
     def get_name(self):
         return self.__class__.__name__
+
+    def partial_metric(self, output: torch.Tensor, *targets: torch.Tensor) -> Any:
+        """Sufficient statistics of one disjoint patch (only meaningful when ``reducible``)."""
+        raise NotImplementedError(f"{self.get_name()} is not reducible: it has no partial state.")
+
+    def combine_metric(self, states: list[Any]) -> Any:
+        """Combine per-patch states into exactly what ``forward`` returns on the whole volume."""
+        raise NotImplementedError(f"{self.get_name()} is not reducible: it cannot combine states.")
 
     @abstractmethod
     def forward(self, output: torch.Tensor, *targets: torch.Tensor) -> torch.Tensor:
@@ -180,6 +196,68 @@ class MaskedLoss(Criterion):
         loss = loss / true_nb
         return loss, loss.detach().item()
 
+    # -- Streamed-evaluation hooks -------------------------------------------------------------------
+    # A subclass whose ``loss`` reduces to a running sum provides its sufficient statistic and its
+    # finisher, and declares itself ``reducible``; the generic partial/combine below then reproduces
+    # ``forward`` exactly from disjoint patches (masked and unmasked paths alike).
+
+    def _stat(self, x: torch.Tensor, y: torch.Tensor) -> float:
+        """Sum-contribution of one (output, target) pair to this loss's running total."""
+        raise NotImplementedError()
+
+    def _finish(self, total: float, count: int) -> float:
+        """The value ``self.loss`` would return from a running (total, count)."""
+        raise NotImplementedError()
+
+    def partial_metric(self, output: torch.Tensor, *targets: torch.Tensor) -> Any:
+        if len(targets) == 0:
+            raise ValueError("MaskedLoss expects at least one target tensor.")
+        target = targets[0].to(device=output.device)
+        mask = self.get_mask(list(targets[1:]))
+        if mask is None:
+            x, y = output.float(), target.float()
+            return ("whole", self._stat(x, y), x.numel())
+        mask = mask.to(device=output.device)
+        items = []
+        for batch in range(output.shape[0]):
+            mask_b = mask[batch, ...] == 1
+            if not torch.any(mask_b):
+                items.append((0.0, 0, False))
+                continue
+            output_b, target_b = output[batch, ...].float(), target[batch, ...].float()
+            if self.mode_image_masked:
+                mask_f = mask_b.to(dtype=output_b.dtype)
+                items.append((self._stat(output_b * mask_f, target_b * mask_f), output_b.numel(), True))
+            else:
+                items.append(
+                    (
+                        self._stat(torch.masked_select(output_b, mask_b), torch.masked_select(target_b, mask_b)),
+                        int(mask_b.sum().item()),
+                        True,
+                    )
+                )
+        return ("items", items)
+
+    def combine_metric(self, states: list[Any]) -> Any:
+        if states[0][0] == "whole":
+            total = sum(state[1] for state in states)
+            count = sum(state[2] for state in states)
+            value = self._finish(total, count)
+            return torch.tensor(value), value
+        # Masked: sum each batch item's statistic across patches, finish per item, then average the
+        # items that saw any masked voxel -- the exact structure of ``forward``.
+        n_items = len(states[0][1])
+        values = []
+        for item in range(n_items):
+            total = sum(state[1][item][0] for state in states)
+            count = sum(state[1][item][1] for state in states)
+            if any(state[1][item][2] for state in states):
+                values.append(self._finish(total, count))
+        if not values:
+            return torch.tensor(0.0), np.nan
+        value = float(np.mean(values))
+        return torch.tensor(value), value
+
 
 class MSE(MaskedLoss):
     @staticmethod
@@ -188,6 +266,14 @@ class MSE(MaskedLoss):
 
     def __init__(self, reduction: str = "mean") -> None:
         super().__init__(partial(MSE._loss, reduction), False)
+        self._reduction = reduction
+        self.reducible = reduction in ("mean", "sum")
+
+    def _stat(self, x: torch.Tensor, y: torch.Tensor) -> float:
+        return float((x - y).pow(2).sum().item())
+
+    def _finish(self, total: float, count: int) -> float:
+        return total / count if self._reduction == "mean" else total
 
 
 class MAE(MaskedLoss):
@@ -197,9 +283,19 @@ class MAE(MaskedLoss):
 
     def __init__(self, reduction: str = "mean") -> None:
         super().__init__(partial(MAE._loss, reduction), False)
+        self._reduction = reduction
+        self.reducible = reduction in ("mean", "sum")
+
+    def _stat(self, x: torch.Tensor, y: torch.Tensor) -> float:
+        return float((x - y).abs().sum().item())
+
+    def _finish(self, total: float, count: int) -> float:
+        return total / count if self._reduction == "mean" else total
 
 
 class ME(MaskedLoss):
+    reducible = True
+
     @staticmethod
     def _loss(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         return (x - y).mean()
@@ -207,12 +303,21 @@ class ME(MaskedLoss):
     def __init__(self) -> None:
         super().__init__(ME._loss, False)
 
+    def _stat(self, x: torch.Tensor, y: torch.Tensor) -> float:
+        return float((x - y).sum().item())
+
+    def _finish(self, total: float, count: int) -> float:
+        return total / count
+
 
 class MAESaveMap(MAE):
     def __init__(self, reduction: str = "mean", dataset: str | None = None, group: str | None = None) -> None:
         super().__init__(reduction)
         self.dataset = dataset
         self.group = group
+        # The per-voxel error map is a whole-volume output; until it streams through a region write,
+        # this metric needs the whole case.
+        self.reducible = False
 
     def forward(self, output: torch.Tensor, *targets: torch.Tensor):  # type: ignore[override]
         loss, true_loss = super().forward(output, *targets)
@@ -234,6 +339,8 @@ class MAESaveMap(MAE):
 
 
 class PSNR(MaskedLoss):
+    reducible = True
+
     @staticmethod
     def _loss(dynamic_range: float, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         mse = torch.mean((x - y).pow(2))
@@ -243,6 +350,14 @@ class PSNR(MaskedLoss):
     def __init__(self, dynamic_range: float | None = None) -> None:
         dynamic_range = dynamic_range if dynamic_range else 1024 + 3071
         super().__init__(partial(PSNR._loss, dynamic_range), False)
+        self._dynamic_range = float(dynamic_range)
+
+    def _stat(self, x: torch.Tensor, y: torch.Tensor) -> float:
+        return float((x - y).pow(2).sum().item())
+
+    def _finish(self, total: float, count: int) -> float:
+        # The log is a function of the RUNNING mean, applied once at the end -- never per patch.
+        return float(10 * np.log10(self._dynamic_range**2 / (total / count)))
 
 
 class SSIM(MaskedLoss):
@@ -355,8 +470,11 @@ class Dice(Criterion):
             return loss, result
         return 1 - loss / count, result
 
+    reducible = True
+
     def __init__(self, labels: list[int] | None = None) -> None:
         super().__init__()
+        self._labels = labels
         self.loss = partial(Dice._loss, labels)
 
     def forward(self, output: torch.Tensor, *targets: torch.Tensor) -> tuple[torch.Tensor, float]:
@@ -370,12 +488,65 @@ class Dice(Criterion):
         else:
             return self.loss(output, targets[0])
 
+    def partial_metric(self, output: torch.Tensor, *targets: torch.Tensor) -> Any:
+        mask = MaskedLoss.get_mask(list(targets[1:]))
+        target = targets[0]
+        if mask is not None:
+            mask01 = torch.where(mask == 1, 1, 0)
+            output = output * mask01.to(output.dtype)
+            target = target * mask01.to(target.dtype)
+        if tuple(target.shape[2:]) != tuple(output.shape[2:]):
+            raise MeasureError(
+                "Dice can only stream patches when output and target share the spatial grid",
+                f"output {tuple(output.shape[2:])} vs target {tuple(target.shape[2:])}",
+                "Evaluate this pair whole (unset the memory budget) or resample the prediction first.",
+            )
+        labels = self._labels if self._labels is not None else [int(v) for v in torch.unique(target) if int(v) != 0]
+        state: dict[int, tuple[float, float, float, bool]] = {}
+        for label in labels:
+            tp = target == label
+            pp = output[:, label].unsqueeze(1) if output.shape[1] > 1 else (output == label)
+            ppf, tpf = pp.float(), tp.float()
+            state[label] = (
+                float((ppf * tpf).sum().item()),
+                float(ppf.sum().item()),
+                float(tpf.sum().item()),
+                bool(tp.any().item()),
+            )
+        return state
+
+    def combine_metric(self, states: list[Any]) -> Any:
+        # The whole volume's label set is exactly the union of the patches' label sets (sorted, as
+        # torch.unique returns them); every dice is the ratio of GLOBAL sums, the smooth term applied
+        # once here -- never a mean of per-patch dices.
+        labels = self._labels if self._labels is not None else sorted({label for state in states for label in state})
+        result: dict[int, float] = {}
+        total = 0.0
+        count = 0
+        for label in labels:
+            inter = sum(state[label][0] for state in states if label in state)
+            output_sum = sum(state[label][1] for state in states if label in state)
+            target_sum = sum(state[label][2] for state in states if label in state)
+            if any(state[label][3] for state in states if label in state):
+                dice = (2.0 * inter + 1e-6) / (output_sum + target_sum + 1e-6)
+                result[label] = dice
+                total += dice
+                count += 1
+            else:
+                result[label] = np.nan
+        if count == 0:
+            return torch.tensor(0.0), result
+        return torch.tensor(1 - total / count), result
+
 
 class DiceSaveMap(Dice):
     def __init__(self, labels: list[int] | None = None, dataset: str | None = None, group: str | None = None) -> None:
         super().__init__(labels)
         self.dataset = dataset
         self.group = group
+        # The per-voxel error map is a whole-volume output; until it streams through a region write,
+        # this metric needs the whole case.
+        self.reducible = False
 
     def forward(self, output: torch.Tensor, *targets: torch.Tensor):  # type: ignore[override]
         loss, true_loss = super().forward(output, *targets)

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -48,6 +48,7 @@ from konfai.data.patching import (
     _halo_radii,
     _remap_pull,
     _scale_pull,
+    blend_overlap,
 )
 from konfai.data.transform import (
     LocalityKind,
@@ -287,12 +288,12 @@ class OutputDataset(Dataset, NeedDevice, ABC):
     def set_patch_config(
         self,
         patch_size: list[int] | None,
-        overlap: int | None,
+        overlap: int | float | str | list[int | float | str] | None,
         nb_data_augmentation: int,
     ) -> None:
         if patch_size is not None and overlap is not None:
             if self.patch_combine is not None:
-                self.patch_combine.set_patch_config(patch_size, overlap)
+                self.patch_combine.set_patch_config(patch_size, blend_overlap(overlap, patch_size))
         else:
             self.patch_combine = None
         self.nb_data_augmentation = nb_data_augmentation

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -73,7 +73,8 @@ from konfai.utils.runtime import (
     run_distributed_app,
     safe_torch_load,
 )
-from konfai.utils.utils import get_module, split_path_spec
+from konfai.utils.utils import concretize_patch_size, get_module, split_path_spec
+from konfai.utils.vram import next_patch_candidate, usable_vram
 
 
 class Reduction(ABC):
@@ -337,6 +338,15 @@ class OutputDataset(Dataset, NeedDevice, ABC):
     def write_prediction(self, index: int, name: str, layer: torch.Tensor) -> None:
         super().write(self.group, name, layer.detach().cpu().numpy(), self.attributes[index][0][0])
         self.attributes.pop(index)
+
+    def reset(self) -> None:
+        """Drop every in-flight accumulation (the OOM-restart path re-runs the rank's cases from scratch)."""
+        self.output_layer_accumulator.clear()
+        self.attributes.clear()
+        self.names.clear()
+        self._accum_device.clear()
+        self._reduce_device.clear()
+        self._pin_buffer = None
 
     def __str__(self) -> str:
         params = {
@@ -882,6 +892,19 @@ class OutSameAsGroupDataset(OutputDataset):
         for stage in stages:
             result = stage(self.names[index], result, attribute)
         return result, attribute
+
+    def reset(self) -> None:
+        # Aborting an attempt mid-stream: exit each open sink WITH an error so the backend removes
+        # the partial entry (a reader must never see a half-written volume); the restart rewrites it.
+        abort = PredictorError("prediction restart: the partial streamed output is discarded")
+        for sink in self._stream_sinks.values():
+            sink.__exit__(type(abort), abort, None)
+        self._stream_sinks.clear()
+        self._stream_plans.clear()
+        self._region_states.clear()
+        self._stream_buffers.clear()
+        self._post_prefix_attributes.clear()
+        super().reset()
 
     def _close_stream(self, index: int) -> None:
         """Finalize the case's sink and drop its bookkeeping (``is_done`` then reports nothing left)."""
@@ -1521,6 +1544,15 @@ class Predictor(DistributedObject):
         super().__init__(train_name)
         self.manual_seed = manual_seed
         self.dataset = dataset
+        # Auto-patching (VRAM): a per-axis 0 in the user's patch_size marks a FREE axis and opts into
+        # the OOM restart loop -- captured before any re-plan materialises concrete sizes over it.
+        patch = dataset.patch
+        self._vram_patch_template: list[int] | None = (
+            [int(size) for size in patch.patch_size]
+            if patch is not None and patch.patch_size is not None and any(size == 0 for size in patch.patch_size)
+            else None
+        )
+        self._vram_patch_candidate: list[int] | None = None
         module, name = get_module(combine, "konfai.predictor")
         if module.__name__ == "konfai.predictor":
             self.combine = getattr(module, name)()
@@ -1693,18 +1725,78 @@ class Predictor(DistributedObject):
             for output_dataset in self.outputs_dataset.values():
                 output_dataset.to(local_rank * self.size)
         model_composite = Model(model_composite)
-        with _Predictor(
-            world_size,
-            global_rank,
-            local_rank,
-            self.autocast,
-            self.predict_path,
-            self.data_log,
-            self.outputs_dataset,
-            model_composite,
-            *dataloaders,
-        ) as p:
-            p.run()
+        device = local_rank * self.size if len(cuda_visible_devices()) else None
+        dataloader = dataloaders[0]
+        while True:
+            try:
+                with _Predictor(
+                    world_size,
+                    global_rank,
+                    local_rank,
+                    self.autocast,
+                    self.predict_path,
+                    self.data_log,
+                    self.outputs_dataset,
+                    model_composite,
+                    dataloader,
+                ) as p:
+                    p.run()
+                return
+            except torch.cuda.OutOfMemoryError:
+                if self._vram_patch_template is None:
+                    raise  # no free axis declared: not auto-patched, the OOM propagates unchanged
+                # The restart loop IS the sizing iteration (no probe phase): the run that just OOMed
+                # already measured the step's transient for free. Read it BEFORE the reset (the peak
+                # still includes the resident accumulators on both sides of the difference), free the
+                # in-flight state, then read the honest free VRAM.
+                measured = self._transient_at_oom(device)
+                for output_dataset in self.outputs_dataset.values():
+                    output_dataset.reset()
+                candidate = self._shrunken_patch(measured, self._usable_vram_after_oom(device))
+                if candidate is None:
+                    raise
+                print(
+                    f"[KonfAI] VRAM: rank {global_rank} ran out of memory -> "
+                    f"re-planning the free patch axes to {candidate} and restarting this rank's cases."
+                )
+                self._vram_patch_candidate = candidate
+                self.dataset.replan_patch(candidate)
+                dataloader = self.dataset.get_data(world_size)[0][global_rank][0]
+
+    def _shrunken_patch(self, measured: int | None, usable: float) -> list[int] | None:
+        """One shrink step for the free patch axes after a CUDA OOM (``None`` = not auto, or floor).
+
+        The first OOM starts from the worst prepared case at full extent (the size the failed grid
+        effectively ran); later ones shrink the current candidate further.
+        """
+        if self._vram_patch_template is None:
+            return None
+        worst = self.dataset.worst_case_shape()
+        if worst is None:
+            return None
+        candidate = self._vram_patch_candidate or concretize_patch_size(self._vram_patch_template, worst)
+        return next_patch_candidate(candidate, self._vram_patch_template, worst, measured, usable)
+
+    def _transient_at_oom(self, device: int | None) -> int | None:
+        """The failed step's measured transient (CUDA peak over resident), ``None`` when unreadable."""
+        if device is None:
+            return None
+        try:
+            transient = int(torch.cuda.max_memory_allocated(device) - torch.cuda.memory_allocated(device))
+        except Exception:  # nosec B110 - an unreadable measurement just falls back to the fixed step
+            return None
+        return transient if transient > 0 else None
+
+    def _usable_vram_after_oom(self, device: int | None) -> float:
+        """The VRAM budget the next attempt's step may claim, read once the failed state is freed."""
+        if device is None:
+            return 0.0
+        try:
+            torch.cuda.empty_cache()
+            free, _ = torch.cuda.mem_get_info(device)
+        except Exception:  # nosec B110 - an unreadable budget refuses the restart (the OOM re-raises)
+            return 0.0
+        return usable_vram(free)
 
     def __str__(self) -> str:
         params = {

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -898,7 +898,10 @@ class OutSameAsGroupDataset(OutputDataset):
         # the partial entry (a reader must never see a half-written volume); the restart rewrites it.
         abort = PredictorError("prediction restart: the partial streamed output is discarded")
         for sink in self._stream_sinks.values():
-            sink.__exit__(type(abort), abort, None)
+            try:
+                sink.__exit__(type(abort), abort, None)
+            except Exception:  # nosec B110 - one sink failing to abort must not leak the others
+                pass
         self._stream_sinks.clear()
         self._stream_plans.clear()
         self._region_states.clear()
@@ -1743,18 +1746,21 @@ class Predictor(DistributedObject):
                     p.run()
                 return
             except torch.cuda.OutOfMemoryError:
-                if self._vram_patch_template is None:
-                    raise  # no free axis declared: not auto-patched, the OOM propagates unchanged
                 # The restart loop IS the sizing iteration (no probe phase): the run that just OOMed
                 # already measured the step's transient for free. Read it BEFORE the reset (the peak
                 # still includes the resident accumulators on both sides of the difference), free the
-                # in-flight state, then read the honest free VRAM.
+                # in-flight state -- open streamed sinks abort and remove their partial entries, so a
+                # reader never sees a half-written volume even when the OOM is fatal -- then read the
+                # honest free VRAM.
                 measured = self._transient_at_oom(device)
                 for output_dataset in self.outputs_dataset.values():
                     output_dataset.reset()
+                if self._vram_patch_template is None:
+                    raise  # no free axis declared: not auto-patched, the OOM propagates unchanged
                 candidate = self._shrunken_patch(measured, device)
                 if candidate is None:
                     raise
+                self._reset_cuda_peak(device)
                 print(
                     f"[KonfAI] VRAM: rank {global_rank} ran out of memory -> "
                     f"re-planning the free patch axes to {candidate} and restarting this rank's cases."
@@ -1807,6 +1813,21 @@ class Predictor(DistributedObject):
             voxels = candidate[0] * np.prod(worst[1:], dtype=np.int64) if streams else np.prod(worst, dtype=np.int64)
             reserve += float((out_channels + 1) * voxels * elem * nb_augmentation)
         return reserve
+
+    @staticmethod
+    def _reset_cuda_peak(device: int | None) -> None:
+        """Drop the failed attempt's high-water mark so the rerun measures its own steps.
+
+        ``max_memory_allocated`` only rises: left in place, the full-extent attempt's peak would
+        overstate every later transient -- a second shrink would overshoot, and the accumulation
+        gate would keep the rerun's blend on the CPU.
+        """
+        if device is None:
+            return
+        try:
+            torch.cuda.reset_peak_memory_stats(device)
+        except Exception:  # nosec B110 - stale stats only cost precision, never correctness
+            pass
 
     def _transient_at_oom(self, device: int | None) -> int | None:
         """The failed step's measured transient (CUDA peak over resident), ``None`` when unreadable."""

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -1752,7 +1752,7 @@ class Predictor(DistributedObject):
                 measured = self._transient_at_oom(device)
                 for output_dataset in self.outputs_dataset.values():
                     output_dataset.reset()
-                candidate = self._shrunken_patch(measured, self._usable_vram_after_oom(device))
+                candidate = self._shrunken_patch(measured, device)
                 if candidate is None:
                     raise
                 print(
@@ -1763,11 +1763,15 @@ class Predictor(DistributedObject):
                 self.dataset.replan_patch(candidate)
                 dataloader = self.dataset.get_data(world_size)[0][global_rank][0]
 
-    def _shrunken_patch(self, measured: int | None, usable: float) -> list[int] | None:
+    def _shrunken_patch(self, measured: int | None, device: int | None) -> list[int] | None:
         """One shrink step for the free patch axes after a CUDA OOM (``None`` = not auto, or floor).
 
         The first OOM starts from the worst prepared case at full extent (the size the failed grid
-        effectively ran); later ones shrink the current candidate further.
+        effectively ran); later ones shrink the current candidate further. When the framework picks
+        the size, it must also leave the blend on the GPU: the accumulation footprint is RESERVED
+        beside the forward, so the sized patch passes the accumulation gate. Only when that reserve
+        fits at no size (or cannot be priced) is the forward sized alone -- the gate's memory-safe
+        CPU blend absorbs that case.
         """
         if self._vram_patch_template is None:
             return None
@@ -1775,7 +1779,34 @@ class Predictor(DistributedObject):
         if worst is None:
             return None
         candidate = self._vram_patch_candidate or concretize_patch_size(self._vram_patch_template, worst)
+        usable = self._usable_vram_after_oom(device)
+        reserve = self._accumulation_reserve(candidate, worst)
+        if reserve is not None:
+            shrunk = next_patch_candidate(candidate, self._vram_patch_template, worst, measured, usable - reserve)
+            if shrunk is not None:
+                return shrunk
         return next_patch_candidate(candidate, self._vram_patch_template, worst, measured, usable)
+
+    def _accumulation_reserve(self, candidate: list[int], worst: list[int]) -> float | None:
+        """Bytes each case keeps resident while its patches accumulate, per output writer: the
+        streamed window (one patch extent x the cross-section) when the writer will stream --
+        single augmentation, voxel-local reduction -- the assembled volume otherwise. ``None``
+        when a writer's channels cannot be read off the model trace (no reserve, gate decides).
+        """
+        trace = {name: args.out_channels for name, _, args in self.model.named_module_args_dict()}
+        elem = 2  # ModelComposite casts float32 outputs to float16 before accumulation
+        reserve = 0.0
+        for name, writer in self.outputs_dataset.items():
+            out_channels = trace.get(name.replace(";accu;", ""))
+            if not out_channels:
+                return None
+            if isinstance(self.combine, Concat):
+                out_channels *= max(1, len(self.path_to_models))
+            nb_augmentation = max(1, writer.nb_data_augmentation)
+            streams = nb_augmentation == 1 and writer.reduction.voxel_local
+            voxels = candidate[0] * np.prod(worst[1:], dtype=np.int64) if streams else np.prod(worst, dtype=np.int64)
+            reserve += float((out_channels + 1) * voxels * elem * nb_augmentation)
+        return reserve
 
     def _transient_at_oom(self, device: int | None) -> int | None:
         """The failed step's measured transient (CUDA peak over resident), ``None`` when unreadable."""

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -57,6 +57,8 @@ from konfai.utils.runtime import (
     safe_torch_load,
     synchronize_data,
 )
+from konfai.utils.utils import concretize_patch_size
+from konfai.utils.vram import next_patch_candidate, usable_vram
 
 
 class EarlyStoppingBase:
@@ -656,6 +658,15 @@ class Trainer(DistributedObject):
         super().__init__(train_name)
         self.manual_seed = manual_seed
         self.dataset = dataset
+        # Auto-patching (VRAM): a per-axis 0 in the user's patch_size marks a FREE axis and opts into
+        # the OOM restart loop -- captured before any re-plan materialises concrete sizes over it.
+        patch = dataset.patch
+        self._vram_patch_template: list[int] | None = (
+            [int(size) for size in patch.patch_size]
+            if patch is not None and patch.patch_size is not None and any(size == 0 for size in patch.patch_size)
+            else None
+        )
+        self._vram_patch_candidate: list[int] | None = None
         self.autocast = autocast
         self.epochs = epochs
         self.epoch = 0
@@ -803,26 +814,93 @@ class Trainer(DistributedObject):
             model = Model(model)
         if self.model_ema is not None:
             self.model_ema.module = Network.to(self.model_ema.module, local_rank * self.size)
-        with _Trainer(
-            world_size,
-            global_rank,
-            local_rank,
-            self.size,
-            self.name,
-            self.early_stopping,
-            self.data_log,
-            self.save_checkpoint_mode,
-            self.epochs,
-            self.epoch,
-            self.autocast,
-            self.it_validation,
-            self.it_lr_update,
-            self.it,
-            model,
-            self.model_ema,
-            *dataloaders,
-        ) as t:
-            t.run()
+        device = local_rank * self.size if len(cuda_visible_devices()) else None
+        while True:
+            try:
+                with _Trainer(
+                    world_size,
+                    global_rank,
+                    local_rank,
+                    self.size,
+                    self.name,
+                    self.early_stopping,
+                    self.data_log,
+                    self.save_checkpoint_mode,
+                    self.epochs,
+                    self.epoch,
+                    self.autocast,
+                    self.it_validation,
+                    self.it_lr_update,
+                    self.it,
+                    model,
+                    self.model_ema,
+                    *dataloaders,
+                ) as t:
+                    t.run()
+                return
+            except torch.cuda.OutOfMemoryError:
+                if self._vram_patch_template is None:
+                    raise  # no free axis declared: not auto-patched, the OOM propagates unchanged
+                # The restart loop IS the sizing iteration: the step that just OOMed already measured
+                # its transient for free. Drop the failed step's gradients before reading free VRAM.
+                measured = self._transient_at_oom(device)
+                self.model.zero_grad(set_to_none=True)
+                candidate = self._shrunken_patch(measured, self._usable_vram_after_oom(device))
+                # Every rank must train the same grid, so the shrink is agreed at a rendezvous: each
+                # failing rank proposes its own candidate and all adopt the per-axis MIN. A rank that
+                # did NOT run out never reaches this all-gather; the job then dies at the collective
+                # timeout, exactly as an unhandled OOM kills it. Ranks failing together -- the
+                # common case, they share the patch size -- recover together.
+                proposals = [
+                    proposal
+                    for proposal in synchronize_data(world_size, local_rank * self.size, candidate)
+                    if proposal is not None
+                ]
+                if not proposals:
+                    raise
+                agreed = [min(sizes) for sizes in zip(*proposals, strict=True)]
+                print(
+                    f"[KonfAI] VRAM: rank {global_rank} ran out of memory -> "
+                    f"re-planning the free patch axes to {agreed} and restarting the training run."
+                )
+                self._vram_patch_candidate = agreed
+                self.dataset.replan_patch(agreed)
+                dataloaders = self.dataset.get_data(world_size)[0][global_rank]
+
+    def _shrunken_patch(self, measured: int | None, usable: float) -> list[int] | None:
+        """One shrink step for the free patch axes after a CUDA OOM (``None`` = not auto, or floor).
+
+        The first OOM starts from the worst prepared case at full extent (the size the failed grid
+        effectively ran); later ones shrink the current candidate further.
+        """
+        if self._vram_patch_template is None:
+            return None
+        worst = self.dataset.worst_case_shape()
+        if worst is None:
+            return None
+        candidate = self._vram_patch_candidate or concretize_patch_size(self._vram_patch_template, worst)
+        return next_patch_candidate(candidate, self._vram_patch_template, worst, measured, usable)
+
+    def _transient_at_oom(self, device: int | None) -> int | None:
+        """The failed step's measured transient (CUDA peak over resident), ``None`` when unreadable."""
+        if device is None:
+            return None
+        try:
+            transient = int(torch.cuda.max_memory_allocated(device) - torch.cuda.memory_allocated(device))
+        except Exception:  # nosec B110 - an unreadable measurement just falls back to the fixed step
+            return None
+        return transient if transient > 0 else None
+
+    def _usable_vram_after_oom(self, device: int | None) -> float:
+        """The VRAM budget the next attempt's step may claim, read once the failed state is freed."""
+        if device is None:
+            return 0.0
+        try:
+            torch.cuda.empty_cache()
+            free, _ = torch.cuda.mem_get_info(device)
+        except Exception:  # nosec B110 - an unreadable budget refuses the restart (the OOM re-raises)
+            return 0.0
+        return usable_vram(free)
 
 
 def build_train(

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -865,6 +865,7 @@ class Trainer(DistributedObject):
                 )
                 self._vram_patch_candidate = agreed
                 self.dataset.replan_patch(agreed)
+                self._reset_cuda_peak(device)
                 dataloaders = self.dataset.get_data(world_size)[0][global_rank]
 
     def _shrunken_patch(self, measured: int | None, usable: float) -> list[int] | None:
@@ -880,6 +881,16 @@ class Trainer(DistributedObject):
             return None
         candidate = self._vram_patch_candidate or concretize_patch_size(self._vram_patch_template, worst)
         return next_patch_candidate(candidate, self._vram_patch_template, worst, measured, usable)
+
+    @staticmethod
+    def _reset_cuda_peak(device: int | None) -> None:
+        """Drop the failed attempt's high-water mark so the rerun measures its own steps."""
+        if device is None:
+            return
+        try:
+            torch.cuda.reset_peak_memory_stats(device)
+        except Exception:  # nosec B110 - stale stats only cost precision, never correctness
+            pass
 
     def _transient_at_oom(self, device: int | None) -> int | None:
         """The failed step's measured transient (CUDA peak over resident), ``None`` when unreadable."""

--- a/konfai/utils/utils.py
+++ b/konfai/utils/utils.py
@@ -82,12 +82,133 @@ def get_patch_slices_from_nb_patch_per_dim(
     return patch_slices
 
 
+#: Default overlap on tiled axes when a free-axis patch does not say otherwise: 20 % of the patch.
+DEFAULT_OVERLAP_FRACTION = 0.2
+
+OverlapSpec = int | float | str | list["int | float | str"] | None
+
+
+def concretize_patch_size(patch_size: list[int] | None, shape: list[int] | tuple[int, ...]) -> list[int]:
+    """Resolve the per-axis patch convention onto a concrete shape: ``0`` = free axis -> full extent.
+
+    ``[0,0,0]`` (or ``None``) is the whole volume; ``[1,0,0]`` is a full 2D slice; a positive entry is
+    fixed by the user and passes through (clamped to the extent so a patch never exceeds the volume).
+    """
+    if patch_size is None:
+        return list(shape)
+    if len(shape) != len(patch_size):
+        raise DatasetManagerError(
+            f"Dimension mismatch: 'patch_size' has {len(patch_size)} dimensions, but 'shape' has {len(shape)}.",
+            f"patch_size: {patch_size}",
+            f"shape: {shape}",
+            "Both must have the same number of dimensions (e.g., 3D patch for 3D volume).",
+        )
+    return [int(shape[d]) if p == 0 else min(int(p), int(shape[d])) for d, p in enumerate(patch_size)]
+
+
+def resolve_overlap(overlap: OverlapSpec, patch_size: list[int], shape: list[int] | tuple[int, ...]) -> list[int]:
+    """Resolve an overlap spec into per-axis voxels for a CONCRETE ``patch_size``.
+
+    Accepted forms: ``None`` -> ``DEFAULT_OVERLAP_FRACTION`` of the patch per axis; an ``int`` ->
+    absolute voxels on every axis; a ``float`` in [0,1[ or a ``"20%"`` string -> that fraction of the
+    patch per axis; a per-axis list mixing those forms. Whatever the spec, an axis that is not tiled
+    (single patch spans the extent) resolves to 0 -- overlap only exists between patches.
+    """
+
+    def one(spec: int | float | str, size: int) -> int:
+        if isinstance(spec, str):
+            text = spec.strip()
+            if not text.endswith("%"):
+                raise ValueError(f"overlap: '{spec}' is not a percentage; use e.g. '20%', a voxel int or a fraction.")
+            spec = float(text[:-1]) / 100.0
+        if isinstance(spec, float):
+            if not 0.0 <= spec < 1.0:
+                raise ValueError(f"overlap: fraction {spec} must be in [0, 1[.")
+            return int(size * spec)
+        if spec < 0:
+            raise ValueError(f"overlap: {spec} must be >= 0 voxels.")
+        return int(spec)
+
+    if overlap is None:
+        overlap = DEFAULT_OVERLAP_FRACTION
+    specs: list[int | float | str] = (
+        list(overlap) if isinstance(overlap, list) else [overlap] * len(patch_size)  # scalar broadcast
+    )
+    if len(specs) != len(patch_size):
+        raise ValueError(f"overlap: {len(specs)} entries for {len(patch_size)} axes; give one per axis or a scalar.")
+    resolved = []
+    for spec, size, extent in zip(specs, patch_size, shape, strict=True):
+        # No overlap on an axis that is not tiled (one patch spans it) nor on a length-1 patch axis
+        # (2D slicing: nothing to blend along a single-voxel patch).
+        voxels = one(spec, size) if 1 < size < extent else 0
+        if voxels >= size:
+            raise ValueError(f"overlap: {voxels} voxels must be smaller than the patch size {size}.")
+        resolved.append(voxels)
+    return resolved
+
+
+#: Fraction of the budget the sized patch may use; the rest absorbs intermediates the estimate misses.
+PATCH_BUDGET_SAFETY_FRACTION = 0.8
+
+
+def resolve_patch(
+    patch_size: list[int] | None,
+    shape: list[int] | tuple[int, ...],
+    channels: int,
+    dtype_bytes: int,
+    budget_bytes: float | None,
+    resident_images: int = 1,
+    intermediate_factor: float = 1.0,
+    snap: list[int] | None = None,
+) -> list[int]:
+    """Size the free axes of ``patch_size`` so ONE patch fits ``budget_bytes``; fixed axes never move.
+
+    ``0`` entries are free (their max = the volume's extent); positive entries are pinned by the user.
+    A patch's footprint is ``(resident_images + intermediate_factor) * voxels * channels * dtype_bytes``
+    -- ``resident_images`` is exact (counted from the config: output + targets + masks), the
+    ``intermediate_factor`` covers the op's working copies. When everything fits, the free axes take
+    their full extent (the whole volume when all axes are free). Otherwise the free axes shrink
+    ISOTROPICALLY (the patch keeps the volume's proportions), optionally snapped down to ``snap``
+    multiples (a model's valid input sizes). ``budget_bytes=None`` disables sizing (free = extent).
+    Fixed axes alone exceeding the budget is an error: the user pinned more than the budget allows.
+    """
+    concrete = concretize_patch_size(patch_size, shape)
+    free = [d for d, p in enumerate(patch_size) if p == 0] if patch_size is not None else list(range(len(concrete)))
+    if budget_bytes is None or not free:
+        return concrete
+
+    def snapped(axis: int, value: int) -> int:
+        if snap is None or snap[axis] <= 1:
+            return max(1, value)
+        return max(min(snap[axis], int(shape[axis])), (value // snap[axis]) * snap[axis])
+
+    bytes_per_voxel = (resident_images + intermediate_factor) * channels * dtype_bytes
+    fixed_voxels = int(np.prod([concrete[d] for d in range(len(concrete)) if d not in free]))
+    cap = (budget_bytes * PATCH_BUDGET_SAFETY_FRACTION) / (bytes_per_voxel * fixed_voxels)
+    if cap < 1.0:
+        raise DatasetManagerError(
+            f"The fixed patch axes alone ({fixed_voxels} voxels x {channels} channels) exceed the memory budget.",
+            f"budget: {budget_bytes / 2**30:.2f} GiB | bytes/voxel: {bytes_per_voxel:.0f}",
+            "Raise the budget, free an axis (0), or pin smaller sizes.",
+        )
+    free_extents = [int(shape[d]) for d in free]
+    if float(np.prod(free_extents)) <= cap:
+        return concrete
+    ratio = (cap / float(np.prod(free_extents))) ** (1.0 / len(free))
+    for d, extent in zip(free, free_extents, strict=True):
+        concrete[d] = snapped(d, int(extent * ratio))
+    return concrete
+
+
 def get_patch_slices_from_shape(
-    patch_size: list[int], shape: list[int], overlap_tmp: int | None
+    patch_size: list[int], shape: list[int], overlap_tmp: OverlapSpec
 ) -> tuple[list[tuple[slice, ...]], list[tuple[int, bool]]]:
 
+    has_free_axis = patch_size is not None and any(p == 0 for p in patch_size) and not all(p == 0 for p in patch_size)
     if patch_size is None or all(p == 0 for p in patch_size):
         patch_size = shape
+    else:
+        patch_size = concretize_patch_size(patch_size, shape)
     if len(shape) != len(patch_size):
         raise DatasetManagerError(
             f"Dimension mismatch: 'patch_size' has {len(patch_size)} dimensions, but 'shape' has {len(shape)}.",
@@ -99,14 +220,24 @@ def get_patch_slices_from_shape(
     nb_patch_per_dim = []
     slices: list[list[slice]] = []
     if overlap_tmp is None:
-        size = [np.ceil(a / b) for a, b in zip(shape, patch_size, strict=False)]
-        tmp = np.zeros(len(size), dtype=np.int_)
-        for i, s in enumerate(size):
-            if s > 1:
-                tmp[i] = np.mod(patch_size[i] - np.mod(shape[i], patch_size[i]), patch_size[i]) // (size[i] - 1)
-        overlap = tmp
-    else:
+        if has_free_axis:
+            # Free axes are new territory (no config predates them), so they take the modern default:
+            # DEFAULT_OVERLAP_FRACTION of the patch on tiled axes, 0 on untiled ones.
+            overlap = np.array(resolve_overlap(None, patch_size, shape), dtype=np.int_)
+        else:
+            # Fully-fixed patch with no spec: spread the last patch's remainder evenly across each axis.
+            size = [np.ceil(a / b) for a, b in zip(shape, patch_size, strict=False)]
+            tmp = np.zeros(len(size), dtype=np.int_)
+            for i, s in enumerate(size):
+                if s > 1:
+                    tmp[i] = np.mod(patch_size[i] - np.mod(shape[i], patch_size[i]), patch_size[i]) // (size[i] - 1)
+            overlap = tmp
+    elif isinstance(overlap_tmp, int):
+        # Plain int: the same voxel overlap on every axis whose patch is > 1.
         overlap = [overlap_tmp if size > 1 else 0 for size in patch_size]
+    else:
+        # Rich spec: a fraction, a "20%" string, or a per-axis list mixing forms.
+        overlap = resolve_overlap(overlap_tmp, patch_size, shape)
 
     for dim in range(len(shape)):
         if overlap[dim] >= patch_size[dim]:

--- a/konfai/utils/vram.py
+++ b/konfai/utils/vram.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""VRAM-driven patch sizing: measure on the real run, shrink one step on OOM, restart.
+
+A model's VRAM footprint cannot be computed from headers -- it is its activations -- so it is
+MEASURED, and measured for free: the real workflow run is the probe. The contract, shared by
+prediction and training, is ``transient(step) + resident(patch) <= free_VRAM x margin``, where each
+workflow declares its step (a forward; a forward+backward+optimizer step) and its resident set
+(accumulators and the streamed assembly window; parameters, gradients and optimizer state). The
+provisional grid starts at the worst case's full extent; when a step runs out of memory, the caller
+catches it, asks :func:`next_patch_candidate` for one shrink step -- scaled by the last measured
+transient when there is one, a fixed factor when the OOM left no number -- re-plans the grid and
+restarts. When everything fits (the common case) nothing here runs at all.
+"""
+
+from collections.abc import Callable
+
+import torch
+
+#: Fraction of the free VRAM a step may claim; the reserve absorbs allocator fragmentation and
+#: transients the measured run did not exercise (mirrors the accumulation gate's margin).
+VRAM_BUDGET_SAFETY_FRACTION = 0.8
+
+#: Per-axis shrink applied when an OOM left no usable measurement to scale from.
+_OOM_SHRINK_STEP = 0.8
+
+
+def measure_transient_bytes(run: Callable[[], None], device: torch.device | int) -> int | None:
+    """Measure the transient VRAM one ``run()`` peaks above the resident set, or ``None`` on OOM.
+
+    The caller provides the run (a forward for prediction, forward+backward for training) so this
+    stays model-agnostic; an out-of-memory run is reported as ``None`` -- a valid "does not fit"
+    measurement -- with the partial allocations released. ``max_memory_allocated`` is a running
+    high-water mark, so a stale peak can only over-estimate the transient, never under.
+    """
+    torch.cuda.synchronize(device)
+    torch.cuda.reset_peak_memory_stats(device)
+    resident = torch.cuda.memory_allocated(device)
+    try:
+        run()
+    except torch.cuda.OutOfMemoryError:
+        torch.cuda.empty_cache()
+        return None
+    torch.cuda.synchronize(device)
+    return int(torch.cuda.max_memory_allocated(device) - resident)
+
+
+def usable_vram(free_bytes: float, resident_bytes: float = 0.0, margin: float = VRAM_BUDGET_SAFETY_FRACTION) -> float:
+    """The VRAM a step's transient may claim: free memory under the safety margin, minus what must
+    stay resident alongside the step (accumulators and the streamed assembly window for prediction;
+    nothing extra for training, whose resident set is already allocated when ``free_bytes`` is read).
+    """
+    return free_bytes * margin - resident_bytes
+
+
+def next_patch_candidate(
+    candidate: list[int],
+    patch_size: list[int] | None,
+    shape: list[int] | tuple[int, ...],
+    measured_bytes: int | None,
+    usable_bytes: float,
+    snap: list[int] | None = None,
+) -> list[int] | None:
+    """One shrink step toward a patch whose step fits ``usable_bytes``; ``None`` = nothing smaller.
+
+    ``candidate`` is the size that just failed; ``patch_size`` is the user's per-axis convention
+    (``0`` = free, ``N`` = pinned, ``None`` = all free) -- only free axes move. With a measured
+    transient the free axes scale ISOTROPICALLY by ``(usable / measured) ** (1 / n_free)`` (the
+    volume ratio activations follow, ~linear in voxels: one step lands near the target); without one
+    -- or when the measurement claims the candidate already fits, so scaling would not shrink -- each
+    free axis takes the fixed OOM step. Sizes snap DOWN to the model's valid multiples, floored at
+    ``min(snap, extent)``. ``None`` means no smaller candidate exists (every free axis at its floor,
+    or ``usable_bytes`` leaves the step no memory at all) -- the caller owns the error message.
+    """
+    free = [d for d, p in enumerate(patch_size) if p == 0] if patch_size is not None else list(range(len(candidate)))
+    if not free or usable_bytes <= 0:
+        return None
+    if measured_bytes is not None and measured_bytes > usable_bytes:
+        ratio = (usable_bytes / measured_bytes) ** (1.0 / len(free))
+    else:
+        ratio = _OOM_SHRINK_STEP
+
+    def snapped(axis: int, value: int) -> int:
+        if snap is None or snap[axis] <= 1:
+            return max(1, value)
+        return max(min(snap[axis], int(shape[axis])), (value // snap[axis]) * snap[axis])
+
+    shrunk = list(candidate)
+    for axis in free:
+        shrunk[axis] = min(snapped(axis, int(candidate[axis] * ratio)), candidate[axis])
+    return shrunk if shrunk != list(candidate) else None

--- a/tests/assets/Workflows/TinySynth.py
+++ b/tests/assets/Workflows/TinySynth.py
@@ -24,6 +24,24 @@ class Head(network.ModuleArgsDict):
         self.add_module("Tanh", torch.nn.Tanh())
 
 
+class Affine(torch.nn.Module):
+    """Per-voxel ``y = w * x + b`` as elementwise ops.
+
+    The same input value gives the same output bits whatever the tensor shape, which is what the
+    patched-equals-whole byte-identity tests compare across. A 1x1 convolution is not that: it
+    routes through shape-dependent GEMM kernels whose FMA tail handling can differ by one ULP
+    between patch sizes (observed on macOS arm64 Accelerate).
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(1))
+        self.bias = torch.nn.Parameter(torch.zeros(1))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x * self.weight + self.bias
+
+
 class TinySynthNet(network.Network):
     def __init__(
         self,
@@ -38,8 +56,5 @@ class TinySynthNet(network.Network):
             outputs_criterions=outputs_criterions,
             dim=2,
         )
-        self.add_module(
-            "Projection",
-            torch.nn.Conv2d(1, 1, kernel_size=1, bias=True),
-        )
+        self.add_module("Projection", Affine())
         self.add_module("Head", Head())

--- a/tests/integration/test_konfai_auto_patch_prediction.py
+++ b/tests/integration/test_konfai_auto_patch_prediction.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""VRAM auto-patching in prediction (``patch_size`` with free ``0`` axes): an OOM mid-run must
+shrink the free axes, re-plan the grid, restart, and produce a prediction byte-identical to the
+whole-volume run. The model is pointwise (1x1 conv) and the overlap 0, so patched == whole holds
+exactly and any grid/mapping/accumulation mistake shows up as a voxel difference."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from test_konfai_core_workflows import _prepare_experiment_dir, _subprocess_env
+from test_konfai_ensemble_tta import _replace_once
+
+pytestmark = pytest.mark.integration
+
+SimpleITK = pytest.importorskip("SimpleITK")
+
+TRAIN_NAME = "AUTOPATCH"
+
+RUNNER_SOURCE = '''
+import os
+from pathlib import Path
+
+import torch
+
+import konfai.predictor as predictor_module
+from konfai.predictor import build_predict, predict
+from konfai.trainer import train
+
+ATTEMPTS = []
+
+
+def install_auto_patch_probes() -> None:
+    """Force the first attempt to OOM and stub the CUDA readings (this is a CPU-only run)."""
+    original_run = predictor_module._Predictor.run
+
+    def run_with_forced_oom(self):
+        ATTEMPTS.append(list(self.dataset.get_patch_config()[0]))
+        if len(ATTEMPTS) == 1:
+            raise torch.cuda.OutOfMemoryError("forced OOM: pretend the full-slice forward does not fit")
+        return original_run(self)
+
+    predictor_module._Predictor.run = run_with_forced_oom
+    predictor_module.Predictor._transient_at_oom = lambda self, device: None
+    predictor_module.Predictor._usable_vram_after_oom = lambda self, device: 1.0
+
+
+def main() -> None:
+    root = Path.cwd()
+    train(
+        overwrite=True,
+        gpu=[],
+        cpu=1,
+        quiet=True,
+        tensorboard=False,
+        config=root / "Config.yml",
+        checkpoints_dir=root / "Checkpoints",
+        statistics_dir=root / "Statistics",
+    )
+    checkpoints = sorted((root / "Checkpoints" / "__TRAIN_NAME__").glob("*.pt"))
+    if not checkpoints:
+        raise RuntimeError("no checkpoints produced")
+    predict(
+        models=[checkpoints[-1]],
+        overwrite=True,
+        gpu=[],
+        cpu=1,
+        quiet=True,
+        tensorboard=False,
+        prediction_file=root / "Prediction.yml",
+        predictions_dir=root / "Predictions_reference",
+    )
+    # The workflow normally runs in a spawned child, where a monkeypatch would not survive; run the
+    # single rank IN-PROCESS so the forced OOM and the stubbed VRAM readings stay visible.
+    os.environ["KONFAI_OVERWRITE"] = "True"
+    os.environ["KONFAI_VERBOSE"] = "False"
+    install_auto_patch_probes()
+    predictor = build_predict(
+        models=[checkpoints[-1]],
+        prediction_file=root / "PredictionAuto.yml",
+        predictions_dir=root / "Predictions_auto",
+    )
+    with predictor as configured:
+        configured.setup(1)
+        configured(0)
+    # Attempt 1: the free axes at full extent; attempt 2: one fixed 0.8 shrink of the free Y/X axes
+    # (the pinned Z=1 never moves). Anything else means the restart loop did not do its job.
+    if ATTEMPTS != [[1, 0, 0], [1, 12, 12]]:
+        raise RuntimeError(f"unexpected restart sequence: {ATTEMPTS}")
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+@pytest.fixture(scope="module")
+def auto_patch_experiment(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
+    """Train once, predict whole-slice (reference), then with a forced-OOM auto-patch restart."""
+    experiment_dir = tmp_path_factory.mktemp("auto_patch") / "experiment"
+    paths = _prepare_experiment_dir(experiment_dir, TRAIN_NAME)
+    base = (experiment_dir / "Prediction.yml").read_text(encoding="utf-8")
+    auto = _replace_once(base, "patch_size: [1, 16, 16]", "patch_size: [1, 0, 0]")
+    auto = _replace_once(auto, "overlap: None", "overlap: 0")
+    (experiment_dir / "PredictionAuto.yml").write_text(auto, encoding="utf-8")
+
+    runner_path = experiment_dir / "run_auto_patch_prediction.py"
+    runner_path.write_text(RUNNER_SOURCE.replace("__TRAIN_NAME__", TRAIN_NAME), encoding="utf-8")
+    subprocess.run(
+        [sys.executable, str(runner_path)],
+        cwd=experiment_dir,
+        env=_subprocess_env(),
+        check=True,
+    )
+    return {
+        "dataset_dir": paths["dataset_dir"],
+        "reference": experiment_dir / "Predictions_reference",
+        "auto": experiment_dir / "Predictions_auto",
+    }
+
+
+def _prediction_path(predictions_dir: Path, case: str) -> Path:
+    path = predictions_dir / TRAIN_NAME / "Dataset" / case / "sCT.mha"
+    assert path.exists(), f"missing prediction output: {path}"
+    return path
+
+
+def test_auto_patch_restart_is_voxel_identical_to_whole_volume(auto_patch_experiment: dict[str, Path]) -> None:
+    cases = sorted(path.name for path in auto_patch_experiment["dataset_dir"].iterdir() if path.is_dir())
+    assert cases, "synthetic dataset is empty"
+    for case in cases:
+        reference = SimpleITK.ReadImage(str(_prediction_path(auto_patch_experiment["reference"], case)))
+        auto = SimpleITK.ReadImage(str(_prediction_path(auto_patch_experiment["auto"], case)))
+        assert auto.GetOrigin() == reference.GetOrigin(), case
+        assert auto.GetSpacing() == reference.GetSpacing(), case
+        assert auto.GetDirection() == reference.GetDirection(), case
+        reference_array = SimpleITK.GetArrayFromImage(reference)
+        auto_array = SimpleITK.GetArrayFromImage(auto)
+        assert auto_array.dtype == reference_array.dtype, case
+        np.testing.assert_array_equal(auto_array, reference_array, err_msg=case)

--- a/tests/integration/test_konfai_auto_patch_training.py
+++ b/tests/integration/test_konfai_auto_patch_training.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""VRAM auto-patching in training (``patch_size`` with free ``0`` axes): an OOM at the first step
+must shrink the free axes through the rank rendezvous, re-plan the grid, restart the run, and
+train to completion (checkpoints produced)."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from test_konfai_core_workflows import _prepare_experiment_dir, _subprocess_env
+from test_konfai_ensemble_tta import _replace_once
+
+pytestmark = pytest.mark.integration
+
+pytest.importorskip("SimpleITK")
+
+TRAIN_NAME = "AUTOPATCHTRAIN"
+
+RUNNER_SOURCE = '''
+import os
+from pathlib import Path
+
+import torch
+
+import konfai.trainer as trainer_module
+from konfai.trainer import build_train
+
+ATTEMPTS = []
+
+
+def install_auto_patch_probes() -> None:
+    """Force the first attempt to OOM and stub the CUDA readings (this is a CPU-only run)."""
+    original_run = trainer_module._Trainer.run
+
+    def run_with_forced_oom(self):
+        ATTEMPTS.append(list(self.dataloader_training.dataset.get_patch_config()[0]))
+        if len(ATTEMPTS) == 1:
+            raise torch.cuda.OutOfMemoryError("forced OOM: pretend the full-slice step does not fit")
+        return original_run(self)
+
+    trainer_module._Trainer.run = run_with_forced_oom
+    trainer_module.Trainer._transient_at_oom = lambda self, device: None
+    trainer_module.Trainer._usable_vram_after_oom = lambda self, device: 1.0
+
+
+def main() -> None:
+    root = Path.cwd()
+    # The workflow normally runs in a spawned child, where a monkeypatch would not survive; run the
+    # single rank IN-PROCESS so the forced OOM and the stubbed VRAM readings stay visible.
+    os.environ["KONFAI_OVERWRITE"] = "True"
+    os.environ["KONFAI_VERBOSE"] = "False"
+    # Normally created by the Log wrapper of execute_distributed_object, which this bypasses.
+    (root / "Statistics" / "__TRAIN_NAME__").mkdir(parents=True, exist_ok=True)
+    install_auto_patch_probes()
+    trainer = build_train(
+        config=root / "ConfigAuto.yml",
+        checkpoints_dir=root / "Checkpoints",
+        statistics_dir=root / "Statistics",
+    )
+    with trainer as configured:
+        configured.setup(1)
+        configured(0)
+    # Attempt 1: the free axes at full extent; attempt 2: one fixed 0.8 shrink of the free Y/X axes
+    # (the pinned Z=1 never moves). Anything else means the restart loop did not do its job.
+    if ATTEMPTS != [[1, 0, 0], [1, 12, 12]]:
+        raise RuntimeError(f"unexpected restart sequence: {ATTEMPTS}")
+    checkpoints = sorted((root / "Checkpoints" / "__TRAIN_NAME__").glob("*.pt"))
+    if not checkpoints:
+        raise RuntimeError("the restarted training produced no checkpoint")
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+def test_auto_patch_training_restarts_and_completes(tmp_path: Path) -> None:
+    experiment_dir = tmp_path / "experiment"
+    _prepare_experiment_dir(experiment_dir, TRAIN_NAME)
+    base = (experiment_dir / "Config.yml").read_text(encoding="utf-8")
+    auto = _replace_once(base, "patch_size: [1, 16, 16]", "patch_size: [1, 0, 0]")
+    auto = _replace_once(auto, "overlap: None", "overlap: 0")
+    (experiment_dir / "ConfigAuto.yml").write_text(auto, encoding="utf-8")
+
+    runner_path = experiment_dir / "run_auto_patch_training.py"
+    runner_path.write_text(RUNNER_SOURCE.replace("__TRAIN_NAME__", TRAIN_NAME), encoding="utf-8")
+    subprocess.run(
+        [sys.executable, str(runner_path)],
+        cwd=experiment_dir,
+        env=_subprocess_env(),
+        check=True,
+    )

--- a/tests/integration/test_konfai_streamed_evaluation.py
+++ b/tests/integration/test_konfai_streamed_evaluation.py
@@ -57,6 +57,10 @@ EVALUATION_TEMPLATE = """Evaluator:
               reduction: mean
             PSNR:
               dynamic_range: 2.0
+            MAESaveMap:
+              reduction: mean
+              dataset: ./ErrorMaps:mha
+              group: None
   Dataset:
     groups_src:
       CT:
@@ -192,3 +196,20 @@ def test_streamed_evaluation_matches_whole_volume(tmp_path: Path) -> None:
                 assert got == pytest.approx(value, rel=1e-4), f"{case}:{key}: whole={value} streamed={got}"
             compared += 1
     assert compared >= 9  # 3 cases x 3 metrics: the comparison actually exercised the report
+
+    # The per-voxel error map streams region by region under the budget; being voxel-local over a
+    # disjoint unpadded grid, it must land byte-identical to the whole-volume map.
+    for idx in range(3):
+        case = f"CASE_{idx:03d}"
+        whole_map_path = whole_dir / "ErrorMaps" / case / "sCT.mha"
+        streamed_map_path = streamed_dir / "ErrorMaps" / case / "sCT.mha"
+        assert whole_map_path.exists(), f"whole-volume run wrote no error map for {case}"
+        assert streamed_map_path.exists(), f"streamed run wrote no error map for {case}"
+        whole_map = SimpleITK.ReadImage(str(whole_map_path))
+        streamed_map = SimpleITK.ReadImage(str(streamed_map_path))
+        assert streamed_map.GetSpacing() == whole_map.GetSpacing(), case
+        np.testing.assert_array_equal(
+            SimpleITK.GetArrayFromImage(streamed_map),
+            SimpleITK.GetArrayFromImage(whole_map),
+            err_msg=case,
+        )

--- a/tests/integration/test_konfai_streamed_evaluation.py
+++ b/tests/integration/test_konfai_streamed_evaluation.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Streamed evaluation ends on the same numbers as whole-volume evaluation.
+
+With a ``memory_budget`` too small for a case, evaluation cuts it into the largest disjoint patches
+that fit and combines each metric's partial states; this proves end-to-end on disk that the produced
+``Metric_TRAIN.json`` matches the whole-volume run within float tolerance -- the invariant the whole
+feature stands on -- and that the budget run actually took the patched path.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+SimpleITK = pytest.importorskip("SimpleITK")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TRAIN_NAME = "STREAMED_EVAL_01"
+
+
+def _subprocess_env() -> dict[str, str]:
+    env = os.environ.copy()
+    pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = str(REPO_ROOT) if not pythonpath else f"{REPO_ROOT}{os.pathsep}{pythonpath}"
+    return env
+
+
+EVALUATION_TEMPLATE = """Evaluator:
+  metrics:
+    sCT:
+      targets_criterions:
+        CT:
+          criterions_loader:
+            MAE:
+              reduction: mean
+            MSE:
+              reduction: mean
+            PSNR:
+              dynamic_range: 2.0
+  Dataset:
+    groups_src:
+      CT:
+        groups_dest:
+          CT:
+            transforms:
+              TensorCast:
+                dtype: float32
+                inverse: true
+            patch_transforms: None
+            is_input: true
+      sCT:
+        groups_dest:
+          sCT:
+            transforms:
+              TensorCast:
+                dtype: float32
+                inverse: true
+            patch_transforms: None
+            is_input: true
+    subset: None
+    validation: None
+    memory_budget: __MEMORY_BUDGET__
+    dataset_filenames:
+      - __DATASET_DIR__:a:mha
+      - __PREDICTIONS_DIR__:i:mha
+    use_cache: false
+  train_name: __TRAIN_NAME__
+"""
+
+
+def _write_image(path: Path, array: np.ndarray, pixel_id: int) -> None:
+    image = SimpleITK.GetImageFromArray(array)
+    image.SetSpacing((1.0, 1.0, 1.0))
+    image = SimpleITK.Cast(image, pixel_id)
+    SimpleITK.WriteImage(image, str(path))
+
+
+def _create_paired_dataset(dataset_dir: Path, predictions_dir: Path) -> None:
+    """Ground-truth CT and a spatially-varying 'prediction' per case, so the metrics are non-trivial."""
+    rng = np.random.default_rng(7)
+    for idx in range(3):
+        (dataset_dir / f"CASE_{idx:03d}").mkdir(parents=True)
+        (predictions_dir / f"CASE_{idx:03d}").mkdir(parents=True)
+        ct = rng.normal(size=(5, 16, 16)).astype(np.float32)
+        sct = (0.85 * ct + 0.1 * rng.normal(size=ct.shape) + 0.02 * idx).astype(np.float32)
+        _write_image(dataset_dir / f"CASE_{idx:03d}" / "CT.mha", ct, SimpleITK.sitkFloat32)
+        _write_image(predictions_dir / f"CASE_{idx:03d}" / "sCT.mha", sct, SimpleITK.sitkFloat32)
+
+
+def _run_evaluation(experiment_dir: Path, memory_budget: str) -> str:
+    dataset_dir = experiment_dir / "Dataset"
+    predictions_dir = experiment_dir / "PredictionsData"
+    _create_paired_dataset(dataset_dir, predictions_dir)
+    (experiment_dir / "Evaluation.yml").write_text(
+        EVALUATION_TEMPLATE.replace("__DATASET_DIR__", str(dataset_dir))
+        .replace("__PREDICTIONS_DIR__", str(predictions_dir))
+        .replace("__TRAIN_NAME__", TRAIN_NAME)
+        .replace("__MEMORY_BUDGET__", memory_budget),
+        encoding="utf-8",
+    )
+    runner = experiment_dir / "run_eval.py"
+    runner.write_text(
+        textwrap.dedent(
+            """
+            from pathlib import Path
+            from konfai.evaluator import evaluate
+
+
+            def main() -> None:
+                evaluate(
+                    overwrite=True,
+                    gpu=[],
+                    cpu=1,
+                    quiet=True,
+                    tensorboard=False,
+                    evaluations_file=Path.cwd() / "Evaluation.yml",
+                    evaluations_dir=Path.cwd() / "Evaluations",
+                )
+
+
+            if __name__ == "__main__":
+                main()
+            """
+        ),
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        [sys.executable, str(runner)],
+        cwd=experiment_dir,
+        env=_subprocess_env(),
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, f"evaluation failed:\n{completed.stdout}\n{completed.stderr}"
+    return completed.stdout + completed.stderr
+
+
+def _read_metrics(experiment_dir: Path) -> dict:
+    metrics_path = experiment_dir / "Evaluations" / TRAIN_NAME / "Metric_TRAIN.json"
+    assert metrics_path.exists(), f"no metrics written under {metrics_path}"
+    return json.loads(metrics_path.read_text(encoding="utf-8"))
+
+
+def test_streamed_evaluation_matches_whole_volume(tmp_path: Path) -> None:
+    whole_dir = tmp_path / "whole"
+    streamed_dir = tmp_path / "streamed"
+    whole_dir.mkdir()
+    streamed_dir.mkdir()
+
+    _run_evaluation(whole_dir, "None")
+    # A case here is 2 groups x 5x16x16 float32 ~= 10 KiB resident; 8000 bytes cannot hold it, so the
+    # run must patch. The log line is the proof the streamed path actually executed.
+    streamed_log = _run_evaluation(streamed_dir, "8000b")
+    assert "disjoint patches" in streamed_log, f"budget run did not take the patched path:\n{streamed_log}"
+
+    whole = _read_metrics(whole_dir)
+    streamed = _read_metrics(streamed_dir)
+
+    whole_cases = whole["case"] if "case" in whole else whole
+    streamed_cases = streamed["case"] if "case" in streamed else streamed
+    assert set(whole_cases) == set(streamed_cases)
+    compared = 0
+    for case, values in whole_cases.items():
+        if not isinstance(values, dict):
+            continue
+        assert set(values) == set(streamed_cases[case])
+        for key, value in values.items():
+            got = streamed_cases[case][key]
+            if value is None or (isinstance(value, float) and np.isnan(value)):
+                assert got is None or np.isnan(got)
+            else:
+                assert got == pytest.approx(value, rel=1e-4), f"{case}:{key}: whole={value} streamed={got}"
+            compared += 1
+    assert compared >= 9  # 3 cases x 3 metrics: the comparison actually exercised the report

--- a/tests/unit/test_auto_patching.py
+++ b/tests/unit/test_auto_patching.py
@@ -239,11 +239,33 @@ class TestMetricReductionContract:
         grids = [self._patches(shape[2:], p) for p in ([8, 8, 8], [1, 23, 17])]
         self._identity(metric, args, grids)
 
-    def test_savemap_metrics_are_not_reducible(self):
+    def test_savemap_metrics_are_reducible_and_their_maps_voxel_local(self):
+        import torch
         from konfai.metric.measure import DiceSaveMap, MAESaveMap
 
-        assert not MAESaveMap().reducible
-        assert not DiceSaveMap().reducible
+        # Scalars reduce like their parents; the map streams because it is voxel-local: a patch's
+        # map must equal the SAME region of the whole-case map, exactly (the streamed evaluation
+        # writes it region by region on that contract).
+        assert MAESaveMap().reducible
+        assert DiceSaveMap().reducible
+        rng = np.random.default_rng(3)
+        shape = (1, 1, 8, 9, 7)
+        output = torch.tensor(rng.normal(size=shape).astype(np.float32))
+        target = torch.tensor(rng.normal(size=shape).astype(np.float32))
+        mask = torch.tensor((rng.random(shape) > 0.3).astype(np.float32))
+        metric = MAESaveMap()
+        whole = metric.partial_map(output, target, mask)
+        for z0, z1 in [(0, 3), (3, 8)]:
+            patch = metric.partial_map(output[..., z0:z1, :, :], target[..., z0:z1, :, :], mask[..., z0:z1, :, :])
+            torch.testing.assert_close(patch, whole[..., z0:z1, :, :], rtol=0, atol=0)
+
+        labels_out = torch.tensor(rng.integers(0, 3, size=shape).astype(np.float32))
+        labels_ref = torch.tensor(rng.integers(0, 3, size=shape).astype(np.float32))
+        dice = DiceSaveMap()
+        whole_dice = dice.partial_map(labels_out, labels_ref)
+        assert whole_dice.dtype == torch.uint8
+        patch_dice = dice.partial_map(labels_out[..., 2:6, :, :], labels_ref[..., 2:6, :, :])
+        torch.testing.assert_close(patch_dice, whole_dice[..., 2:6, :, :], rtol=0, atol=0)
 
     def test_non_reducible_metric_raises_actionably(self):
         import torch

--- a/tests/unit/test_auto_patching.py
+++ b/tests/unit/test_auto_patching.py
@@ -165,3 +165,89 @@ class TestPatchedReductionIdentity:
         assert count == out.size  # disjoint AND exhaustive tiling
         assert abs_sum / count == pytest.approx(np.abs(out - tgt).mean(), rel=1e-12)
         assert sq_sum / count == pytest.approx(((out - tgt) ** 2).mean(), rel=1e-12)
+
+
+class TestMetricReductionContract:
+    """partial_metric/combine_metric must reproduce forward exactly on disjoint patches."""
+
+    @staticmethod
+    def _patches(shape, patch):
+        slices, _ = get_patch_slices_from_shape(patch, list(shape), 0)
+        return [(slice(None), slice(None), *sl) for sl in slices]
+
+    @staticmethod
+    def _identity(metric, whole_args, patch_grids):
+
+        expected = metric(*whole_args)
+        expected_value = expected[1] if isinstance(expected, tuple) else expected.item()
+        for grid in patch_grids:
+            states = [metric.partial_metric(*[t[sl] for t in whole_args]) for sl in grid]
+            combined = metric.combine_metric(states)
+            got = combined[1] if isinstance(combined, tuple) else combined
+            if isinstance(expected_value, dict):
+                assert set(got) == set(expected_value)
+                for k, v in expected_value.items():
+                    if np.isnan(v):
+                        assert np.isnan(got[k])
+                    else:
+                        assert got[k] == pytest.approx(v, rel=1e-5)
+            elif isinstance(expected_value, float) and np.isnan(expected_value):
+                assert np.isnan(got)
+            else:
+                assert got == pytest.approx(expected_value, rel=1e-5)
+
+    @pytest.mark.parametrize("batch", [1, 2])
+    @pytest.mark.parametrize("masked", [False, True])
+    def test_masked_losses(self, batch, masked):
+        import torch
+        from konfai.metric.measure import MAE, ME, MSE, PSNR
+
+        torch.manual_seed(0)
+        shape = (batch, 2, 19, 23, 17)
+        out, tgt = torch.rand(*shape) * 100, torch.rand(*shape) * 100
+        args = [out, tgt]
+        if masked:
+            args.append((torch.rand(batch, 2, 19, 23, 17) > 0.4).float())
+        grids = [self._patches(shape[2:], p) for p in ([8, 8, 8], [1, 23, 17], [19, 23, 17])]
+        for metric in (MSE(), MAE(), MSE("sum"), MAE("sum"), ME(), PSNR()):
+            assert metric.reducible
+            self._identity(metric, args, grids)
+
+    def test_masked_loss_with_empty_mask_is_nan(self):
+        import torch
+        from konfai.metric.measure import MAE
+
+        out, tgt = torch.rand(1, 1, 8, 8, 8), torch.rand(1, 1, 8, 8, 8)
+        mask = torch.zeros(1, 1, 8, 8, 8)
+        self._identity(MAE(), [out, tgt, mask], [self._patches((8, 8, 8), [4, 4, 4])])
+
+    @pytest.mark.parametrize("explicit_labels", [None, [1, 2, 5]])
+    @pytest.mark.parametrize("masked", [False, True])
+    def test_dice(self, explicit_labels, masked):
+        import torch
+        from konfai.metric.measure import Dice
+
+        torch.manual_seed(1)
+        shape = (1, 1, 19, 23, 17)
+        out = torch.randint(0, 4, shape).float()  # label 5 never present -> nan branch with explicit labels
+        tgt = torch.randint(0, 4, shape).float()
+        args = [out, tgt]
+        if masked:
+            args.append((torch.rand(*shape) > 0.3).float())
+        metric = Dice(labels=explicit_labels)
+        assert metric.reducible
+        grids = [self._patches(shape[2:], p) for p in ([8, 8, 8], [1, 23, 17])]
+        self._identity(metric, args, grids)
+
+    def test_savemap_metrics_are_not_reducible(self):
+        from konfai.metric.measure import DiceSaveMap, MAESaveMap
+
+        assert not MAESaveMap().reducible
+        assert not DiceSaveMap().reducible
+
+    def test_non_reducible_metric_raises_actionably(self):
+        import torch
+        from konfai.metric.measure import GradientImages
+
+        with pytest.raises(NotImplementedError, match="not reducible"):
+            GradientImages().partial_metric(torch.rand(1, 1, 4, 4, 4))

--- a/tests/unit/test_auto_patching.py
+++ b/tests/unit/test_auto_patching.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The per-axis patch convention (0 = free axis) and its sizing/overlap resolution.
+
+A patch entry of 0 leaves that axis to the framework: full extent when it fits, shrunk to the memory
+budget when it does not. A positive entry is pinned by the user and never moves. Overlap accepts voxels,
+fractions, percent strings and per-axis mixes, resolves AFTER the patch size, and is 0 on any axis a
+single patch spans.
+"""
+
+import numpy as np
+import pytest
+from konfai.utils.utils import (
+    concretize_patch_size,
+    get_patch_slices_from_shape,
+    resolve_overlap,
+    resolve_patch,
+)
+
+
+class TestConcretize:
+    def test_zero_axes_take_the_full_extent(self):
+        assert concretize_patch_size([0, 0, 0], [37, 41, 29]) == [37, 41, 29]
+
+    def test_mixed_fixed_and_free(self):
+        assert concretize_patch_size([1, 0, 0], [37, 41, 29]) == [1, 41, 29]
+        assert concretize_patch_size([0, 128, 128], [500, 400, 300]) == [500, 128, 128]
+
+    def test_fixed_larger_than_the_volume_is_clamped(self):
+        assert concretize_patch_size([128, 128, 128], [96, 96, 96]) == [96, 96, 96]
+
+    def test_none_is_the_whole_volume(self):
+        assert concretize_patch_size(None, [10, 20, 30]) == [10, 20, 30]
+
+
+class TestResolveOverlap:
+    def test_default_is_a_fifth_of_the_patch_per_axis(self):
+        # patch 10 -> 2 (the settled default), and per axis of ITS patch size.
+        assert resolve_overlap(None, [10, 50, 100], [100, 500, 1000]) == [2, 10, 20]
+
+    def test_absolute_voxels_broadcast(self):
+        assert resolve_overlap(16, [128, 128, 128], [512, 512, 512]) == [16, 16, 16]
+
+    def test_fraction_and_percent_string(self):
+        assert resolve_overlap(0.25, [64, 64, 64], [512, 512, 512]) == [16, 16, 16]
+        assert resolve_overlap("25%", [64, 64, 64], [512, 512, 512]) == [16, 16, 16]
+
+    def test_per_axis_mix(self):
+        assert resolve_overlap([8, 0.1, "50%"], [64, 100, 10], [512, 512, 512]) == [8, 10, 5]
+
+    def test_untiled_axis_gets_zero_whatever_the_spec(self):
+        # First axis: one patch spans the extent -> no overlap there.
+        assert resolve_overlap(16, [512, 128, 128], [512, 512, 512]) == [0, 16, 16]
+
+    def test_single_voxel_patch_axis_gets_zero(self):
+        # 2D slicing: nothing to blend along a length-1 patch axis.
+        assert resolve_overlap(16, [1, 128, 128], [300, 512, 512]) == [0, 16, 16]
+
+    def test_overlap_not_smaller_than_patch_is_refused(self):
+        with pytest.raises(ValueError, match="smaller than the patch"):
+            resolve_overlap(64, [64, 64, 64], [512, 512, 512])
+
+    def test_bad_forms_are_refused(self):
+        with pytest.raises(ValueError, match="percentage"):
+            resolve_overlap("big", [64, 64, 64], [512, 512, 512])
+        with pytest.raises(ValueError, match=r"\[0, 1\["):
+            resolve_overlap(1.5, [64, 64, 64], [512, 512, 512])
+        with pytest.raises(ValueError, match="one per axis"):
+            resolve_overlap([1, 2], [64, 64, 64], [512, 512, 512])
+
+
+class TestPatchGrid:
+    def test_2d_slicing_grid(self):
+        # [1,0,0] -> one full slice per Z index: exactly Z patches, each spanning Y and X.
+        slices, nb_per_dim = get_patch_slices_from_shape([1, 0, 0], [37, 41, 29], None)
+        assert len(slices) == 37
+        assert slices[0] == (slice(0, 1), slice(0, 41), slice(0, 29))
+        assert nb_per_dim[0] == (37, True)
+
+    def test_free_axes_cover_the_volume_disjointly(self):
+        # A fixed Z with free in-plane axes tiles Z only; the plane stays whole.
+        slices, _ = get_patch_slices_from_shape([16, 0, 0], [37, 41, 29], None)
+        zs = sorted({(s[0].start, s[0].stop) for s in slices})
+        assert all(s[1] == slice(0, 41) and s[2] == slice(0, 29) for s in slices)
+        covered = set()
+        for start, stop in zs:
+            covered.update(range(start, stop))
+        assert covered == set(range(37))
+
+    def test_all_zero_is_the_whole_volume(self):
+        slices, _ = get_patch_slices_from_shape([0, 0, 0], [10, 20, 30], None)
+        assert slices == [(slice(0, 10), slice(0, 20), slice(0, 30))]
+
+    def test_fixed_patch_grid_stays_bit_identical(self):
+        # A fully-fixed patch keeps the remainder-spreading overlap grid: every stored model was
+        # trained and evaluated on it.
+        fixed, _ = get_patch_slices_from_shape([16, 16, 16], [37, 41, 29], None)
+        assert fixed[0] == (slice(0, 16), slice(0, 16), slice(0, 16))
+        assert all(s[0].stop <= 37 and s[1].stop <= 41 and s[2].stop <= 29 for s in fixed)
+
+
+class TestResolvePatch:
+    def test_whole_volume_when_it_fits(self):
+        # 64^3 float32 single channel = 1 MiB; a 100 MiB budget swallows it whole.
+        assert resolve_patch([0, 0, 0], [64, 64, 64], 1, 4, 100 * 2**20, 2, 1.0) == [64, 64, 64]
+
+    def test_no_budget_means_full_extent(self):
+        assert resolve_patch([0, 0, 0], [512, 512, 512], 1, 4, None) == [512, 512, 512]
+
+    def test_shrinks_isotropically_when_too_big(self):
+        shape = [512, 512, 512]
+        sized = resolve_patch([0, 0, 0], shape, 1, 4, 64 * 2**20, 2, 1.0)
+        assert all(1 <= p < s for p, s in zip(sized, shape, strict=True))
+        # Isotropic on an isotropic volume: all free axes shrink alike.
+        assert len(set(sized)) == 1
+        # And the sized patch actually fits the safety-scaled budget.
+        assert 3 * np.prod(sized) * 4 <= 64 * 2**20 * 0.8 * 1.001
+
+    def test_fixed_axes_never_move(self):
+        sized = resolve_patch([1, 0, 0], [300, 4096, 4096], 1, 4, 8 * 2**20, 2, 1.0)
+        assert sized[0] == 1
+        assert all(1 <= p < 4096 for p in sized[1:])
+
+    def test_snap_rounds_free_axes_down_to_model_multiples(self):
+        sized = resolve_patch([0, 0, 0], [500, 500, 500], 1, 4, 64 * 2**20, 2, 1.0, snap=[16, 16, 16])
+        assert all(p % 16 == 0 for p in sized)
+
+    def test_pinned_axes_exceeding_the_budget_raise(self):
+        from konfai.utils.errors import DatasetManagerError
+
+        with pytest.raises(DatasetManagerError, match="exceed the memory budget"):
+            resolve_patch([512, 512, 0], [512, 512, 512], 4, 4, 1 * 2**20)
+
+
+class TestPatchedReductionIdentity:
+    """combine(disjoint patches) == metric(whole): the numerical foundation of auto-patched evaluation."""
+
+    @pytest.mark.parametrize("patch", [[16, 16, 16], [1, 41, 29], [8, 7, 5]])
+    def test_running_sums_reproduce_whole_volume_metrics(self, patch):
+        rng = np.random.default_rng(0)
+        out = rng.random((37, 41, 29))
+        tgt = rng.random((37, 41, 29))
+        slices, _ = get_patch_slices_from_shape(patch, [37, 41, 29], 0)
+
+        abs_sum, sq_sum, count = 0.0, 0.0, 0
+        for sl in slices:
+            diff = out[sl] - tgt[sl]
+            abs_sum += np.abs(diff).sum()
+            sq_sum += (diff**2).sum()
+            count += diff.size
+        assert count == out.size  # disjoint AND exhaustive tiling
+        assert abs_sum / count == pytest.approx(np.abs(out - tgt).mean(), rel=1e-12)
+        assert sq_sum / count == pytest.approx(((out - tgt) ** 2).mean(), rel=1e-12)

--- a/tests/unit/test_vram_sizing.py
+++ b/tests/unit/test_vram_sizing.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""VRAM-driven patch sizing: one measured shrink step per OOM restart, verified fit.
+
+The pure kernel (:func:`next_patch_candidate`) is exercised through the same loop the workflows
+run -- try, measure, shrink, retry -- with synthetic probes (no GPU needed); the measurement
+primitive itself runs on a real CUDA device when one is present.
+"""
+
+import numpy as np
+import pytest
+import torch
+from konfai.utils.utils import concretize_patch_size
+from konfai.utils.vram import measure_transient_bytes, next_patch_candidate, usable_vram
+
+
+def _linear_probe(bytes_per_voxel: float):
+    """A probe whose transient scales linearly in voxels -- the conv-net regime."""
+
+    def probe(patch_size):
+        return int(np.prod(patch_size) * bytes_per_voxel)
+
+    return probe
+
+
+def run_until_fits(patch_size, shape, probe, usable, snap=None):
+    """The workflows' restart loop in miniature: run, measure, shrink one step, run again.
+
+    Returns the first candidate whose measured transient fits ``usable``, or ``None`` when the
+    kernel reports nothing smaller exists. Bounded so a non-shrinking kernel fails the test instead
+    of hanging it.
+    """
+    candidate = concretize_patch_size(patch_size, shape)
+    for _ in range(64):
+        measured = probe(candidate)
+        if measured is not None and measured <= usable:
+            return candidate
+        candidate = next_patch_candidate(candidate, patch_size, shape, measured, usable, snap)
+        if candidate is None:
+            return None
+    raise AssertionError("the shrink loop did not converge")
+
+
+class TestShrinkLoop:
+    def test_whole_volume_when_the_measured_run_fits(self):
+        sized = run_until_fits([0, 0, 0], [64, 64, 64], _linear_probe(10), usable=64**3 * 10)
+        assert sized == [64, 64, 64]
+
+    def test_shrinks_until_the_measured_run_fits(self):
+        probe = _linear_probe(100)
+        usable = 40**3 * 100  # fits 40^3, far below the 64^3 extent
+        sized = run_until_fits([0, 0, 0], [64, 64, 64], probe, usable)
+        assert all(1 <= p < 64 for p in sized)
+        assert probe(sized) <= usable
+
+    def test_a_measured_transient_scales_straight_to_the_target(self):
+        # 8x over budget with 3 free axes -> one isotropic step of (1/8)^(1/3) halves each axis.
+        shrunk = next_patch_candidate([64, 64, 64], [0, 0, 0], [64, 64, 64], measured_bytes=800, usable_bytes=100)
+        assert shrunk == [32, 32, 32]
+
+    def test_pinned_axes_never_move(self):
+        probe = _linear_probe(1000)
+        sized = run_until_fits([1, 0, 0], [64, 256, 256], probe, usable=32_000_000)
+        assert sized[0] == 1
+        assert probe(sized) <= 32_000_000
+
+    def test_snap_keeps_model_valid_multiples(self):
+        sized = run_until_fits([0, 0, 0], [100, 100, 100], _linear_probe(500), usable=120_000_000, snap=[16, 16, 16])
+        assert sized is not None
+        assert all(p % 16 == 0 for p in sized)
+
+    def test_snap_floor_clamps_to_a_small_extent(self):
+        # An extent below the model multiple floors there (padding makes it model-valid), not at 0.
+        shrunk = next_patch_candidate([9, 64, 64], [0, 0, 0], [9, 64, 64], None, usable_bytes=1.0, snap=[16, 16, 16])
+        assert shrunk is not None
+        assert shrunk[0] == 9
+
+    def test_oom_without_a_number_walks_down_by_the_fixed_step(self):
+        calls = []
+
+        def probe(patch_size):
+            calls.append(list(patch_size))
+            return None if np.prod(patch_size) > 20**3 else int(np.prod(patch_size) * 10)
+
+        sized = run_until_fits([0, 0, 0], [64, 64, 64], probe, usable=20**3 * 10)
+        assert np.prod(sized) <= 20**3
+        assert len(calls) > 2  # it actually walked down through the OOMs, one step per restart
+
+    def test_a_stale_fitting_measurement_still_shrinks(self):
+        # The last measured batch "fits" yet an OOM happened -> the kernel must not return the same
+        # candidate (scaling by >= 1 would); it falls back to the fixed step.
+        shrunk = next_patch_candidate([64, 64, 64], [0, 0, 0], [64, 64, 64], measured_bytes=50, usable_bytes=100)
+        assert shrunk is not None
+        assert all(p < 64 for p in shrunk)
+
+    def test_the_floor_is_reported_as_none_not_a_loop(self):
+        assert run_until_fits([0, 0, 0], [64, 64, 64], _linear_probe(1e9), usable=10.0) is None
+
+    def test_no_free_axis_means_nothing_to_shrink(self):
+        assert next_patch_candidate([32, 32, 32], [32, 32, 32], [64, 64, 64], None, usable_bytes=1e9) is None
+
+    def test_no_usable_vram_at_all_means_none(self):
+        assert next_patch_candidate([64, 64, 64], [0, 0, 0], [64, 64, 64], None, usable_bytes=0.0) is None
+
+
+class TestUsableVram:
+    def test_margin_and_resident_come_off_the_free_memory(self):
+        assert usable_vram(1000.0, resident_bytes=300.0) == pytest.approx(1000.0 * 0.8 - 300.0)
+
+    def test_resident_exceeding_the_margin_goes_negative(self):
+        # The kernel then answers None -- the caller raises with its own context.
+        assert usable_vram(1000.0, resident_bytes=900.0) < 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
+class TestMeasurementOnGpu:
+    def test_transient_reflects_a_forward_and_scales_with_the_patch(self):
+        device = torch.device("cuda:0")
+        net = torch.nn.Sequential(
+            torch.nn.Conv3d(1, 8, 3, padding=1), torch.nn.ReLU(), torch.nn.Conv3d(8, 1, 3, padding=1)
+        ).to(device)
+
+        def run_at(size):
+            def run():
+                with torch.inference_mode():
+                    net(torch.zeros(1, 1, *size, device=device))
+
+            return run
+
+        small = measure_transient_bytes(run_at([16, 16, 16]), device)
+        large = measure_transient_bytes(run_at([48, 48, 48]), device)
+        assert small is not None and large is not None
+        assert small > 0
+        # 27x the voxels must cost markedly more -- the measurement really tracks the activations.
+        assert large > small * 4
+
+    def test_the_restart_loop_sizes_a_real_model_into_the_budget(self):
+        device = torch.device("cuda:0")
+        net = torch.nn.Sequential(
+            torch.nn.Conv3d(1, 16, 3, padding=1), torch.nn.ReLU(), torch.nn.Conv3d(16, 1, 3, padding=1)
+        ).to(device)
+
+        def probe(patch_size):
+            def run():
+                with torch.inference_mode():
+                    net(torch.zeros(1, 1, *patch_size, device=device))
+
+            return measure_transient_bytes(run, device)
+
+        whole = probe([96, 96, 96])
+        assert whole is not None
+        usable = whole // 2  # the whole volume does NOT fit -> the loop must shrink and still fit
+        sized = run_until_fits([0, 0, 0], [96, 96, 96], probe, usable)
+        assert sized is not None
+        assert all(p < 96 for p in sized)
+        measured = probe(sized)
+        assert measured is not None and measured <= usable

--- a/tests/unit/test_vram_sizing.py
+++ b/tests/unit/test_vram_sizing.py
@@ -24,6 +24,7 @@ primitive itself runs on a real CUDA device when one is present.
 import numpy as np
 import pytest
 import torch
+from konfai.predictor import Mean, Predictor, Reduction
 from konfai.utils.utils import concretize_patch_size
 from konfai.utils.vram import measure_transient_bytes, next_patch_candidate, usable_vram
 
@@ -124,6 +125,85 @@ class TestUsableVram:
     def test_resident_exceeding_the_margin_goes_negative(self):
         # The kernel then answers None -- the caller raises with its own context.
         assert usable_vram(1000.0, resident_bytes=900.0) < 0
+
+
+class _SpatialReduction(Reduction):
+    """A reduction that reads across voxels: its writer can never stream."""
+
+    voxel_local = False
+
+    def __call__(self, tensors):
+        return tensors[0]
+
+
+class _Args:
+    def __init__(self, out_channels):
+        self.out_channels = out_channels
+
+
+class _Model:
+    def __init__(self, out_channels):
+        self._out_channels = out_channels
+
+    def named_module_args_dict(self):
+        yield "Head.Tanh", None, _Args(self._out_channels)
+
+
+class _Writer:
+    def __init__(self, nb_data_augmentation, reduction):
+        self.nb_data_augmentation = nb_data_augmentation
+        self.reduction = reduction
+
+
+class _Data:
+    def __init__(self, worst):
+        self._worst = worst
+
+    def worst_case_shape(self):
+        return self._worst
+
+
+def _predictor(out_channels, nb_augmentation, reduction, margined, candidate=None):
+    predictor = Predictor.__new__(Predictor)
+    predictor._vram_patch_template = [0, 0, 0]
+    predictor._vram_patch_candidate = candidate
+    predictor.dataset = _Data([100, 100, 100])
+    predictor.model = _Model(out_channels)
+    predictor.combine = Mean()
+    predictor.path_to_models = ["model.pt"]
+    predictor.outputs_dataset = {"Head.Tanh": _Writer(nb_augmentation, reduction)}
+    predictor._usable_vram_after_oom = lambda device: margined
+    return predictor
+
+
+class TestPredictorShrinkBudget:
+    """The shrink budget reserves the accumulation footprint so the sized patch keeps the blend on
+    the GPU; only an unfittable (or unpriceable) reserve falls back to sizing the forward alone."""
+
+    def test_an_assembled_writer_reserves_the_whole_volume(self):
+        # reserve = (3+1)ch x 100^3 x 2B x 2aug = 1.6e7 -> usable 1e6 of the 1.7e7 margined budget;
+        # measured 8e6 -> exact isotropic step (1/8)^(1/3) halves each axis. Without the reserve the
+        # measurement would claim a fit and only the fixed 0.8 step would apply.
+        predictor = _predictor(3, nb_augmentation=2, reduction=Mean(), margined=1.7e7)
+        assert predictor._shrunken_patch(8_000_000, device=None) == [50, 50, 50]
+
+    def test_a_streaming_writer_reserves_only_its_window(self):
+        # Single augmentation + voxel-local reduction -> window = candidate_z x cross-section:
+        # reserve 8e5 -> usable 3.2e6, measured 6.4e6 -> per-axis (1/2)^(1/3). A volume reserve
+        # (8e6) would not fit the 4e6 budget and would have fallen back to [8, 85, 85].
+        predictor = _predictor(3, nb_augmentation=1, reduction=Mean(), margined=4e6, candidate=[10, 100, 100])
+        assert predictor._shrunken_patch(6_400_000, device=None) == [7, 79, 79]
+
+    def test_an_unfittable_reserve_falls_back_to_the_forward_alone(self):
+        # The non-streamable volume reserve (1.6e7) exceeds the whole budget (1e6): the writer will
+        # blend on the CPU, and the patch is still sized for the forward instead of refusing.
+        predictor = _predictor(3, nb_augmentation=2, reduction=_SpatialReduction(), margined=1e6)
+        assert predictor._shrunken_patch(8_000_000, device=None) == [50, 50, 50]
+
+    def test_unpriceable_channels_skip_the_reserve(self):
+        predictor = _predictor(None, nb_augmentation=2, reduction=Mean(), margined=1e6)
+        assert predictor._accumulation_reserve([100, 100, 100], [100, 100, 100]) is None
+        assert predictor._shrunken_patch(8_000_000, device=None) == [50, 50, 50]
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")


### PR DESCRIPTION
**Auto-patching slice** (`a56aa4d..c3854ba`), stacked on #50.

- Per-axis free patch axes (`0` = sized by the framework) + rich overlap specs.
- Memory-bounded evaluation from reducible metric partials; `SaveMap` error maps streamed under a budget.
- VRAM shrink-step kernel + OOM-restart loop (prediction and training), each attempt measured against its own CUDA peak; the accumulation footprint is reserved in the shrink budget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic “free axis” patch sizing for training and prediction when patch dimensions are set to `0`, including CUDA OOM restart recovery.
  * Enabled per-axis overlap configuration (voxels, fractions, percentages, or mixed specs).
  * Added memory-budgeted, streamed evaluation that can reproduce whole-volume results for supported reducible metrics and generate matching error maps.
* **Documentation**
  * Updated config guides for evaluation, prediction, and training “free patch axes”, plus revised large-image tuning guidance.
* **Tests**
  * Added/extended integration and unit coverage for auto-patching, streamed evaluation equivalence, and VRAM-based patch sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->