### PR TITLE
refactor(data): one memory lever — retire use_cache, null memory_budget means auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,14 +196,16 @@ notebook entry points) lives in the
 ## 🩻 How volumes are read
 
 Volumes are read as patches. Whether the volume is *also* held in RAM depends on
-`use_cache` and on whether your preprocessing chain can be streamed — KonfAI
-derives streamability from the transforms you declared:
+the workflow's loading regime (training caches, prediction and evaluation
+stream; `memory_budget` makes it adaptive) and on whether your preprocessing
+chain can be streamed — KonfAI derives streamability from the transforms you
+declared:
 
 | Regime | When | Memory held |
 | --- | --- | --- |
-| **Cache** | `use_cache: true` (training default) | every case, resident for the whole run |
-| **Stream** | `use_cache: false`, chain is streamable | one patch |
-| **Buffer** | `use_cache: false`, chain is not streamable | a FIFO of `max(batch_size + 1, shuffle_window)` cases |
+| **Cache** | training default | every case, resident for the whole run |
+| **Stream** | predict/eval default or budget exceeded; chain streamable | one patch |
+| **Buffer** | same triggers; chain not streamable | a FIFO of `max(batch_size + 1, shuffle_window)` cases |
 
 A chain streams when every step declares the region it needs: the exact patch
 (`OneHot`), a halo (`Dilate`), a remap (`Flip`), a resample (`ResampleToShape`),

--- a/docs/source/concepts/streaming.md
+++ b/docs/source/concepts/streaming.md
@@ -45,7 +45,7 @@ Two keys under `Dataset:`:
 
 | Key | Default | Where | Effect |
 | --- | --- | --- | --- |
-| `memory_budget` | `null` | all three workflows | Derives the regime from the dataset's size. |
+| `memory_budget` | `null` = `auto` | all three workflows | Derives the regime from the dataset's size; an absent key means `auto`. |
 | `subset.shuffle_window` | `null` | `Trainer:` | Bounds how many cases stay resident on the buffer path. |
 
 Both are listed in {doc}`../config_guide/training`.
@@ -53,14 +53,16 @@ Both are listed in {doc}`../config_guide/training`.
 `memory_budget` compares the estimated per-rank dataset size against the budget
 and picks the regime accordingly, printing its decision once. A bare number is
 GiB (`24` means 24 GiB), a string may name its unit (`"24GB"`, `"32 GiB"`,
-`"512mb"`), and `"auto"` offers 80% of the detected node memory, cgroup limit
-included, divided by the ranks sharing it. `null` keeps the workflow's default.
+`"512mb"`), and `"auto"` — also what an absent key means — offers 80% of the
+detected node memory, cgroup limit included, divided by the ranks sharing it.
 
-The budget decides in both directions and in every workflow: a prediction under
-`memory_budget: auto` caches its dataset whenever it fits the budget; a training
-under a budget smaller than its dataset streams instead of caching — declaring a
-deliberately small budget is how you force the streaming path. Set the budget on
-the workflow you mean to bound:
+The budget's cache side applies to training only: a training dataset that fits
+caches, one that does not streams — declaring a budget smaller than the dataset
+is how you force the streaming path. Prediction and evaluation are one-pass
+workflows: each case is read once, a cache is never re-read, so they always
+stream whatever the budget says; in evaluation the same budget instead sizes the
+disjoint patches a too-large case is cut into. Set the budget on the workflow
+you mean to bound:
 
 ```yaml
 Dataset:

--- a/docs/source/concepts/streaming.md
+++ b/docs/source/concepts/streaming.md
@@ -18,61 +18,49 @@ across epochs, with VRAM equal to one batch.
 
 ## The three regimes
 
-Which one a case takes follows from `use_cache` and from the chain itself.
+Which one a case takes follows from the workflow's regime and from the chain
+itself.
 
 | Regime | When | Memory held |
 | --- | --- | --- |
-| **Cache** | `use_cache: true` | every case, resident for the whole run |
-| **Stream** | `use_cache: false` and the chain is streamable | one patch |
-| **Buffer** | `use_cache: false` and the chain is not streamable | a FIFO of `batch_size + 1` cases (or `shuffle_window` cases, whichever is larger) |
+| **Cache** | the training default | every case, resident for the whole run |
+| **Stream** | the predict/eval default, or a budget the dataset exceeds; chain streamable | one patch |
+| **Buffer** | same triggers, chain not streamable | a FIFO of `batch_size + 1` cases (or `shuffle_window` cases, whichever is larger) |
 
-**The cache wins over streaming.** `use_cache: true` preloads every case, and a
-preloaded case is cut from the resident volume even when its chain would stream.
-Set `use_cache: false` to get the streaming path at all.
+**The cache wins over streaming.** A cached case is cut from the resident
+volume even when its chain would stream; the stream/buffer paths only run on
+the streaming regime.
 
 Stream and buffer coexist inside one run. The decision is made per case *and*
 per augmented copy, not once per dataset, so a chain that streams for one
 augmentation draw may load the volume for the next.
 
-`use_cache` is a training key: only `Trainer:` accepts it. Prediction declares
-`false` and evaluation declares `true`. A `memory_budget` overrides that
-declared value in every workflow — see below.
+The regime is not a config key. Training defaults to the cache (epochs re-read
+every case); prediction and evaluation default to streaming (one pass). A
+`memory_budget` replaces the default with a measured decision — see below.
 
 ## What you control
 
-Three keys under `Dataset:`:
+Two keys under `Dataset:`:
 
 | Key | Default | Where | Effect |
 | --- | --- | --- | --- |
-| `use_cache` | `true` | `Trainer:` | `false` opens the stream/buffer path. |
-| `memory_budget` | `null` | all three workflows | Derives `use_cache` from the dataset's size. |
+| `memory_budget` | `null` | all three workflows | Derives the regime from the dataset's size. |
 | `subset.shuffle_window` | `null` | `Trainer:` | Bounds how many cases stay resident on the buffer path. |
 
-All three are listed in {doc}`../config_guide/training`.
+Both are listed in {doc}`../config_guide/training`.
 
 `memory_budget` compares the estimated per-rank dataset size against the budget
-and sets `use_cache` accordingly, printing its decision once. A bare number is
+and picks the regime accordingly, printing its decision once. A bare number is
 GiB (`24` means 24 GiB), a string may name its unit (`"24GB"`, `"32 GiB"`,
 `"512mb"`), and `"auto"` offers 80% of the detected node memory, cgroup limit
-included, divided by the ranks sharing it. `null` leaves `use_cache` exactly as
-declared.
+included, divided by the ranks sharing it. `null` keeps the workflow's default.
 
-`memory_budget` replaces the declared `use_cache`, in both directions and in
-every workflow. A prediction under `memory_budget: auto` caches its dataset
-whenever it fits the budget; an evaluation under a budget smaller than its
-dataset does not cache. Set the budget on the workflow you mean to bound.
-
-To take the stream/buffer path on every case, declare `use_cache` and leave the
-budget out:
-
-```yaml
-Dataset:
-  use_cache: false
-```
-
-To let the dataset's size decide, declare a budget. It settles `use_cache`
-whatever the config says, so the two keys together are not a way to force
-streaming on a dataset that fits:
+The budget decides in both directions and in every workflow: a prediction under
+`memory_budget: auto` caches its dataset whenever it fits the budget; a training
+under a budget smaller than its dataset streams instead of caching — declaring a
+deliberately small budget is how you force the streaming path. Set the budget on
+the workflow you mean to bound:
 
 ```yaml
 Dataset:
@@ -287,5 +275,5 @@ augmentation interpolates on the same terms as `RESCALE`.
 ## Next steps
 
 - {doc}`datasets` — the grouped layout, `groups_src`, and where patching sits
-- {doc}`../config_guide/training` — `use_cache`, `memory_budget`, and `shuffle_window` in a full config
+- {doc}`../config_guide/training` — `memory_budget` and `shuffle_window` in a full config
 - {doc}`../reference/components/storage-backends` — format tokens and the per-backend APIs

--- a/docs/source/config_guide/evaluation.md
+++ b/docs/source/config_guide/evaluation.md
@@ -75,17 +75,19 @@ Common fields:
 
 ### `memory_budget`: memory-bounded evaluation
 
-With a `memory_budget` (a bare number in GiB, `"24GB"`, `"auto"`), each run
-sizes itself from image headers alone: a case that fits the budget is evaluated
-whole, and a case that does not is cut into the largest
+Evaluation bounds itself by default: an absent `memory_budget` means `auto`
+(80% of the detected memory), and explicit values (a bare number in GiB,
+`"24GB"`) narrow it. Each run sizes itself from image headers alone: a case that
+fits the budget is evaluated whole, and a case that does not is cut into the largest
 DISJOINT patches that fit. Metrics accumulate running partial sums per patch and
 combine them into the exact whole-case value (never a mean of per-patch values).
 MAE, MSE, ME, PSNR and Dice — masked or not — support this, and the SaveMap
 error maps stream region by region into their `dataset` (mha, h5 or omezarr).
 One metric that cannot recombine (SSIM, LPIPS, or any custom metric that does
 not declare `reducible`) keeps the whole-volume path for the entire run: correct
-beats bounded. The same budget also decides the loading regime, as in every
-workflow.
+beats bounded. Evaluation streams its data whatever the budget says — one pass,
+a cache is never re-read; in training the same budget also picks cache versus
+streaming.
 
 ## Output files
 

--- a/docs/source/config_guide/training.md
+++ b/docs/source/config_guide/training.md
@@ -128,7 +128,7 @@ Common fields:
 | `augmentations` | mapping or null | one default augmentation list | Data augmentations sampled during training. |
 | `inline_augmentations` | bool | `false` | Keeps base samples cached and generates augmentation tensors only when an augmented sample is requested; augmentation states are re-sampled on each epoch. |
 | `Patch` | mapping or null | `DatasetPatch()` | Dataset-level patch extraction. |
-| `memory_budget` | number / string / null | `null` | RAM budget the loading regime is derived from: the dataset caches when its per-rank share fits, streams otherwise. `null` keeps the training default (cache). |
+| `memory_budget` | number / string / null | `null` = `auto` | RAM budget the loading regime is derived from: the dataset caches when its per-rank share fits, streams otherwise. An absent key (`null`) means `auto`: 80% of the detected memory decides. |
 | `subset` | object | `TrainSubset()` | Restricts which cases are used. |
 | `batch_size` | int | `1` | Batch size. |
 | `num_workers` | int or null | `None` | Number of DataLoader workers. `None` resolves to `0` on the cache regime, and to `max(1, min(cpu_count, 4))` on the stream/buffer regime. A `KonfAIInference` transform in any group forces `0` whatever the value. |
@@ -176,7 +176,8 @@ per-rank share fits the budget, and takes the streaming/buffer path otherwise â€
 a budget below the dataset's size therefore forces streaming. The decision
 is made once on the launcher, before any rank is spawned, and the estimate, the
 budget, its source, and the chosen regime are printed. `null` (the default)
-keeps the training default: the cache.
+means `auto`: the detected memory decides -- a dataset that fits caches exactly
+as before, one that does not streams instead of overrunning the node.
 
 | Value | Read as |
 | --- | --- |

--- a/docs/source/config_guide/training.md
+++ b/docs/source/config_guide/training.md
@@ -128,11 +128,10 @@ Common fields:
 | `augmentations` | mapping or null | one default augmentation list | Data augmentations sampled during training. |
 | `inline_augmentations` | bool | `false` | Keeps base samples cached and generates augmentation tensors only when an augmented sample is requested; augmentation states are re-sampled on each epoch. |
 | `Patch` | mapping or null | `DatasetPatch()` | Dataset-level patch extraction. |
-| `use_cache` | bool | `true` | Holds the whole prepared dataset in RAM. `false` opens the stream/buffer path: a streamable chain reads each patch from disk, and any other loads whole cases into a bounded FIFO. |
-| `memory_budget` | number / string / null | `null` | RAM budget from which `use_cache` is derived. `null` keeps `use_cache` as given. |
+| `memory_budget` | number / string / null | `null` | RAM budget the loading regime is derived from: the dataset caches when its per-rank share fits, streams otherwise. `null` keeps the training default (cache). |
 | `subset` | object | `TrainSubset()` | Restricts which cases are used. |
 | `batch_size` | int | `1` | Batch size. |
-| `num_workers` | int or null | `None` | Number of DataLoader workers. `None` resolves to `0` under `use_cache: true`, and to `max(1, min(cpu_count, 4))` otherwise. A `KonfAIInference` transform in any group forces `0` whatever the value. |
+| `num_workers` | int or null | `None` | Number of DataLoader workers. `None` resolves to `0` on the cache regime, and to `max(1, min(cpu_count, 4))` on the stream/buffer regime. A `KonfAIInference` transform in any group forces `0` whatever the value. |
 | `pin_memory` | bool | `false` | Enables pinned host memory for DataLoader batches. |
 | `prefetch_factor` | int or null | `None` | Prefetched batches per worker. Applies only when workers are enabled, where `None` resolves to `2`. |
 | `persistent_workers` | bool or null | `None` | Keep workers alive across epochs. Applies only when workers are enabled, where `None` resolves to `true`. |
@@ -143,15 +142,16 @@ Common fields:
 
 ### Cache, stream, and buffer
 
-`use_cache` picks how a loader turns a case into patches. It applies to the
-training and validation subsets alike.
+The loading regime picks how a loader turns a case into patches. It applies to
+the training and validation subsets alike. Training defaults to the cache;
+`memory_budget` switches the regime from the dataset's measured size.
 
-- **Cache** (`use_cache: true`, the default). Every case is loaded, preprocessed,
+- **Cache** (the training default). Every case is loaded, preprocessed,
   and held in RAM before the first epoch; patches are cut from the resident
   volume. RAM follows the dataset. `num_workers` defaults to `0` here.
-- **Stream** (`use_cache: false`, patch-compatible preprocessing). Each patch is
+- **Stream** (budget exceeded, patch-compatible preprocessing). Each patch is
   read from its own region of the source file. No volume is materialized.
-- **Buffer** (`use_cache: false`, preprocessing that needs the whole volume).
+- **Buffer** (budget exceeded, preprocessing that needs the whole volume).
   The case is loaded whole into a FIFO of `batch_size + 1` cases —
   `max(batch_size + 1, shuffle_window)` when a window is set — evicting the
   oldest.
@@ -164,19 +164,19 @@ still stream.
 A cached case is resident, so its patches are cut from RAM even when its chain
 would stream.
 
-A 16 GiB uncompressed `.mha` at patch 64³, batch 2, 2 workers and
-`use_cache: false`, run under an 8 GiB memory cap, streams at a peak anonymous
+A 16 GiB uncompressed `.mha` at patch 64³, batch 2, 2 workers on the streaming
+regime, run under an 8 GiB memory cap, streams at a peak anonymous
 RSS of 0.46 GiB, flat across epochs, with one batch (2 MiB) resident on the GPU.
 
 ### `memory_budget`
 
-`memory_budget` derives `use_cache` from a RAM budget. KonfAI estimates the
-dataset size from image headers alone (no voxel read), caches when the per-rank
-share fits the budget, and takes the streaming/buffer path otherwise. A budget
-decides the regime on its own: the declared `use_cache` is ignored. The decision
+`memory_budget` derives the loading regime from a RAM budget. KonfAI estimates
+the dataset size from image headers alone (no voxel read), caches when the
+per-rank share fits the budget, and takes the streaming/buffer path otherwise —
+a budget below the dataset's size therefore forces streaming. The decision
 is made once on the launcher, before any rank is spawned, and the estimate, the
 budget, its source, and the chosen regime are printed. `null` (the default)
-leaves `use_cache` exactly as declared.
+keeps the training default: the cache.
 
 | Value | Read as |
 | --- | --- |

--- a/docs/source/reference/components/transforms.md
+++ b/docs/source/reference/components/transforms.md
@@ -40,10 +40,9 @@ the whole volume: the case is loaded whole, and the result is the same, just
 resident. The **Stream** column below is that answer, per transform.
 
 Streaming happens where the cache is off. A cached case is already in memory, so
-its patches are cut from memory whatever the column says. Training exposes
-`use_cache` under `Dataset:` and defaults it to `true`; PREDICTION carries no
-`use_cache` key and does not cache; EVALUATION caches. A `memory_budget` under
-`Dataset:` overrides all three with a size estimate.
+its patches are cut from memory whatever the column says. Training caches by
+default (epochs re-read every case); PREDICTION and EVALUATION stream. A
+`memory_budget` under `Dataset:` overrides all three with a size estimate.
 
 Three rules apply to the chain rather than to any single transform:
 

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -95,9 +95,9 @@ If the split looks wrong, check which form your config is actually using.
 
 ## Runtime problems
 
-### `use_cache: false` still uses memory proportional to a case
+### The streaming regime still uses memory proportional to a case
 
-`use_cache: false` bounds retention across cases; direct regional reads depend
+The stream/buffer regime bounds retention across cases; direct regional reads depend
 on the transforms. The current fast path supports `TensorCast` and unmasked
 `Normalize`, `Standardize`, and `Clip`. Other transforms and augmentations use
 the bounded full-volume path.

--- a/docs/source/usage/large-images.md
+++ b/docs/source/usage/large-images.md
@@ -34,16 +34,16 @@ image pixels is materialised for that native plane window.
 ## Choose the memory regime
 
 Streaming is derived from the pipeline; there is no `streaming: true` switch.
-`Dataset.use_cache`, the optional `memory_budget`, and the transform chain lead
-each case and augmentation draw to one of three regimes:
+The workflow's default, the optional `memory_budget`, and the transform chain
+lead each case and augmentation draw to one of three regimes:
 
 | Regime | When | Memory held |
 | --- | --- | --- |
-| **Cache** | `use_cache: true` | Every case, resident across epochs. |
-| **Stream** | `use_cache: false` and the chain is streamable | The source region for one patch. |
-| **Buffer** | `use_cache: false` and the chain needs a whole volume | A FIFO of `max(batch_size + 1, shuffle_window)` cases. |
+| **Cache** | the training default | Every case, resident across epochs. |
+| **Stream** | predict/eval default or budget exceeded; chain streamable | The source region for one patch. |
+| **Buffer** | same triggers; the chain needs a whole volume | A FIFO of `max(batch_size + 1, shuffle_window)` cases. |
 
-`memory_budget` may replace the declared `use_cache` decision in any workflow.
+`memory_budget` replaces the workflow's default regime in any workflow.
 A number is interpreted as GiB, strings may include units, and `auto` offers
 80% of the detected per-rank memory limit. It is a size estimate—not a hard
 allocator limit—because transformed shapes, augmented copies, and transient
@@ -54,7 +54,7 @@ exact precedence and {doc}`../config_guide/training` for `shuffle_window`.
 Dataset:
   dataset_filenames:
     - ./Dataset:omezarr
-  use_cache: false
+  memory_budget: auto
   batch_size: 2
   num_workers: 4
   Patch:
@@ -143,8 +143,8 @@ memory or dimensionality requirement. See {doc}`../concepts/model-graph`.
 
 ## Tune in this order
 
-1. Set `use_cache: false` to force the stream/buffer path, or set a
-   `memory_budget` when dataset size should decide.
+1. Set a `memory_budget` (`auto`, or a value below the dataset's size to
+   force the stream/buffer path).
 2. Leave `patch_size` axes at `0` so the framework sizes them (the whole volume
    when it fits, a measured shrink on OOM), or pin the largest size that fits
    the model and required context.

--- a/docs/source/usage/large-images.md
+++ b/docs/source/usage/large-images.md
@@ -143,8 +143,9 @@ memory or dimensionality requirement. See {doc}`../concepts/model-graph`.
 
 ## Tune in this order
 
-1. Set a `memory_budget` (`auto`, or a value below the dataset's size to
-   force the stream/buffer path).
+1. The default `memory_budget` (`auto`) already decides from the dataset's
+   size; set an explicit value below the dataset's size to force the
+   stream/buffer path.
 2. Leave `patch_size` axes at `0` so the framework sizes them (the whole volume
    when it fits, a measured shrink on OOM), or pin the largest size that fits
    the model and required context.

--- a/examples/Registration/Config.yml
+++ b/examples/Registration/Config.yml
@@ -93,7 +93,6 @@ Trainer:
     dataset_filenames:  # Dataset source (format: folder_path:mode:image_format)
     - ./Dataset:a:mha
     inline_augmentations: false
-    use_cache: true
     batch_size: 4
     validation: 0.25  # Hold out 25% of the cases for validation
     validation_augmentations: false

--- a/examples/Registration/Prediction.yml
+++ b/examples/Registration/Prediction.yml
@@ -55,7 +55,6 @@ Predictor:
     filter: None
     dataset_filenames:
     - ./Dataset:a:mha
-    use_cache: false
     batch_size: 4
     num_workers: None
     pin_memory: false

--- a/examples/Segmentation/Config.yml
+++ b/examples/Segmentation/Config.yml
@@ -99,7 +99,6 @@ Trainer:
     dataset_filenames:
     - ./Dataset:a:mha
     inline_augmentations: true
-    use_cache: true
     batch_size: 8
     validation: 0.2
     validation_augmentations: true

--- a/examples/Segmentation/Prediction.yml
+++ b/examples/Segmentation/Prediction.yml
@@ -50,7 +50,6 @@ Predictor:
     filter: None
     dataset_filenames:
     - ./Dataset:a:mha
-    use_cache: false
     batch_size: 8
   outputs_dataset:
     UNetBlock_0:Head:Argmax:

--- a/examples/Synthesis/Config.yml
+++ b/examples/Synthesis/Config.yml
@@ -155,7 +155,6 @@ Trainer:
     dataset_filenames:  # Dataset sources (format: folder_path:mode:image_format; mode = a = add cases, i = keep only common cases across datasets)
     - ./Dataset/:a:mha
     inline_augmentations: true # Apply new augmentations at each epoch
-    use_cache: true # Cache processed data in memory for faster training
     batch_size: 1 # Number of samples per training batch
     validation: None  # None = no validation split, or use a case-list file / list of files / case names
     validation_augmentations: true # Set to false to validate only on non-augmented samples

--- a/examples/Synthesis/Config_GAN.yml
+++ b/examples/Synthesis/Config_GAN.yml
@@ -233,7 +233,6 @@ Trainer:
     dataset_filenames:
     - ./Dataset/:a:mha
     inline_augmentations: true
-    use_cache: true
     batch_size: 1
     validation: None
     validation_augmentations: true

--- a/examples/Synthesis/Prediction.yml
+++ b/examples/Synthesis/Prediction.yml
@@ -86,7 +86,6 @@ Predictor:
     filter: None # Optional dataset filtering
     dataset_filenames: # Dataset sources (format: folder_path:mode:image_format)
     - ./Dataset:a:mha
-    use_cache: false # Disable caching to reduce RAM usage during prediction
     batch_size: 32 # Number of patches processed per batch during inference
   outputs_dataset:
     Head:Tanh:  # Model output used to generate the predicted dataset

--- a/konfai-mcp/konfai_mcp/runner.py
+++ b/konfai-mcp/konfai_mcp/runner.py
@@ -555,7 +555,7 @@ def _force_single_process_loading(workflow_object: Any) -> int:
     """Force num_workers=0 on the dataset before setup builds the dataloader; return the requested value.
 
     The validation subprocess is daemonic (run_api_in_subprocess), and daemonic processes cannot spawn
-    children, so a DataLoader with num_workers>0 (the default when use_cache is false) would raise
+    children, so a DataLoader with num_workers>0 (the default on the streaming path) would raise
     'daemonic processes are not allowed to have children'. Loading single-process also means the real
     error surfaces here instead of being masked by a dying worker. Guarded so a core rename degrades
     gracefully rather than crashing the dry-run. The original ``num_workers`` is returned so the caller
@@ -602,7 +602,7 @@ def _check_worker_spawn_picklability(workflow_object: Any, requested_num_workers
                     "spawn DataLoader workers by pickling this dataset, and that pickling fails, so "
                     "training would die at setup with a masked worker crash. Make every dataset/transform "
                     "attribute picklable (no lambdas, open handles, or SimpleITK objects kept on self), "
-                    "or set Dataset.num_workers: 0 / Dataset.use_cache: true."
+                    "or set Dataset.num_workers: 0."
                 ),
             )
             return result

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -107,7 +107,7 @@ def _parse_memory_budget_bytes(value: str | float) -> int:
     raise ConfigError(
         f"memory_budget: '{value}' is not a valid memory size.",
         "Use a number in GiB (e.g. 24), a unit string ('24GB', '32GiB', '512MB'), 'auto', or None to "
-        "keep 'use_cache' as given.",
+        "keep the workflow's default loading regime.",
     )
 
 
@@ -1536,7 +1536,6 @@ class DataTrain(Data):
         augmentations: dict[str, DataAugmentationsList] | None = {"DataAugmentation_0": DataAugmentationsList()},
         inline_augmentations: bool = False,
         patch: DatasetPatch | None = DatasetPatch(),
-        use_cache: bool = True,
         memory_budget: str | float | None = None,
         subset: TrainSubset = TrainSubset(),
         batch_size: int = 1,
@@ -1551,7 +1550,10 @@ class DataTrain(Data):
             dataset_filenames,
             groups_src,
             patch,
-            use_cache,
+            # Training re-reads every case each epoch, so the cache is the right default; the config
+            # no longer exposes the mechanism -- 'memory_budget' replaces it with the fit-test, which
+            # streams whenever the dataset outgrows the budget (an old 'use_cache' key is inert).
+            True,
             subset,
             batch_size,
             validation,

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -1690,7 +1690,10 @@ class DataMetric(Data):
             dataset_filenames=dataset_filenames,
             groups_src=groups_src,
             patch=None,
-            use_cache=True,
+            # Evaluation reads each case exactly once (no augmentations, one pass): a cache is never
+            # re-read, it only fronts the whole dataset's RAM. Stream instead; a ``memory_budget``
+            # whose fit-test passes may still flip the cache on.
+            use_cache=False,
             subset=subset,
             batch_size=1,
             validation=validation,
@@ -1700,6 +1703,8 @@ class DataMetric(Data):
             num_workers=num_workers,
             pin_memory=pin_memory,
             prefetch_factor=prefetch_factor,
-            persistent_workers=persistent_workers,
+            # One pass: workers are never reused across epochs, and persistent workers race the
+            # process teardown (the terminated worker trips torch's failure handler at exit).
+            persistent_workers=False if persistent_workers is None else persistent_workers,
             memory_budget=memory_budget,
         )

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -106,8 +106,8 @@ def _parse_memory_budget_bytes(value: str | float) -> int:
         return int(float(match.group("number")) * factor)
     raise ConfigError(
         f"memory_budget: '{value}' is not a valid memory size.",
-        "Use a number in GiB (e.g. 24), a unit string ('24GB', '32GiB', '512MB'), 'auto', or None to "
-        "keep the workflow's default loading regime.",
+        "Use a number in GiB (e.g. 24), a unit string ('24GB', '32GiB', '512MB'), 'auto', or None "
+        "(the default) -- which means 'auto': size from the detected memory.",
     )
 
 
@@ -937,24 +937,33 @@ class Data(ABC):
                     total += int(np.prod(manager.base_shape, dtype=np.int64)) * _CACHE_ELEMENT_BYTES * copies
         return total
 
-    def _resolve_cache_regime(self, world_size: int) -> None:
-        """Derive ``use_cache`` from ``memory_budget``, or leave the declared value untouched.
+    #: Whether a ``memory_budget`` that fits may choose the cache. True for training (epochs
+    #: re-read every case); overridden False by the one-pass workflows, where a cache is never
+    #: re-read and the regime is always stream/buffer.
+    _budget_caches_when_fit = True
 
-        ``None`` keeps today's behaviour exactly. Otherwise the cache is chosen iff the per-rank
-        dataset (``dataset / world_size`` -- ``Data._split`` shards cases across ranks) fits the
-        per-rank budget: an explicit budget is taken as declared per rank; ``"auto"`` divides the
-        detected node memory (cgroup-capped) by the ranks sharing it, so its ``world_size`` cancels
-        and it reduces to "does the whole dataset fit the node". The decision is logged once here --
-        ``get_data`` runs on the launcher alone, before any worker is spawned.
+    def _resolve_cache_regime(self, world_size: int) -> None:
+        """Derive ``use_cache`` from ``memory_budget``. ``None`` means ``"auto"``.
+
+        The cache is chosen iff the per-rank dataset (``dataset / world_size`` -- ``Data._split``
+        shards cases across ranks) fits the per-rank budget: an explicit budget is taken as declared
+        per rank; ``"auto"`` -- also what an absent key means -- divides the detected node memory
+        (cgroup-capped) by the ranks sharing it, so its ``world_size`` cancels and it reduces to
+        "does the whole dataset fit the node". The decision is logged once here -- ``get_data`` runs
+        on the launcher alone, before any worker is spawned.
         """
-        if self.memory_budget is None:
+        if not self._budget_caches_when_fit:
+            # One-pass workflows (prediction, evaluation) read each case exactly once: a cache is
+            # never re-read, so the regime is always stream/buffer and there is nothing to derive.
             return
         world_size = max(1, world_size)
         n_cases = len(self._prepared_train_names) + len(self._prepared_validation_names)
         dataset_bytes = self._estimate_cached_bytes()
         per_rank_bytes = dataset_bytes / world_size
 
-        if isinstance(self.memory_budget, str) and self.memory_budget.strip().lower() == "auto":
+        if self.memory_budget is None or (
+            isinstance(self.memory_budget, str) and self.memory_budget.strip().lower() == "auto"
+        ):
             node_bytes, source = available_memory_bytes()
             per_rank_budget = node_bytes * _AUTO_MEMORY_SAFETY_FRACTION / world_size
             budget_desc = f"auto: {_format_gib(node_bytes)} {source} x {_AUTO_MEMORY_SAFETY_FRACTION:.0%}, per-rank"
@@ -1550,9 +1559,8 @@ class DataTrain(Data):
             dataset_filenames,
             groups_src,
             patch,
-            # Training re-reads every case each epoch, so the cache is the right default; the config
-            # no longer exposes the mechanism -- 'memory_budget' replaces it with the fit-test, which
-            # streams whenever the dataset outgrows the budget (an old 'use_cache' key is inert).
+            # Training re-reads every case each epoch: cache when the dataset fits the
+            # 'memory_budget' fit-test, stream when it does not.
             True,
             subset,
             batch_size,
@@ -1571,6 +1579,9 @@ class DataTrain(Data):
 @config("Dataset")
 class DataPrediction(Data):
     """Dataset configuration used by the prediction workflow."""
+
+    # One pass: each case is read once, a cache is never re-read -- always stream/buffer.
+    _budget_caches_when_fit = False
 
     def __init__(
         self,
@@ -1610,12 +1621,16 @@ class DataPrediction(Data):
 class DataMetric(Data):
     """Dataset configuration used by the evaluation workflow.
 
-    Evaluation never exposes a patch: with a ``memory_budget`` set, each run sizes its own -- a case
-    that fits the budget is evaluated whole (exact); one that does not is cut into the
-    largest DISJOINT patches that fit (overlap 0, no padding) and the reducible metrics combine their
-    running partials into the exact whole-case value. The evaluator disables this sizing when any of
-    its metrics is not reducible, so a metric that needs the whole volume always gets it.
+    Evaluation never exposes a patch: each run sizes its own from ``memory_budget`` (a missing key
+    means ``"auto"``) -- a case that fits the budget is evaluated whole (exact); one
+    that does not is cut into the largest DISJOINT patches that fit (overlap 0, no padding) and the
+    reducible metrics combine their running partials into the exact whole-case value. The evaluator
+    disables this sizing when any of its metrics is not reducible, so a metric that needs the whole
+    volume always gets it.
     """
+
+    # One pass: each case is read once, a cache is never re-read -- always stream/buffer.
+    _budget_caches_when_fit = False
 
     #: Working copies a metric makes of the patch pair (float casts, the difference, a masked select):
     #: measured ~<= 2x the resident tensors; the sizing keeps this conservative and the 0.8 safety
@@ -1623,7 +1638,9 @@ class DataMetric(Data):
     _METRIC_INTERMEDIATE_FACTOR = 2.0
 
     def _maybe_auto_patch(self) -> None:
-        if self.memory_budget is None or self.patch is not None or not getattr(self, "auto_patch_allowed", True):
+        # A missing budget means "auto": evaluation bounds itself by default. An explicit patch or a
+        # non-reducible metric (auto_patch_allowed) vetoes the sizing.
+        if self.patch is not None or not getattr(self, "auto_patch_allowed", True):
             return
         sources = self._resolve_dataset_sources()
         # Header-only scan: for each case, its resident bytes per spatial voxel is the sum of its
@@ -1646,7 +1663,9 @@ class DataMetric(Data):
             spatial_by_name,
             key=lambda name: channels_by_name[name] * int(np.prod(spatial_by_name[name], dtype=np.int64)),
         )
-        if isinstance(self.memory_budget, str) and self.memory_budget.strip().lower() == "auto":
+        if self.memory_budget is None or (
+            isinstance(self.memory_budget, str) and self.memory_budget.strip().lower() == "auto"
+        ):
             node_bytes, _source = available_memory_bytes()
             budget = node_bytes * _AUTO_MEMORY_SAFETY_FRACTION
         else:
@@ -1693,8 +1712,7 @@ class DataMetric(Data):
             groups_src=groups_src,
             patch=None,
             # Evaluation reads each case exactly once (no augmentations, one pass): a cache is never
-            # re-read, it only fronts the whole dataset's RAM. Stream instead; a ``memory_budget``
-            # whose fit-test passes may still flip the cache on.
+            # re-read, it only fronts the whole dataset's RAM. Stream.
             use_cache=False,
             subset=subset,
             batch_size=1,

--- a/tests/assets/Workflows/Config.yml
+++ b/tests/assets/Workflows/Config.yml
@@ -60,7 +60,6 @@ Trainer:
     dataset_filenames:
       - __DATASET_DIR__:a:mha
     inline_augmentations: false
-    use_cache: false
     batch_size: 16
     validation: 0.25
   train_name: __TRAIN_NAME__

--- a/tests/assets/Workflows/Evaluation.yml
+++ b/tests/assets/Workflows/Evaluation.yml
@@ -32,5 +32,4 @@ Evaluator:
       - __DATASET_DIR__:a:mha
       - __PREDICTIONS_DATASET_DIR__:i:mha
     batch_size: 4
-    use_cache: false
   train_name: __TRAIN_NAME__

--- a/tests/assets/Workflows/Prediction.yml
+++ b/tests/assets/Workflows/Prediction.yml
@@ -22,7 +22,6 @@ Predictor:
     filter: None
     dataset_filenames:
       - __DATASET_DIR__:a:mha
-    use_cache: false
     batch_size: 16
   outputs_dataset:
     Head:Tanh:

--- a/tests/integration/test_konfai_streamed_evaluation.py
+++ b/tests/integration/test_konfai_streamed_evaluation.py
@@ -87,7 +87,6 @@ EVALUATION_TEMPLATE = """Evaluator:
     dataset_filenames:
       - __DATASET_DIR__:a:mha
       - __PREDICTIONS_DIR__:i:mha
-    use_cache: false
   train_name: __TRAIN_NAME__
 """
 

--- a/tests/unit/test_dataset_streaming.py
+++ b/tests/unit/test_dataset_streaming.py
@@ -306,7 +306,10 @@ def test_dataset_iter_streams_patch_reads_when_cache_disabled() -> None:
 
 
 def test_data_train_enables_worker_prefetch_when_cache_is_disabled() -> None:
-    dataset = DataTrain(use_cache=False, augmentations=None)
+    # The cache regime is no longer a config knob; the budget resolver flips it through the same
+    # re-entry point used here.
+    dataset = DataTrain(augmentations=None)
+    dataset._configure_data_loading(use_cache=False)
 
     assert cast(int, dataset.dataLoader_args["num_workers"]) >= 1
     assert dataset.dataLoader_args["prefetch_factor"] == 2

--- a/tests/unit/test_dataset_streaming.py
+++ b/tests/unit/test_dataset_streaming.py
@@ -306,8 +306,7 @@ def test_dataset_iter_streams_patch_reads_when_cache_disabled() -> None:
 
 
 def test_data_train_enables_worker_prefetch_when_cache_is_disabled() -> None:
-    # The cache regime is no longer a config knob; the budget resolver flips it through the same
-    # re-entry point used here.
+    # The budget resolver flips the regime through this same re-entry point.
     dataset = DataTrain(augmentations=None)
     dataset._configure_data_loading(use_cache=False)
 

--- a/tests/unit/test_memory_budget.py
+++ b/tests/unit/test_memory_budget.py
@@ -180,13 +180,28 @@ def test_budget_smaller_than_dataset_does_not_cache() -> None:
     assert data.resolved_num_workers > 0  # the streaming/buffer path spins workers up
 
 
-def test_none_budget_leaves_declared_use_cache_untouched() -> None:
-    train = _make_train(None)
-    train.use_cache = True
-    train._resolve_cache_regime(world_size=1)
-    assert train.use_cache is True  # compat default: the declared regime is honoured verbatim
+def test_none_budget_means_auto_for_training(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No key declared -> "auto": the tiny dataset fits the detected memory, so training caches; on
+    # a node too small for it, the same absent key streams instead of blowing past the RAM.
+    roomy = _make_train(None)
+    monkeypatch.setattr(data_manager, "available_memory_bytes", lambda: (_DATASET_BYTES * 10, "host"))
+    roomy._resolve_cache_regime(world_size=1)
+    assert roomy.use_cache is True
 
-    prediction = DataPrediction(augmentations=None)  # use_cache hardwired False, memory_budget None
+    tight = _make_train(None)
+    monkeypatch.setattr(
+        data_manager,
+        "available_memory_bytes",
+        lambda: (int(_DATASET_BYTES / _AUTO_MEMORY_SAFETY_FRACTION) - 1, "cgroup limit"),
+    )
+    tight._resolve_cache_regime(world_size=1)
+    assert tight.use_cache is False
+
+
+def test_one_pass_workflows_never_cache_whatever_the_budget() -> None:
+    # Prediction and evaluation read each case exactly once: a cache is never re-read, so even a
+    # budget the dataset comfortably fits keeps them on the stream/buffer path.
+    prediction = DataPrediction(augmentations=None, memory_budget=f"{_DATASET_BYTES * 100}b")
     prediction._prepared_data = {"CT": [SimpleNamespace(base_shape=[1, 2, 2, 2])]}  # type: ignore[assignment]
     prediction._prepared_validation_data = {}
     prediction._prepared_train_names = ["case_a"]


### PR DESCRIPTION
**Loading-regime slice** (`c3854ba..9780c13`), stacked on #52.

- Stream evaluation data instead of caching the dataset.
- Retire the `use_cache` config knob.
- A missing `memory_budget` means `auto` (one memory lever).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Loading behavior now adapts automatically to available memory and dataset size.
  * Training selects cache/stream/buffer modes using `memory_budget` (with `auto` support).
  * Prediction and evaluation run in one-pass streaming/buffering regardless of budget, with evaluation using budget-based automatic patch sizing and recombining metrics to exact whole-case values.
* **Documentation**
  * Updated config guides, streaming concepts, troubleshooting, and large-image guidance to reflect the new `memory_budget`-centric regime model; refreshed example configs accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->