### PR TITLE
feat(predict): streamed TTA, the perf cluster, and the audit/review follow-up

### DIFF
--- a/docs/source/concepts/streaming.md
+++ b/docs/source/concepts/streaming.md
@@ -12,9 +12,9 @@ every kind but a resample, which gathers the same samples through a different
 coordinate frame and lands within the tolerance stated below. They differ in
 memory and speed.
 
-A 16 GiB uncompressed `.mha` at patch 64³, batch 2, two workers, cache off,
-under an 8 GiB memory cap trains at a peak anonymous RSS of **0.46 GiB**, stable
-across epochs, with VRAM equal to one batch.
+A 16 GiB uncompressed `.mha` at patch 64³, batch 2, two workers, under an 8 GiB
+`memory_budget` (below the dataset size, so the run streams) trains at a peak
+anonymous RSS of **0.46 GiB**, stable across epochs, with VRAM equal to one batch.
 
 ## The three regimes
 

--- a/docs/source/concepts/streaming.md
+++ b/docs/source/concepts/streaming.md
@@ -190,9 +190,18 @@ These transforms load the volume because their answer needs it:
   a patch cannot locate itself in.
 - `Clip` with percentile bounds needs the whole histogram, as does
   `HistogramMatching`.
-- `Save` writes the whole preprocessed volume. A `Save` whose cache already
-  exists becomes the streaming source instead, and only the transforms after it
-  are planned.
+- `Save` writes the whole preprocessed volume — but rarely loads it. A `Save`
+  whose cache exists becomes the streaming source, and only the transforms
+  after it are planned. A `Save` whose cache is missing is **materialized slab
+  by slab** when the transforms before it stream: each slab of the Save's own
+  space is read through the composed region plan and region-written, the entry
+  appears only once complete, and the case then streams from it as if the
+  cache had always existed. This runs the prefix once — instead of once per
+  patch per epoch — and lets a global statistic seed after a value-changing
+  stage (`[Clip, Save, Standardize]` streams; `[Clip, Standardize]` cannot).
+  Only a `Save` fed by an unstreamable prefix, or writing to a format without
+  region writes (anything but uncompressed `mha`, `h5`, OME-Zarr), still loads
+  the volume.
 - `Argmax`, `Softmax`, and `Sum` over a spatial `dim` reduce across the whole
   extent.
 - `Canonical` on an oblique direction resamples.

--- a/docs/source/config_guide/prediction.md
+++ b/docs/source/config_guide/prediction.md
@@ -106,7 +106,9 @@ out-of-memory the run reads what the failed forward cost (the measurement is
 free — it already ran), shrinks the free axes by that ratio (pinned axes never
 move), re-plans the patch grid and re-runs the rank's cases — typically one
 restart. The chosen size also reserves room for the accumulation, so the blend
-stays on the GPU. `overlap` accepts voxels, a fraction (`0.2`), a percent string
+stays on the GPU; when that reservation cannot fit (or cannot be measured), the
+forward is sized alone and the writer blends on the host instead. `overlap`
+accepts voxels, a fraction (`0.2`), a percent string
 (`"20%"`) or a per-axis list, resolved after the size; an axis a single patch
 spans gets none. A `patch_size` without a `0` is never resized: the OOM
 propagates.

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -98,8 +98,12 @@ If the split looks wrong, check which form your config is actually using.
 ### The streaming regime still uses memory proportional to a case
 
 The stream/buffer regime bounds retention across cases; direct regional reads depend
-on the transforms. The current fast path supports `TensorCast` and unmasked
-`Normalize`, `Standardize`, and `Clip`. Other transforms and augmentations use
+on the transforms. Any chain of pointwise transforms (`TensorCast`, unmasked
+`Normalize`/`Standardize`/`Clip`) and region transforms (`Flip`, `Permute`,
+`Canonical`, `Padding`, `ResampleToShape`/`ResampleToResolution`, `Dilate`,
+`Gradient`) streams — each declares its locality (see the transform reference).
+A transform that reads a second volume (`Mask`, masked `Clip`/`Standardize`), a
+global histogram (`HistogramMatching`), or an undeclared custom transform uses
 the bounded full-volume path.
 
 Reduce the transform chain to identify the boundary, or materialise expensive

--- a/docs/source/usage/large-images.md
+++ b/docs/source/usage/large-images.md
@@ -94,7 +94,10 @@ The backend must also serve a disk region efficiently. HDF5 and OME-Zarr do so
 natively, DICOM reads selected slices, and SimpleITK supports regional reads for
 uncompressed MetaImage and non-gzipped NIfTI. Compressed/unsupported formats
 still return correct patches but may decode the volume for every request, with
-a warning. The complete planner rules, built-in declarations, equivalence
+a warning. A single-store HDF5 file is serialized per process: a streamed write
+into it (a `Save` materialization, a prediction sink) holds the store for its
+whole duration, so same-process threads reading other cases from that file wait.
+The complete planner rules, built-in declarations, equivalence
 tolerances, and custom-transform contract live in {doc}`../concepts/streaming`.
 
 ## OME-Zarr layout and levels
@@ -175,9 +178,10 @@ slab by slab without ever being held whole. A masked finalize (`Mask`) streams
 too: each slab reads only its aligned mask region. What streaming cannot honour
 (a whole-volume transform or a destination without region writes) splits
 instead: the pointwise prefix still streams into a light post-reduction buffer
-and the remaining stages run once on it. Only several augmentations (TTA inverses
-apply to the assembled volume) or a non-voxel-local reduction keep the
-whole-volume path. A streamed case is voxel-identical to the assembled path on a
+and the remaining stages run once on it. Only a TTA draw whose inverse moves the
+slab axis (a z-flip, a z-moving permute), a TTA case too light to be worth the
+slab-synchronized reduce, or a non-voxel-local reduction keep the whole-volume
+path. A streamed case is voxel-identical to the assembled path on a
 given device, except a linear-resample inverse, which streams by default and
 matches the whole-volume `F.interpolate` to float rounding rather than
 bit-for-bit. `KONFAI_STREAMED_WRITES=0` forces the whole-volume path globally.

--- a/docs/source/usage/large-images.md
+++ b/docs/source/usage/large-images.md
@@ -183,6 +183,15 @@ transcendental-terminated float chain can differ by ~1 ULP between a GPU window
 and a CPU whole-volume run. `KONFAI_STREAMED_WRITES=0` forces the whole-volume
 path globally.
 
+Streaming bounds the reassembly *accumulator*, not the *reduction*. A
+multi-model ensemble with `combine: Concat` — used when the members must stay
+separate, e.g. to write an `InferenceStack` for uncertainty — keeps every
+member's channels resident through the finalize, so on a large volume the
+channel-reduction working set, not the accumulator, is the memory peak, and
+streaming does not shrink it. For a memory-tight run, `combine: Mean` (or
+`Median`) collapses the members first and streams within a patch window; keep
+`combine: Concat` only when you need the per-member stack.
+
 ## Verify the behaviour you care about
 
 Do not infer streaming from a successful run alone—the fallback is designed to

--- a/docs/source/usage/large-images.md
+++ b/docs/source/usage/large-images.md
@@ -43,7 +43,9 @@ lead each case and augmentation draw to one of three regimes:
 | **Stream** | predict/eval default or budget exceeded; chain streamable | The source region for one patch. |
 | **Buffer** | same triggers; the chain needs a whole volume | A FIFO of `max(batch_size + 1, shuffle_window)` cases. |
 
-`memory_budget` replaces the workflow's default regime in any workflow.
+`memory_budget` drives the memory lever of each workflow: in **training** it
+chooses cache versus stream/buffer; in **evaluation** it sizes the auto-patch.
+Prediction and evaluation are always one-pass (stream/buffer), never cached.
 A number is interpreted as GiB, strings may include units, and `auto` offers
 80% of the detected per-rank memory limit. It is a size estimate—not a hard
 allocator limit—because transformed shapes, augmented copies, and transient
@@ -84,11 +86,12 @@ requested output patch back to the source region on disk.
 | Rescale | `ResampleToShape`, `ResampleToResolution` | Map through scale and add interpolation context. |
 | Whole volume | masked transforms, histogram matching, arbitrary displacement | Use the bounded buffer. |
 
-One region stage may appear in a streamable chain. Two remaps/halos/rescales,
-an undeclared custom transform, an excessively large halo, or a global
-statistic after a value-changing stage selects the safe whole-volume path.
-`WHOLE_VOLUME` is the default for custom transforms, so missing locality
-metadata reduces performance rather than silently changing results.
+Region stages compose — any number of them, each pulling its read through the
+one before it — so a chain of remaps/halos/rescales still streams. An undeclared
+custom transform, an excessively large halo, or a global statistic after a
+value-changing stage selects the safe whole-volume path. `WHOLE_VOLUME` is the
+default for custom transforms, so missing locality metadata reduces performance
+rather than silently changing results.
 
 The backend must also serve a disk region efficiently. HDF5 and OME-Zarr do so
 natively, DICOM reads selected slices, and SimpleITK supports regional reads for

--- a/docs/source/usage/large-images.md
+++ b/docs/source/usage/large-images.md
@@ -183,14 +183,19 @@ transcendental-terminated float chain can differ by ~1 ULP between a GPU window
 and a CPU whole-volume run. `KONFAI_STREAMED_WRITES=0` forces the whole-volume
 path globally.
 
-Streaming bounds the reassembly *accumulator*, not the *reduction*. A
-multi-model ensemble with `combine: Concat` — used when the members must stay
-separate, e.g. to write an `InferenceStack` for uncertainty — keeps every
-member's channels resident through the finalize, so on a large volume the
-channel-reduction working set, not the accumulator, is the memory peak, and
-streaming does not shrink it. For a memory-tight run, `combine: Mean` (or
-`Median`) collapses the members first and streams within a patch window; keep
-`combine: Concat` only when you need the per-member stack.
+Streaming bounds the reassembly *accumulator* and the streamable finalize
+stages, but one stage stays whole-volume by choice: a **float (linear)
+resample inverse**. The streamed resample is bit-identical to the whole-volume
+`F.interpolate` only in `nearest` mode, so a linear resample — resampling
+probabilities/logits back to the native grid, before an `argmax` — is run once
+on the whole volume rather than trade exactness for a window. On a large
+multi-class output that whole-volume `F.interpolate` is the memory peak (tens
+of GB), and a `combine: Concat` ensemble makes it worse by keeping every
+member's channels in the tensor being resampled. To bound it on a memory-tight
+run: resample the `argmax`'d labels (a `nearest`, streaming resample) instead
+of the probabilities where the task allows, and use `combine: Mean`/`Median` to
+collapse the members first; keep `combine: Concat` only when you need the
+per-member stack.
 
 ## Verify the behaviour you care about
 

--- a/docs/source/usage/large-images.md
+++ b/docs/source/usage/large-images.md
@@ -211,7 +211,9 @@ implemented and tested; general speedup claims require separate evidence.
 - **RSS still scales with case size:** the planner selected the bounded
   whole-volume path for that case or augmentation draw. Inspect the locality
   rules, or preprocess the unsupported operation once with `Save` and stream
-  from that materialised dataset.
+  from that materialised dataset. The `Save` itself streams: when the
+  transforms before it stream, its cache is written slab by slab on first
+  access — the volume is never assembled, even the first time.
 - **OME-Zarr is slow:** inspect chunk shape, compression, pyramid level, worker
   count, and overlap. Avoid assuming more workers always improve remote storage.
 - **Output seams are visible:** add overlap and select a compatible

--- a/docs/source/usage/large-images.md
+++ b/docs/source/usage/large-images.md
@@ -171,31 +171,29 @@ a `Canonical`/`Flip`/`Permute` inverse remaps each slab to its written region, a
 `Padding` inverse crops it in flight, a `ResampleToResolution`/`ResampleToShape`
 inverse resamples back through a sliding window — chained in any number, each
 pulling through the next — so a huge output at ORIGINAL resolution is written
-slab by slab without ever being held whole. What streaming cannot honour (a
-whole-volume transform, a float resample — whose interpolation is only bit-equal
-whole-volume — or a destination without region writes) splits instead: the
-pointwise prefix still streams into a light post-reduction buffer and the
-remaining stages run once on it. Only several augmentations (TTA inverses apply
-to the assembled volume) or a non-voxel-local reduction keep the whole-volume
-path. Every streamed or split case is voxel-identical to the
-assembled path on a given device; as with the assembled path, only a
-transcendental-terminated float chain can differ by ~1 ULP between a GPU window
-and a CPU whole-volume run. `KONFAI_STREAMED_WRITES=0` forces the whole-volume
-path globally.
+slab by slab without ever being held whole. A masked finalize (`Mask`) streams
+too: each slab reads only its aligned mask region. What streaming cannot honour
+(a whole-volume transform or a destination without region writes) splits
+instead: the pointwise prefix still streams into a light post-reduction buffer
+and the remaining stages run once on it. Only several augmentations (TTA inverses
+apply to the assembled volume) or a non-voxel-local reduction keep the
+whole-volume path. A streamed case is voxel-identical to the assembled path on a
+given device, except a linear-resample inverse, which streams by default and
+matches the whole-volume `F.interpolate` to float rounding rather than
+bit-for-bit. `KONFAI_STREAMED_WRITES=0` forces the whole-volume path globally.
 
-Streaming bounds the reassembly *accumulator* and the streamable finalize
-stages, but one stage stays whole-volume by choice: a **float (linear)
-resample inverse**. The streamed resample is bit-identical to the whole-volume
-`F.interpolate` only in `nearest` mode, so a linear resample — resampling
-probabilities/logits back to the native grid, before an `argmax` — is run once
-on the whole volume rather than trade exactness for a window. On a large
-multi-class output that whole-volume `F.interpolate` is the memory peak (tens
-of GB), and a `combine: Concat` ensemble makes it worse by keeping every
-member's channels in the tensor being resampled. To bound it on a memory-tight
-run: resample the `argmax`'d labels (a `nearest`, streaming resample) instead
-of the probabilities where the task allows, and use `combine: Mean`/`Median` to
-collapse the members first; keep `combine: Concat` only when you need the
-per-member stack.
+A **float (linear) resample inverse** — resampling probabilities/logits back to
+the native grid before an `argmax` — streams within the sliding window by
+default like the other geometry inverses. On a large multi-class output the
+whole-volume `F.interpolate` is otherwise the memory peak (tens of GB), and a
+`combine: Concat` ensemble makes it worse by keeping every member's channels in
+the tensor being resampled; streaming bounds both. It matches the whole-volume
+`F.interpolate` to float rounding, not bit-for-bit — `argmax`'d labels absorb it
+(a boundary voxel or two may flip; a raw float output differs by ~float-rounding).
+Set `KONFAI_STREAM_LINEAR_RESAMPLE=0` to force the exact whole-volume linear
+resample when you need bit-identity or the per-member stack; resampling the
+`argmax`'d labels (a `nearest`, streaming resample) or collapsing members with
+`combine: Mean`/`Median` first also avoids the peak.
 
 ## Verify the behaviour you care about
 

--- a/konfai-mcp/konfai_mcp/server_jobs.py
+++ b/konfai-mcp/konfai_mcp/server_jobs.py
@@ -174,7 +174,7 @@ def _extract_error_excerpt(log_path: Path, max_scan_lines: int = 400) -> str | N
         excerpt += (
             " [KonfAI hint] A DataLoader worker crashed, so the real error is hidden by multiprocessing "
             "(usually out-of-memory, or an exception inside a dataset transform). Re-run with "
-            "'Dataset.num_workers: 0' (or 'Dataset.use_cache: true', which also loads without workers) to "
+            "'Dataset.num_workers: 0' to "
             "surface the real traceback; if it then trains, the crash was worker memory pressure — reduce "
             "Dataset.num_workers, batch_size, or patch_size."
         )

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -1721,8 +1721,11 @@ class DataMetric(Data):
             # The auto budget is the NODE's memory, shared by every rank evaluating on it. Sizing runs
             # at build time -- before the spawn where world_size exists -- so the launcher leaves the
             # per-node rank count in the environment (an explicit budget is per-rank by contract, and a
-            # direct-API caller without the launcher keeps today's undivided behaviour).
-            budget //= max(1, int(os.environ.get("KONFAI_LOCAL_RANKS", "1")))
+            # caller without the launcher -- or with a garbled variable -- keeps the undivided default).
+            try:
+                budget //= max(1, int(os.environ.get("KONFAI_LOCAL_RANKS", "1")))
+            except ValueError:
+                pass
         sized = resolve_patch(
             [0] * len(spatial_by_name[worst]),
             spatial_by_name[worst],

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -326,7 +326,7 @@ class GroupMetric(dict[str, GroupTransformMetric]):
         super().__init__(groups_dest)
 
 
-def _interleaved_case_entries(patch: "DatasetPatch", entries: list[tuple[int, int]]) -> list[tuple[int, int]]:
+def _interleaved_case_entries(patches: list["DatasetPatch"], entries: list[tuple[int, int]]) -> list[tuple[int, int]]:
     """One case's ``(copy, patch)`` entries ordered so the copies advance together along the slab axis.
 
     A streamed TTA write reduces the copies slab by slab, so it can only advance to the slowest
@@ -335,8 +335,23 @@ def _interleaved_case_entries(patch: "DatasetPatch", entries: list[tuple[int, in
     skew at one patch extent, whatever grid each copy was cut on. The sort is total on
     ``(start, copy, patch)``, so within a copy the order is untouched — per-copy accumulation is
     byte-identical either way, and the whole-volume path reduces at the end whatever the order.
+
+    ``patches`` holds every destination group's grid for the case: one shared order must serve them
+    all, so if the groups disagree on the slab starts — or a group cannot even index an entry — the
+    plain order is kept. The interleave is a memory bound, never a correctness requirement.
     """
-    return sorted(entries, key=lambda entry: (patch.get_patch_slices(entry[0])[entry[1]][0].start, *entry))
+
+    def starts(patch: "DatasetPatch") -> list[int] | None:
+        try:
+            return [patch.get_patch_slices(copy)[index][0].start for copy, index in entries]
+        except (IndexError, KeyError):
+            return None
+
+    reference = starts(patches[0])
+    if reference is None or any(starts(patch) != reference for patch in patches[1:]):
+        return entries
+    order = dict(zip(entries, reference, strict=True))
+    return sorted(entries, key=lambda entry: (order[entry], *entry))
 
 
 class WindowedCaseSampler(Sampler[int]):
@@ -1416,7 +1431,7 @@ class Data(ABC):
         for x in range(nb_dataset):
             entries = [(y, z) for y in range(nb_augmentation) for z in range(nb_patch[x][y])]
             if interleave:
-                entries = _interleaved_case_entries(data[next(reversed(data))][x].patch, entries)
+                entries = _interleaved_case_entries([managers[x].patch for managers in data.values()], entries)
             mapping.extend((x, y, z) for y, z in entries)
         return data, mapping
 

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -1426,8 +1426,9 @@ class Data(ABC):
 
         # PREDICTION walks the mapping in order, and the copies of a TTA case must advance together
         # along the slab axis for the streamed write to hold a bounded window (see
-        # ``_interleaved_case_entries``). TRAIN shuffles the mapping anyway and keeps the plain order.
-        interleave = nb_augmentation > 1 and konfai_state() == str(State.PREDICTION)
+        # ``_interleaved_case_entries``). TRAIN shuffles the mapping anyway and keeps the plain
+        # order — as does a dataset prepared outside any workflow, where no state is set at all.
+        interleave = nb_augmentation > 1 and os.environ.get("KONFAI_STATE") == str(State.PREDICTION)
         for x in range(nb_dataset):
             entries = [(y, z) for y in range(nb_augmentation) for z in range(nb_patch[x][y])]
             if interleave:

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -1716,7 +1716,13 @@ class DataMetric(Data):
             spatial_by_name,
             key=lambda name: channels_by_name[name] * int(np.prod(spatial_by_name[name], dtype=np.int64)),
         )
-        budget, _budget_desc, _is_auto = self._resolved_budget_bytes()
+        budget, _budget_desc, is_auto = self._resolved_budget_bytes()
+        if is_auto:
+            # The auto budget is the NODE's memory, shared by every rank evaluating on it. Sizing runs
+            # at build time -- before the spawn where world_size exists -- so the launcher leaves the
+            # per-node rank count in the environment (an explicit budget is per-rank by contract, and a
+            # direct-API caller without the launcher keeps today's undivided behaviour).
+            budget //= max(1, int(os.environ.get("KONFAI_LOCAL_RANKS", "1")))
         sized = resolve_patch(
             [0] * len(spatial_by_name[worst]),
             spatial_by_name[worst],

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -1078,6 +1078,14 @@ class Data(ABC):
             return None
         return [max(int(shape[axis]) for shape in shapes) for axis in range(len(shapes[0]))]
 
+    def set_free_axis_multiple(self, multiple: list[int] | None) -> None:
+        """Record the model's per-axis downsampling factor on the shared patch BEFORE ``prepare()`` cuts
+        the grids, so every case's free (``0``) axis rounds up to a valid model input. A no-op without a
+        patch (evaluation) or without a free axis; harmless once a re-plan has made the sizes concrete.
+        """
+        if self.patch is not None:
+            self.patch.free_axis_multiple = multiple
+
     def replan_patch(self, patch_size: list[int]) -> None:
         """Re-cut every prepared grid for a new GLOBAL patch size (the OOM-restart path).
 

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -880,9 +880,6 @@ class Data(ABC):
         self.batch_size = batch_size
         self.inline_augmentations = inline_augmentations
         self.memory_budget = memory_budget
-        # The evaluation workflow may veto budget-driven auto-patching (a non-reducible metric
-        # needs whole volumes); harmless default for every other workflow.
-        self.auto_patch_allowed = True
         self.requires_single_process_loading = self._groups_require_single_process_loading(groups_src)
 
         # A window keeps ``shuffle_window`` cases resident, so the FIFO buffer must be at least that
@@ -906,6 +903,23 @@ class Data(ABC):
         self._prepared_validation_mapping: list[tuple[int, int, int]] = []
         self._prepared_train_names: list[str] = []
         self._prepared_validation_names: list[str] = []
+
+    def _resolved_budget_bytes(self) -> tuple[float, str, bool]:
+        """The configured memory budget as ``(bytes, description, is_auto)``.
+
+        ``None``/``"auto"`` offers ``_AUTO_MEMORY_SAFETY_FRACTION`` of the node's allocatable
+        memory — a NODE budget, which ranks sharing the node split; an explicit budget is the
+        caller's own figure, taken as is."""
+        if self.memory_budget is None or (
+            isinstance(self.memory_budget, str) and self.memory_budget.strip().lower() == "auto"
+        ):
+            node_bytes, source = available_memory_bytes()
+            return (
+                node_bytes * _AUTO_MEMORY_SAFETY_FRACTION,
+                f"auto: {_format_gib(node_bytes)} {source} x {_AUTO_MEMORY_SAFETY_FRACTION:.0%}",
+                True,
+            )
+        return float(_parse_memory_budget_bytes(self.memory_budget)), f"{self.memory_budget!r}", False
 
     def _configure_data_loading(self, use_cache: bool) -> None:
         """Build the loader from the cache regime: the DatasetIter factory and the worker settings.
@@ -989,15 +1003,9 @@ class Data(ABC):
         dataset_bytes = self._estimate_cached_bytes()
         per_rank_bytes = dataset_bytes / world_size
 
-        if self.memory_budget is None or (
-            isinstance(self.memory_budget, str) and self.memory_budget.strip().lower() == "auto"
-        ):
-            node_bytes, source = available_memory_bytes()
-            per_rank_budget = node_bytes * _AUTO_MEMORY_SAFETY_FRACTION / world_size
-            budget_desc = f"auto: {_format_gib(node_bytes)} {source} x {_AUTO_MEMORY_SAFETY_FRACTION:.0%}, per-rank"
-        else:
-            per_rank_budget = float(_parse_memory_budget_bytes(self.memory_budget))
-            budget_desc = f"{self.memory_budget!r}, per-rank"
+        budget, budget_desc, is_auto = self._resolved_budget_bytes()
+        per_rank_budget = budget / world_size if is_auto else budget
+        budget_desc = f"{budget_desc}, per-rank"
 
         use_cache = per_rank_bytes <= per_rank_budget
         self._configure_data_loading(use_cache)
@@ -1671,10 +1679,13 @@ class DataMetric(Data):
     #: fraction absorbs the rest.
     _METRIC_INTERMEDIATE_FACTOR = 2.0
 
+    # The evaluator clears this when any of its metrics is not reducible: that metric needs whole
+    # volumes, so the budget sizing must not cut the case.
+    auto_patch_allowed = True
+
     def _maybe_auto_patch(self) -> None:
-        # A missing budget means "auto": evaluation bounds itself by default. An explicit patch or a
-        # non-reducible metric (auto_patch_allowed) vetoes the sizing.
-        if self.patch is not None or not getattr(self, "auto_patch_allowed", True):
+        # An explicit patch or a non-reducible metric vetoes the sizing.
+        if self.patch is not None or not self.auto_patch_allowed:
             return
         sources = self._resolve_dataset_sources()
         # Header-only scan: for each case, its resident bytes per spatial voxel is the sum of its
@@ -1697,13 +1708,7 @@ class DataMetric(Data):
             spatial_by_name,
             key=lambda name: channels_by_name[name] * int(np.prod(spatial_by_name[name], dtype=np.int64)),
         )
-        if self.memory_budget is None or (
-            isinstance(self.memory_budget, str) and self.memory_budget.strip().lower() == "auto"
-        ):
-            node_bytes, _source = available_memory_bytes()
-            budget = node_bytes * _AUTO_MEMORY_SAFETY_FRACTION
-        else:
-            budget = float(_parse_memory_budget_bytes(self.memory_budget))
+        budget, _budget_desc, _is_auto = self._resolved_budget_bytes()
         sized = resolve_patch(
             [0] * len(spatial_by_name[worst]),
             spatial_by_name[worst],

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -326,6 +326,19 @@ class GroupMetric(dict[str, GroupTransformMetric]):
         super().__init__(groups_dest)
 
 
+def _interleaved_case_entries(patch: "DatasetPatch", entries: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    """One case's ``(copy, patch)`` entries ordered so the copies advance together along the slab axis.
+
+    A streamed TTA write reduces the copies slab by slab, so it can only advance to the slowest
+    copy's frontier: walked copy-major, the first copy would be complete — and fully retained —
+    before the second began. Ordering by each patch's declared first-spatial-axis start bounds that
+    skew at one patch extent, whatever grid each copy was cut on. The sort is total on
+    ``(start, copy, patch)``, so within a copy the order is untouched — per-copy accumulation is
+    byte-identical either way, and the whole-volume path reduces at the end whatever the order.
+    """
+    return sorted(entries, key=lambda entry: (patch.get_patch_slices(entry[0])[entry[1]][0].start, *entry))
+
+
 class WindowedCaseSampler(Sampler[int]):
     """Locality-aware training order: shuffle cases, window them, shuffle patches within each window.
 
@@ -1375,7 +1388,7 @@ class Data(ABC):
         nb_dataset = len(names)
         nb_patch: list[list[int]]
         data = {}
-        mapping = []
+        mapping: list[tuple[int, int, int]] = []
         source_filename_by_group = self._get_source_filename_by_group(dataset_name)
         nb_augmentation = self._get_nb_augmentation(data_augmentations_list)
 
@@ -1396,10 +1409,15 @@ class Data(ABC):
                 ]
                 nb_patch = [[dataset.get_size(a) for a in range(nb_augmentation)] for dataset in data[group_dest]]
 
+        # PREDICTION walks the mapping in order, and the copies of a TTA case must advance together
+        # along the slab axis for the streamed write to hold a bounded window (see
+        # ``_interleaved_case_entries``). TRAIN shuffles the mapping anyway and keeps the plain order.
+        interleave = nb_augmentation > 1 and konfai_state() == str(State.PREDICTION)
         for x in range(nb_dataset):
-            for y in range(nb_augmentation):
-                for z in range(nb_patch[x][y]):
-                    mapping.append((x, y, z))
+            entries = [(y, z) for y in range(nb_augmentation) for z in range(nb_patch[x][y])]
+            if interleave:
+                entries = _interleaved_case_entries(data[next(reversed(data))][x].patch, entries)
+            mapping.extend((x, y, z) for y, z in entries)
         return data, mapping
 
     def get_groups_dest(self):

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -1226,7 +1226,9 @@ class DatasetManager:
         for stage in stages:
             loc = stage.patch_locality(Attribute(evolved))
             localities.append(loc)
-            if loc.kind is LocalityKind.WHOLE_VOLUME:
+            if loc.kind in (LocalityKind.WHOLE_VOLUME, LocalityKind.SLAB):
+                # SLAB is a write-side contract: its side effect needs the slab's place in the
+                # OUTPUT, which a patch read has no notion of.
                 return False, ()
             if loc.kind is LocalityKind.GLOBAL_STAT:
                 # The seed is the STORED volume's statistic, which is this transform's input only when

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -17,7 +17,6 @@
 """Patch extraction, accumulation, and patch-combination helpers for KonfAI."""
 
 import copy
-import os
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator
@@ -37,6 +36,7 @@ from konfai.utils.errors import PatchError
 from konfai.utils.utils import (
     SUPPORTED_EXTENSIONS,
     OverlapSpec,
+    env_flag,
     get_module,
     get_patch_slices_from_shape,
     resolve_overlap,
@@ -209,9 +209,8 @@ class _PatchStreamSource:
 @dataclass(frozen=True)
 class _PendingSweep:
     """One unsatisfied :class:`Save` and the segment that feeds it. Materializing reads each slab of
-    the Save's own space through the segment and region-writes it to ``destination``, after which the
-    Save is a satisfied source boundary. The segment is re-planned at sweep time — its source is
-    materialized by then, so a deferred statistic seeds from the real entry."""
+    the Save's own space through the segment — re-planned at sweep time, see ``_materialize_save`` —
+    and region-writes it to ``destination``, after which the Save is a satisfied source boundary."""
 
     destination: Dataset
     group: str
@@ -373,26 +372,35 @@ class Accumulator:
         self._weight_patch: torch.Tensor | None = None
         self._weighted: torch.Tensor | None = None
 
-    def add_layer(self, index: int, layer: torch.Tensor) -> list[tuple[slice, torch.Tensor]] | None:
+    def add_layer(self, index: int, layer: torch.Tensor) -> list[tuple[slice, torch.Tensor]]:
+        """Blend one patch in; returns the slabs this completes (none for the whole-volume base)."""
         # Blend each patch straight into the running accumulator and drop the patch, rather than
         # storing all patches for a single assemble() at the end. The overlap blend is a weighted sum,
         # so accumulating incrementally is equivalent; re-adding an index is a no-op (last-write wins is
         # not possible once blended, and the prediction pipeline adds each patch exactly once).
         if self._done[index]:
-            return None
-        n = self._n
+            return []
         if self._result is None:
             # Allocate to the ACTUAL volume extent (self.shape), not the patch-size-extended grid. The
             # last patch of each axis is padded up to patch_size for the model, but that padded tail lies
             # OUTSIDE the volume; blending it would over-allocate the accumulator by up to
             # (patch_size - overlap) per axis (then get cropped away). We crop each patch to its in-volume
             # part at blend time instead, so nothing outside the volume is ever allocated.
+            n = self._n
             self._result = torch.zeros(list(layer.shape[:n]) + list(self.shape), dtype=layer.dtype, device=layer.device)
             if self.patch_combine is not None:
                 # Match the result dtype so the final ``result / weight_sum`` does not promote the whole
                 # (channels x volume) accumulator to float32.
                 self._weight_sum = torch.zeros(list(self.shape), dtype=layer.dtype, device=layer.device)
-        patch_slice = self.patch_slices[index]
+        self._blend(layer, self.patch_slices[index])
+        self._done[index] = True
+        self._filled += 1
+        return []
+
+    def _blend(self, layer: torch.Tensor, patch_slice: tuple[slice, ...], row_offset: int = 0) -> None:
+        """Blend one patch at its in-volume destination, ``row_offset`` rows down on the first spatial
+        axis (the streaming window origin — 0 for the whole-volume base)."""
+        n = self._n
         data = layer
         for dim, s in enumerate(patch_slice):
             if s.stop - s.start == 1:
@@ -401,12 +409,14 @@ class Accumulator:
         # matching in-volume extent so the padded tail of border patches is discarded, not stored.
         dest = [slice(s.start, min(s.stop, self.shape[dim])) for dim, s in enumerate(patch_slice)]
         crop = tuple([slice(None)] * n + [slice(0, d.stop - d.start) for d in dest])
-        slices_dest = tuple([slice(self._result.shape[i]) for i in range(n)] + dest)
+        dest[0] = slice(dest[0].start - row_offset, dest[0].stop - row_offset)
+        slices_dest = tuple([slice(cast(torch.Tensor, self._result).shape[i]) for i in range(n)] + dest)
         # Overlap blending weights each patch (edge bands < 1 so interior overlaps sum to unity).
         # A voxel covered by fewer patches (a volume border without whole-image padding) would sum
         # to < 1 and come out darkened (x0.5 edges, x0.25 corners), so divide by the accumulated weight.
+        result = cast(torch.Tensor, self._result)
         if self.patch_combine is not None and self._weight_sum is not None:
-            self._result[slices_dest] += self._weighted_patch(data)[crop]
+            result[slices_dest] += self._weighted_patch(data)[crop]
             if self._weight_patch is None:
                 # Spatial-only ones: the weight is per-voxel, and deriving it from a channel-sized
                 # ones_like would allocate (and weight) C copies just to index one back out.
@@ -415,16 +425,13 @@ class Accumulator:
                 )
             self._weight_sum[tuple(dest)] += self._weight_patch[crop[n:]]
         else:
-            self._result[slices_dest] = data[crop]
-        self._done[index] = True
-        self._filled += 1
-        return None
+            result[slices_dest] = data[crop]
 
     def _weighted_patch(self, data: torch.Tensor) -> torch.Tensor:
-        """``patch_combine(data)`` into a staging buffer the patches share.
+        """``patch_combine(data)`` into a staging buffer the patches share, one patch-sized allocation
+        per accumulator instead of per blend.
 
-        A weighted copy per patch was one patch-sized allocation per blend; one reused buffer per
-        accumulator serves them all. The multiply stays out of place: the caller's tensor is never
+        The multiply stays out of place: the caller's tensor is never
         touched, so the OOM retry (which re-blends the same patch on the CPU) never re-weights it.
         """
         combine = cast(PathCombine, self.patch_combine)
@@ -471,13 +478,16 @@ class Accumulator:
             result.div_(self._weight_sum.clamp(min=torch.finfo(self._weight_sum.dtype).tiny))
         # No final crop: patches are cropped to the volume at blend time, so result is already self.shape.
 
+        self._reset()
+        return result
+
+    def _reset(self) -> None:
         self._result = None
         self._weight_sum = None
         self._weight_patch = None
         self._weighted = None
         self._filled = 0
         self._done = [False] * self._count
-        return result
 
 
 class StreamingAccumulator(Accumulator):
@@ -536,27 +546,7 @@ class StreamingAccumulator(Accumulator):
             )
             if self.patch_combine is not None:
                 self._weight_sum = torch.zeros(self._result.shape[n:], dtype=layer.dtype, device=layer.device)
-        data = layer
-        for dim, s in enumerate(patch_slice):
-            if s.stop - s.start == 1:
-                data = data.unsqueeze(dim=dim + n)
-        # Same blend as the parent (clamped destination, cropped patch, weighted overlap); the only
-        # difference is that the destination's first spatial index is relative to the window origin.
-        dest = [slice(s.start, min(s.stop, self.shape[dim])) for dim, s in enumerate(patch_slice)]
-        crop = tuple([slice(None)] * n + [slice(0, d.stop - d.start) for d in dest])
-        dest[0] = slice(dest[0].start - self._flushed, dest[0].stop - self._flushed)
-        slices_dest = tuple([slice(self._result.shape[i]) for i in range(n)] + dest)
-        if self.patch_combine is not None and self._weight_sum is not None:
-            self._result[slices_dest] += self.patch_combine(data)[crop]
-            if self._weight_patch is None:
-                # Spatial-only ones: the weight is per-voxel, and deriving it from a channel-sized
-                # ones_like would allocate (and weight) C copies just to index one back out.
-                self._weight_patch = self.patch_combine(
-                    torch.ones(data.shape[n:], dtype=data.dtype, device=data.device)
-                )
-            self._weight_sum[tuple(dest)] += self._weight_patch[crop[n:]]
-        else:
-            self._result[slices_dest] = data[crop]
+        self._blend(layer, patch_slice, row_offset=self._flushed)
         self._done[index] = True
         self._filled += 1
         return slabs
@@ -564,12 +554,7 @@ class StreamingAccumulator(Accumulator):
     def finalize(self) -> list[tuple[slice, torch.Tensor]]:
         """Flush the remaining window and reset for reuse; call once ``is_full()``."""
         slabs = self._advance_to(self.shape[0])
-        self._result = None
-        self._weight_sum = None
-        self._weight_patch = None
-        self._weighted = None
-        self._filled = 0
-        self._done = [False] * self._count
+        self._reset()
         self._flushed = 0
         return slabs
 
@@ -1323,8 +1308,6 @@ class DatasetManager:
                 # from the evolving 'Spacing' (a free geometry stat, no read_data_statistics).
                 return False, (), evolved
             plan = self._plan_read_stage(stage, loc, shape, evolved)
-            if plan is None:
-                return False, (), evolved
             plans.append(plan)
             shape = list(plan.out_shape)
         expected = landing_shape if landing_shape is not None else self.shapes[a]
@@ -1334,7 +1317,7 @@ class DatasetManager:
 
     def _plan_read_stage(
         self, stage: Stage, loc: PatchLocality, shape: list[int], evolved: Attribute
-    ) -> "_ReadStagePlan | None":
+    ) -> "_ReadStagePlan":
         """One stage's slot in the composed plan: its shapes, its pull map, and — for a region stage —
         the geometry it leaves for the stages after it (``write_stream_cache_attribute``)."""
         if loc.kind not in _REGION_KINDS:
@@ -1455,7 +1438,7 @@ class DatasetManager:
         whole-volume path: the segment feeding it must itself stream, and the destination must serve
         region writes (probed by capability, so a refusal costs nothing). Returns the pending sweep
         and the case state its cache will carry, which the stages after the Save plan against."""
-        if self._sweep_failed or os.environ.get("KONFAI_STREAMED_WRITES", "1").lower() in ("0", "false"):
+        if self._sweep_failed or not env_flag("KONFAI_STREAMED_WRITES", True):
             return None
         landing = [int(extent) for extent in source_shape[1:]]
         probe = Attribute(base_attributes)
@@ -1515,10 +1498,12 @@ class DatasetManager:
 
         Each slab of the Save's own space is read through the segment — the same composed replay a
         patch uses — and region-written. The segment is re-planned here: its source is materialized
-        by now, so a statistic the pending plan deferred seeds from the real entry. The cache appears
-        only when complete (a DataStream renames on finalize), so a concurrent resolve never takes a
-        partial entry as a source boundary; on failure the partial entry is removed and the case
-        falls back to the whole-volume path, which writes the cache classically."""
+        by now, so a statistic the pending plan deferred seeds from the real entry (a disk-scan seed,
+        so a GLOBAL_STAT segment matches the classic cache to float rounding — the streamed read's
+        own contract — where every other kind matches it exactly). The cache appears only when
+        complete (a DataStream renames on finalize), so a concurrent resolve never takes a partial
+        entry as a source boundary; on failure the partial entry is removed and the case falls back
+        to the whole-volume path, which writes the cache classically."""
         if sweep.destination.is_dataset_exist(sweep.group, self.name):
             return True
         streamable, stage_plans, evolved = self._plan_stream_region(
@@ -1540,8 +1525,11 @@ class DatasetManager:
         try:
             for start in range(0, spatial[0], _SWEEP_SLAB_ROWS):
                 target = (slice(start, min(start + _SWEEP_SLAB_ROWS, spatial[0])), *(slice(0, e) for e in spatial[1:]))
+                # The first slab hands a throwaway case scope to the replay so the region-geometry
+                # check runs: a region stage recording geometry nowhere the case can read refuses the
+                # sweep (PatchError -> whole-volume fallback), exactly as the patch path refuses it.
                 tensor, slab_attribute, keys_before = self._replay_streamed_region(
-                    source, target, Attribute(sweep.base_attributes), None
+                    source, target, Attribute(sweep.base_attributes), Attribute(evolved) if start == 0 else None
                 )
                 block = tensor.numpy()
                 if stream is None:
@@ -1559,11 +1547,11 @@ class DatasetManager:
                     stream.__enter__()
                 stream.write_slice((slice(0, int(block.shape[0])), *target), block)
             if stream is not None:
-                stream.__exit__(None, None, None)
+                stream.close()
             return True
         except Exception as exception:
             if stream is not None:
-                stream.__exit__(type(exception), exception, exception.__traceback__)
+                stream.abort(exception)
             warnings.warn(
                 f"Streamed materialization of Save cache '{sweep.group}/{self.name}' failed"
                 f" ({type(exception).__name__}: {exception}); falling back to the whole-volume path.",

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -440,7 +440,7 @@ class Accumulator:
 
 class StreamingAccumulator(Accumulator):
     """Accumulator holding only the active window along the first spatial axis; it yields each finalized
-    slab as its patches complete, so peak memory is one patch extent.
+    slab as its patches complete, so peak memory is two patch extents (the window and its slide room).
 
     The patch-grid order (``get_patch_slices_from_shape`` iterates ``itertools.product`` with the first
     spatial axis outermost) has patch starts along that axis never decreasing, so when a patch starting
@@ -468,21 +468,12 @@ class StreamingAccumulator(Accumulator):
                 "get_patch_slices_from_shape generates this order; a custom patch source must preserve it.",
             )
         self._flushed = 0
-        # The window is a ring: emitted rows are zeroed and reused in place, and ``_origin`` is the
-        # buffer row holding absolute row ``_flushed`` — advancing moves the origin, never the data
-        # (the shift previously cloned the whole retained window on every advance).
+        # The window slides through a double-length buffer: ``_origin`` is the buffer row holding
+        # absolute row ``_flushed``, emissions advance it, and a blend about to run off the end
+        # slides the live rows back to row 0 — one bounded copy per buffer traversed, instead of one
+        # per advance, while every blend and emission stays a single contiguous row range (a modulo
+        # ring splits them at its wrap point, which costs more than the copies it saves).
         self._origin = 0
-
-    def _segments(self, start: int, stop: int) -> list[tuple[slice, slice]]:
-        """Buffer-row and window-relative-row slice pairs covering absolute rows [start, stop), split
-        at the ring's wrap point."""
-        row = (self._origin + (start - self._flushed)) % self._window
-        length = stop - start
-        first = min(length, self._window - row)
-        segments = [(slice(row, row + first), slice(0, first))]
-        if first < length:
-            segments.append((slice(0, length - first), slice(first, length)))
-        return segments
 
     def add_layer(self, index: int, layer: torch.Tensor) -> list[tuple[slice, torch.Tensor]]:
         if self._done[index]:
@@ -503,7 +494,7 @@ class StreamingAccumulator(Accumulator):
         slabs = self._advance_to(patch_slice[0].start)
         if self._result is None:
             self._result = torch.zeros(
-                [*layer.shape[:n], self._window, *self.shape[1:]],
+                [*layer.shape[:n], 2 * self._window, *self.shape[1:]],
                 dtype=layer.dtype,
                 device=layer.device,
             )
@@ -514,24 +505,35 @@ class StreamingAccumulator(Accumulator):
             if s.stop - s.start == 1:
                 data = data.unsqueeze(dim=dim + n)
         # Same blend as the parent (clamped destination, cropped patch, weighted overlap); the only
-        # difference is that the destination rows live in the ring, split at its wrap point.
+        # difference is that the destination's first spatial index is relative to the sliding origin.
         dest = [slice(s.start, min(s.stop, self.shape[dim])) for dim, s in enumerate(patch_slice)]
-        crop = [slice(0, d.stop - d.start) for d in dest]
-        lead = tuple(slice(self._result.shape[i]) for i in range(n))
+        crop = tuple([slice(None)] * n + [slice(0, d.stop - d.start) for d in dest])
+        lead = (slice(None),) * n
+        first = self._origin + (dest[0].start - self._flushed)
+        if first + (dest[0].stop - dest[0].start) > 2 * self._window:
+            # Written rows never reach past the buffer (a blend that would slides first), so the live
+            # region is [origin, 2 * window): move it back to row 0 and clear the rest.
+            live = 2 * self._window - self._origin
+            self._result[(*lead, slice(0, live))] = self._result[(*lead, slice(self._origin, None))].clone()
+            self._result[(*lead, slice(live, None))] = 0
+            if self._weight_sum is not None:
+                self._weight_sum[:live] = self._weight_sum[self._origin :].clone()
+                self._weight_sum[live:] = 0
+            first -= self._origin
+            self._origin = 0
+        dest[0] = slice(first, first + (dest[0].stop - dest[0].start))
+        slices_dest = tuple([slice(self._result.shape[i]) for i in range(n)] + dest)
         if self.patch_combine is not None and self._weight_sum is not None:
-            weighted = self._weighted_patch(data)
+            self._result[slices_dest] += self._weighted_patch(data)[crop]
             if self._weight_patch is None:
                 # Spatial-only ones: the weight is per-voxel, and deriving it from a channel-sized
                 # ones_like would allocate (and weight) C copies just to index one back out.
                 self._weight_patch = self.patch_combine(
                     torch.ones(data.shape[n:], dtype=data.dtype, device=data.device)
                 )
-            for rows, patch_rows in self._segments(dest[0].start, dest[0].stop):
-                self._result[(*lead, rows, *dest[1:])] += weighted[(*(slice(None),) * n, patch_rows, *crop[1:])]
-                self._weight_sum[(rows, *dest[1:])] += self._weight_patch[(patch_rows, *crop[1:])]
+            self._weight_sum[tuple(dest)] += self._weight_patch[crop[n:]]
         else:
-            for rows, patch_rows in self._segments(dest[0].start, dest[0].stop):
-                self._result[(*lead, rows, *dest[1:])] = data[(*(slice(None),) * n, patch_rows, *crop[1:])]
+            self._result[slices_dest] = data[crop]
         self._done[index] = True
         self._filled += 1
         return slabs
@@ -551,11 +553,12 @@ class StreamingAccumulator(Accumulator):
 
     @property
     def footprint_shape(self) -> list[int]:
-        # Only the window is resident, so the blend-device budget is the window's: a huge volume streams
-        # on the GPU within bounded VRAM. Blend and IEEE-correctly-rounded finalize ops (+, *, /, argmax,
-        # cast) are bit-identical CPU/CUDA; only a transcendental-terminated float output (Softmax/Sigmoid)
-        # can differ by ~1 ULP between a window on the GPU and a whole-volume reference on the CPU.
-        return [self._window, *self.shape[1:]]
+        # Only the sliding buffer (two windows) is resident, so the blend-device budget is bounded by
+        # it whatever the volume: a huge case streams on the GPU within bounded VRAM. Blend and
+        # IEEE-correctly-rounded finalize ops (+, *, /, argmax, cast) are bit-identical CPU/CUDA; only
+        # a transcendental-terminated float output (Softmax/Sigmoid) can differ by ~1 ULP between a
+        # window on the GPU and a whole-volume reference on the CPU.
+        return [2 * self._window, *self.shape[1:]]
 
     def assemble(self) -> torch.Tensor:
         raise PatchError(
@@ -564,7 +567,7 @@ class StreamingAccumulator(Accumulator):
         )
 
     def _advance_to(self, z: int) -> list[tuple[slice, torch.Tensor]]:
-        """Finalize the ring up to ``z`` (absolute) and move the origin there."""
+        """Finalize the buffer up to ``z`` (absolute) and advance the origin past the emitted rows."""
         z = min(z, self.shape[0])
         if self._result is None or z <= self._flushed:
             return []
@@ -576,22 +579,22 @@ class StreamingAccumulator(Accumulator):
                 "Patch starts may advance by at most one patch extent per step (checked at construction).",
             )
         lead = (slice(None),) * n
+        rows = slice(self._origin, self._origin + length)
         slab = torch.empty(
             [*self._result.shape[:n], length, *self.shape[1:]], dtype=self._result.dtype, device=self._result.device
         )
-        for rows, out_rows in self._segments(self._flushed, z):
-            if self.patch_combine is not None and self._weight_sum is not None:
-                # Same division and fp16 floor as Accumulator.assemble, applied to the finalized rows.
-                torch.div(
-                    self._result[(*lead, rows)],
-                    self._weight_sum[rows].clamp(min=torch.finfo(self._weight_sum.dtype).tiny),
-                    out=slab[(*lead, out_rows)],
-                )
-                self._weight_sum[rows] = 0
-            else:
-                slab[(*lead, out_rows)].copy_(self._result[(*lead, rows)])
-            self._result[(*lead, rows)] = 0
-        self._origin = (self._origin + length) % self._window
+        if self.patch_combine is not None and self._weight_sum is not None:
+            # Same division and fp16 floor as Accumulator.assemble, applied to the finalized rows.
+            torch.div(
+                self._result[(*lead, rows)],
+                self._weight_sum[rows].clamp(min=torch.finfo(self._weight_sum.dtype).tiny),
+                out=slab,
+            )
+            self._weight_sum[rows] = 0
+        else:
+            slab.copy_(self._result[(*lead, rows)])
+        self._result[(*lead, rows)] = 0
+        self._origin += length
         region = slice(self._flushed, z)
         self._flushed = z
         return [(region, slab)]

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -469,12 +469,6 @@ class StreamingAccumulator(Accumulator):
                 "get_patch_slices_from_shape generates this order; a custom patch source must preserve it.",
             )
         self._flushed = 0
-        # The window slides through a double-length buffer: ``_origin`` is the buffer row holding
-        # absolute row ``_flushed``, emissions advance it, and a blend about to run off the end
-        # slides the live rows back to row 0 — one bounded copy per buffer traversed, instead of one
-        # per advance, while every blend and emission stays a single contiguous row range (a modulo
-        # ring splits them at its wrap point, which costs more than the copies it saves).
-        self._origin = 0
 
     def add_layer(self, index: int, layer: torch.Tensor) -> list[tuple[slice, torch.Tensor]]:
         if self._done[index]:
@@ -495,7 +489,7 @@ class StreamingAccumulator(Accumulator):
         slabs = self._advance_to(patch_slice[0].start)
         if self._result is None:
             self._result = torch.zeros(
-                [*layer.shape[:n], 2 * self._window, *self.shape[1:]],
+                [*layer.shape[:n], self._window, *self.shape[1:]],
                 dtype=layer.dtype,
                 device=layer.device,
             )
@@ -506,26 +500,13 @@ class StreamingAccumulator(Accumulator):
             if s.stop - s.start == 1:
                 data = data.unsqueeze(dim=dim + n)
         # Same blend as the parent (clamped destination, cropped patch, weighted overlap); the only
-        # difference is that the destination's first spatial index is relative to the sliding origin.
+        # difference is that the destination's first spatial index is relative to the window origin.
         dest = [slice(s.start, min(s.stop, self.shape[dim])) for dim, s in enumerate(patch_slice)]
         crop = tuple([slice(None)] * n + [slice(0, d.stop - d.start) for d in dest])
-        lead = (slice(None),) * n
-        first = self._origin + (dest[0].start - self._flushed)
-        if first + (dest[0].stop - dest[0].start) > 2 * self._window:
-            # Written rows never reach past the buffer (a blend that would slides first), so the live
-            # region is [origin, 2 * window): move it back to row 0 and clear the rest.
-            live = 2 * self._window - self._origin
-            self._result[(*lead, slice(0, live))] = self._result[(*lead, slice(self._origin, None))].clone()
-            self._result[(*lead, slice(live, None))] = 0
-            if self._weight_sum is not None:
-                self._weight_sum[:live] = self._weight_sum[self._origin :].clone()
-                self._weight_sum[live:] = 0
-            first -= self._origin
-            self._origin = 0
-        dest[0] = slice(first, first + (dest[0].stop - dest[0].start))
+        dest[0] = slice(dest[0].start - self._flushed, dest[0].stop - self._flushed)
         slices_dest = tuple([slice(self._result.shape[i]) for i in range(n)] + dest)
         if self.patch_combine is not None and self._weight_sum is not None:
-            self._result[slices_dest] += self._weighted_patch(data)[crop]
+            self._result[slices_dest] += self.patch_combine(data)[crop]
             if self._weight_patch is None:
                 # Spatial-only ones: the weight is per-voxel, and deriving it from a channel-sized
                 # ones_like would allocate (and weight) C copies just to index one back out.
@@ -549,17 +530,15 @@ class StreamingAccumulator(Accumulator):
         self._filled = 0
         self._done = [False] * self._count
         self._flushed = 0
-        self._origin = 0
         return slabs
 
     @property
     def footprint_shape(self) -> list[int]:
-        # Only the sliding buffer (two windows) is resident, so the blend-device budget is bounded by
-        # it whatever the volume: a huge case streams on the GPU within bounded VRAM. Blend and
-        # IEEE-correctly-rounded finalize ops (+, *, /, argmax, cast) are bit-identical CPU/CUDA; only
-        # a transcendental-terminated float output (Softmax/Sigmoid) can differ by ~1 ULP between a
-        # window on the GPU and a whole-volume reference on the CPU.
-        return [2 * self._window, *self.shape[1:]]
+        # Only the window is resident, so the blend-device budget is the window's: a huge volume streams
+        # on the GPU within bounded VRAM. Blend and IEEE-correctly-rounded finalize ops (+, *, /, argmax,
+        # cast) are bit-identical CPU/CUDA; only a transcendental-terminated float output (Softmax/Sigmoid)
+        # can differ by ~1 ULP between a window on the GPU and a whole-volume reference on the CPU.
+        return [self._window, *self.shape[1:]]
 
     def assemble(self) -> torch.Tensor:
         raise PatchError(
@@ -568,7 +547,7 @@ class StreamingAccumulator(Accumulator):
         )
 
     def _advance_to(self, z: int) -> list[tuple[slice, torch.Tensor]]:
-        """Finalize the buffer up to ``z`` (absolute) and advance the origin past the emitted rows."""
+        """Finalize the window up to ``z`` (absolute) and shift the window origin there."""
         z = min(z, self.shape[0])
         if self._result is None or z <= self._flushed:
             return []
@@ -580,22 +559,19 @@ class StreamingAccumulator(Accumulator):
                 "Patch starts may advance by at most one patch extent per step (checked at construction).",
             )
         lead = (slice(None),) * n
-        rows = slice(self._origin, self._origin + length)
-        slab = torch.empty(
-            [*self._result.shape[:n], length, *self.shape[1:]], dtype=self._result.dtype, device=self._result.device
-        )
+        slab = self._result[(*lead, slice(0, length))]
         if self.patch_combine is not None and self._weight_sum is not None:
-            # Same division and fp16 floor as Accumulator.assemble, applied to the finalized rows.
-            torch.div(
-                self._result[(*lead, rows)],
-                self._weight_sum[rows].clamp(min=torch.finfo(self._weight_sum.dtype).tiny),
-                out=slab,
-            )
-            self._weight_sum[rows] = 0
+            # Same division and fp16 floor as Accumulator.assemble, applied to the finalized slab.
+            slab = slab / self._weight_sum[:length].clamp(min=torch.finfo(self._weight_sum.dtype).tiny)
         else:
-            slab.copy_(self._result[(*lead, rows)])
-        self._result[(*lead, rows)] = 0
-        self._origin += length
+            slab = slab.clone()
+        keep = self._window - length
+        # .clone(): source and destination views overlap when length < window.
+        self._result[(*lead, slice(0, keep))] = self._result[(*lead, slice(length, self._window))].clone()
+        self._result[(*lead, slice(keep, self._window))] = 0
+        if self._weight_sum is not None:
+            self._weight_sum[:keep] = self._weight_sum[length : self._window].clone()
+            self._weight_sum[keep:] = 0
         region = slice(self._flushed, z)
         self._flushed = z
         return [(region, slab)]

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -17,9 +17,11 @@
 """Patch extraction, accumulation, and patch-combination helpers for KonfAI."""
 
 import copy
+import os
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from itertools import pairwise
 from typing import Protocol, cast
 
@@ -30,7 +32,7 @@ import torch.nn.functional as F
 from konfai.data.augmentation import DataAugmentation, DataAugmentationsList
 from konfai.data.transform import LocalityKind, PatchLocality, Resample, Save, Transform
 from konfai.utils.config import apply_config, config
-from konfai.utils.dataset import Attribute, Dataset
+from konfai.utils.dataset import Attribute, Dataset, DataStream
 from konfai.utils.errors import PatchError
 from konfai.utils.utils import (
     SUPPORTED_EXTENSIONS,
@@ -43,6 +45,10 @@ from konfai.utils.utils import (
 
 # How far a halo may reach, as a fraction of the patch it surrounds. See DatasetManager._affords_halo.
 _MAX_HALO_FRACTION = 0.5
+
+# Rows per Save-sweep slab: full-plane slabs keep the materialization bounded to a window while the
+# composed region reads stay chunk-friendly. See DatasetManager._materialize_save.
+_SWEEP_SLAB_ROWS = 64
 
 
 def _halo_radii(halo: tuple[int, ...], n_axes: int) -> list[int]:
@@ -159,13 +165,29 @@ class _ReadStagePlan:
     pull: Callable[[tuple[slice, ...]], list[slice]] | None
 
 
+def _save_destination(save: Save, default_dataset: Dataset, default_group: str) -> tuple[Dataset, str]:
+    """The dataset and group a :class:`Save` caches into, the manager's own when it names none."""
+    if save.dataset:
+        filename, _, file_format = split_path_spec(
+            save.dataset,
+            default_format="mha",
+            supported_extensions=SUPPORTED_EXTENSIONS,
+        )
+        dataset = Dataset(filename, file_format)
+    else:
+        dataset = default_dataset
+    return dataset, save.group if save.group else default_group
+
+
 @dataclass(frozen=True)
 class _PatchStreamSource:
     """What a copy's patches are read from, and what runs on them once read.
 
     ``stage_plans`` mirrors ``stages`` one to one: the region plans locate every stage that reads
     somewhere other than the target patch (they compose, each pulling through the one before it); the
-    rest are pointwise, so they run wherever the regions put them.
+    rest are pointwise, so they run wherever the regions put them. ``pending_sweeps`` are the
+    unsatisfied :class:`Save` caches the source reads through: each must be materialized — and the
+    source re-resolved from disk — before any patch flows.
     """
 
     dataset: Dataset
@@ -173,6 +195,7 @@ class _PatchStreamSource:
     shape: list[int]
     stages: list[Stage]
     stage_plans: tuple[_ReadStagePlan, ...]
+    pending_sweeps: tuple["_PendingSweep", ...] = ()
 
     @property
     def region_index(self) -> int | None:
@@ -181,6 +204,24 @@ class _PatchStreamSource:
             if plan.kind in _REGION_KINDS:
                 return index
         return None
+
+
+@dataclass(frozen=True)
+class _PendingSweep:
+    """One unsatisfied :class:`Save` and the segment that feeds it. Materializing reads each slab of
+    the Save's own space through the segment and region-writes it to ``destination``, after which the
+    Save is a satisfied source boundary. The segment is re-planned at sweep time — its source is
+    materialized by then, so a deferred statistic seeds from the real entry."""
+
+    destination: Dataset
+    group: str
+    stages: list[Stage]
+    source_dataset: Dataset
+    source_group: str
+    source_shape: list[int]
+    out_spatial: tuple[int, ...]
+    # The case state the segment replays from (copied per slab).
+    base_attributes: Attribute = field(repr=False)
 
 
 @dataclass(frozen=True)
@@ -1016,6 +1057,7 @@ class DatasetManager:
         self.data_augmentations_list = data_augmentations_list
         self._patch_stream_sources: dict[tuple[int, bool], _PatchStreamSource | None] = {}
         self._stream_attributes_persisted: set[int] = set()
+        self._sweep_failed = False
         self._disk_statistics: dict[tuple[Dataset, str, tuple[int, ...] | None], dict[str, float]] = {}
         # reset_state=False: the first manager built for a case draws (state_init draws a missing
         # index), and every later group's manager reuses that draw -- redrawing here would give each
@@ -1070,16 +1112,7 @@ class DatasetManager:
         data = None
         for transform_function in reversed(pre_transform):
             if isinstance(transform_function, Save):
-                if transform_function.dataset:
-                    if len(transform_function.dataset.split(":")) > 1:
-                        filename, file_format = transform_function.dataset.split(":")
-                    else:
-                        filename = transform_function.dataset
-                        file_format = "mha"
-                    dataset = Dataset(filename, file_format)
-                else:
-                    dataset = self.dataset
-                group_dest = transform_function.group if transform_function.group else self.group_dest
+                dataset, group_dest = _save_destination(transform_function, self.dataset, self.group_dest)
                 if dataset.is_dataset_exist(group_dest, self.name):
                     data, attrib = dataset.read_data(group_dest, self.name)
                     self.cache_attributes[0].update(attrib)
@@ -1095,16 +1128,7 @@ class DatasetManager:
             for transform_function in pre_transform[i:]:
                 data = transform_function(self.name, data, self.cache_attributes[0])
                 if isinstance(transform_function, Save):
-                    if transform_function.dataset:
-                        if len(transform_function.dataset.split(":")) > 1:
-                            filename, file_format = transform_function.dataset.split(":")
-                        else:
-                            filename = transform_function.dataset
-                            file_format = "mha"
-                        dataset = Dataset(filename, file_format)
-                    else:
-                        dataset = self.dataset
-                    group_dest = transform_function.group if transform_function.group else self.group_dest
+                    dataset, group_dest = _save_destination(transform_function, self.dataset, self.group_dest)
                     dataset.write(
                         group_dest,
                         self.name,
@@ -1245,20 +1269,26 @@ class DatasetManager:
         source_group: str,
         cache_attribute: Attribute,
         source_spatial_shape: list[int],
-    ) -> tuple[bool, tuple[_ReadStagePlan, ...]]:
-        """Validate a copy's locality declarations and plan its region stages, which compose.
+        landing_shape: list[int] | None = None,
+        seed_statistics: bool = True,
+    ) -> tuple[bool, tuple[_ReadStagePlan, ...], Attribute]:
+        """Validate a chain's locality declarations and plan its region stages, which compose.
 
-        Returns ``(streamable, stage_plans)``. The chain streams when every stage is pointwise, a
-        region kind (``HALO``/``ORIENTATION``/``CROP``/``RESCALE`` — any number, each pulling through
-        the one before it), or a ``GLOBAL_STAT`` with a pre-populated statistic. The plan walks the
-        chain once with one evolving case state, so each stage declares against — and remaps from —
-        the geometry the stages before it left, and folds the spatial shapes stage by stage; a fold
-        that does not land on the copy's own grid refuses (the safety net for a stage whose shape map
-        is not declared). Any ``WHOLE_VOLUME`` declaration, an unreadable ``GLOBAL_STAT``, a
-        ``RESCALE`` without a known ``Spacing`` (or that is not a :class:`Resample`), or a halo too
-        wide to be worth reading rejects streaming. Nothing here names a stage: each declares its own
-        contract, and this is where the declarations are read -- which is why a transform and an
-        augmentation are planned side by side.
+        Returns ``(streamable, stage_plans, evolved)`` — ``evolved`` being the case state the plan
+        leaves, which a :class:`Save` sweep writes as its cache header. The chain streams when every
+        stage is pointwise, a region kind (``HALO``/``ORIENTATION``/``CROP``/``RESCALE`` — any
+        number, each pulling through the one before it), or a ``GLOBAL_STAT`` with a pre-populated
+        statistic. The plan walks the chain once with one evolving case state, so each stage declares
+        against — and remaps from — the geometry the stages before it left, and folds the spatial
+        shapes stage by stage; a fold that does not land on ``landing_shape`` (the copy's own grid by
+        default) refuses (the safety net for a stage whose shape map is not declared). Any
+        ``WHOLE_VOLUME`` declaration, an unreadable ``GLOBAL_STAT``, a ``RESCALE`` without a known
+        ``Spacing`` (or that is not a :class:`Resample`), or a halo too wide to be worth reading
+        rejects streaming. ``seed_statistics=False`` accepts a missing statistic instead of reading
+        it — for a chain fed by a cache that is not materialized yet, whose re-resolution seeds it
+        from the real entry. Nothing here names a stage: each declares its own contract, and this is
+        where the declarations are read -- which is why a transform and an augmentation are planned
+        side by side.
         """
         evolved = Attribute(cache_attribute)
         shape = [int(extent) for extent in source_spatial_shape]
@@ -1270,31 +1300,37 @@ class DatasetManager:
             if loc.kind in (LocalityKind.WHOLE_VOLUME, LocalityKind.SLAB):
                 # SLAB is a write-side contract: its side effect needs the slab's place in the
                 # OUTPUT, which a patch read has no notion of.
-                return False, ()
+                return False, (), evolved
             if loc.kind is LocalityKind.GLOBAL_STAT:
                 # The seed is the STORED volume's statistic, which is this transform's input only when
                 # every earlier stage preserves it; otherwise ([Clip(-200, 400), Standardize()]) every
                 # patch would be standardized by the pre-Clip statistic -- fall back to the whole volume.
                 if not all(previous.statistics_preserving for previous in localities[:-1]):
-                    return False, ()
-                if not self._ensure_stream_stats(
+                    return False, (), evolved
+                if seed_statistics and not self._ensure_stream_stats(
                     source_dataset, source_group, cache_attribute, set(loc.stat_keys), loc.stat_channels
                 ):
-                    return False, ()
+                    return False, (), evolved
+                # The evolving case state carries the seed too: a Save sweep writes it as the cache
+                # header, exactly as the whole-volume pass leaves the statistic in the attribute.
+                for stat_key in loc.stat_keys:
+                    if stat_key in cache_attribute and stat_key not in evolved:
+                        evolved[stat_key] = cache_attribute[stat_key]
             if loc.kind is LocalityKind.HALO and not self._affords_halo(a, loc.halo):
-                return False, ()
+                return False, (), evolved
             if loc.kind is LocalityKind.RESCALE and (not isinstance(stage, Resample) or "Spacing" not in evolved):
                 # A resample is patch-native only when the source geometry is known: the scale is read
                 # from the evolving 'Spacing' (a free geometry stat, no read_data_statistics).
-                return False, ()
+                return False, (), evolved
             plan = self._plan_read_stage(stage, loc, shape, evolved)
             if plan is None:
-                return False, ()
+                return False, (), evolved
             plans.append(plan)
             shape = list(plan.out_shape)
-        if shape != [int(extent) for extent in self.shapes[a]]:
-            return False, ()
-        return True, tuple(plans)
+        expected = landing_shape if landing_shape is not None else self.shapes[a]
+        if shape != [int(extent) for extent in expected]:
+            return False, (), evolved
+        return True, tuple(plans), evolved
 
     def _plan_read_stage(
         self, stage: Stage, loc: PatchLocality, shape: list[int], evolved: Attribute
@@ -1322,15 +1358,6 @@ class DatasetManager:
         stage.write_stream_cache_attribute(evolved, list(shape))
         return _ReadStagePlan(loc.kind, tuple(shape), tuple(out), pull)
 
-    @staticmethod
-    def _dataset_from_spec(dataset_spec: str) -> Dataset:
-        filename, _, file_format = split_path_spec(
-            dataset_spec,
-            default_format="mha",
-            supported_extensions=SUPPORTED_EXTENSIONS,
-        )
-        return Dataset(filename, file_format)
-
     def _resolve_patch_stream_source(self, a: int, apply_augmentations: bool = True) -> _PatchStreamSource | None:
         key = (a, apply_augmentations)
         if key in self._patch_stream_sources:
@@ -1338,53 +1365,211 @@ class DatasetManager:
 
         source_dataset = self.dataset
         source_group = self.group_src
-        source_shape = self.base_shape
-        boundary_attributes: Attribute | None = None
-        trailing_transforms: list[Stage] = list(self.transforms)
+        source_shape = list(self.base_shape)
+        # Plan from the case as STORED (the pristine backup), never from the live attribute: the live
+        # one carries what earlier patches or epochs wrote (a Resample's target Spacing, a Canonical's
+        # canonical Direction), and planning from it would hand a stage its own output as the
+        # description of its input on every epoch after the first.
+        stream_cache_attribute = Attribute(self.cache_attributes_bak[0])
+        pending: list[_PendingSweep] = []
+        trailing_transforms: list[Stage] = []
 
-        for index in range(len(self.transforms) - 1, -1, -1):
-            transform = self.transforms[index]
+        for transform in self.transforms:
             if isinstance(transform, Save):
-                dataset = self._dataset_from_spec(transform.dataset) if transform.dataset else self.dataset
-                group = transform.group if transform.group else self.group_dest
+                dataset, group = _save_destination(transform, self.dataset, self.group_dest)
                 if dataset.is_dataset_exist(group, self.name):
-                    source_dataset = dataset
-                    source_group = group
+                    source_dataset, source_group = dataset, group
                     source_shape, boundary_attributes = dataset.get_infos(group, self.name)
-                    trailing_transforms = list(self.transforms[index + 1 :])
-                    break
+                    source_shape = list(source_shape)
+                    # Streaming from a Save cache: the stored volume is the cache, so the stages after
+                    # the boundary read its geometry -- stacked over the source keys exactly as the
+                    # whole-volume cache-hit merges the cached header.
+                    stream_cache_attribute = Attribute(self.cache_attributes_bak[0])
+                    for attribute_key, attribute_value in boundary_attributes.items():
+                        stream_cache_attribute[attribute_key] = attribute_value
+                    pending.clear()
+                    trailing_transforms = []
+                    continue
+                planned = self._plan_save_sweep(
+                    dataset,
+                    group,
+                    trailing_transforms,
+                    source_dataset,
+                    source_group,
+                    source_shape,
+                    stream_cache_attribute,
+                    seed_statistics=not pending,
+                )
+                if planned is not None:
+                    sweep, stream_cache_attribute = planned
+                    source_dataset, source_group = dataset, group
+                    source_shape = [source_shape[0], *sweep.out_spatial]
+                    pending.append(sweep)
+                    trailing_transforms = []
+                    continue
+            trailing_transforms.append(transform)
 
         # What copy `a` is: the trailing transforms, then its own draw. The draw is applied to the
         # transformed volume, so it goes last, and the whole thing is planned as one chain -- a region
         # transform and a region augmentation are then two regions, which is exactly what they are.
         stages = trailing_transforms + (self._augmentation_stages(a) if apply_augmentations else [])
 
-        # Plan from the case as STORED (the pristine backup), never from the live attribute: the live
-        # one carries what earlier patches or epochs wrote (a Resample's target Spacing, a Canonical's
-        # canonical Direction), and planning from it would hand a stage its own output as the
-        # description of its input on every epoch after the first.
-        stream_cache_attribute = Attribute(self.cache_attributes_bak[0])
-        if boundary_attributes is not None:
-            # Streaming from a Save cache: the stored volume is the cache, so the stages after the
-            # boundary read its geometry -- stacked over the source keys exactly as the whole-volume
-            # cache-hit merges the cached header.
-            for attribute_key, attribute_value in boundary_attributes.items():
-                stream_cache_attribute[attribute_key] = attribute_value
-        streamable, stage_plans = self._plan_stream_region(
-            a, stages, source_dataset, source_group, stream_cache_attribute, list(source_shape[1:])
+        streamable, stage_plans, _ = self._plan_stream_region(
+            a,
+            stages,
+            source_dataset,
+            source_group,
+            stream_cache_attribute,
+            list(source_shape[1:]),
+            seed_statistics=not pending,
         )
-        if streamable:
+        if not streamable:
+            self._patch_stream_sources[key] = None
+        elif pending:
+            # The pending source only answers the regime probes: no attribute is persisted and no
+            # patch flows from it -- the sweeps run at first data access, and the source is then
+            # re-resolved from the materialized caches (the satisfied-Save path above).
+            self._patch_stream_sources[key] = _PatchStreamSource(
+                source_dataset, source_group, source_shape, stages, stage_plans, tuple(pending)
+            )
+        else:
             self.cache_attributes[a] = Attribute(stream_cache_attribute)
             self.cache_attributes_bak[a] = Attribute(stream_cache_attribute)
             self._patch_stream_sources[key] = _PatchStreamSource(
-                source_dataset, source_group, list(source_shape), stages, stage_plans
+                source_dataset, source_group, source_shape, stages, stage_plans
             )
-        else:
-            self._patch_stream_sources[key] = None
         return self._patch_stream_sources[key]
+
+    def _plan_save_sweep(
+        self,
+        destination: Dataset,
+        group: str,
+        segment: list[Stage],
+        source_dataset: Dataset,
+        source_group: str,
+        source_shape: list[int],
+        base_attributes: Attribute,
+        seed_statistics: bool,
+    ) -> tuple[_PendingSweep, Attribute] | None:
+        """Plan the materialization of one unsatisfied :class:`Save`, or ``None`` to leave it on the
+        whole-volume path: the segment feeding it must itself stream, and the destination must serve
+        region writes (probed by capability, so a refusal costs nothing). Returns the pending sweep
+        and the case state its cache will carry, which the stages after the Save plan against."""
+        if self._sweep_failed or os.environ.get("KONFAI_STREAMED_WRITES", "1").lower() in ("0", "false"):
+            return None
+        landing = [int(extent) for extent in source_shape[1:]]
+        probe = Attribute(base_attributes)
+        for stage in segment:
+            landing = [
+                int(e) for e in cast(Transform, stage).transform_shape(self.group_src, self.name, landing, probe)
+            ]
+        planning = Attribute(base_attributes)
+        streamable, _, evolved = self._plan_stream_region(
+            0,
+            segment,
+            source_dataset,
+            source_group,
+            planning,
+            [int(extent) for extent in source_shape[1:]],
+            landing_shape=landing,
+            seed_statistics=seed_statistics,
+        )
+        if not streamable or not destination.can_stream_data(evolved):
+            return None
+        sweep = _PendingSweep(
+            destination,
+            group,
+            list(segment),
+            source_dataset,
+            source_group,
+            list(source_shape),
+            tuple(landing),
+            planning,
+        )
+        return sweep, evolved
 
     def can_stream_patch(self, a: int, apply_augmentations: bool = True) -> bool:
         return self._resolve_patch_stream_source(a, apply_augmentations) is not None
+
+    def _stream_ready(self, a: int, apply_augmentations: bool = True) -> bool:
+        """Whether this copy can stream its patches, materializing what that requires.
+
+        Resolves the source and, the first time a case whose chain reads through unmaterialized Save
+        caches is actually asked for data, sweeps them and re-resolves from disk — all data then
+        flows through the satisfied-boundary path, exactly as if the caches had always existed. The
+        regime probes (``can_stream_patch``) answer from the plan alone and never write."""
+        source = self._resolve_patch_stream_source(a, apply_augmentations)
+        if source is None:
+            return False
+        if not source.pending_sweeps:
+            return True
+        if not all(self._materialize_save(sweep) for sweep in source.pending_sweeps):
+            self._sweep_failed = True
+        # Every copy replans: the pending plans pointed at caches that did not exist yet (or, after a
+        # failure, never will -- _sweep_failed reroutes them to the whole-volume path).
+        self._patch_stream_sources.clear()
+        return not self._sweep_failed and self._resolve_patch_stream_source(a, apply_augmentations) is not None
+
+    def _materialize_save(self, sweep: _PendingSweep) -> bool:
+        """Write one Save cache slab by slab, without ever holding the volume.
+
+        Each slab of the Save's own space is read through the segment — the same composed replay a
+        patch uses — and region-written. The segment is re-planned here: its source is materialized
+        by now, so a statistic the pending plan deferred seeds from the real entry. The cache appears
+        only when complete (a DataStream renames on finalize), so a concurrent resolve never takes a
+        partial entry as a source boundary; on failure the partial entry is removed and the case
+        falls back to the whole-volume path, which writes the cache classically."""
+        if sweep.destination.is_dataset_exist(sweep.group, self.name):
+            return True
+        streamable, stage_plans, evolved = self._plan_stream_region(
+            0,
+            sweep.stages,
+            sweep.source_dataset,
+            sweep.source_group,
+            sweep.base_attributes,
+            [int(extent) for extent in sweep.source_shape[1:]],
+            landing_shape=list(sweep.out_spatial),
+        )
+        if not streamable:
+            return False
+        source = _PatchStreamSource(
+            sweep.source_dataset, sweep.source_group, list(sweep.source_shape), sweep.stages, stage_plans
+        )
+        spatial = list(sweep.out_spatial)
+        stream: DataStream | None = None
+        try:
+            for start in range(0, spatial[0], _SWEEP_SLAB_ROWS):
+                target = (slice(start, min(start + _SWEEP_SLAB_ROWS, spatial[0])), *(slice(0, e) for e in spatial[1:]))
+                tensor, slab_attribute, keys_before = self._replay_streamed_region(
+                    source, target, Attribute(sweep.base_attributes), None
+                )
+                block = tensor.numpy()
+                if stream is None:
+                    # The header is the plan-time case state, completed by what the chain's stages
+                    # add in __call__ -- the same keys the whole-volume pass would leave at the Save.
+                    attributes = Attribute(evolved)
+                    for key in slab_attribute.keys():
+                        if key not in keys_before and key not in attributes:
+                            attributes[key] = slab_attribute[key]
+                    stream = sweep.destination.open_data_stream(
+                        sweep.group, self.name, [int(block.shape[0]), *spatial], block.dtype, attributes
+                    )
+                    if stream is None:
+                        return False
+                    stream.__enter__()
+                stream.write_slice((slice(0, int(block.shape[0])), *target), block)
+            if stream is not None:
+                stream.__exit__(None, None, None)
+            return True
+        except Exception as exception:
+            if stream is not None:
+                stream.__exit__(type(exception), exception, exception.__traceback__)
+            warnings.warn(
+                f"Streamed materialization of Save cache '{sweep.group}/{self.name}' failed"
+                f" ({type(exception).__name__}: {exception}); falling back to the whole-volume path.",
+                stacklevel=2,
+            )
+            return False
 
     def _get_streamed_data(
         self,
@@ -1396,6 +1581,11 @@ class DatasetManager:
         stream_source = self._resolve_patch_stream_source(a, apply_augmentations)
         if stream_source is None:
             raise RuntimeError("Patch streaming requested on a dataset manager without a streaming source.")
+        if stream_source.pending_sweeps:
+            raise PatchError(
+                "Streamed read on a source with unmaterialized Save caches.",
+                "Report this: _stream_ready() must run the sweeps before any patch flows.",
+            )
 
         if stream_source.region_index is None:
             # POINTWISE / GLOBAL_STAT only: read the exact patch and run the whole chain on it.
@@ -1449,9 +1639,35 @@ class DatasetManager:
         stream_source: _PatchStreamSource,
         is_input: bool,
     ) -> tuple[torch.Tensor, Attribute]:
-        """Patch-native region chain: read only the source region a target patch pulls, composed.
+        """Patch-native region chain: one target patch replayed through the composed region plans,
+        padded back to ``patch_size`` like the whole-volume path (see ``_replay_streamed_region``,
+        which a Save sweep drives with slab targets instead of patch targets)."""
+        target_slices = tuple(self.patch.get_patch_slices(a)[index])
+        # Each patch re-runs the chain from the state the whole-volume pass started from: the case as
+        # stored (plus planned stats), never the live attribute -- that one carries the chain's own
+        # output.
+        persist = a not in self._stream_attributes_persisted
+        tensor, cache_attribute, keys_before = self._replay_streamed_region(
+            stream_source,
+            target_slices,
+            Attribute(self.cache_attributes_bak[a]),
+            self.cache_attributes[a] if persist else None,
+        )
+        tensor = self._finalize_stream_patch(tensor, index, a, is_input)
+        if persist:
+            self._persist_stream_attributes(a, cache_attribute, keys_before)
+        return tensor, cache_attribute
 
-        The region stages' pull maps fold backward from the target patch down to the stored volume —
+    def _replay_streamed_region(
+        self,
+        stream_source: _PatchStreamSource,
+        target_slices: tuple[slice, ...],
+        cache_attribute: Attribute,
+        case_attribute: Attribute | None,
+    ) -> tuple[torch.Tensor, Attribute, set[str]]:
+        """Read only the source region a target region pulls, composed, and run the chain on it.
+
+        The region stages' pull maps fold backward from the target region down to the stored volume —
         each stage's region pulls through the one before it — so one bounded read serves any number of
         them; the chain then runs forward over the sub-region, each stage on the region pair the same
         fold computed for it. HALO reads the region enlarged by the declared radius (clamped to the
@@ -1462,9 +1678,13 @@ class DatasetManager:
         region is requested; whether that avoids decoding the whole volume depends on the storage
         format -- compressed MetaImage and NRRD decode the full volume per read
         (see ``_supports_region_read``).
+
+        ``cache_attribute`` is this region's own scope, evolved by the chain; ``case_attribute``,
+        when given, receives each region stage's case-level geometry (computed once, from the FULL
+        shape of the stage's input). Returns the region tensor, the evolved scope, and the keys the
+        scope held before the chain ran (whatever the chain added is what the caller may persist).
         """
         stages, plans = stream_source.stages, stream_source.stage_plans
-        target_slices = tuple(self.patch.get_patch_slices(a)[index])
         n_prefix = len(stream_source.shape) - len(target_slices)
 
         spans: list[list[slice]] = [list(target_slices)]
@@ -1476,19 +1696,14 @@ class DatasetManager:
         data, attributes = stream_source.dataset.read_data_slice(stream_source.group, self.name, data_slices)
         tensor = torch.from_numpy(data)
 
-        # Each patch re-runs the chain from the state the whole-volume pass started from: the case as
-        # stored (plus planned stats), never the live attribute -- that one carries the chain's own
-        # output.
-        cache_attribute = Attribute(self.cache_attributes_bak[a])
         cache_attribute.update(attributes)
-        persist = a not in self._stream_attributes_persisted
-        keys_before = set(cache_attribute.keys()) if persist else set()
+        keys_before = set(cache_attribute.keys())
 
         for stage, plan, source, target in zip(stages, plans, spans[:-1], spans[1:], strict=True):
             if plan.kind not in _REGION_KINDS:
                 tensor = stage(self.name, tensor, cache_attribute)
                 continue
-            # A region stage's geometry writes describe the patch's extent, not the volume's: give it
+            # A region stage's geometry writes describe the region's extent, not the volume's: give it
             # a throwaway scope, and write the case-level answer once from the FULL shape below
             # (write_stream_cache_attribute).
             scoped = Attribute(cache_attribute)
@@ -1506,18 +1721,11 @@ class DatasetManager:
                     lead = tensor.dim() - len(target)
                     crop = [slice(t.start - s.start, t.stop - s.start) for t, s in zip(target, source, strict=False)]
                     tensor = tensor[(*[slice(None)] * lead, *crop)]
-            if persist:
-                # The stage's own geometry writes went to the patch-scoped copy above, so this is
-                # where the case gets them: computed once, from the FULL shape of the stage's input,
-                # against the attribute that still describes the whole volume.
-                stage.write_stream_cache_attribute(self.cache_attributes[a], list(plan.in_shape))
+            if case_attribute is not None:
+                stage.write_stream_cache_attribute(case_attribute, list(plan.in_shape))
                 self._check_region_geometry_reaches_the_case(stage, scoped, cache_attribute)
 
-        tensor = self._finalize_stream_patch(tensor, index, a, is_input)
-
-        if persist:
-            self._persist_stream_attributes(a, cache_attribute, keys_before)
-        return tensor, cache_attribute
+        return tensor, cache_attribute, keys_before
 
     def _check_region_geometry_reaches_the_case(
         self, region_stage: Stage, scoped: Attribute, cache_attribute: Attribute
@@ -1560,9 +1768,13 @@ class DatasetManager:
         is_input: bool,
         apply_augmentations: bool = True,
     ) -> torch.Tensor:
-        if not self.loaded and self.can_stream_patch(a, apply_augmentations):
+        if not self.loaded and self._stream_ready(a, apply_augmentations):
             data, _ = self._get_streamed_data(index, a, is_input, apply_augmentations)
         else:
+            if not self.loaded:
+                # A failed Save sweep lands here past the buffered-path guard (which saw a pending
+                # plan and skipped the full load): load classically, which writes the caches too.
+                self.load(self.transforms, self.data_augmentations_list, load_augmentations=False)
             data = self.patch.get_data(self._get_tensor(a), index, a, is_input)
         if patch_transforms:
             # Per-patch scope: writing to the shared case attribute would freeze the first patch's

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -219,7 +219,8 @@ class PathCombine(ABC):
             data = data.unsqueeze(-1) * window
         self.data = data
 
-    def __call__(self, tensor: torch.Tensor) -> torch.Tensor:
+    def weight(self, tensor: torch.Tensor) -> torch.Tensor:
+        """The per-voxel blend window on ``tensor``'s device and dtype (cached per pair)."""
         key = (tensor.device, tensor.dtype)
         if key not in self._data_per_device:
             # Match the tensor dtype: the weight has no reason to carry more precision than the data it
@@ -231,7 +232,10 @@ class PathCombine(ABC):
                 # the weight at the dtype's smallest normal so single-coverage voxels stay recoverable.
                 weight = weight.clamp(min=torch.finfo(weight.dtype).tiny)
             self._data_per_device[key] = weight
-        return self._data_per_device[key] * tensor
+        return self._data_per_device[key]
+
+    def __call__(self, tensor: torch.Tensor) -> torch.Tensor:
+        return self.weight(tensor) * tensor
 
     @abstractmethod
     def _window_1d(self, size: int, overlap: int) -> torch.Tensor:
@@ -325,6 +329,7 @@ class Accumulator:
         self._result: torch.Tensor | None = None
         self._weight_sum: torch.Tensor | None = None
         self._weight_patch: torch.Tensor | None = None
+        self._weighted: torch.Tensor | None = None
 
     def add_layer(self, index: int, layer: torch.Tensor) -> list[tuple[slice, torch.Tensor]] | None:
         # Blend each patch straight into the running accumulator and drop the patch, rather than
@@ -359,7 +364,7 @@ class Accumulator:
         # A voxel covered by fewer patches (a volume border without whole-image padding) would sum
         # to < 1 and come out darkened (x0.5 edges, x0.25 corners), so divide by the accumulated weight.
         if self.patch_combine is not None and self._weight_sum is not None:
-            self._result[slices_dest] += self.patch_combine(data)[crop]
+            self._result[slices_dest] += self._weighted_patch(data)[crop]
             if self._weight_patch is None:
                 # Spatial-only ones: the weight is per-voxel, and deriving it from a channel-sized
                 # ones_like would allocate (and weight) C copies just to index one back out.
@@ -372,6 +377,24 @@ class Accumulator:
         self._done[index] = True
         self._filled += 1
         return None
+
+    def _weighted_patch(self, data: torch.Tensor) -> torch.Tensor:
+        """``patch_combine(data)`` into a staging buffer the patches share.
+
+        A weighted copy per patch was one patch-sized allocation per blend; one reused buffer per
+        accumulator serves them all. The multiply stays out of place: the caller's tensor is never
+        touched, so the OOM retry (which re-blends the same patch on the CPU) never re-weights it.
+        """
+        combine = cast(PathCombine, self.patch_combine)
+        if (
+            self._weighted is None
+            or self._weighted.shape != data.shape
+            or self._weighted.dtype != data.dtype
+            or self._weighted.device != data.device
+        ):
+            self._weighted = torch.empty_like(data)
+        torch.mul(data, combine.weight(data), out=self._weighted)
+        return self._weighted
 
     def is_empty(self) -> bool:
         """True until the first patch has been blended in (no volume-sized buffer allocated yet)."""
@@ -409,6 +432,7 @@ class Accumulator:
         self._result = None
         self._weight_sum = None
         self._weight_patch = None
+        self._weighted = None
         self._filled = 0
         self._done = [False] * self._count
         return result
@@ -435,13 +459,30 @@ class StreamingAccumulator(Accumulator):
         super().__init__(patch_slices, patch_size, patch_combine, batch)
         self._window = min(max(patch[0].stop - patch[0].start for patch in self.patch_slices), self.shape[0])
         starts = [patch[0].start for patch in self.patch_slices]
-        if any(0 > current - previous or current - previous > self._window for previous, current in pairwise(starts)):
+        if (starts and starts[0] != 0) or any(
+            0 > current - previous or current - previous > self._window for previous, current in pairwise(starts)
+        ):
             raise PatchError(
-                "StreamingAccumulator requires patches ordered by non-decreasing start on the first spatial axis,"
-                " advancing by at most one patch extent per step.",
+                "StreamingAccumulator requires patches starting at row 0 and ordered by non-decreasing start on"
+                " the first spatial axis, advancing by at most one patch extent per step.",
                 "get_patch_slices_from_shape generates this order; a custom patch source must preserve it.",
             )
         self._flushed = 0
+        # The window is a ring: emitted rows are zeroed and reused in place, and ``_origin`` is the
+        # buffer row holding absolute row ``_flushed`` — advancing moves the origin, never the data
+        # (the shift previously cloned the whole retained window on every advance).
+        self._origin = 0
+
+    def _segments(self, start: int, stop: int) -> list[tuple[slice, slice]]:
+        """Buffer-row and window-relative-row slice pairs covering absolute rows [start, stop), split
+        at the ring's wrap point."""
+        row = (self._origin + (start - self._flushed)) % self._window
+        length = stop - start
+        first = min(length, self._window - row)
+        segments = [(slice(row, row + first), slice(0, first))]
+        if first < length:
+            segments.append((slice(0, length - first), slice(first, length)))
+        return segments
 
     def add_layer(self, index: int, layer: torch.Tensor) -> list[tuple[slice, torch.Tensor]]:
         if self._done[index]:
@@ -473,22 +514,24 @@ class StreamingAccumulator(Accumulator):
             if s.stop - s.start == 1:
                 data = data.unsqueeze(dim=dim + n)
         # Same blend as the parent (clamped destination, cropped patch, weighted overlap); the only
-        # difference is that the destination's first spatial index is relative to the window origin.
+        # difference is that the destination rows live in the ring, split at its wrap point.
         dest = [slice(s.start, min(s.stop, self.shape[dim])) for dim, s in enumerate(patch_slice)]
-        crop = tuple([slice(None)] * n + [slice(0, d.stop - d.start) for d in dest])
-        dest[0] = slice(dest[0].start - self._flushed, dest[0].stop - self._flushed)
-        slices_dest = tuple([slice(self._result.shape[i]) for i in range(n)] + dest)
+        crop = [slice(0, d.stop - d.start) for d in dest]
+        lead = tuple(slice(self._result.shape[i]) for i in range(n))
         if self.patch_combine is not None and self._weight_sum is not None:
-            self._result[slices_dest] += self.patch_combine(data)[crop]
+            weighted = self._weighted_patch(data)
             if self._weight_patch is None:
                 # Spatial-only ones: the weight is per-voxel, and deriving it from a channel-sized
                 # ones_like would allocate (and weight) C copies just to index one back out.
                 self._weight_patch = self.patch_combine(
                     torch.ones(data.shape[n:], dtype=data.dtype, device=data.device)
                 )
-            self._weight_sum[tuple(dest)] += self._weight_patch[crop[n:]]
+            for rows, patch_rows in self._segments(dest[0].start, dest[0].stop):
+                self._result[(*lead, rows, *dest[1:])] += weighted[(*(slice(None),) * n, patch_rows, *crop[1:])]
+                self._weight_sum[(rows, *dest[1:])] += self._weight_patch[(patch_rows, *crop[1:])]
         else:
-            self._result[slices_dest] = data[crop]
+            for rows, patch_rows in self._segments(dest[0].start, dest[0].stop):
+                self._result[(*lead, rows, *dest[1:])] = data[(*(slice(None),) * n, patch_rows, *crop[1:])]
         self._done[index] = True
         self._filled += 1
         return slabs
@@ -499,9 +542,11 @@ class StreamingAccumulator(Accumulator):
         self._result = None
         self._weight_sum = None
         self._weight_patch = None
+        self._weighted = None
         self._filled = 0
         self._done = [False] * self._count
         self._flushed = 0
+        self._origin = 0
         return slabs
 
     @property
@@ -519,26 +564,34 @@ class StreamingAccumulator(Accumulator):
         )
 
     def _advance_to(self, z: int) -> list[tuple[slice, torch.Tensor]]:
-        """Finalize the window up to ``z`` (absolute) and shift the window origin there."""
+        """Finalize the ring up to ``z`` (absolute) and move the origin there."""
         z = min(z, self.shape[0])
         if self._result is None or z <= self._flushed:
             return []
         n = self._n
         length = z - self._flushed
+        if length > self._window:
+            raise PatchError(
+                f"StreamingAccumulator asked to finalize {length} rows at once with a {self._window}-row window.",
+                "Patch starts may advance by at most one patch extent per step (checked at construction).",
+            )
         lead = (slice(None),) * n
-        slab = self._result[(*lead, slice(0, length))]
-        if self.patch_combine is not None and self._weight_sum is not None:
-            # Same division and fp16 floor as Accumulator.assemble, applied to the finalized slab.
-            slab = slab / self._weight_sum[:length].clamp(min=torch.finfo(self._weight_sum.dtype).tiny)
-        else:
-            slab = slab.clone()
-        keep = self._window - length
-        # .clone(): source and destination views overlap when length < window.
-        self._result[(*lead, slice(0, keep))] = self._result[(*lead, slice(length, self._window))].clone()
-        self._result[(*lead, slice(keep, self._window))] = 0
-        if self._weight_sum is not None:
-            self._weight_sum[:keep] = self._weight_sum[length : self._window].clone()
-            self._weight_sum[keep:] = 0
+        slab = torch.empty(
+            [*self._result.shape[:n], length, *self.shape[1:]], dtype=self._result.dtype, device=self._result.device
+        )
+        for rows, out_rows in self._segments(self._flushed, z):
+            if self.patch_combine is not None and self._weight_sum is not None:
+                # Same division and fp16 floor as Accumulator.assemble, applied to the finalized rows.
+                torch.div(
+                    self._result[(*lead, rows)],
+                    self._weight_sum[rows].clamp(min=torch.finfo(self._weight_sum.dtype).tiny),
+                    out=slab[(*lead, out_rows)],
+                )
+                self._weight_sum[rows] = 0
+            else:
+                slab[(*lead, out_rows)].copy_(self._result[(*lead, rows)])
+            self._result[(*lead, rows)] = 0
+        self._origin = (self._origin + length) % self._window
         region = slice(self._flushed, z)
         self._flushed = z
         return [(region, slab)]

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -842,10 +842,14 @@ class Patch(ABC):
         # A consumer that REDUCES patches instead (streamed evaluation) must see only in-volume voxels:
         # padded ones would pollute its running sums, so it turns this off and takes the cropped patch.
         self.pad_to_patch = True
+        # The model's per-axis downsampling factor a FREE (``0``) axis rounds up to, set before the grids
+        # are cut so each case's whole-axis extent lands on a valid model input. ``None`` outside a model
+        # (evaluation) or for a network that never downsamples.
+        self.free_axis_multiple: list[int] | None = None
 
     def load(self, shape: list[int], a: int = 0) -> None:
         self._patch_slices[a], self._nb_patch_per_dim[a] = get_patch_slices_from_shape(
-            self.patch_size, shape, self.overlap
+            self.patch_size, shape, self.overlap, self.free_axis_multiple
         )
 
     @abstractmethod
@@ -884,13 +888,25 @@ class Patch(ABC):
                 reflect_padding[-1] = self._patch_slices[a][index][0].stop + top - data_shape[len(slices_pre)]
 
         constant_padding = []
-        if self.pad_to_patch and self.patch_size is not None and not all(p == 0 for p in self.patch_size):
+        if self.pad_to_patch and self.patch_size is not None:
+            nspatial = len(slices)
             for dim_it, _slice in enumerate(reversed(slices)):
-                p = (
-                    0
-                    if _slice.start + self.patch_size[-dim_it - 1] <= data_shape[-dim_it - 1]
-                    else self.patch_size[-dim_it - 1] - (data_shape[-dim_it - 1] - _slice.start)
-                )
+                axis = nspatial - 1 - dim_it
+                extent = data_shape[-dim_it - 1]
+                declared = self.patch_size[axis]
+                if declared != 0:
+                    target = declared
+                else:
+                    # A FREE axis pads up to THIS case's extent rounded to the model's downsampling
+                    # multiple, so a small heterogeneous case still reaches the network at a valid input
+                    # size (the up-front worst-case sizing only guarantees the largest case).
+                    m = (
+                        int(self.free_axis_multiple[axis])
+                        if self.free_axis_multiple is not None and axis < len(self.free_axis_multiple)
+                        else 1
+                    )
+                    target = ((extent + m - 1) // m) * m if m > 1 else extent
+                p = 0 if _slice.start + target <= extent else target - (extent - _slice.start)
                 constant_padding.append(0)
                 constant_padding.append(p)
 
@@ -1035,6 +1051,9 @@ class DatasetManager:
             # The manager works on its own copy (per-case grids); carry the reduction-vs-model contract
             # with it, or a streamed evaluation would silently get padded border patches back.
             self.patch.pad_to_patch = patch.pad_to_patch
+            # Carry the model's downsampling multiple too, so each per-case free axis rounds up to a valid
+            # input size on this copy's grid, not just on the up-front worst-case sizing.
+            self.patch.free_axis_multiple = patch.free_axis_multiple
         self.patch.load(_shape, 0)
         # The spatial grid each copy's patches are cut on: the un-augmented copy's is the source shape
         # folded by the transforms, and a copy whose draw changes shape (Permute, Mask) has its own.

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -687,6 +687,68 @@ class SlabRegionStream:
         return window[(*lead, slice(None), *source[1:])]
 
 
+class SlabAligner:
+    """Merge several slab streams over the same axis into jointly finalized intervals.
+
+    The cross-stream mirror of :class:`StreamingAccumulator`: each stream (a TTA copy's accumulator)
+    emits finalized slabs in non-decreasing order along the shared first spatial axis, and a consumer
+    that needs every stream's rows together — a cross-copy reduction — can only advance to the
+    slowest frontier. ``push`` takes one stream's new slabs and returns the intervals that just
+    became complete, each carrying every stream's rows; only the inter-stream skew is ever buffered,
+    and a single stream passes through untouched. Nothing here knows what a stream is: it is pure
+    interval arithmetic over ``nb_streams`` ordered emitters.
+    """
+
+    def __init__(self, nb_streams: int, lead_dims: int = 1) -> None:
+        self._nb_streams = nb_streams
+        self._lead = lead_dims
+        self._pending: dict[int, list[tuple[int, torch.Tensor]]] = {}
+        self._frontiers: dict[int, int] = {}
+        self._consumed = 0
+        self._completed: set[int] = set()
+
+    @property
+    def complete(self) -> bool:
+        """Whether every stream has pushed its last slab."""
+        return len(self._completed) == self._nb_streams
+
+    def push(
+        self, stream: int, slabs: list[tuple[slice, torch.Tensor]], finished: bool = False
+    ) -> list[tuple[slice, dict[int, torch.Tensor]]]:
+        """Take ``stream``'s freshly finalized slabs and return the newly joint-final intervals."""
+        pending = self._pending.setdefault(stream, [])
+        for region, slab in slabs:
+            pending.append((region.start, slab))
+            self._frontiers[stream] = region.stop
+        if finished:
+            self._completed.add(stream)
+        if len(self._frontiers) < self._nb_streams:
+            return []
+        joint = min(self._frontiers.values())
+        if joint <= self._consumed:
+            return []
+        lead = (slice(None),) * self._lead
+        rows: dict[int, torch.Tensor] = {}
+        for key in sorted(self._pending):
+            pieces = [
+                slab[
+                    (
+                        *lead,
+                        slice(max(start, self._consumed) - start, min(start + slab.shape[self._lead], joint) - start),
+                    )
+                ]
+                for start, slab in self._pending[key]
+                if start < joint and start + slab.shape[self._lead] > self._consumed
+            ]
+            rows[key] = pieces[0] if len(pieces) == 1 else torch.cat(pieces, dim=self._lead)
+            self._pending[key] = [
+                (start, slab) for start, slab in self._pending[key] if start + slab.shape[self._lead] > joint
+            ]
+        interval = slice(self._consumed, joint)
+        self._consumed = joint
+        return [(interval, rows)]
+
+
 class Patch(ABC):
     """Abstract base class for dataset-level and model-level patch definitions."""
 

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -740,6 +740,11 @@ class SlabAligner:
                 for start, slab in self._pending[key]
                 if start < joint and start + slab.shape[self._lead] > self._consumed
             ]
+            if not pieces:
+                raise PatchError(
+                    f"SlabAligner stream {key} holds no rows for [{self._consumed}, {joint}).",
+                    "Push the slabs exactly as the accumulators finalize them, without skipping a stream.",
+                )
             rows[key] = pieces[0] if len(pieces) == 1 else torch.cat(pieces, dim=self._lead)
             self._pending[key] = [
                 (start, slab) for start, slab in self._pending[key] if start + slab.shape[self._lead] > joint

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -37,6 +37,7 @@ from konfai.utils.utils import (
     SUPPORTED_EXTENSIONS,
     OverlapSpec,
     env_flag,
+    free_axis_rounding,
     get_module,
     get_patch_slices_from_shape,
     resolve_overlap,
@@ -900,11 +901,7 @@ class Patch(ABC):
                     # A FREE axis pads up to THIS case's extent rounded to the model's downsampling
                     # multiple, so a small heterogeneous case still reaches the network at a valid input
                     # size (the up-front worst-case sizing only guarantees the largest case).
-                    m = (
-                        int(self.free_axis_multiple[axis])
-                        if self.free_axis_multiple is not None and axis < len(self.free_axis_multiple)
-                        else 1
-                    )
+                    m = free_axis_rounding(self.free_axis_multiple, axis, nspatial)
                     target = ((extent + m - 1) // m) * m if m > 1 else extent
                 p = 0 if _slice.start + target <= extent else target - (extent - _slice.start)
                 constant_padding.append(0)

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -305,17 +305,18 @@ class Accumulator:
         batch: bool = True,
     ) -> None:
         self.patch_slices: list[tuple[slice, ...]] = []
+        self.shape = max([[v.stop for v in patch] for patch in patch_slices])
 
         if patch_size is not None and not all(p == 0 for p in patch_size):
+            # The last patch of an axis is padded up to the patch size for the model, then cropped; a
+            # free axis (0) spans the full extent, so concretise it here or ``s.start + 0`` would
+            # collapse the axis to a zero-width slice.
+            concrete = [size if size > 0 else self.shape[dim] for dim, size in enumerate(patch_size)]
             for patch in patch_slices:
-                slices: list[slice] = []
-                for s, shape in zip(patch, patch_size, strict=False):
-                    slices.append(slice(s.start, s.start + shape))
+                slices = [slice(s.start, s.start + concrete[dim]) for dim, s in enumerate(patch)]
                 self.patch_slices.append(tuple(slices))
         else:
             self.patch_slices = patch_slices
-
-        self.shape = max([[v.stop for v in patch] for patch in patch_slices])
         self.patch_size = patch_size
         self.patch_combine = patch_combine
         self.batch = batch
@@ -970,7 +971,10 @@ class ModelPatch(Patch):
             self.patch_combine = apply_config(key)(getattr(module, name))()
         if self.patch_size is not None and self.overlap is not None:
             if self.patch_combine is not None:
-                kept = [i for i in self.patch_size if i > 1]
+                # Keep every axis so the weight broadcasts against the patch whatever the axis position
+                # (dropping trailing axes misaligns the broadcast); a singleton (1) or free (0) axis
+                # carries a uniform weight, a >1 axis its tapered window.
+                kept = [i if i > 1 else 1 for i in self.patch_size]
                 self.patch_combine.set_patch_config(kept, blend_overlap(self.overlap, kept))
         else:
             self.patch_combine = None

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -1407,8 +1407,9 @@ class Save(Transform):
         self.dataset = dataset
         self.group = group
 
-    # WHOLE_VOLUME on purpose: a Save still in the chain must WRITE the preprocessed volume, and the
-    # streamed path never has one to write. (A Save whose cache exists is a source boundary instead.)
+    # WHOLE_VOLUME by declaration, yet the case may still stream: a Save whose cache exists is a
+    # source boundary, and an unsatisfied Save with a streamable prefix is materialized slab by slab
+    # first (DatasetManager._materialize_save). Only an unsweepable prefix loads the whole volume.
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         return tensor

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -2014,14 +2014,15 @@ class InferenceStack(Transform):
             target = (slice(0, stack.shape[0]), region, *(slice(0, extent) for extent in spatial_shape[1:]))
             self._stack_sinks[name].write_slice(target, stack)
             if region.stop == spatial_shape[0]:
-                self._stack_sinks.pop(name).__exit__(None, None, None)
+                self._stack_sinks.pop(name).close()
         return self._reduce(tensor)
 
     def stream_abort(self, name: str) -> None:
         self._stack_buffers.pop(name, None)
         sink = self._stack_sinks.pop(name, None)
         if sink is not None:
-            sink.__exit__(None, None, None)
+            # Abort, not close: finalizing would publish the partial stack under its final name.
+            sink.abort()
 
 
 class Norm(Transform):

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -877,8 +877,8 @@ class Resample(TransformInverse, ABC):
         half-pixel source (``scale * (o + 0.5) - 0.5``, plus the ``+2``/``halo`` margin for the i1
         neighbour) AND the voxel nearest picks (``floor(o * scale)`` -- F.interpolate's own nearest
         index). Under strong downsampling the nearest voxel of the first output column falls BELOW the
-        linear window's start, so omitting it read one voxel short and the gather wrapped a negative
-        local index onto the far edge.
+        linear window's start: the window must include it, or the gather wraps a negative local index
+        onto the far edge.
         """
         source_slices: list[slice] = []
         for k, sl in enumerate(target_slices):

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -37,7 +37,7 @@ import torch.nn.functional as F
 
 from konfai import cuda_visible_devices
 from konfai.utils.config import _escape_key_component, apply_config
-from konfai.utils.dataset import Attribute, Dataset, data_to_image, image_to_data
+from konfai.utils.dataset import Attribute, Dataset, DataStream, data_to_image, image_to_data
 from konfai.utils.errors import TransformError
 from konfai.utils.ITK import _require_simpleitk, box_with_mask, crop_with_mask
 from konfai.utils.runtime import NeedDevice
@@ -61,6 +61,10 @@ class LocalityKind(Enum):
     - ``GLOBAL_STAT`` -- needs whole-volume stats (``stat_keys`` subset of Min/Max/Mean/Std), obtained
       once from disk and cached: read the exact patch + the cached stat.
     - ``RESCALE``     -- resample: source region via the scale mapping + interpolation halo.
+    - ``SLAB``        -- per-voxel value map, plus a side effect that needs the slab's place in the
+      volume (a per-region side write): the streamed-WRITE dispatcher runs it through
+      :meth:`Transform.stream_slab` with region context; the read dispatcher has no such context and
+      treats it as ``WHOLE_VOLUME``.
     - ``WHOLE_VOLUME``-- genuinely needs the whole volume: the dispatcher falls back to a full load.
     """
 
@@ -70,6 +74,7 @@ class LocalityKind(Enum):
     CROP = "crop"
     GLOBAL_STAT = "global_stat"
     RESCALE = "rescale"
+    SLAB = "slab"
     WHOLE_VOLUME = "whole_volume"
 
     @property
@@ -174,6 +179,24 @@ class Transform(NeedDevice, ABC):
             f"{type(self).__name__} declared a region patch-locality but does not implement stream_region_source().",
             "Implement stream_region_source() or declare a non-region patch_locality().",
         )
+
+    def stream_slab(
+        self,
+        name: str,
+        tensor: torch.Tensor,
+        region: slice,
+        spatial_shape: list[int],
+        cache_attribute: Attribute,
+    ) -> torch.Tensor:
+        """Run this transform on one finalized slab — rows ``region`` of a ``spatial_shape`` volume.
+
+        The streamed-write dispatcher calls this instead of ``__call__`` for a ``SLAB`` declaration:
+        the value map is per-voxel, so the default whole-volume call is exact on the slab, but the
+        stage's side effect needs to know where the slab sits — which is what a ``SLAB`` transform
+        overrides this to read. Slabs arrive in order and tile the volume exactly once per case.
+        """
+        del region, spatial_shape
+        return self(name, tensor, cache_attribute)
 
     def write_stream_cache_attribute(self, cache_attribute: Attribute, source_spatial_shape: list[int]) -> None:
         """Record the geometry a whole-volume ``__call__`` would, given the FULL source shape.
@@ -1890,25 +1913,71 @@ class InferenceStack(Transform):
             self.dataset = Dataset(filename, file_format)
         self.name = name
         self.mode = mode
+        self._stack_sinks: dict[str, DataStream] = {}
+        self._stack_buffers: dict[str, list[np.ndarray]] = {}
 
-    # patch_locality stays the WHOLE_VOLUME default: the member reduction is pointwise, but __call__
-    # also WRITES the whole per-member stack to disk (like Save), which a per-patch pass cannot do. It
-    # is an ensemble/finalize transform, never in a streaming input chain, so this costs no streaming.
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # The member reduction is per-voxel; the per-member stack write is the side effect that needs
+        # the slab's place in the volume, which is exactly what SLAB declares (whole-volume on the
+        # read side, streamed region by region on the write side via ``stream_slab``).
+        return PatchLocality(LocalityKind.SLAB)
 
-    def __call__(self, name: str, tensors: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
-        if tensors.shape[0] == 1:
-            return tensors.squeeze(0)
+    def _stack(self, tensors: torch.Tensor) -> np.ndarray:
         if self.mode == "Seg":
             _tensors = torch.argmax(torch.softmax(tensors, dim=1), dim=1).to(torch.uint8)
         else:
             _tensors = tensors.squeeze(1)
-        dataset = self.dataset if self.dataset else self.datasets[-1]
-        dataset.write("InferenceStack", name, _tensors.float().cpu().numpy(), cache_attribute)
+        return _tensors.float().cpu().numpy()
+
+    def _reduce(self, tensors: torch.Tensor) -> torch.Tensor:
         return (
             torch.median(tensors.float(), dim=0).values.to(tensors.dtype)
             if self.mode == "median"
             else tensors.float().mean(0).to(tensors.dtype)
         )
+
+    def __call__(self, name: str, tensors: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
+        if tensors.shape[0] == 1:
+            return tensors.squeeze(0)
+        dataset = self.dataset if self.dataset else self.datasets[-1]
+        dataset.write("InferenceStack", name, self._stack(tensors), cache_attribute)
+        return self._reduce(tensors)
+
+    def stream_slab(
+        self,
+        name: str,
+        tensor: torch.Tensor,
+        region: slice,
+        spatial_shape: list[int],
+        cache_attribute: Attribute,
+    ) -> torch.Tensor:
+        """The whole-volume call, region by region: reduce the members per voxel and write the slab's
+        rows of the per-member stack into a region sink opened at the first slab. A destination that
+        cannot serve region writes falls back to buffering the stack and writing it classically at
+        the last slab — the memory cost of the whole-volume path, never a lost stack."""
+        if tensor.shape[0] == 1:
+            return tensor.squeeze(0)
+        stack = self._stack(tensor)
+        dataset = self.dataset if self.dataset else self.datasets[-1]
+        if name not in self._stack_sinks and name not in self._stack_buffers:
+            sink = dataset.open_data_stream(
+                "InferenceStack", name, [stack.shape[0], *spatial_shape], stack.dtype, cache_attribute
+            )
+            if sink is None:
+                self._stack_buffers[name] = []
+            else:
+                self._stack_sinks[name] = sink
+        if name in self._stack_buffers:
+            self._stack_buffers[name].append(stack)
+            if region.stop == spatial_shape[0]:
+                whole = np.concatenate(self._stack_buffers.pop(name), axis=1)
+                dataset.write("InferenceStack", name, whole, cache_attribute)
+        else:
+            target = (slice(0, stack.shape[0]), region, *(slice(0, extent) for extent in spatial_shape[1:]))
+            self._stack_sinks[name].write_slice(target, stack)
+            if region.stop == spatial_shape[0]:
+                self._stack_sinks.pop(name).__exit__(None, None, None)
+        return self._reduce(tensor)
 
 
 class Norm(Transform):

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -198,6 +198,13 @@ class Transform(NeedDevice, ABC):
         del region, spatial_shape
         return self(name, tensor, cache_attribute)
 
+    def stream_abort(self, name: str) -> None:
+        """Drop whatever ``stream_slab`` holds open for ``name`` after a mid-case failure.
+
+        Called by the streamed-write dispatcher when a case dies between slabs, so a ``SLAB`` stage's
+        region sink or buffer does not outlive the case. The base holds nothing.
+        """
+
     def write_stream_cache_attribute(self, cache_attribute: Attribute, source_spatial_shape: list[int]) -> None:
         """Record the geometry a whole-volume ``__call__`` would, given the FULL source shape.
 
@@ -1978,6 +1985,12 @@ class InferenceStack(Transform):
             if region.stop == spatial_shape[0]:
                 self._stack_sinks.pop(name).__exit__(None, None, None)
         return self._reduce(tensor)
+
+    def stream_abort(self, name: str) -> None:
+        self._stack_buffers.pop(name, None)
+        sink = self._stack_sinks.pop(name, None)
+        if sink is not None:
+            sink.__exit__(None, None, None)
 
 
 class Norm(Transform):

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -737,6 +737,9 @@ class Squeeze(TransformInverse):
         super().__init__(inverse)
         self.dim = dim
 
+    # WHOLE_VOLUME on purpose: squeeze/unsqueeze changes the tensor rank, and the streamed write sizes
+    # each slab from the pre-finalize accumulator grid -- a rank change past it cannot region-stream.
+
     def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
         # ``shape`` is the channel-stripped spatial shape (patching strips [C, *spatial] before folding),
         # so the runtime tensor is [C, *shape] and ``self.dim`` indexes into that. Squeezing the channel
@@ -2031,6 +2034,9 @@ class Norm(Transform):
 
     def __init__(self) -> None:
         super().__init__()
+
+    # WHOLE_VOLUME on purpose: the magnitude drops the trailing spatial axis, and the streamed write
+    # sizes each slab from the pre-finalize accumulator grid -- a rank change past it cannot region-stream.
 
     def __call__(self, name: str, tensors: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         if "Origin" in cache_attribute:

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -1142,9 +1142,11 @@ class ResampleTransform(TransformInverse):
 class Mask(Transform):
     """Set everything outside a mask to a constant.
 
-    Whole-volume: ``__call__`` does not know where its tensor sits, so it cannot read the matching
-    region of the mask (``Clip(mask=)`` and ``Standardize(mask=)`` load whole volumes for the same
-    reason).
+    Per-voxel, so it declares ``SLAB``: the value map is exact on a slab, and the only thing that
+    needs the slab's place in the volume is *which rows of the mask to read*. The mask is assumed
+    aligned to the volume at this point, so a slab reads the matching rows of the mask (a dataset mask
+    region-read, a ``.mha`` mask sliced from the one cached copy) instead of loading the whole volume.
+    ``__call__`` (the whole-volume path, and the read side, which has no region to place) stays exact.
     """
 
     def __init__(self, path: str = "./default.mha", value_outside: int = 0) -> None:
@@ -1153,24 +1155,49 @@ class Mask(Transform):
         self.value_outside = value_outside
         self._cached_mask: torch.Tensor | None = None
 
-    def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
-        if self.path.endswith(".mha"):
-            _require_simpleitk()
-            if self._cached_mask is None:
-                self._cached_mask = torch.tensor(sitk.GetArrayFromImage(sitk.ReadImage(self.path))).unsqueeze(0)
-            mask = self._cached_mask
-        else:
-            mask = None
-            for dataset in self.datasets:
-                if dataset.is_dataset_exist(self.path, name):
-                    mask, _ = dataset.read_data(self.path, name)
-                    break
-            if mask is None:
-                raise NameError(f"Mask : {self.path}/{name} not found")
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        return PatchLocality(LocalityKind.SLAB)
+
+    def _apply(self, tensor: torch.Tensor, mask: torch.Tensor | np.ndarray) -> torch.Tensor:
         # Index on the tensor's own device so the mask works whether the volume is on CPU or GPU
         # (``torch.as_tensor`` keeps a torch mask as-is and wraps a numpy one, moving it to the device).
         tensor[torch.as_tensor(mask, device=tensor.device) == 0] = self.value_outside
         return tensor
+
+    def _cached_mha(self) -> torch.Tensor:
+        _require_simpleitk()
+        if self._cached_mask is None:
+            self._cached_mask = torch.tensor(sitk.GetArrayFromImage(sitk.ReadImage(self.path))).unsqueeze(0)
+        return self._cached_mask
+
+    def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
+        if self.path.endswith(".mha"):
+            return self._apply(tensor, self._cached_mha())
+        for dataset in self.datasets:
+            if dataset.is_dataset_exist(self.path, name):
+                mask, _ = dataset.read_data(self.path, name)
+                return self._apply(tensor, mask)
+        raise NameError(f"Mask : {self.path}/{name} not found")
+
+    def stream_slab(
+        self,
+        name: str,
+        tensor: torch.Tensor,
+        region: slice,
+        spatial_shape: list[int],
+        cache_attribute: Attribute,
+    ) -> torch.Tensor:
+        # Read only the slab's rows of the (aligned) mask, so the output streams within a window: a
+        # dataset mask is region-read; a ``.mha`` mask is sliced from the single cached copy (the mask
+        # is 1-channel, far smaller than the C-channel output it would otherwise hold whole).
+        if self.path.endswith(".mha"):
+            return self._apply(tensor, self._cached_mha()[:, region])
+        slices = (slice(None), region, *(slice(0, extent) for extent in spatial_shape[1:]))
+        for dataset in self.datasets:
+            if dataset.is_dataset_exist(self.path, name):
+                mask, _ = dataset.read_data_slice(self.path, name, slices)
+                return self._apply(tensor, mask)
+        raise NameError(f"Mask : {self.path}/{name} not found")
 
 
 class Dilate(Transform):

--- a/konfai/evaluator.py
+++ b/konfai/evaluator.py
@@ -384,17 +384,7 @@ class Evaluator(DistributedObject):
             output_tensor = batch_sample[output_group].tensor
             metric_device = output_tensor.device
             for target_group in self.metrics[output_group]:
-                targets = [
-                    (
-                        batch_sample[group].tensor.to(
-                            metric_device, non_blocking=batch_sample[group].tensor.device.type == "cpu"
-                        )
-                        if batch_sample[group].tensor.device != metric_device
-                        else batch_sample[group].tensor
-                    )
-                    for group in target_group.split(";")
-                    if group in batch_sample
-                ]
+                targets = self._targets_on(batch_sample, target_group, metric_device)
                 target_attribute = [batch_sample[output_group].attribute] + [
                     batch_sample[group].attribute for group in target_group.split(";") if group in batch_sample
                 ]
@@ -442,6 +432,21 @@ class Evaluator(DistributedObject):
         return result
 
     @staticmethod
+    def _targets_on(batch_sample: BatchSample, target_group: str, metric_device: torch.device) -> list[torch.Tensor]:
+        """The target tensors of a ``;``-joined group spec, moved to the metric's device."""
+        return [
+            (
+                batch_sample[group].tensor.to(
+                    metric_device, non_blocking=batch_sample[group].tensor.device.type == "cpu"
+                )
+                if batch_sample[group].tensor.device != metric_device
+                else batch_sample[group].tensor
+            )
+            for group in target_group.split(";")
+            if group in batch_sample
+        ]
+
+    @staticmethod
     def _record_value(
         result: dict[str, float],
         statistics: Statistics,
@@ -473,7 +478,7 @@ class Evaluator(DistributedObject):
         rank), so a change of case name marks the previous case complete -- ``_flush_pending`` at the
         end of the split closes the last one.
         """
-        name = next(batch_sample[output_group].name[0] for output_group in self.metrics)
+        name = batch_sample[next(iter(self.metrics))].name[0]
         if self._pending_name is not None and name != self._pending_name:
             self._flush_pending(statistics)
         self._pending_name = name
@@ -481,17 +486,7 @@ class Evaluator(DistributedObject):
             output_tensor = batch_sample[output_group].tensor
             metric_device = output_tensor.device
             for target_group in self.metrics[output_group]:
-                targets = [
-                    (
-                        batch_sample[group].tensor.to(
-                            metric_device, non_blocking=batch_sample[group].tensor.device.type == "cpu"
-                        )
-                        if batch_sample[group].tensor.device != metric_device
-                        else batch_sample[group].tensor
-                    )
-                    for group in target_group.split(";")
-                    if group in batch_sample
-                ]
+                targets = self._targets_on(batch_sample, target_group, metric_device)
                 for index, metric in enumerate(self.metrics[output_group][target_group]):
                     with torch.no_grad():
                         state = metric.partial_metric(output_tensor, *targets)
@@ -597,74 +592,46 @@ class Evaluator(DistributedObject):
             - Only the main process (`global_rank == 0`) writes final results to disk.
         """
 
+        self._evaluate_split(dataloaders[0], self.statistics_train, "TRAIN", world_size, gpu, global_rank)
+        if len(dataloaders) == 2:
+            self._evaluate_split(dataloaders[1], self.statistics_validation, "VALIDATION", world_size, gpu, global_rank)
+
+    def _evaluate_split(
+        self,
+        dataloader: DataLoader,
+        statistics: Statistics,
+        label: str,
+        world_size: int,
+        gpu: int,
+        global_rank: int,
+    ) -> None:
         def description(measure):
             return (
-                f"Metric TRAIN : {' | '.join(f'{k}: {v:.4f}' for k, v in measure.items())}"
+                f"Metric {label} : {' | '.join(f'{k}: {v:.4f}' for k, v in measure.items())}"
                 if measure is not None
-                else "Metric TRAIN : "
+                else f"Metric {label} : "
             )
 
-        self._iter_dataset = dataloaders[0].dataset
+        self._iter_dataset = dataloader.dataset
         try:
             with tqdm.tqdm(
-                iterable=enumerate(dataloaders[0]),
+                iterable=enumerate(dataloader),
                 leave=True,
                 desc=description(None),
-                total=len(dataloaders[0]),
+                total=len(dataloader),
                 ncols=0,
             ) as batch_iter:
                 for _, batch_sample in batch_iter:
-                    batch_iter.set_description(
-                        description(
-                            self.update(
-                                batch_sample,
-                                self.statistics_train,
-                            )
-                        )
-                    )
-            self._flush_pending(self.statistics_train)  # close the split's last case
+                    batch_iter.set_description(description(self.update(batch_sample, statistics)))
+            self._flush_pending(statistics)  # close the split's last case
         except BaseException as error:
             # A half-written error map must not survive as a valid-looking file: abort the open
             # region-write sinks so their backends remove the partial entries, then re-raise.
             self._abort_map_sinks(error)
             raise
-        outputs = synchronize_data(world_size, gpu, self.statistics_train.measures)
+        outputs = synchronize_data(world_size, gpu, statistics.measures)
         if global_rank == 0:
-            self.statistics_train.write(outputs)
-        if len(dataloaders) == 2:
-
-            def description(measure):
-                return (
-                    f"Metric VALIDATION : {' | '.join(f'{k}: {v:.4f}' for k, v in measure.items())}"
-                    if measure is not None
-                    else "Metric VALIDATION : "
-                )
-
-            self._iter_dataset = dataloaders[1].dataset
-            try:
-                with tqdm.tqdm(
-                    iterable=enumerate(dataloaders[1]),
-                    leave=True,
-                    desc=description(None),
-                    total=len(dataloaders[1]),
-                    ncols=0,
-                ) as batch_iter:
-                    for _, batch_sample in batch_iter:
-                        batch_iter.set_description(
-                            description(
-                                self.update(
-                                    batch_sample,
-                                    self.statistics_validation,
-                                )
-                            )
-                        )
-                self._flush_pending(self.statistics_validation)  # close the split's last case
-            except BaseException as error:
-                self._abort_map_sinks(error)
-                raise
-            outputs = synchronize_data(world_size, gpu, self.statistics_validation.measures)
-            if global_rank == 0:
-                self.statistics_validation.write(outputs)
+            statistics.write(outputs)
 
 
 def build_evaluate(

--- a/konfai/evaluator.py
+++ b/konfai/evaluator.py
@@ -551,7 +551,7 @@ class Evaluator(DistributedObject):
     def _abort_map_sinks(self, error: BaseException) -> None:
         """Close open map sinks WITH the error so the backends remove their partial entries."""
         for sink in self._map_sinks.values():
-            sink.__exit__(type(error), error, error.__traceback__)
+            sink.abort(error)
         self._map_sinks = {}
 
     def _flush_pending(self, statistics: Statistics) -> None:
@@ -566,7 +566,7 @@ class Evaluator(DistributedObject):
             base_key = f"{output_group}:{target_group}:{metric.get_name()}"
             Evaluator._record_value(result, statistics, base_key, true_loss, direction)
         for sink in self._map_sinks.values():
-            sink.__exit__(None, None, None)
+            sink.close()
         self._map_sinks = {}
         if len(self.metrics) > 0:
             statistics.add(result, self._pending_name)

--- a/konfai/network/network.py
+++ b/konfai/network/network.py
@@ -513,6 +513,28 @@ def _leaf_spatial_stride(module: torch.nn.Module) -> list[int] | None:
     return [int(s) for s in (stride if isinstance(stride, (tuple, list)) else [stride] * ndim)]
 
 
+def _flat_downsampling(module: torch.nn.Module, ndim: int) -> list[int]:
+    """Product of every strided ``Conv``/``MaxPool`` inside ``module`` (itself included), each
+    trailing-aligned to ``ndim`` -- a leaf of lower dimensionality acts on the LAST axes, so a 2D conv in
+    a 3D graph leaves the leading axis untouched.
+
+    This is the factor for an OPAQUE child: a plain torch module whose internal graph the branch trace
+    cannot see (a wrapped torchvision/MONAI/smp net added as one ``add_module`` leaf). The flat product
+    over-counts a parallel strided shortcut inside it, but over-padding is safe where under-counting
+    crashes the model's skip reassembly.
+    """
+    factor = [1] * ndim
+    for leaf in module.modules():
+        stride = _leaf_spatial_stride(leaf)
+        if stride is None:
+            continue
+        offset = ndim - len(stride)
+        for axis, size in enumerate(stride):
+            if axis + offset >= 0:
+                factor[axis + offset] *= size
+    return factor
+
+
 class ModuleArgsDict(torch.nn.Module, ABC):
     """Named module graph container supporting KonfAI branch routing metadata."""
 
@@ -824,8 +846,9 @@ class ModuleArgsDict(torch.nn.Module, ABC):
         """Propagate the per-axis downsampling factor through the branch register, recording each branch
         value in ``seen``. Parallel branches -- a residual shortcut beside the main path -- accumulate from
         the SAME seed and merge at their ``Add`` without multiplying, so a strided projection is not
-        double-counted the way a flat ``modules()`` walk would. An unwritten branch reads the block input,
-        exactly as ``named_forward`` seeds it. Returns the factor at this block's last output.
+        double-counted the way a flat ``modules()`` walk would. A child that is NOT a routed block is
+        opaque and contributes its flat internal product (``_flat_downsampling``). An unwritten branch
+        reads the block input, exactly as ``named_forward`` seeds it. Returns the last output's factor.
         """
         branches: dict[str, list[int]] = {"0": seed}
         out_f = seed
@@ -835,8 +858,7 @@ class ModuleArgsDict(torch.nn.Module, ABC):
             if isinstance(module, ModuleArgsDict):
                 out_f = module._trace_downsampling(in_f, seen)
             else:
-                stride = _leaf_spatial_stride(module)
-                out_f = [a * b for a, b in zip(in_f, stride, strict=False)] if stride is not None else in_f
+                out_f = [a * b for a, b in zip(in_f, _flat_downsampling(module, len(seed)), strict=True)]
             for out_branch in module_args.out_branch:
                 branches[out_branch] = out_f
             seen.append(out_f)
@@ -1207,13 +1229,10 @@ class Network(ModuleArgsDict, ABC):
         (parallel to its strided main conv, merged by ``Add``) counts ONCE, not twice. Used to size a
         free (``0``) patch axis to a valid extent (padded up, cropped back after the forward).
         """
-        ndim: int | None = None
-        for module in self.modules():
-            stride = _leaf_spatial_stride(module)
-            if stride is not None:
-                ndim = len(stride)
-                break
-        if ndim is None:
+        # The graph's spatial rank = the WIDEST strided leaf (a 2D side head in a 3D net must not lock
+        # the rank to 2); every leaf stride then aligns to the trailing axes of that rank.
+        ndim = max((len(s) for s in map(_leaf_spatial_stride, self.modules()) if s is not None), default=0)
+        if ndim == 0:
             return None
         seen: list[list[int]] = []
         self._trace_downsampling([1] * ndim, seen)

--- a/konfai/network/network.py
+++ b/konfai/network/network.py
@@ -1155,6 +1155,37 @@ class Network(ModuleArgsDict, ABC):
 
         return in_channels, in_is_channel, out_channels, out_is_channel
 
+    def downsampling_factor(self) -> list[int] | None:
+        """Per-axis factor the input spatial size must be a multiple of, or ``None`` if the graph never
+        downsamples.
+
+        An encoder/decoder graph (U-Net) only reassembles its skip connections when the input divides
+        evenly at every level, so the input must be a multiple of the product of the encoder's
+        downsampling strides. That product is read straight off the graph: every ``MaxPool`` and every
+        stride>1 ``Conv`` multiplies the factor. The residual branch's ``AvgPool`` and the decoder's
+        ``ConvTranspose``/``Upsample`` do not shrink the skip path, so they are not counted. Used to
+        size a free (``0``) patch axis to a valid extent (padded up, cropped back after the forward).
+        """
+        factor: list[int] | None = None
+        for module in self.modules():
+            stride: int | tuple[int, ...] | None = None
+            if isinstance(module, (torch.nn.MaxPool1d, torch.nn.MaxPool2d, torch.nn.MaxPool3d)):
+                stride = module.stride if module.stride is not None else module.kernel_size
+            elif isinstance(module, (torch.nn.Conv1d, torch.nn.Conv2d, torch.nn.Conv3d)):
+                stride = module.stride
+            if stride is None:
+                continue
+            name = type(module).__name__
+            ndim = 3 if name.endswith("3d") else 2 if name.endswith("2d") else 1
+            strides = list(stride) if isinstance(stride, (tuple, list)) else [stride] * ndim
+            if all(s <= 1 for s in strides):
+                continue
+            if factor is None:
+                factor = [1] * len(strides)
+            for axis, s in enumerate(strides):
+                factor[axis] *= s
+        return factor
+
     @_function_network()
     def init(self, autocast: bool, state: State, group_dest: list[str], key: str) -> None:
         if self.outputs_criterions_loader:

--- a/konfai/network/network.py
+++ b/konfai/network/network.py
@@ -496,13 +496,25 @@ class Measure:
 
 
 def _leaf_spatial_stride(module: torch.nn.Module) -> list[int] | None:
-    """Per-axis stride of a leaf that shrinks the grid (a ``Conv`` or ``MaxPool``), else ``None``.
+    """Per-axis stride of a leaf that shrinks the grid (a ``Conv``, ``MaxPool`` or ``AvgPool``), else
+    ``None``.
 
-    ``ConvTranspose``/``Upsample`` (they grow the grid) and a residual branch's ``AvgPool`` (it does not
-    shrink the skip the graph reassembles) are not strided-down leaves, so they read ``None`` and the
-    downsampling trace passes their input factor straight through.
+    ``ConvTranspose``/``Upsample`` grow the grid, so they read ``None`` and the trace passes their input
+    factor straight through. ``AvgPool`` IS a downsampler (a model may pool on its main path) and is
+    counted: a residual branch's ``AvgPool`` does not inflate the factor because the branch-aware trace
+    merges the parallel main path and shortcut by their per-axis MAX, not their product.
     """
-    if isinstance(module, (torch.nn.MaxPool1d, torch.nn.MaxPool2d, torch.nn.MaxPool3d)):
+    if isinstance(
+        module,
+        (
+            torch.nn.MaxPool1d,
+            torch.nn.MaxPool2d,
+            torch.nn.MaxPool3d,
+            torch.nn.AvgPool1d,
+            torch.nn.AvgPool2d,
+            torch.nn.AvgPool3d,
+        ),
+    ):
         stride = module.stride if module.stride is not None else module.kernel_size
     elif isinstance(module, (torch.nn.Conv1d, torch.nn.Conv2d, torch.nn.Conv3d)):
         stride = module.stride
@@ -842,23 +854,28 @@ class ModuleArgsDict(torch.nn.Module, ABC):
                 if len(keys) == 0:
                     break
 
-    def _trace_downsampling(self, seed: list[int], seen: list[list[int]]) -> list[int]:
+    def _trace_downsampling(self, seeds: list[list[int]], seen: list[list[int]]) -> list[int]:
         """Propagate the per-axis downsampling factor through the branch register, recording each branch
         value in ``seen``. Parallel branches -- a residual shortcut beside the main path -- accumulate from
         the SAME seed and merge at their ``Add`` without multiplying, so a strided projection is not
         double-counted the way a flat ``modules()`` walk would. A child that is NOT a routed block is
-        opaque and contributes its flat internal product (``_flat_downsampling``). An unwritten branch
-        reads the block input, exactly as ``named_forward`` seeds it. Returns the last output's factor.
+        opaque and contributes its flat internal product (``_flat_downsampling``).
+
+        ``seeds`` are this block's input factors, one per positional input; the register is seeded from
+        all of them (a decoder block reading ``[upsampled, skip]`` keeps each at its own resolution) and
+        an unwritten branch falls back to the first, exactly as ``named_forward`` seeds it. A module
+        downsamples along its FIRST input branch; the others only route. Returns the last output's factor.
         """
-        branches: dict[str, list[int]] = {"0": seed}
-        out_f = seed
+        branches: dict[str, list[int]] = {str(i): seed for i, seed in enumerate(seeds)}
+        default = seeds[0]
+        out_f = default
         for name, module in self.items():
             module_args = self._modulesArgs[name]
-            in_f = branches.get(module_args.in_branch[0], seed)
+            in_factors = [branches.get(in_branch, default) for in_branch in module_args.in_branch]
             if isinstance(module, ModuleArgsDict):
-                out_f = module._trace_downsampling(in_f, seen)
+                out_f = module._trace_downsampling(in_factors, seen)
             else:
-                out_f = [a * b for a, b in zip(in_f, _flat_downsampling(module, len(seed)), strict=True)]
+                out_f = [a * b for a, b in zip(in_factors[0], _flat_downsampling(module, len(default)), strict=True)]
             for out_branch in module_args.out_branch:
                 branches[out_branch] = out_f
             seen.append(out_f)
@@ -1235,7 +1252,7 @@ class Network(ModuleArgsDict, ABC):
         if ndim == 0:
             return None
         seen: list[list[int]] = []
-        self._trace_downsampling([1] * ndim, seen)
+        self._trace_downsampling([[1] * ndim], seen)
         factor = [max((f[axis] for f in seen), default=1) for axis in range(ndim)]
         return factor if any(f > 1 for f in factor) else None
 

--- a/konfai/network/network.py
+++ b/konfai/network/network.py
@@ -495,6 +495,24 @@ class Measure:
         return _scheduler
 
 
+def _leaf_spatial_stride(module: torch.nn.Module) -> list[int] | None:
+    """Per-axis stride of a leaf that shrinks the grid (a ``Conv`` or ``MaxPool``), else ``None``.
+
+    ``ConvTranspose``/``Upsample`` (they grow the grid) and a residual branch's ``AvgPool`` (it does not
+    shrink the skip the graph reassembles) are not strided-down leaves, so they read ``None`` and the
+    downsampling trace passes their input factor straight through.
+    """
+    if isinstance(module, (torch.nn.MaxPool1d, torch.nn.MaxPool2d, torch.nn.MaxPool3d)):
+        stride = module.stride if module.stride is not None else module.kernel_size
+    elif isinstance(module, (torch.nn.Conv1d, torch.nn.Conv2d, torch.nn.Conv3d)):
+        stride = module.stride
+    else:
+        return None
+    name = type(module).__name__
+    ndim = 3 if name.endswith("3d") else 2 if name.endswith("2d") else 1
+    return [int(s) for s in (stride if isinstance(stride, (tuple, list)) else [stride] * ndim)]
+
+
 class ModuleArgsDict(torch.nn.Module, ABC):
     """Named module graph container supporting KonfAI branch routing metadata."""
 
@@ -801,6 +819,28 @@ class ModuleArgsDict(torch.nn.Module, ABC):
                 keys.remove(name)
                 if len(keys) == 0:
                     break
+
+    def _trace_downsampling(self, seed: list[int], seen: list[list[int]]) -> list[int]:
+        """Propagate the per-axis downsampling factor through the branch register, recording each branch
+        value in ``seen``. Parallel branches -- a residual shortcut beside the main path -- accumulate from
+        the SAME seed and merge at their ``Add`` without multiplying, so a strided projection is not
+        double-counted the way a flat ``modules()`` walk would. An unwritten branch reads the block input,
+        exactly as ``named_forward`` seeds it. Returns the factor at this block's last output.
+        """
+        branches: dict[str, list[int]] = {"0": seed}
+        out_f = seed
+        for name, module in self.items():
+            module_args = self._modulesArgs[name]
+            in_f = branches.get(module_args.in_branch[0], seed)
+            if isinstance(module, ModuleArgsDict):
+                out_f = module._trace_downsampling(in_f, seen)
+            else:
+                stride = _leaf_spatial_stride(module)
+                out_f = [a * b for a, b in zip(in_f, stride, strict=False)] if stride is not None else in_f
+            for out_branch in module_args.out_branch:
+                branches[out_branch] = out_f
+            seen.append(out_f)
+        return out_f
 
 
 class OutputsGroup(list):
@@ -1160,31 +1200,25 @@ class Network(ModuleArgsDict, ABC):
         downsamples.
 
         An encoder/decoder graph (U-Net) only reassembles its skip connections when the input divides
-        evenly at every level, so the input must be a multiple of the product of the encoder's
-        downsampling strides. That product is read straight off the graph: every ``MaxPool`` and every
-        stride>1 ``Conv`` multiplies the factor. The residual branch's ``AvgPool`` and the decoder's
-        ``ConvTranspose``/``Upsample`` do not shrink the skip path, so they are not counted. Used to
-        size a free (``0``) patch axis to a valid extent (padded up, cropped back after the forward).
+        evenly at every level, so the input must be a multiple of the coarsest downsampling the graph
+        reaches. That factor is traced through the branch register: a strided ``Conv`` or a ``MaxPool``
+        multiplies the branch it writes, while ``ConvTranspose``/``Upsample`` and a residual branch's
+        ``AvgPool`` pass through. Because the trace follows branches, a residual block's strided shortcut
+        (parallel to its strided main conv, merged by ``Add``) counts ONCE, not twice. Used to size a
+        free (``0``) patch axis to a valid extent (padded up, cropped back after the forward).
         """
-        factor: list[int] | None = None
+        ndim: int | None = None
         for module in self.modules():
-            stride: int | tuple[int, ...] | None = None
-            if isinstance(module, (torch.nn.MaxPool1d, torch.nn.MaxPool2d, torch.nn.MaxPool3d)):
-                stride = module.stride if module.stride is not None else module.kernel_size
-            elif isinstance(module, (torch.nn.Conv1d, torch.nn.Conv2d, torch.nn.Conv3d)):
-                stride = module.stride
-            if stride is None:
-                continue
-            name = type(module).__name__
-            ndim = 3 if name.endswith("3d") else 2 if name.endswith("2d") else 1
-            strides = list(stride) if isinstance(stride, (tuple, list)) else [stride] * ndim
-            if all(s <= 1 for s in strides):
-                continue
-            if factor is None:
-                factor = [1] * len(strides)
-            for axis, s in enumerate(strides):
-                factor[axis] *= s
-        return factor
+            stride = _leaf_spatial_stride(module)
+            if stride is not None:
+                ndim = len(stride)
+                break
+        if ndim is None:
+            return None
+        seen: list[list[int]] = []
+        self._trace_downsampling([1] * ndim, seen)
+        factor = [max((f[axis] for f in seen), default=1) for axis in range(ndim)]
+        return factor if any(f > 1 for f in factor) else None
 
     @_function_network()
     def init(self, autocast: bool, state: State, group_dest: list[str], key: str) -> None:

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -23,6 +23,7 @@ import shutil
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -571,6 +572,11 @@ class OutSameAsGroupDataset(OutputDataset):
             sink = self._stream_sinks.pop(index_dataset, None)
             if sink is not None:
                 sink.__exit__(type(error), error, error.__traceback__)
+            plan = self._stream_plans.get(index_dataset)
+            if plan is not None:
+                for position in plan.slab_stages:
+                    with suppress(Exception):
+                        plan.stages[position].transform.stream_abort(self.names[index_dataset])
             raise
         if finished:
             self._close_stream(index_dataset)

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -704,7 +704,11 @@ class OutSameAsGroupDataset(OutputDataset):
         if self.nb_data_augmentation != 1 and not self._tta_streamable(dataset, index, attribute):
             return None
         for transform in self.before_reduction_transforms:
-            if not self._voxel_local(transform.patch_locality(Attribute(attribute)), attribute):
+            locality = transform.patch_locality(Attribute(attribute))
+            # A SLAB before-reduction transform (e.g. Mask) streams per slab through ``stream_slab`` in
+            # ``_prepare_copy_slab``, so it does not force the whole-volume path; anything else that is
+            # not voxel-local (a spatial mix, an unseeded statistic) still refuses outright.
+            if not self._voxel_local(locality, attribute) and locality.kind is not LocalityKind.SLAB:
                 return None
         stages = [
             *(_FinalizeStage(transform, False) for transform in self.after_reduction_transforms),
@@ -1071,10 +1075,14 @@ class OutSameAsGroupDataset(OutputDataset):
         layer: torch.Tensor,
         number_of_channels_per_model: list[int] | None,
         dataset: DatasetIter,
+        region: slice,
+        spatial: list[int],
     ) -> torch.Tensor:
         """One copy's slab through the per-copy head of ``_get_output``: un-augment it (exact on a
         slab — the gate admitted only slab-parallel draws), split the model chunks, run
-        before_reduction on each, and stack to the copy's ``[1, M, C, ...]`` block."""
+        before_reduction on each, and stack to the copy's ``[1, M, C, ...]`` block. A SLAB
+        before-reduction transform learns where the slab sits through ``stream_slab`` (the accumulator
+        grid, where before_reduction runs), so it reads its slab region instead of the whole volume."""
         layer = self._unaugment(dataset, index, index_augmentation, layer)
         attribute = Attribute(self.attributes[index][index_augmentation][0])
         if number_of_channels_per_model and layer.shape[0] == sum(number_of_channels_per_model):
@@ -1085,7 +1093,10 @@ class OutSameAsGroupDataset(OutputDataset):
         results = []
         for chunk in chunks:
             for transform in self.before_reduction_transforms:
-                chunk = transform(self.names[index], chunk, Attribute(attribute))
+                if transform.patch_locality(Attribute(attribute)).kind is LocalityKind.SLAB:
+                    chunk = transform.stream_slab(self.names[index], chunk, region, spatial, Attribute(attribute))
+                else:
+                    chunk = transform(self.names[index], chunk, Attribute(attribute))
             results.append(chunk)
         # A lone chunk stacks as a view: torch.stack would copy the slab once per slab of the case.
         if len(results) == 1:
@@ -1111,8 +1122,11 @@ class OutSameAsGroupDataset(OutputDataset):
         case attribute (transform writes stay slab-local, and case-level pops repeat identically per
         slab).
         """
+        spatial = [int(extent) for extent in self.output_layer_accumulator[index][0].shape]
         blocks = [
-            self._prepare_copy_slab(index, index_augmentation, layer, number_of_channels_per_model, dataset)
+            self._prepare_copy_slab(
+                index, index_augmentation, layer, number_of_channels_per_model, dataset, region, spatial
+            )
             for index_augmentation, layer in copies.items()
         ]
         # Mixed devices can only come from a mid-case OOM fallback: reconcile on the host, exactly as
@@ -1128,7 +1142,6 @@ class OutSameAsGroupDataset(OutputDataset):
         first = next(iter(copies.values()))
         if number_of_channels_per_model and first.shape[0] == sum(number_of_channels_per_model):
             attribute["number_of_channels_per_model_0"] = torch.tensor(number_of_channels_per_model)
-        spatial = [int(extent) for extent in self.output_layer_accumulator[index][0].shape]
         for position, stage in enumerate(plan.stages[: plan.boundary]):
             if position in plan.slab_stages:
                 result = stage.transform.stream_slab(self.names[index], result, region, spatial, attribute)

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -1937,6 +1937,9 @@ class Predictor(DistributedObject):
                     )
 
         self.gpu_checkpoints = gpu_checkpoints
+        # Cut the grids with the model's downsampling multiple already known, so each case's free axis
+        # rounds up to a valid input size (the graph -- hence the factor -- is final before init()).
+        self.dataset.set_free_axis_multiple(self.model.downsampling_factor())
         self.dataset.prepare()
         self.model.init(self.autocast, State.PREDICTION, self.dataset.get_groups_dest())
         self.model.init_outputs_group()

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -1810,6 +1810,8 @@ class Predictor(DistributedObject):
             else None
         )
         self._vram_patch_candidate: list[int] | None = None
+        # Per-axis input multiple the model needs (its downsampling factor); a free axis is sized to it.
+        self._downsampling_factor: list[int] | None = None
         module, name = get_module(combine, "konfai.predictor")
         if module.__name__ == "konfai.predictor":
             self.combine = getattr(module, name)()
@@ -1851,6 +1853,8 @@ class Predictor(DistributedObject):
         self.model.init(self.autocast, State.PREDICTION, self.dataset.get_groups_dest())
         self.model.init_outputs_group()
         self.model._compute_channels_trace(self.model, self.model.in_channels, None, self.gpu_checkpoints)
+        # The per-axis multiple a free patch axis rounds up to, read off the model's downsampling graph.
+        self._downsampling_factor = self.model.downsampling_factor()
         self.output_modules = [name for name, _, _ in self.model.named_module_args_dict()]
 
         for output_group in self.outputs_dataset.keys():
@@ -1984,6 +1988,18 @@ class Predictor(DistributedObject):
         model_composite = Model(model_composite)
         device = local_rank * self.size if len(cuda_visible_devices()) else None
         dataloader = dataloaders[0]
+        # Round a free patch axis up to the model's valid input multiple before the first attempt, so
+        # the network's encoder/decoder skips align instead of crashing on a non-divisible extent (the
+        # border padding fills the round-up, cropped back after the forward). A whole-axis extent that
+        # is still too large for VRAM OOMs into the shrink loop below, which keeps the size valid too.
+        if self._vram_patch_template is not None and self._downsampling_factor and self._vram_patch_candidate is None:
+            worst = self.dataset.worst_case_shape()
+            if worst is not None:
+                sized = concretize_patch_size(self._vram_patch_template, worst, self._downsampling_factor)
+                if sized != concretize_patch_size(self._vram_patch_template, worst):
+                    self._vram_patch_candidate = sized
+                    self.dataset.replan_patch(sized)
+                    dataloader = self.dataset.get_data(world_size)[0][global_rank][0]
         while True:
             try:
                 with _Predictor(
@@ -2038,14 +2054,17 @@ class Predictor(DistributedObject):
         worst = self.dataset.worst_case_shape()
         if worst is None:
             return None
-        candidate = self._vram_patch_candidate or concretize_patch_size(self._vram_patch_template, worst)
+        candidate = self._vram_patch_candidate or concretize_patch_size(
+            self._vram_patch_template, worst, self._downsampling_factor
+        )
         usable = self._usable_vram_after_oom(device)
         reserve = self._accumulation_reserve(candidate, worst)
+        snap = self._downsampling_factor
         if reserve is not None:
-            shrunk = next_patch_candidate(candidate, self._vram_patch_template, worst, measured, usable - reserve)
+            shrunk = next_patch_candidate(candidate, self._vram_patch_template, worst, measured, usable - reserve, snap)
             if shrunk is not None:
                 return shrunk
-        return next_patch_candidate(candidate, self._vram_patch_template, worst, measured, usable)
+        return next_patch_candidate(candidate, self._vram_patch_template, worst, measured, usable, snap)
 
     def _accumulation_reserve(self, candidate: list[int], worst: list[int]) -> float | None:
         """Bytes each case keeps resident while its patches accumulate, per output writer: the

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -577,6 +577,7 @@ class OutSameAsGroupDataset(OutputDataset):
         self._region_states: dict[int, _RegionState] = {}
         self._stream_buffers: dict[int, torch.Tensor] = {}
         self._post_prefix_attributes: dict[int, Attribute] = {}
+        self._reported_paths: set[str] = set()
         # One aligner per streamed case: the copies' accumulators emit slabs at their own pace, and
         # the finalize needs every copy's rows together (the cross-copy reduction). A single copy is
         # simply a one-stream aligner — same path, no special case.
@@ -604,11 +605,19 @@ class OutSameAsGroupDataset(OutputDataset):
                 self.output_layer_accumulator[index_dataset] = {}
                 self.attributes[index_dataset] = {}
                 self.names[index_dataset] = input_dataset.name
-                self._stream_plans[index_dataset] = (
+                plan = (
                     self._plan_stream(dataset, index_dataset, source_attribute, layer, number_of_channels_per_model)
                     if self._streaming_enabled
                     else None
                 )
+                self._stream_plans[index_dataset] = plan
+                if self._streaming_enabled and (plan is None or not plan.to_sink):
+                    # The whole-volume fallback is a normal outcome, but a silent one hides that a
+                    # large case pays it: say so, once per distinct path.
+                    path = (
+                        "whole-volume" if plan is None else "buffered (the prefix streams, the tail runs whole-volume)"
+                    )
+                    self._report_once(path, f"streaming: case '{input_dataset.name}' takes the {path} path.")
             self.attributes[index_dataset][index_augmentation] = {}
 
             accumulator_type = StreamingAccumulator if self._stream_plans[index_dataset] else Accumulator
@@ -632,6 +641,12 @@ class OutSameAsGroupDataset(OutputDataset):
         accumulator = self.output_layer_accumulator[index_dataset][index_augmentation]
         if index_dataset not in self._accum_device:
             self._accum_device[index_dataset] = self._accumulate_device(layer, accumulator)
+            if layer.device.type != "cpu" and self._accum_device[index_dataset].type == "cpu":
+                self._report_once(
+                    "host-accumulate",
+                    f"streaming: case '{self.names[index_dataset]}' accumulates on the host"
+                    " (the accumulator does not fit the VRAM budget).",
+                )
         target = self._accum_device[index_dataset]
         # When the accumulator lives on the GPU, blend the patch straight in (no host round-trip);
         # otherwise offload each patch to CPU so its device memory is released after post-processing.
@@ -690,6 +705,12 @@ class OutSameAsGroupDataset(OutputDataset):
         if locality.kind is LocalityKind.POINTWISE:
             return True
         return locality.kind is LocalityKind.GLOBAL_STAT and all(key in attribute for key in locality.stat_keys)
+
+    def _report_once(self, key: str, message: str) -> None:
+        """One line the first time a distinct non-window-bounded outcome appears; repeats are silent."""
+        if key not in self._reported_paths:
+            self._reported_paths.add(key)
+            print(f"[KonfAI] {message}")
 
     def _tta_worth_streaming(
         self,

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -252,18 +252,28 @@ class OutputDataset(Dataset, NeedDevice, ABC):
         self._accum_device: dict[int, torch.device] = {}
         # Same single-decision rule for the CPU-blend reduction device (see ``_reduction_device``).
         self._reduce_device: dict[int, torch.device] = {}
-        # Disk writes go to a background writer whenever the destination serves disjoint files per
-        # entry (see ``Dataset.concurrent_write_safe``): the device-to-host copy and the write then
-        # overlap the next forward, byte-identically — same operations, same order. A single-store
-        # destination stays inline, so nothing ever writes one store from two threads.
-        # ``KONFAI_ASYNC_WRITES=0`` is the ops/debug kill-switch, mirroring KONFAI_STREAMED_WRITES.
-        self._async_writes = (
-            os.environ.get("KONFAI_ASYNC_WRITES", "1").lower() not in ("0", "false") and self.concurrent_write_safe()
-        )
+        # Disk writes go to a background writer when the destination serves disjoint files per entry
+        # (see ``Dataset.concurrent_write_safe``) AND the output runs on a GPU: the device-to-host
+        # copy and the write then overlap the next forward, byte-identically — same operations, same
+        # order. A single-store destination stays inline, so nothing ever writes one store from two
+        # threads; a CPU-only loop stays inline too — its blend shares the memory bandwidth the
+        # writer would consume, so there is nothing to overlap and something to lose.
+        # ``KONFAI_ASYNC_WRITES`` is tri-state: unset = automatic, ``0`` kills, ``1`` forces (tests).
+        raw = os.environ.get("KONFAI_ASYNC_WRITES", "").lower()
+        self._async_writes: bool | None
+        if raw in ("0", "false") or not self.concurrent_write_safe():
+            self._async_writes = False
+        elif raw in ("1", "true"):
+            self._async_writes = True
+        else:
+            self._async_writes = None  # decided at the first write, once the device is placed
         self._writer: _AsyncWriter | None = None
 
     def _submit_write(self, operation: Callable[[], None]) -> None:
         """Run ``operation`` on the background writer, or inline when the destination must stay serial."""
+        if self._async_writes is None:
+            device = torch.device("cuda", self.device) if isinstance(self.device, int) else self.device
+            self._async_writes = device.type == "cuda"
         if not self._async_writes:
             operation()
             return

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -19,7 +19,9 @@
 import copy
 import importlib
 import os
+import queue
 import shutil
+import threading
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable
@@ -147,6 +149,53 @@ class Concat(Reduction):
         return torch.cat(tensors, dim=1)
 
 
+class _AsyncWriter:
+    """A background thread owning one output dataset's disk writes, in submission order.
+
+    The prediction loop otherwise waits on every device-to-host copy and destination write between
+    two forwards; submitting them here overlaps that tail with the next batch. The queue is bounded,
+    so a slow destination back-pressures the loop instead of buffering the run; the first failure is
+    kept, later operations drain unexecuted, and the failure re-raises at the next submission and at
+    ``close`` — a run never ends with a write silently missing.
+    """
+
+    _CAPACITY = 4
+
+    def __init__(self) -> None:
+        self._queue: queue.Queue[Callable[[], None] | None] = queue.Queue(maxsize=self._CAPACITY)
+        self._error: BaseException | None = None
+        self._thread = threading.Thread(target=self._run, name="konfai-writer", daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        while True:
+            operation = self._queue.get()
+            try:
+                if operation is None:
+                    return
+                if self._error is None:
+                    operation()
+            except BaseException as error:  # kept and re-raised on the loop thread
+                self._error = error
+            finally:
+                self._queue.task_done()
+
+    def submit(self, operation: Callable[[], None]) -> None:
+        self._raise_pending()
+        self._queue.put(operation)
+
+    def close(self) -> None:
+        """Drain every submitted operation, stop the thread, and surface any failure."""
+        self._queue.put(None)
+        self._thread.join()
+        self._raise_pending()
+
+    def _raise_pending(self) -> None:
+        if self._error is not None:
+            error, self._error = self._error, None
+            raise error
+
+
 class OutputDataset(Dataset, NeedDevice, ABC):
     """
     Abstract prediction sink that accumulates model outputs and writes them to disk.
@@ -203,6 +252,30 @@ class OutputDataset(Dataset, NeedDevice, ABC):
         self._accum_device: dict[int, torch.device] = {}
         # Same single-decision rule for the CPU-blend reduction device (see ``_reduction_device``).
         self._reduce_device: dict[int, torch.device] = {}
+        # Disk writes go to a background writer whenever the destination serves disjoint files per
+        # entry (see ``Dataset.concurrent_write_safe``): the device-to-host copy and the write then
+        # overlap the next forward, byte-identically — same operations, same order. A single-store
+        # destination stays inline, so nothing ever writes one store from two threads.
+        # ``KONFAI_ASYNC_WRITES=0`` is the ops/debug kill-switch, mirroring KONFAI_STREAMED_WRITES.
+        self._async_writes = (
+            os.environ.get("KONFAI_ASYNC_WRITES", "1").lower() not in ("0", "false") and self.concurrent_write_safe()
+        )
+        self._writer: _AsyncWriter | None = None
+
+    def _submit_write(self, operation: Callable[[], None]) -> None:
+        """Run ``operation`` on the background writer, or inline when the destination must stay serial."""
+        if not self._async_writes:
+            operation()
+            return
+        if self._writer is None:
+            self._writer = _AsyncWriter()
+        self._writer.submit(operation)
+
+    def finalize_writes(self) -> None:
+        """Drain and stop the background writer; every submitted write is on disk when this returns."""
+        if self._writer is not None:
+            writer, self._writer = self._writer, None
+            writer.close()
 
     # A pageable D2H copy on a large multi-class patch is a slow, fully synchronous PCIe transfer;
     # staging through page-locked memory only pays off once the patch is large enough that the copy,
@@ -339,8 +412,14 @@ class OutputDataset(Dataset, NeedDevice, ABC):
         raise NotImplementedError()
 
     def write_prediction(self, index: int, name: str, layer: torch.Tensor) -> None:
-        super().write(self.group, name, layer.detach().cpu().numpy(), self.attributes[index][0][0])
+        attribute = self.attributes[index][0][0]
         self.attributes.pop(index)
+        write = super().write
+
+        def operation() -> None:
+            write(self.group, name, layer.detach().cpu().numpy(), attribute)
+
+        self._submit_write(operation)
 
     def reset(self) -> None:
         """Drop every in-flight accumulation (the OOM-restart path re-runs the rank's cases from scratch)."""
@@ -569,9 +648,14 @@ class OutSameAsGroupDataset(OutputDataset):
             if finished:
                 self._finish_stream(index_dataset)
         except BaseException as error:
-            sink = self._stream_sinks.pop(index_dataset, None)
-            if sink is not None:
-                sink.__exit__(type(error), error, error.__traceback__)
+
+            def abort(error: BaseException = error, index: int = index_dataset) -> None:
+                sink = self._stream_sinks.pop(index, None)
+                if sink is not None:
+                    sink.__exit__(type(error), error, error.__traceback__)
+
+            with suppress(Exception):
+                self._submit_write(abort)
             plan = self._stream_plans.get(index_dataset)
             if plan is not None:
                 for position in plan.slab_stages:
@@ -917,26 +1001,35 @@ class OutSameAsGroupDataset(OutputDataset):
         self, index: int, target: tuple[slice, ...], block: torch.Tensor, attribute: Attribute
     ) -> None:
         """Write one finalized output block into the case's sink (opened at the first block, once the
-        chain has fixed the output's shape, channel count and dtype)."""
-        array = block.detach().cpu().numpy()
-        if index not in self._stream_sinks:
-            state = self._region_states.get(index)
-            spatial = (
-                state.shapes[-1]
-                if state is not None
-                else [int(extent) for extent in self.output_layer_accumulator[index][0].shape]
-            )
-            sink = self.open_data_stream(
-                self.group, self.names[index], [array.shape[0], *spatial], array.dtype, attribute
-            )
+        chain has fixed the output's shape, channel count and dtype).
+
+        The whole write — device-to-host copy, lazy sink open, region write — is one submitted
+        operation, so ``_stream_sinks`` is only ever touched in submission order; the attribute is
+        snapshotted because the region state's evolves with later emissions."""
+        state = self._region_states.get(index)
+        spatial = (
+            state.shapes[-1]
+            if state is not None
+            else [int(extent) for extent in self.output_layer_accumulator[index][0].shape]
+        )
+        name = self.names[index]
+        attribute = Attribute(attribute)
+
+        def operation() -> None:
+            array = block.detach().cpu().numpy()
+            sink = self._stream_sinks.get(index)
             if sink is None:
-                raise PredictorError(
-                    f"Streamed write refused by the '{self.file_format}' backend for dtype"
-                    f" '{array.dtype}' on output '{self.group}': write it to an h5 or omezarr"
-                    f" dataset, or set KONFAI_STREAMED_WRITES=0 to force the whole-volume path."
-                )
-            self._stream_sinks[index] = sink
-        self._stream_sinks[index].write_slice((slice(0, array.shape[0]), *target), array)
+                sink = self.open_data_stream(self.group, name, [array.shape[0], *spatial], array.dtype, attribute)
+                if sink is None:
+                    raise PredictorError(
+                        f"Streamed write refused by the '{self.file_format}' backend for dtype"
+                        f" '{array.dtype}' on output '{self.group}': write it to an h5 or omezarr"
+                        f" dataset, or set KONFAI_STREAMED_WRITES=0 to force the whole-volume path."
+                    )
+                self._stream_sinks[index] = sink
+            sink.write_slice((slice(0, array.shape[0]), *target), array)
+
+        self._submit_write(operation)
 
     def _finish_stream(self, index: int) -> None:
         """Complete the case: flush the region scheduler, or run the whole-volume tail on the buffer
@@ -954,7 +1047,12 @@ class OutSameAsGroupDataset(OutputDataset):
         name = self.names[index]
         for stage in plan.stages[plan.tail_start :]:
             result = stage(name, result, attribute)
-        super().write(self.group, name, result.detach().cpu().numpy(), attribute)
+        write = super().write
+
+        def operation() -> None:
+            write(self.group, name, result.detach().cpu().numpy(), attribute)
+
+        self._submit_write(operation)
 
     def _prepare_copy_slab(
         self,
@@ -1046,9 +1144,13 @@ class OutSameAsGroupDataset(OutputDataset):
 
     def _close_stream(self, index: int) -> None:
         """Finalize the case's sink and drop its bookkeeping (``is_done`` then reports nothing left)."""
-        sink = self._stream_sinks.pop(index, None)
-        if sink is not None:
-            sink.__exit__(None, None, None)
+
+        def operation() -> None:
+            sink = self._stream_sinks.pop(index, None)
+            if sink is not None:
+                sink.__exit__(None, None, None)
+
+        self._submit_write(operation)
         self._stream_plans.pop(index, None)
         self._region_states.pop(index, None)
         self._stream_buffers.pop(index, None)
@@ -1355,6 +1457,15 @@ class _Predictor:
         self.model_composite.eval()
         self.model_composite.module.set_state(NetState.PREDICTION)
         self.dataloader_prediction.dataset.load("Prediction")
+        try:
+            self._run_batches()
+        finally:
+            # Every submitted write must be on disk before the run returns — including on the error
+            # path, where the drain also closes the sinks the abort operations enqueued.
+            for output_dataset in self.outputs_dataset.values():
+                output_dataset.finalize_writes()
+
+    def _run_batches(self) -> None:
         with tqdm.tqdm(
             iterable=enumerate(self.dataloader_prediction),
             leave=True,

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -72,6 +72,7 @@ from konfai.utils.runtime import (
     DistributedObject,
     NeedDevice,
     State,
+    available_memory_bytes,
     configure_workflow_environment,
     confirm_overwrite_or_raise,
     description,
@@ -460,6 +461,12 @@ class OutputDataset(Dataset, NeedDevice, ABC):
 # same set the read dispatcher accepts as its region stages; on both sides they compose).
 _REGION_KINDS = (LocalityKind.HALO, LocalityKind.ORIENTATION, LocalityKind.CROP, LocalityKind.RESCALE)
 
+# Streamed TTA pays a slab-synchronized reduce; when the assembled accumulators of all copies are
+# below this fraction of allocatable memory (a 2.5D case), holding them whole costs nothing and the
+# case takes the whole-volume path. KONFAI_STREAMED_TTA_THRESHOLD overrides the fraction (tests set
+# 0 to exercise the streamed reduce on toy volumes). See OutSameAsGroupDataset._tta_worth_streaming.
+_STREAMED_TTA_MIN_FRACTION = 0.05
+
 
 @dataclass(frozen=True)
 class _FinalizeStage:
@@ -597,10 +604,10 @@ class OutSameAsGroupDataset(OutputDataset):
                 self.output_layer_accumulator[index_dataset] = {}
                 self.attributes[index_dataset] = {}
                 self.names[index_dataset] = input_dataset.name
-                # Plan how (or whether) this case streams. No warning on a refusal: streaming is
-                # transparent, so the whole-volume path is a normal outcome, not a misconfiguration.
                 self._stream_plans[index_dataset] = (
-                    self._plan_stream(dataset, index_dataset, source_attribute) if self._streaming_enabled else None
+                    self._plan_stream(dataset, index_dataset, source_attribute, layer, number_of_channels_per_model)
+                    if self._streaming_enabled
+                    else None
                 )
             self.attributes[index_dataset][index_augmentation] = {}
 
@@ -684,7 +691,30 @@ class OutSameAsGroupDataset(OutputDataset):
             return True
         return locality.kind is LocalityKind.GLOBAL_STAT and all(key in attribute for key in locality.stat_keys)
 
-    def _plan_stream(self, dataset: DatasetIter, index: int, attribute: Attribute) -> _StreamPlan | None:
+    def _tta_worth_streaming(
+        self,
+        dataset: DatasetIter,
+        index: int,
+        layer: torch.Tensor,
+        number_of_channels_per_model: list[int] | None,
+    ) -> bool:
+        """Whether this case's TTA accumulators are heavy enough for the slab-synchronized reduce to
+        pay: every copy holds a volume-sized accumulator, and when all of them together are a sliver
+        of allocatable memory (a 2.5D case) the assembled path costs nothing to hold."""
+        spatial = dataset.get_dataset_from_index(self.group_dest, index).shapes[0]
+        channels = sum(number_of_channels_per_model) if number_of_channels_per_model else int(layer.shape[0])
+        assembled = channels * int(np.prod(spatial)) * layer.element_size() * self.nb_data_augmentation
+        fraction = float(os.environ.get("KONFAI_STREAMED_TTA_THRESHOLD", _STREAMED_TTA_MIN_FRACTION))
+        return assembled >= fraction * available_memory_bytes()[0]
+
+    def _plan_stream(
+        self,
+        dataset: DatasetIter,
+        index: int,
+        attribute: Attribute,
+        layer: torch.Tensor | None = None,
+        number_of_channels_per_model: list[int] | None = None,
+    ) -> _StreamPlan | None:
         """The streaming plan for this case, or ``None`` for the whole-volume path.
 
         The streamed part of the finalize chain is ``[pointwise*][region and pointwise stages]``:
@@ -694,15 +724,19 @@ class OutSameAsGroupDataset(OutputDataset):
         into a light post-reduction buffer and the tail runs once on that buffer. A destination that
         cannot serve region writes buffers too, and writes classically. Only a non-streamable start
         refuses outright: a reduction that is not voxel-local, a non-voxel-local before-reduction
-        transform (it runs per model chunk inside the slab prefix), or a TTA copy whose un-augment
-        does not act slab by slab (see ``_tta_streamable``).
+        transform (it runs per model chunk inside the slab prefix), a TTA copy whose un-augment does
+        not act slab by slab (see ``_tta_streamable``), or a TTA case too light for the reduce to pay
+        (``_tta_worth_streaming`` — gauged from ``layer`` when the caller has one).
         """
         if self.nb_data_augmentation < 1:
             return None
         if not self.reduction.voxel_local:
             return None
-        if self.nb_data_augmentation != 1 and not self._tta_streamable(dataset, index, attribute):
-            return None
+        if self.nb_data_augmentation != 1:
+            if layer is not None and not self._tta_worth_streaming(dataset, index, layer, number_of_channels_per_model):
+                return None
+            if not self._tta_streamable(dataset, index, attribute):
+                return None
         for transform in self.before_reduction_transforms:
             locality = transform.patch_locality(Attribute(attribute))
             # A SLAB before-reduction transform (e.g. Mask) streams per slab through ``stream_slab`` in

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -78,7 +78,7 @@ from konfai.utils.runtime import (
     run_distributed_app,
     safe_torch_load,
 )
-from konfai.utils.utils import concretize_patch_size, get_module, split_path_spec
+from konfai.utils.utils import concretize_patch_size, get_module, size_free_axes, split_path_spec
 from konfai.utils.vram import next_patch_candidate, usable_vram
 
 
@@ -1990,16 +1990,16 @@ class Predictor(DistributedObject):
         dataloader = dataloaders[0]
         # Round a free patch axis up to the model's valid input multiple before the first attempt, so
         # the network's encoder/decoder skips align instead of crashing on a non-divisible extent (the
-        # border padding fills the round-up, cropped back after the forward). A whole-axis extent that
-        # is still too large for VRAM OOMs into the shrink loop below, which keeps the size valid too.
-        if self._vram_patch_template is not None and self._downsampling_factor and self._vram_patch_candidate is None:
-            worst = self.dataset.worst_case_shape()
-            if worst is not None:
-                sized = concretize_patch_size(self._vram_patch_template, worst, self._downsampling_factor)
-                if sized != concretize_patch_size(self._vram_patch_template, worst):
-                    self._vram_patch_candidate = sized
-                    self.dataset.replan_patch(sized)
-                    dataloader = self.dataset.get_data(world_size)[0][global_rank][0]
+        # border padding fills the round-up, cropped back after the forward). A whole-axis extent still
+        # too large for VRAM OOMs into the shrink loop below, which keeps the size valid too.
+        if self._vram_patch_candidate is None:
+            sized = size_free_axes(
+                self._vram_patch_template, self.dataset.worst_case_shape(), self._downsampling_factor
+            )
+            if sized is not None:
+                self._vram_patch_candidate = sized
+                self.dataset.replan_patch(sized)
+                dataloader = self.dataset.get_data(world_size)[0][global_rank][0]
         while True:
             try:
                 with _Predictor(

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -1271,14 +1271,16 @@ class OutSameAsGroupDataset(OutputDataset):
         # working volume is budgeted separately, at ``get_output`` time, by ``_reduction_device``.
         needed = accumulator_bytes + transient
         if isinstance(accumulator, StreamingAccumulator):
-            # Flushing a slab divides it out-of-place and clones the shifted window: up to two
-            # window-sized transients coexist with the resident window while a slab finalizes.
+            # Transients on top of the resident buffer (``voxels`` is the double-window footprint):
+            # the slide's clone of the live rows, the emission slab and its weight clamp, and — when
+            # the background writer engages — up to ``_AsyncWriter._CAPACITY`` emitted blocks alive
+            # on the device until their device-to-host copy runs. Two footprints bound the sum.
             needed += 2 * layer.shape[0] * voxels * layer.element_size()
             if self.nb_data_augmentation > 1:
-                # Slab-aligned TTA holds up to a window of pending slabs per copy (the arrival skew)
-                # and reduces the joint interval through a float32 accumulate: budget one window per
-                # copy plus two more for the reduction's transients.
-                needed += (self.nb_data_augmentation + 2) * layer.shape[0] * voxels * layer.element_size()
+                # Slab-aligned TTA holds pending slabs per copy (the arrival skew) and reduces the
+                # joint interval through a float32 accumulate: budget half a footprint per copy plus
+                # one more for the reduction's transients.
+                needed += (self.nb_data_augmentation + 2) * layer.shape[0] * (voxels // 2) * layer.element_size()
         return device if needed < free * self._ACCUMULATE_MARGIN else torch.device("cpu")
 
     def get_output(self, index: int, number_of_channels_per_model: list[int], dataset: DatasetIter) -> torch.Tensor:

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -470,11 +470,12 @@ class OutputDataset(Dataset, NeedDevice, ABC):
 # same set the read dispatcher accepts as its region stages; on both sides they compose).
 _REGION_KINDS = (LocalityKind.HALO, LocalityKind.ORIENTATION, LocalityKind.CROP, LocalityKind.RESCALE)
 
-# Streamed TTA pays a slab-synchronized reduce; when the assembled accumulators of all copies are
-# below this fraction of allocatable memory (a 2.5D case), holding them whole costs nothing and the
-# case takes the whole-volume path. KONFAI_STREAMED_TTA_THRESHOLD overrides the fraction (tests set
-# 0 to exercise the streamed reduce on toy volumes). See OutSameAsGroupDataset._tta_worth_streaming.
-_STREAMED_TTA_MIN_FRACTION = 0.05
+# Streaming pays per-slab work (the pipe traversal, region writes, the TTA aligner); when the
+# assembled accumulators of all copies are below this fraction of allocatable memory (a 2.5D case),
+# holding them whole costs nothing and the case takes the whole-volume path.
+# KONFAI_STREAM_WORTH_THRESHOLD overrides the fraction (tests set 0 to exercise the streamed
+# machinery on toy volumes). See OutSameAsGroupDataset._worth_streaming.
+_STREAM_WORTH_MIN_FRACTION = 0.05
 
 
 @dataclass(frozen=True)
@@ -719,10 +720,11 @@ class OutSameAsGroupDataset(OutputDataset):
             self._reported_paths.add(key)
             print(f"[KonfAI] {message}")
 
-    def _tta_worth_streaming(self, dataset: DatasetIter, index: int, layer: torch.Tensor) -> bool:
-        """Whether this case's TTA accumulators are heavy enough for the slab-synchronized reduce to
-        pay: every copy holds a volume-sized accumulator, and when all of them together are a sliver
-        of allocatable memory (a 2.5D case) the assembled path costs nothing to hold.
+    def _worth_streaming(self, dataset: DatasetIter, index: int, layer: torch.Tensor) -> bool:
+        """Whether this case's accumulators are heavy enough for the per-slab machinery to pay:
+        every copy holds a volume-sized accumulator, and when all of them together are a sliver of
+        allocatable memory (a 2.5D case) the assembled path costs nothing to hold — streaming it
+        would spend pipe traversals and region writes to save nothing.
 
         ``layer`` carries the accumulator's channel count and dtype whatever the ensemble combine is
         (a Concat layer arrives already concatenated); the estimate is taken before the patch-level
@@ -730,15 +732,15 @@ class OutSameAsGroupDataset(OutputDataset):
         margin."""
         spatial = dataset.get_dataset_from_index(self.group_dest, index).shapes[0]
         assembled = int(layer.shape[0]) * int(np.prod(spatial)) * layer.element_size() * self.nb_data_augmentation
-        raw = os.environ.get("KONFAI_STREAMED_TTA_THRESHOLD")
+        raw = os.environ.get("KONFAI_STREAM_WORTH_THRESHOLD")
         try:
-            fraction = float(raw) if raw is not None else _STREAMED_TTA_MIN_FRACTION
+            fraction = float(raw) if raw is not None else _STREAM_WORTH_MIN_FRACTION
         except ValueError:
             warnings.warn(
-                f"KONFAI_STREAMED_TTA_THRESHOLD={raw!r} is not a number; using {_STREAMED_TTA_MIN_FRACTION}.",
+                f"KONFAI_STREAM_WORTH_THRESHOLD={raw!r} is not a number; using {_STREAM_WORTH_MIN_FRACTION}.",
                 stacklevel=2,
             )
-            fraction = _STREAMED_TTA_MIN_FRACTION
+            fraction = _STREAM_WORTH_MIN_FRACTION
         return assembled >= fraction * available_memory_bytes()[0]
 
     def _plan_stream(
@@ -759,18 +761,17 @@ class OutSameAsGroupDataset(OutputDataset):
         cannot serve region writes buffers too, and writes classically. Only a non-streamable start
         refuses outright: a reduction that is not voxel-local, a non-voxel-local before-reduction
         transform (it runs per model chunk inside the slab prefix), a TTA copy whose un-augment does
-        not act slab by slab (see ``_tta_streamable``), or a TTA case too light for the reduce to pay
-        (``_tta_worth_streaming`` — gauged from ``layer`` when the caller has one).
+        not act slab by slab (see ``_tta_streamable``), or a case too light for the per-slab
+        machinery to pay (``_worth_streaming`` — gauged from ``layer`` when the caller has one).
         """
         if self.nb_data_augmentation < 1:
             return None
         if not self.reduction.voxel_local:
             return None
-        if self.nb_data_augmentation != 1:
-            if layer is not None and not self._tta_worth_streaming(dataset, index, layer):
-                return None
-            if not self._tta_streamable(dataset, index, attribute):
-                return None
+        if layer is not None and not self._worth_streaming(dataset, index, layer):
+            return None
+        if self.nb_data_augmentation != 1 and not self._tta_streamable(dataset, index, attribute):
+            return None
         for transform in self.before_reduction_transforms:
             locality = transform.patch_locality(Attribute(attribute))
             # A SLAB before-reduction transform (e.g. Mask) streams per slab through ``stream_slab`` in

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -1081,6 +1081,13 @@ class OutSameAsGroupDataset(OutputDataset):
             else:
                 resample.write_stream_cache_attribute(attribute, in_shape)
             return result
+        if kind is LocalityKind.ORIENTATION and not stage.inverted:
+            # A forward orientation writes the case origin/direction from the extent it is handed; run
+            # the tensor action on a throwaway scope so it does not record the SLAB's extent, then write
+            # the case geometry from the full ``in_shape`` (its documented contract) -- as RESCALE does.
+            result = stage(name, block, Attribute(attribute))
+            cast(TransformInverse, stage.transform).write_stream_cache_attribute(attribute, in_shape)
+            return result
         result = stage(name, block, attribute)
         if kind is LocalityKind.HALO:
             lead = (slice(None),) * (result.dim() - len(target))

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -2061,7 +2061,8 @@ class Predictor(DistributedObject):
         Launch prediction on the given process rank.
 
         Args:
-            world_size (int): Total number of processes.
+            world_size (int): Number of model replicas sharding the data -- the spawned process count
+                already divided by the model-parallel size (``gpu_checkpoints``), NOT the GPU count.
             global_rank (int): Rank of the current process.
             local_rank (int): Local device rank.
             dataloaders (list[DataLoader]): List of data loaders for prediction.

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -38,10 +38,12 @@ except ImportError:
     SummaryWriter = None  # type: ignore[assignment,misc]
 
 from konfai import config_file, cuda_visible_devices, konfai_root, predictions_directory
+from konfai.data.augmentation import DataAugmentation
 from konfai.data.data_manager import BatchSample, DataPrediction, DatasetIter
 from konfai.data.patching import (
     Accumulator,
     PathCombine,
+    SlabAligner,
     SlabRegionStream,
     StreamingAccumulator,
     _halo_pull,
@@ -405,6 +407,9 @@ class _StreamPlan:
     pipe_start: int | None
     tail_start: int
     to_sink: bool
+    # Prefix stages whose declaration is SLAB: per-voxel value maps with a per-region side effect,
+    # run through ``Transform.stream_slab`` so they learn where each slab sits.
+    slab_stages: frozenset[int] = frozenset()
 
     @property
     def boundary(self) -> int:
@@ -475,6 +480,10 @@ class OutSameAsGroupDataset(OutputDataset):
         self._region_states: dict[int, _RegionState] = {}
         self._stream_buffers: dict[int, torch.Tensor] = {}
         self._post_prefix_attributes: dict[int, Attribute] = {}
+        # One aligner per streamed case: the copies' accumulators emit slabs at their own pace, and
+        # the finalize needs every copy's rows together (the cross-copy reduction). A single copy is
+        # simply a one-stream aligner — same path, no special case.
+        self._aligners: dict[int, SlabAligner] = {}
 
     def add_layer(
         self,
@@ -501,7 +510,7 @@ class OutSameAsGroupDataset(OutputDataset):
                 # Plan how (or whether) this case streams. No warning on a refusal: streaming is
                 # transparent, so the whole-volume path is a normal outcome, not a misconfiguration.
                 self._stream_plans[index_dataset] = (
-                    self._plan_stream(dataset, source_attribute) if self._streaming_enabled else None
+                    self._plan_stream(dataset, index_dataset, source_attribute) if self._streaming_enabled else None
                 )
             self.attributes[index_dataset][index_augmentation] = {}
 
@@ -548,11 +557,14 @@ class OutSameAsGroupDataset(OutputDataset):
             slabs = accumulator.add_layer(index_patch, self._offload_to_cpu(layer)) or []
         if not self._stream_plans.get(index_dataset):
             return
-        finished = accumulator.is_full()
-        if finished:
+        copy_finished = accumulator.is_full()
+        if copy_finished:
             slabs = slabs + cast(StreamingAccumulator, accumulator).finalize()
         try:
-            self._consume_slabs(index_dataset, slabs, number_of_channels_per_model)
+            aligner = self._aligners.setdefault(index_dataset, SlabAligner(self.nb_data_augmentation))
+            joint = aligner.push(index_augmentation, slabs, copy_finished)
+            self._consume_slabs(index_dataset, joint, number_of_channels_per_model, dataset)
+            finished = aligner.complete
             if finished:
                 self._finish_stream(index_dataset)
         except BaseException as error:
@@ -572,7 +584,7 @@ class OutSameAsGroupDataset(OutputDataset):
             return True
         return locality.kind is LocalityKind.GLOBAL_STAT and all(key in attribute for key in locality.stat_keys)
 
-    def _plan_stream(self, dataset: DatasetIter, attribute: Attribute) -> _StreamPlan | None:
+    def _plan_stream(self, dataset: DatasetIter, index: int, attribute: Attribute) -> _StreamPlan | None:
         """The streaming plan for this case, or ``None`` for the whole-volume path.
 
         The streamed part of the finalize chain is ``[pointwise*][region and pointwise stages]``:
@@ -581,11 +593,15 @@ class OutSameAsGroupDataset(OutputDataset):
         statistic nothing seeded — becomes a whole-volume TAIL: the prefix still streams slab by slab
         into a light post-reduction buffer and the tail runs once on that buffer. A destination that
         cannot serve region writes buffers too, and writes classically. Only a non-streamable start
-        refuses outright: several augmentations (TTA inverses apply to the assembled volume), a
-        reduction that is not voxel-local, or a non-voxel-local before-reduction transform (it runs
-        per model chunk inside the slab prefix).
+        refuses outright: a reduction that is not voxel-local, a non-voxel-local before-reduction
+        transform (it runs per model chunk inside the slab prefix), or a TTA copy whose un-augment
+        does not act slab by slab (see ``_tta_streamable``).
         """
-        if self.nb_data_augmentation != 1 or not self.reduction.voxel_local:
+        if self.nb_data_augmentation < 1:
+            return None
+        if not self.reduction.voxel_local:
+            return None
+        if self.nb_data_augmentation != 1 and not self._tta_streamable(dataset, index, attribute):
             return None
         for transform in self.before_reduction_transforms:
             if not self._voxel_local(transform.patch_locality(Attribute(attribute)), attribute):
@@ -601,38 +617,113 @@ class OutSameAsGroupDataset(OutputDataset):
         ]
         pipe_start: int | None = None
         tail_start = len(stages)
-        for index, stage in enumerate(stages):
+        slab_stages = set()
+        for position, stage in enumerate(stages):
             locality = stage.locality(Attribute(attribute))
             if self._voxel_local(locality, attribute):
                 continue
+            if locality.kind is LocalityKind.SLAB and not stage.inverted and pipe_start is None:
+                # A per-voxel stage with a per-region side effect streams through ``stream_slab`` —
+                # but only on the accumulator grid: past a region stage the emissions are regions of
+                # ANOTHER space, so there it falls to the tail (whose whole-volume call is its
+                # classic behaviour).
+                slab_stages.add(position)
+                continue
             if locality.kind in _REGION_KINDS:
                 if pipe_start is None:
-                    pipe_start = index
+                    pipe_start = position
                 continue
-            tail_start = index
+            tail_start = position
             break
         if tail_start < len(stages) or not self.can_stream_data(attribute):
             # A whole-volume tail swallows the region stages too: the buffer sits on the accumulator
             # grid, and the tail runs the true whole-volume operators on it — byte-identical for free.
             if pipe_start is not None:
                 tail_start = min(tail_start, pipe_start)
-            return _StreamPlan(stages, None, tail_start, to_sink=False)
-        return _StreamPlan(stages, pipe_start, len(stages), to_sink=True)
+            return _StreamPlan(stages, None, tail_start, to_sink=False, slab_stages=frozenset(slab_stages))
+        return _StreamPlan(stages, pipe_start, len(stages), to_sink=True, slab_stages=frozenset(slab_stages))
+
+    @staticmethod
+    def _copy_draw(dataset: DatasetIter, index_augmentation: int) -> tuple[list[DataAugmentation], int] | None:
+        """The augmentations copy ``index_augmentation`` carries and its index within their list, or
+        ``None`` for the un-augmented copy."""
+        if index_augmentation == 0:
+            return None
+        i = index_augmentation - 1
+        for data_augmentations in dataset.data_augmentations_list:
+            if i < data_augmentations.nb:
+                return data_augmentations.data_augmentations, i
+            i -= data_augmentations.nb
+        return None
+
+    def _unaugment(
+        self, dataset: DatasetIter, index: int, index_augmentation: int, tensor: torch.Tensor
+    ) -> torch.Tensor:
+        """Undo copy ``index_augmentation``'s draw on ``tensor`` — the augmentations applied in
+        reverse, bound by the case index the draw was made under (the manager's own)."""
+        draw = self._copy_draw(dataset, index_augmentation)
+        if draw is None:
+            return tensor
+        augmentations, a = draw
+        case = dataset.get_dataset_from_index(self.group_dest, index).index
+        for data_augmentation in reversed(augmentations):
+            tensor = data_augmentation.inverse(case, a, tensor)
+        return tensor
+
+    def _tta_streamable(self, dataset: DatasetIter, index: int, attribute: Attribute) -> bool:
+        """Whether every copy's un-augment acts slab by slab, read from the declarations alone.
+
+        The slab-synchronized reduce applies each augmentation's ``inverse`` to a finalized z-slab,
+        which equals the whole-volume inverse restricted to that slab exactly when the draw maps every
+        slab onto itself: a POINTWISE draw does (a per-voxel map inverts per voxel), and an
+        ORIENTATION draw does when its declared region remap fixes the slab axis row for row and its
+        shape fold keeps the slab extent — probed here against ``stream_region_source``, never by
+        running patches. A z-flip mirrors the rows (row 0 pulls the last), a z-moving permute
+        relocates them: both fail the probe and the case falls back to the whole-volume path. Any
+        other kind (a halo'd translate, a whole-volume draw) refuses outright.
+        """
+        try:
+            input_dataset = dataset.get_dataset_from_index(self.group_dest, index)
+            case = input_dataset.index
+            for index_augmentation in range(1, self.nb_data_augmentation):
+                draw = self._copy_draw(dataset, index_augmentation)
+                if draw is None:
+                    continue
+                augmentations, a = draw
+                shape = [int(extent) for extent in input_dataset.shapes[0]]
+                for augmentation in augmentations:
+                    locality = augmentation.patch_locality(case, a, Attribute(attribute))
+                    if locality.kind is LocalityKind.POINTWISE:
+                        continue
+                    if locality.kind is not LocalityKind.ORIENTATION:
+                        return False
+                    out_shape = [int(extent) for extent in augmentation.stream_shape(case, a, list(shape))]
+                    if out_shape[0] != shape[0]:
+                        return False
+                    plane = tuple(slice(0, extent) for extent in out_shape[1:])
+                    for row in range(out_shape[0]):
+                        source = augmentation.stream_region_source(case, a, (slice(row, row + 1), *plane), shape)
+                        if (source[0].start, source[0].stop) != (row, row + 1):
+                            return False
+                    shape = out_shape
+        except Exception:  # nosec B110 - an unprobeable draw just keeps the case on the whole-volume path
+            return False
+        return True
 
     def _consume_slabs(
         self,
         index: int,
-        slabs: list[tuple[slice, torch.Tensor]],
+        slabs: list[tuple[slice, dict[int, torch.Tensor]]],
         number_of_channels_per_model: list[int] | None,
+        dataset: DatasetIter,
     ) -> None:
-        """Run each finalized slab through the plan: prefix per slab, then sink, region stream, or
-        buffer. The first slab fixes the case's state (post-prefix attribute, region scheduler or
-        buffer) and may demote a RESCALE region to the buffered tail (see ``_init_stream_state``)."""
+        """Run each jointly finalized slab through the plan: prefix per slab, then sink, region
+        stream, or buffer. The first slab fixes the case's state (post-prefix attribute, region
+        scheduler or buffer) and may demote a RESCALE region to the buffered tail (see
+        ``_init_stream_state``)."""
         plan = cast(_StreamPlan, self._stream_plans[index])
-        for region, slab in slabs:
-            block, attribute = self._finalize_slab(
-                index, slab, number_of_channels_per_model, plan.stages[: plan.boundary]
-            )
+        for region, copies in slabs:
+            block, attribute = self._finalize_slab(index, copies, number_of_channels_per_model, plan, dataset, region)
             if index not in self._post_prefix_attributes:
                 plan = self._init_stream_state(index, plan, block, attribute)
             state = self._region_states.get(index)
@@ -663,7 +754,7 @@ class OutSameAsGroupDataset(OutputDataset):
         if plan.pipe_start is not None:
             state = self._make_pipe_state(index, plan, spatial, block)
             if state is None:
-                plan = _StreamPlan(plan.stages, None, plan.pipe_start, to_sink=False)
+                plan = _StreamPlan(plan.stages, None, plan.pipe_start, to_sink=False, slab_stages=plan.slab_stages)
                 self._stream_plans[index] = plan
             else:
                 self._region_states[index] = state
@@ -859,21 +950,19 @@ class OutSameAsGroupDataset(OutputDataset):
             result = stage(name, result, attribute)
         super().write(self.group, name, result.detach().cpu().numpy(), attribute)
 
-    def _finalize_slab(
+    def _prepare_copy_slab(
         self,
         index: int,
+        index_augmentation: int,
         layer: torch.Tensor,
         number_of_channels_per_model: list[int] | None,
-        stages: list[_FinalizeStage],
-    ) -> tuple[torch.Tensor, Attribute]:
-        """The single-augmentation finalize chain of ``_get_output``/``get_output``, on one z-slab, up
-        to the plan's prefix boundary.
-
-        Every prefix stage passed the gate as voxel-local, so applying it slab by slab yields the same
-        voxels as applying it to the assembled volume. Each slab gets its own copy of the case
-        attribute (transform writes stay slab-local, and case-level pops repeat identically per slab).
-        """
-        attribute = Attribute(self.attributes[index][0][0])
+        dataset: DatasetIter,
+    ) -> torch.Tensor:
+        """One copy's slab through the per-copy head of ``_get_output``: un-augment it (exact on a
+        slab — the gate admitted only slab-parallel draws), split the model chunks, run
+        before_reduction on each, and stack to the copy's ``[1, M, C, ...]`` block."""
+        layer = self._unaugment(dataset, index, index_augmentation, layer)
+        attribute = Attribute(self.attributes[index][index_augmentation][0])
         if number_of_channels_per_model and layer.shape[0] == sum(number_of_channels_per_model):
             attribute["number_of_channels_per_model_0"] = torch.tensor(number_of_channels_per_model)
             chunks = list(torch.split(layer, number_of_channels_per_model, dim=0))
@@ -884,13 +973,53 @@ class OutSameAsGroupDataset(OutputDataset):
             for transform in self.before_reduction_transforms:
                 chunk = transform(self.names[index], chunk, Attribute(attribute))
             results.append(chunk)
+        # A lone chunk stacks as a view: torch.stack would copy the slab once per slab of the case.
+        if len(results) == 1:
+            return results[0].unsqueeze(0).unsqueeze(0)
+        return torch.stack(results, dim=0).unsqueeze(0)
+
+    def _finalize_slab(
+        self,
+        index: int,
+        copies: dict[int, torch.Tensor],
+        number_of_channels_per_model: list[int] | None,
+        plan: _StreamPlan,
+        dataset: DatasetIter,
+        region: slice,
+    ) -> tuple[torch.Tensor, Attribute]:
+        """The finalize chain of ``_get_output``/``get_output``, on one z-slab of every copy, up to
+        the plan's prefix boundary.
+
+        Every prefix stage passed the gate as voxel-local (a SLAB stage additionally learns where the
+        slab sits, through ``stream_slab``) and every copy as slab-parallel, so each step is the
+        whole-volume computation restricted to the slab — same ops, same order, same reduction call —
+        which is what makes the streamed output byte-identical. Each slab gets its own copy of the
+        case attribute (transform writes stay slab-local, and case-level pops repeat identically per
+        slab).
+        """
+        blocks = [
+            self._prepare_copy_slab(index, index_augmentation, layer, number_of_channels_per_model, dataset)
+            for index_augmentation, layer in copies.items()
+        ]
+        # Mixed devices can only come from a mid-case OOM fallback: reconcile on the host, exactly as
+        # ``get_output`` does.
+        if len({block.device for block in blocks}) > 1:
+            blocks = [block.cpu() if block.device.type != "cpu" else block for block in blocks]
         # Reduce, then drop the singleton stack axis; Mean/Median also drop the singleton model axis,
         # while Concat keeps the [M, C, ...] model axis for after_reduction (Sum) to merge into labels.
-        result = self.reduction([torch.stack(results, dim=0).unsqueeze(0)]).squeeze(0)
+        result = self.reduction(blocks).squeeze(0)
         if isinstance(self.reduction, Mean | Median):
             result = result.squeeze(0)
-        for stage in stages:
-            result = stage(self.names[index], result, attribute)
+        attribute = Attribute(self.attributes[index][0][0])
+        first = next(iter(copies.values()))
+        if number_of_channels_per_model and first.shape[0] == sum(number_of_channels_per_model):
+            attribute["number_of_channels_per_model_0"] = torch.tensor(number_of_channels_per_model)
+        spatial = [int(extent) for extent in self.output_layer_accumulator[index][0].shape]
+        for position, stage in enumerate(plan.stages[: plan.boundary]):
+            if position in plan.slab_stages:
+                result = stage.transform.stream_slab(self.names[index], result, region, spatial, attribute)
+            else:
+                result = stage(self.names[index], result, attribute)
         return result, attribute
 
     def reset(self) -> None:
@@ -918,6 +1047,7 @@ class OutSameAsGroupDataset(OutputDataset):
         self._region_states.pop(index, None)
         self._stream_buffers.pop(index, None)
         self._post_prefix_attributes.pop(index, None)
+        self._aligners.pop(index, None)
         self.output_layer_accumulator.pop(index, None)
         self.attributes.pop(index, None)
         self._accum_device.pop(index, None)
@@ -938,17 +1068,7 @@ class OutSameAsGroupDataset(OutputDataset):
         self, index: int, index_augmentation: int, number_of_channels_per_model: list[int], dataset: DatasetIter
     ) -> torch.Tensor:
         layer = self.output_layer_accumulator[index][index_augmentation].assemble()  # if concat then [N*C] else [C]
-
-        if index_augmentation > 0:
-            i = 0
-            index_augmentation_tmp = index_augmentation - 1
-            for data_augmentations in dataset.data_augmentations_list:
-                if index_augmentation_tmp >= i and index_augmentation_tmp < i + data_augmentations.nb:
-                    for data_augmentation in reversed(data_augmentations.data_augmentations):
-                        layer = data_augmentation.inverse(index, index_augmentation_tmp - i, layer)
-                    break
-                i += data_augmentations.nb
-
+        layer = self._unaugment(dataset, index, index_augmentation, layer)
         base_attr = self.attributes[index][index_augmentation][0]
         if layer.shape[0] == sum(number_of_channels_per_model):
             base_attr["number_of_channels_per_model_0"] = torch.tensor(number_of_channels_per_model)
@@ -1036,6 +1156,11 @@ class OutSameAsGroupDataset(OutputDataset):
             # Flushing a slab divides it out-of-place and clones the shifted window: up to two
             # window-sized transients coexist with the resident window while a slab finalizes.
             needed += 2 * layer.shape[0] * voxels * layer.element_size()
+            if self.nb_data_augmentation > 1:
+                # Slab-aligned TTA holds up to a window of pending slabs per copy (the arrival skew)
+                # and reduces the joint interval through a float32 accumulate: budget one window per
+                # copy plus two more for the reduction's transients.
+                needed += (self.nb_data_augmentation + 2) * layer.shape[0] * voxels * layer.element_size()
         return device if needed < free * self._ACCUMULATE_MARGIN else torch.device("cpu")
 
     def get_output(self, index: int, number_of_channels_per_model: list[int], dataset: DatasetIter) -> torch.Tensor:

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -1271,16 +1271,16 @@ class OutSameAsGroupDataset(OutputDataset):
         # working volume is budgeted separately, at ``get_output`` time, by ``_reduction_device``.
         needed = accumulator_bytes + transient
         if isinstance(accumulator, StreamingAccumulator):
-            # Transients on top of the resident buffer (``voxels`` is the double-window footprint):
-            # the slide's clone of the live rows, the emission slab and its weight clamp, and — when
-            # the background writer engages — up to ``_AsyncWriter._CAPACITY`` emitted blocks alive
-            # on the device until their device-to-host copy runs. Two footprints bound the sum.
+            # Transients on top of the resident window (``voxels`` is the window footprint): the advance
+            # clone of the retained rows, the emission slab and its weight clamp, and — when the
+            # background writer engages — up to ``_AsyncWriter._CAPACITY`` emitted blocks alive on the
+            # device until their device-to-host copy runs. Two window footprints bound the sum.
             needed += 2 * layer.shape[0] * voxels * layer.element_size()
             if self.nb_data_augmentation > 1:
-                # Slab-aligned TTA holds pending slabs per copy (the arrival skew) and reduces the
-                # joint interval through a float32 accumulate: budget half a footprint per copy plus
-                # one more for the reduction's transients.
-                needed += (self.nb_data_augmentation + 2) * layer.shape[0] * (voxels // 2) * layer.element_size()
+                # Slab-aligned TTA holds pending slabs per copy (the arrival skew, ~one window) and
+                # reduces the joint interval through a float32 accumulate: budget one window per copy
+                # plus one more for the reduction's transients.
+                needed += (self.nb_data_augmentation + 2) * layer.shape[0] * voxels * layer.element_size()
         return device if needed < free * self._ACCUMULATE_MARGIN else torch.device("cpu")
 
     def get_output(self, index: int, number_of_channels_per_model: list[int], dataset: DatasetIter) -> torch.Tensor:

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -849,9 +849,10 @@ class OutSameAsGroupDataset(OutputDataset):
         """Fix the case's streaming state at its first slab, when the prefix output is known.
 
         A RESCALE stage streams through ``resample_region``, which matches ``F.interpolate`` bit for
-        bit only in nearest mode (uint8): a pipe whose rescale would interpolate is demoted here to
-        the buffered tail, where the true inverse runs whole-volume — byte-identity is never traded
-        for streaming. The demotion leaves the prefix untouched (the pipe was never part of it).
+        bit in nearest mode (uint8) and to ~float-rounding in linear mode, so a rescale streams by
+        default and bounds a large float resample to a window. ``KONFAI_STREAM_LINEAR_RESAMPLE=0``
+        demotes a float rescale here to the buffered whole-volume tail for a run that needs exactness;
+        the demotion leaves the prefix untouched (the pipe was never part of it).
         """
         self._post_prefix_attributes[index] = Attribute(attribute)
         spatial = [int(extent) for extent in self.output_layer_accumulator[index][0].shape]
@@ -886,8 +887,8 @@ class OutSameAsGroupDataset(OutputDataset):
         with one evolving attribute: each stage declares against, and remaps from, the state the
         stages before it left — a second resample pops the Size stack the first one already popped,
         a reorientation after a permute reads the moved axes — and the walk carries the dtype, so a
-        RESCALE that would interpolate (``resample_region`` matches ``F.interpolate`` bit for bit
-        only in nearest mode) answers ``None`` instead: byte-identity is never traded for streaming.
+        float RESCALE (``resample_region`` matches ``F.interpolate`` only to ~float-rounding) answers
+        ``None`` — demoting to the whole-volume tail — only under ``KONFAI_STREAM_LINEAR_RESAMPLE=0``.
         ``produce`` then replays the same transitions on a fresh copy per emission (the same
         slab-local scoping as the prefix).
         """
@@ -911,7 +912,16 @@ class OutSameAsGroupDataset(OutputDataset):
                     shapes.append(list(shape))
                     probe = stage(name, probe, walking)
                 elif locality.kind is LocalityKind.RESCALE:
-                    if probe.dtype is not torch.uint8:
+                    # A float rescale streams within a window: resample_region computes the same linear
+                    # taps the read side already streams, matching the whole-volume F.interpolate to
+                    # ~float-rounding (a boundary voxel or two flips after argmax; a raw float output
+                    # differs by ~1 ULP) -- which bounds a large float resample (a probability volume
+                    # sent back to native) instead of holding it whole. KONFAI_STREAM_LINEAR_RESAMPLE=0
+                    # forces the exact whole-volume resample for a run that needs bit-identity. Nearest
+                    # (uint8) is byte-identical either way.
+                    if probe.dtype is not torch.uint8 and os.environ.get(
+                        "KONFAI_STREAM_LINEAR_RESAMPLE", "1"
+                    ).lower() in ("0", "false"):
                         return None
                     resample = cast(Resample, stage.transform)
                     if stage.inverted:

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -2113,7 +2113,7 @@ class Predictor(DistributedObject):
                 for output_dataset in self.outputs_dataset.values():
                     output_dataset.reset()
                 if self._vram_patch_template is None:
-                    raise  # no free axis declared: not auto-patched, the OOM propagates unchanged
+                    raise  # no free axis declared: not auto-patched
                 candidate = self._shrunken_patch(measured, device)
                 if candidate is None:
                     raise

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -22,6 +22,7 @@ import os
 import queue
 import shutil
 import threading
+import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable
@@ -79,7 +80,7 @@ from konfai.utils.runtime import (
     run_distributed_app,
     safe_torch_load,
 )
-from konfai.utils.utils import concretize_patch_size, get_module, size_free_axes, split_path_spec
+from konfai.utils.utils import concretize_patch_size, env_flag, get_module, size_free_axes, split_path_spec
 from konfai.utils.vram import next_patch_candidate, usable_vram
 
 
@@ -270,11 +271,14 @@ class OutputDataset(Dataset, NeedDevice, ABC):
             self._async_writes = None  # decided at the first write, once the device is placed
         self._writer: _AsyncWriter | None = None
 
+    def _torch_device(self) -> torch.device:
+        """The placed device as ``torch.device`` (``NeedDevice`` may hold a bare CUDA ordinal)."""
+        return torch.device("cuda", self.device) if isinstance(self.device, int) else self.device
+
     def _submit_write(self, operation: Callable[[], None]) -> None:
         """Run ``operation`` on the background writer, or inline when the destination must stay serial."""
         if self._async_writes is None:
-            device = torch.device("cuda", self.device) if isinstance(self.device, int) else self.device
-            self._async_writes = device.type == "cuda"
+            self._async_writes = self._torch_device().type == "cuda"
         if not self._async_writes:
             operation()
             return
@@ -414,23 +418,28 @@ class OutputDataset(Dataset, NeedDevice, ABC):
     def is_done(self, index: int) -> bool:
         # ``.get``: a streamed case cleans itself up inside ``add_layer`` (its slabs are already on
         # disk), so by the time the run loop asks, the index is gone and the answer is "nothing to do".
-        return len(self.output_layer_accumulator.get(index, {})) == self.nb_data_augmentation and all(
-            acc.is_full() for acc in self.output_layer_accumulator[index].values()
-        )
+        accumulators = self.output_layer_accumulator.get(index)
+        if accumulators is None or len(accumulators) != self.nb_data_augmentation:
+            return False
+        return all(acc.is_full() for acc in accumulators.values())
 
     @abstractmethod
     def get_output(self, index: int, number_of_channels_per_model: list[int], dataset: DatasetIter) -> torch.Tensor:
         raise NotImplementedError()
 
-    def write_prediction(self, index: int, name: str, layer: torch.Tensor) -> None:
-        attribute = self.attributes[index][0][0]
-        self.attributes.pop(index)
+    def _submit_final_write(self, name: str, tensor: torch.Tensor, attribute: Attribute) -> None:
+        """Queue one whole-volume entry write (D2H copy included) on the write path."""
         write = super().write
 
         def operation() -> None:
-            write(self.group, name, layer.detach().cpu().numpy(), attribute)
+            write(self.group, name, tensor.detach().cpu().numpy(), attribute)
 
         self._submit_write(operation)
+
+    def write_prediction(self, index: int, name: str, layer: torch.Tensor) -> None:
+        attribute = self.attributes[index][0][0]
+        self.attributes.pop(index)
+        self._submit_final_write(name, layer, attribute)
 
     def reset(self) -> None:
         """Drop every in-flight accumulation (the OOM-restart path re-runs the rank's cases from scratch)."""
@@ -526,11 +535,10 @@ class _RegionState:
 
     ``shapes[i]`` is the spatial shape between pipe stage ``i - 1`` and ``i`` (``shapes[0]`` the
     accumulator's, ``shapes[-1]`` the written image's); a pointwise stage leaves it unchanged, so the
-    per-stage region bookkeeping folds through the same list the pull map composes over.
+    per-stage region bookkeeping folds through the same list the pull map composes over. The pipe's
+    stages themselves live in the ``produce``/``pull`` closures the stream was built on.
     """
 
-    stages: list[_FinalizeStage]
-    kinds: list[LocalityKind]
     shapes: list[list[int]]
     stream: SlabRegionStream | None = None
     # The attribute the latest emission ran the pipe on: what the sink opens with.
@@ -571,7 +579,7 @@ class OutSameAsGroupDataset(OutputDataset):
         # patches complete so RAM is bounded at one patch window; otherwise the whole-volume path is
         # used transparently. ``KONFAI_STREAMED_WRITES=0`` is a global ops/debug kill-switch (also how
         # a test gets the assembled reference), not a per-output option.
-        self._streaming_enabled = os.environ.get("KONFAI_STREAMED_WRITES", "1").lower() not in ("0", "false")
+        self._streaming_enabled = env_flag("KONFAI_STREAMED_WRITES", True)
         self._stream_plans: dict[int, _StreamPlan | None] = {}
         self._stream_sinks: dict[int, DataStream] = {}
         self._region_states: dict[int, _RegionState] = {}
@@ -644,8 +652,7 @@ class OutSameAsGroupDataset(OutputDataset):
             if layer.device.type != "cpu" and self._accum_device[index_dataset].type == "cpu":
                 self._report_once(
                     "host-accumulate",
-                    f"streaming: case '{self.names[index_dataset]}' accumulates on the host"
-                    " (the accumulator does not fit the VRAM budget).",
+                    f"case '{self.names[index_dataset]}' accumulates on the host.",
                 )
         target = self._accum_device[index_dataset]
         # When the accumulator lives on the GPU, blend the patch straight in (no host round-trip);
@@ -684,7 +691,7 @@ class OutSameAsGroupDataset(OutputDataset):
             def abort(error: BaseException = error, index: int = index_dataset) -> None:
                 sink = self._stream_sinks.pop(index, None)
                 if sink is not None:
-                    sink.__exit__(type(error), error, error.__traceback__)
+                    sink.abort(error)
 
             with suppress(Exception):
                 self._submit_write(abort)
@@ -712,20 +719,26 @@ class OutSameAsGroupDataset(OutputDataset):
             self._reported_paths.add(key)
             print(f"[KonfAI] {message}")
 
-    def _tta_worth_streaming(
-        self,
-        dataset: DatasetIter,
-        index: int,
-        layer: torch.Tensor,
-        number_of_channels_per_model: list[int] | None,
-    ) -> bool:
+    def _tta_worth_streaming(self, dataset: DatasetIter, index: int, layer: torch.Tensor) -> bool:
         """Whether this case's TTA accumulators are heavy enough for the slab-synchronized reduce to
         pay: every copy holds a volume-sized accumulator, and when all of them together are a sliver
-        of allocatable memory (a 2.5D case) the assembled path costs nothing to hold."""
+        of allocatable memory (a 2.5D case) the assembled path costs nothing to hold.
+
+        ``layer`` carries the accumulator's channel count and dtype whatever the ensemble combine is
+        (a Concat layer arrives already concatenated); the estimate is taken before the patch-level
+        inverses, so a dtype-widening inverse under-counts by at most 2x — inside the threshold's
+        margin."""
         spatial = dataset.get_dataset_from_index(self.group_dest, index).shapes[0]
-        channels = sum(number_of_channels_per_model) if number_of_channels_per_model else int(layer.shape[0])
-        assembled = channels * int(np.prod(spatial)) * layer.element_size() * self.nb_data_augmentation
-        fraction = float(os.environ.get("KONFAI_STREAMED_TTA_THRESHOLD", _STREAMED_TTA_MIN_FRACTION))
+        assembled = int(layer.shape[0]) * int(np.prod(spatial)) * layer.element_size() * self.nb_data_augmentation
+        raw = os.environ.get("KONFAI_STREAMED_TTA_THRESHOLD")
+        try:
+            fraction = float(raw) if raw is not None else _STREAMED_TTA_MIN_FRACTION
+        except ValueError:
+            warnings.warn(
+                f"KONFAI_STREAMED_TTA_THRESHOLD={raw!r} is not a number; using {_STREAMED_TTA_MIN_FRACTION}.",
+                stacklevel=2,
+            )
+            fraction = _STREAMED_TTA_MIN_FRACTION
         return assembled >= fraction * available_memory_bytes()[0]
 
     def _plan_stream(
@@ -754,7 +767,7 @@ class OutSameAsGroupDataset(OutputDataset):
         if not self.reduction.voxel_local:
             return None
         if self.nb_data_augmentation != 1:
-            if layer is not None and not self._tta_worth_streaming(dataset, index, layer, number_of_channels_per_model):
+            if layer is not None and not self._tta_worth_streaming(dataset, index, layer):
                 return None
             if not self._tta_streamable(dataset, index, attribute):
                 return None
@@ -974,9 +987,7 @@ class OutSameAsGroupDataset(OutputDataset):
                     # sent back to native) instead of holding it whole. KONFAI_STREAM_LINEAR_RESAMPLE=0
                     # forces the exact whole-volume resample for a run that needs bit-identity. Nearest
                     # (uint8) is byte-identical either way.
-                    if probe.dtype is not torch.uint8 and os.environ.get(
-                        "KONFAI_STREAM_LINEAR_RESAMPLE", "1"
-                    ).lower() in ("0", "false"):
+                    if probe.dtype is not torch.uint8 and not env_flag("KONFAI_STREAM_LINEAR_RESAMPLE", True):
                         return None
                     resample = cast(Resample, stage.transform)
                     if stage.inverted:
@@ -1014,7 +1025,7 @@ class OutSameAsGroupDataset(OutputDataset):
         except Exception:  # nosec B110 - an unplannable pipe just keeps the case on the buffered path
             return None
 
-        state = _RegionState(pipe, kinds, shapes)
+        state = _RegionState(shapes)
 
         def spans_for(target: tuple[slice, ...]) -> list[list[slice]]:
             """The region of each inter-stage space behind ``target``, folded back to the accumulator."""
@@ -1126,12 +1137,7 @@ class OutSameAsGroupDataset(OutputDataset):
         name = self.names[index]
         for stage in plan.stages[plan.tail_start :]:
             result = stage(name, result, attribute)
-        write = super().write
-
-        def operation() -> None:
-            write(self.group, name, result.detach().cpu().numpy(), attribute)
-
-        self._submit_write(operation)
+        self._submit_final_write(name, result, attribute)
 
     def _prepare_copy_slab(
         self,
@@ -1150,11 +1156,7 @@ class OutSameAsGroupDataset(OutputDataset):
         grid, where before_reduction runs), so it reads its slab region instead of the whole volume."""
         layer = self._unaugment(dataset, index, index_augmentation, layer)
         attribute = Attribute(self.attributes[index][index_augmentation][0])
-        if number_of_channels_per_model and layer.shape[0] == sum(number_of_channels_per_model):
-            attribute["number_of_channels_per_model_0"] = torch.tensor(number_of_channels_per_model)
-            chunks = list(torch.split(layer, number_of_channels_per_model, dim=0))
-        else:
-            chunks = [layer]
+        chunks = self._split_model_chunks(layer, number_of_channels_per_model, attribute)
         results = []
         for chunk in chunks:
             for transform in self.before_reduction_transforms:
@@ -1194,19 +1196,9 @@ class OutSameAsGroupDataset(OutputDataset):
             )
             for index_augmentation, layer in copies.items()
         ]
-        # Mixed devices can only come from a mid-case OOM fallback: reconcile on the host, exactly as
-        # ``get_output`` does.
-        if len({block.device for block in blocks}) > 1:
-            blocks = [block.cpu() if block.device.type != "cpu" else block for block in blocks]
-        # Reduce, then drop the singleton stack axis; Mean/Median also drop the singleton model axis,
-        # while Concat keeps the [M, C, ...] model axis for after_reduction (Sum) to merge into labels.
-        result = self.reduction(blocks).squeeze(0)
-        if isinstance(self.reduction, Mean | Median):
-            result = result.squeeze(0)
+        result = self._reduce_copies(blocks)
         attribute = Attribute(self.attributes[index][0][0])
-        first = next(iter(copies.values()))
-        if number_of_channels_per_model and first.shape[0] == sum(number_of_channels_per_model):
-            attribute["number_of_channels_per_model_0"] = torch.tensor(number_of_channels_per_model)
+        self._split_model_chunks(next(iter(copies.values())), number_of_channels_per_model, attribute)
         for position, stage in enumerate(plan.stages[: plan.boundary]):
             if position in plan.slab_stages:
                 result = stage.transform.stream_slab(self.names[index], result, region, spatial, attribute)
@@ -1215,12 +1207,12 @@ class OutSameAsGroupDataset(OutputDataset):
         return result, attribute
 
     def reset(self) -> None:
-        # Aborting an attempt mid-stream: exit each open sink WITH an error so the backend removes
-        # the partial entry (a reader must never see a half-written volume); the restart rewrites it.
-        abort = PredictorError("prediction restart: the partial streamed output is discarded")
+        # Aborting an attempt mid-stream: abort each open sink so the backend removes the partial
+        # entry (a reader must never see a half-written volume); the restart rewrites it.
+        error = PredictorError("prediction restart: the partial streamed output is discarded")
         for sink in self._stream_sinks.values():
             try:
-                sink.__exit__(type(abort), abort, None)
+                sink.abort(error)
             except Exception:  # nosec B110 - one sink failing to abort must not leak the others
                 pass
         self._stream_sinks.clear()
@@ -1228,6 +1220,7 @@ class OutSameAsGroupDataset(OutputDataset):
         self._region_states.clear()
         self._stream_buffers.clear()
         self._post_prefix_attributes.clear()
+        self._aligners.clear()
         super().reset()
 
     def _close_stream(self, index: int) -> None:
@@ -1236,7 +1229,7 @@ class OutSameAsGroupDataset(OutputDataset):
         def operation() -> None:
             sink = self._stream_sinks.pop(index, None)
             if sink is not None:
-                sink.__exit__(None, None, None)
+                sink.close()
 
         self._submit_write(operation)
         self._stream_plans.pop(index, None)
@@ -1260,17 +1253,39 @@ class OutSameAsGroupDataset(OutputDataset):
                 f"Destination group '{self.group_dest}' not found. Available groups: {groups[self.group_src]}."
             )
 
+    @staticmethod
+    def _split_model_chunks(
+        layer: torch.Tensor, number_of_channels_per_model: list[int] | None, attribute: Attribute
+    ) -> list[torch.Tensor]:
+        """Split an ensemble layer into per-model chunk views and tag the attribute with the layout; a
+        layer whose channels do not match the ensemble layout stays whole. One splitter serves the
+        whole-volume and slab paths, so the two cannot drift."""
+        if number_of_channels_per_model and layer.shape[0] == sum(number_of_channels_per_model):
+            attribute["number_of_channels_per_model_0"] = torch.tensor(number_of_channels_per_model)
+            return list(torch.split(layer, number_of_channels_per_model, dim=0))
+        return [layer]
+
+    def _reduce_copies(self, copies: list[torch.Tensor]) -> torch.Tensor:
+        """The cross-copy reduction, identical for a slab and a whole volume — the streamed path's
+        byte-identity rests on the two staying in lockstep.
+
+        Mixed devices can only come from a mid-case OOM fallback: reconcile on the host. Reduce, then
+        drop the singleton stack axis; Mean/Median also drop the singleton model axis, while Concat
+        keeps the ``[M, C, ...]`` model axis for after_reduction (Sum) to merge into labels."""
+        if len({copy.device for copy in copies}) > 1:
+            copies = [copy.cpu() if copy.device.type != "cpu" else copy for copy in copies]
+        result = self.reduction(copies).squeeze(0)
+        if isinstance(self.reduction, Mean | Median):
+            result = result.squeeze(0)
+        return result
+
     def _get_output(
         self, index: int, index_augmentation: int, number_of_channels_per_model: list[int], dataset: DatasetIter
     ) -> torch.Tensor:
         layer = self.output_layer_accumulator[index][index_augmentation].assemble()  # if concat then [N*C] else [C]
         layer = self._unaugment(dataset, index, index_augmentation, layer)
         base_attr = self.attributes[index][index_augmentation][0]
-        if layer.shape[0] == sum(number_of_channels_per_model):
-            base_attr["number_of_channels_per_model_0"] = torch.tensor(number_of_channels_per_model)
-            chunks = list(torch.split(layer, number_of_channels_per_model, dim=0))
-        else:
-            chunks = [layer]
+        chunks = self._split_model_chunks(layer, number_of_channels_per_model, base_attr)
 
         # The per-model channel reduction (softmax/argmax over the class dimension of a whole-volume
         # multi-class output) materialises a working volume on top of the resident accumulator. Decide
@@ -1372,13 +1387,7 @@ class OutSameAsGroupDataset(OutputDataset):
         # The volume stays on whatever device it was blended on (GPU when it fit VRAM, else CPU): the
         # reduction and every finalize transform are device- and dtype-transparent, so the whole finalize
         # simply runs where the volume already is. Only the final result is returned to the host.
-        # The per-case device decisions above make the list single-device; if VRAM pressure ever mixes
-        # devices anyway, fall back to the host — the one device guaranteed to fit everything.
-        if len({r.device for r in results}) > 1:
-            results = [r.cpu() if r.device.type != "cpu" else r for r in results]
-        result = self.reduction(results).squeeze(0)
-        if isinstance(self.reduction, Mean) or isinstance(self.reduction, Median):
-            result = result.squeeze(0)
+        result = self._reduce_copies(results)
         # Reduction strategy overview:
         #
         # Terminology:

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -822,14 +822,11 @@ class Trainer(DistributedObject):
         # Round a free patch axis up to the model's valid input multiple before the first step, so the
         # network's skips align instead of crashing on a non-divisible extent; every rank rounds the
         # same worst case to the same size, so no rendezvous is needed here (unlike the OOM shrink).
-        if self._vram_patch_candidate is None:
-            sized = size_free_axes(
-                self._vram_patch_template, self.dataset.worst_case_shape(), self._downsampling_factor
-            )
-            if sized is not None:
-                self._vram_patch_candidate = sized
-                self.dataset.replan_patch(sized)
-                dataloaders = self.dataset.get_data(world_size)[0][global_rank]
+        sized = size_free_axes(self._vram_patch_template, self.dataset.worst_case_shape(), self._downsampling_factor)
+        if sized is not None:
+            self._vram_patch_candidate = sized
+            self.dataset.replan_patch(sized)
+            dataloaders = self.dataset.get_data(world_size)[0][global_rank]
         while True:
             try:
                 with _Trainer(

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -690,6 +690,9 @@ class Trainer(DistributedObject):
         self.size = len(self.gpu_checkpoints) + 1 if self.gpu_checkpoints else 1
 
         state = State[konfai_state()]
+        # Cut the grids with the model's downsampling multiple already known, so each case's free axis
+        # rounds up to a valid input size (the graph -- hence the factor -- is final before init()).
+        self.dataset.set_free_axis_multiple(self.model.downsampling_factor())
         self.dataset.prepare()
         self.model.init(self.autocast, state, self.dataset.get_groups_dest())
         self.model.init_outputs_group()

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -667,7 +667,6 @@ class Trainer(DistributedObject):
             else None
         )
         self._vram_patch_candidate: list[int] | None = None
-        # Per-axis input multiple the model needs (its downsampling factor); a free axis is sized to it.
         self._downsampling_factor: list[int] | None = None
         self.autocast = autocast
         self.epochs = epochs
@@ -852,7 +851,7 @@ class Trainer(DistributedObject):
                 return
             except torch.cuda.OutOfMemoryError:
                 if self._vram_patch_template is None:
-                    raise  # no free axis declared: not auto-patched, the OOM propagates unchanged
+                    raise  # no free axis declared: not auto-patched
                 # The restart loop IS the sizing iteration: the step that just OOMed already measured
                 # its transient for free. Drop the failed step's gradients before reading free VRAM.
                 measured = self._transient_at_oom(device)

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -57,7 +57,7 @@ from konfai.utils.runtime import (
     safe_torch_load,
     synchronize_data,
 )
-from konfai.utils.utils import concretize_patch_size
+from konfai.utils.utils import concretize_patch_size, size_free_axes
 from konfai.utils.vram import next_patch_candidate, usable_vram
 
 
@@ -667,6 +667,8 @@ class Trainer(DistributedObject):
             else None
         )
         self._vram_patch_candidate: list[int] | None = None
+        # Per-axis input multiple the model needs (its downsampling factor); a free axis is sized to it.
+        self._downsampling_factor: list[int] | None = None
         self.autocast = autocast
         self.epochs = epochs
         self.epoch = 0
@@ -698,6 +700,8 @@ class Trainer(DistributedObject):
             self.gradient_checkpoints,
             self.gpu_checkpoints,
         )
+        # The per-axis multiple a free patch axis rounds up to, read off the model's downsampling graph.
+        self._downsampling_factor = self.model.downsampling_factor()
 
     def setup(self, world_size: int):
         """
@@ -815,6 +819,17 @@ class Trainer(DistributedObject):
         if self.model_ema is not None:
             self.model_ema.module = Network.to(self.model_ema.module, local_rank * self.size)
         device = local_rank * self.size if len(cuda_visible_devices()) else None
+        # Round a free patch axis up to the model's valid input multiple before the first step, so the
+        # network's skips align instead of crashing on a non-divisible extent; every rank rounds the
+        # same worst case to the same size, so no rendezvous is needed here (unlike the OOM shrink).
+        if self._vram_patch_candidate is None:
+            sized = size_free_axes(
+                self._vram_patch_template, self.dataset.worst_case_shape(), self._downsampling_factor
+            )
+            if sized is not None:
+                self._vram_patch_candidate = sized
+                self.dataset.replan_patch(sized)
+                dataloaders = self.dataset.get_data(world_size)[0][global_rank]
         while True:
             try:
                 with _Trainer(
@@ -879,8 +894,12 @@ class Trainer(DistributedObject):
         worst = self.dataset.worst_case_shape()
         if worst is None:
             return None
-        candidate = self._vram_patch_candidate or concretize_patch_size(self._vram_patch_template, worst)
-        return next_patch_candidate(candidate, self._vram_patch_template, worst, measured, usable)
+        candidate = self._vram_patch_candidate or concretize_patch_size(
+            self._vram_patch_template, worst, self._downsampling_factor
+        )
+        return next_patch_candidate(
+            candidate, self._vram_patch_template, worst, measured, usable, self._downsampling_factor
+        )
 
     @staticmethod
     def _reset_cuda_peak(device: int | None) -> None:

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -559,17 +559,20 @@ class _Trainer:
                             self.it,
                         )
 
-                    if len(images_log):
-                        for name, layer, _ in model.get_layers(
-                            [v.tensor for v in batch_sample.values() if v.is_input],
-                            images_log,
-                        ):
-                            self.data_log[name][0](
-                                self.tb,
-                                f"{type_log}/{name}{label}",
-                                layer[: self.data_log[name][1]].detach().cpu().numpy(),
-                                self.it,
-                            )
+                if len(images_log):
+                    # get_layers is model-scoped, not per-network: run it once per model, or a
+                    # multi-network model (a GAN's generator + discriminator) repeats the forward
+                    # extraction and writes each image event once per network.
+                    for name, layer, _ in model.get_layers(
+                        [v.tensor for v in batch_sample.values() if v.is_input],
+                        images_log,
+                    ):
+                        self.data_log[name][0](
+                            self.tb,
+                            f"{type_log}/{name}{label}",
+                            layer[: self.data_log[name][1]].detach().cpu().numpy(),
+                            self.it,
+                        )
 
             if type_log == "Training":
                 for name, network in self.model.module.get_networks().items():

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -607,6 +607,32 @@ class _Trainer:
         return self._log("Validation", batch_sample)
 
 
+def _agreed_patch(gathered: list, template: list[int]) -> list[int] | None:
+    """The per-axis MIN of the candidates gathered at the OOM shrink rendezvous, ``None`` when no rank
+    proposed one (every rank is at its floor: the OOM is not recoverable).
+
+    A gathered entry that is not a patch candidate means another rank was still training and its own
+    collective crossed this rendezvous -- an asymmetric OOM. That is not recoverable either, but it
+    must fail as a diagnosis, not as an opaque ``TypeError`` from ``min``.
+    """
+    proposals = [proposal for proposal in gathered if proposal is not None]
+    if not proposals:
+        return None
+    if any(
+        not isinstance(proposal, list)
+        or len(proposal) != len(template)
+        or not all(isinstance(size, int) for size in proposal)
+        for proposal in proposals
+    ):
+        raise TrainerError(
+            "The OOM shrink rendezvous gathered data that is not a patch candidate:",
+            f"gathered: {gathered}",
+            "Another rank was still training, so its collective crossed this rendezvous.",
+            "An asymmetric OOM is not recoverable; rerun with a smaller patch or fewer ranks.",
+        )
+    return [min(sizes) for sizes in zip(*proposals, strict=True)]
+
+
 @config()
 class Trainer(DistributedObject):
     """
@@ -805,7 +831,8 @@ class Trainer(DistributedObject):
         Wraps model with DDP or CPU fallback, attaches EMA, and starts training.
 
         Args:
-            world_size (int): Total number of distributed processes.
+            world_size (int): Number of model replicas sharding the data -- the spawned process count
+                already divided by the model-parallel size (``gpu_checkpoints``), NOT the GPU count.
             global_rank (int): Global rank of the current process.
             local_rank (int): Local rank within the node.
             dataloaders (list[DataLoader]): Training and validation dataloaders.
@@ -863,16 +890,19 @@ class Trainer(DistributedObject):
                 # Every rank must train the same grid, so the shrink is agreed at a rendezvous: each
                 # failing rank proposes its own candidate and all adopt the per-axis MIN. A rank that
                 # did NOT run out never reaches this all-gather; the job then dies at the collective
-                # timeout, exactly as an unhandled OOM kills it. Ranks failing together -- the
-                # common case, they share the patch size -- recover together.
-                proposals = [
-                    proposal
-                    for proposal in synchronize_data(world_size, local_rank * self.size, candidate)
-                    if proposal is not None
-                ]
-                if not proposals:
+                # timeout, exactly as an unhandled OOM kills it. Ranks failing together recover
+                # together when they fail at the same collective offset (the common case -- they
+                # share the patch size); an offset mismatch pairs foreign payloads, caught below.
+                if world_size > 1:
+                    print(
+                        f"[KonfAI] VRAM: rank {global_rank} ran out of memory -> waiting at the shrink"
+                        " rendezvous (a rank that did NOT run out aborts the job at the collective timeout)."
+                    )
+                agreed = _agreed_patch(
+                    synchronize_data(world_size, local_rank * self.size, candidate), self._vram_patch_template
+                )
+                if agreed is None:
                     raise
-                agreed = [min(sizes) for sizes in zip(*proposals, strict=True)]
                 print(
                     f"[KonfAI] VRAM: rank {global_rank} ran out of memory -> "
                     f"re-planning the free patch axes to {agreed} and restarting the training run."

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -884,6 +884,10 @@ class Trainer(DistributedObject):
                     raise  # no free axis declared: not auto-patched
                 # The restart loop IS the sizing iteration: the step that just OOMed already measured
                 # its transient for free. Drop the failed step's gradients before reading free VRAM.
+                # The auto-patch OOM fires on the first batch's FORWARD (the memory peak), before any
+                # optimizer.step(), so no weights are updated. The rare case where it fires mid-step
+                # instead leaves that first batch's partial update in place (the restart continues from
+                # it); this is a bounded one-batch perturbation, not worth a whole-run state snapshot.
                 measured = self._transient_at_oom(device)
                 self.model.zero_grad(set_to_none=True)
                 candidate = self._shrunken_patch(measured, self._usable_vram_after_oom(device))

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import ast
+import contextlib
 import copy
 import csv
 import functools
@@ -364,7 +365,12 @@ class DataStream(ABC):
     ``Dataset.open_data_stream``, which returns ``None`` when the write format cannot serve region writes
     (the caller then assembles the volume and uses ``Dataset.write``). Use as a context manager: a clean
     exit finalizes the entry, an exception removes the partial one so a reader never sees a half-written
-    volume."""
+    volume.
+
+    The entry lives under a temporary name until the clean exit renames it into place: an existence
+    probe (``is_dataset_exist``) or a concurrent reader never sees the entry while it is being written,
+    a replaced entry stays readable until its replacement is complete, and a hard-killed writer leaves
+    only temporary debris, never a plausible-looking partial volume under the final name."""
 
     _file: Dataset.File | None = None
 
@@ -388,15 +394,22 @@ class DataStream(ABC):
 
 
 class _H5DataStream(DataStream):
-    def __init__(self, dataset: h5py.Dataset) -> None:
+    def __init__(self, dataset: h5py.Dataset, final_name: str) -> None:
         self._dataset = dataset
+        self._final_name = final_name
 
     def write_slice(self, slices: tuple[slice, ...], data: np.ndarray) -> None:
         self._dataset[slices] = data
 
     def _close(self, success: bool) -> None:
+        parent = self._dataset.parent
+        temporary_name = self._dataset.name.rsplit("/", 1)[-1]
         if not success:
-            del self._dataset.parent[self._dataset.name.rsplit("/", 1)[-1]]
+            del parent[temporary_name]
+            return
+        if self._final_name in parent:
+            del parent[self._final_name]
+        parent.move(temporary_name, self._final_name)
 
 
 # MetaImage ElementType for each NumPy dtype a streamed .mha can hold.
@@ -421,6 +434,7 @@ class _MhaDataStream(DataStream):
 
     def __init__(self, path: str, shape: list[int], dtype: np.dtype, attributes: Attribute) -> None:
         self.path = path
+        self._temporary_path = f"{path}.tmp"
         spatial = list(shape[1:])
         # The header declares BinaryDataByteOrderMSB=False, so the map must be explicitly little-endian.
         self._dtype = np.dtype(dtype).newbyteorder("<")
@@ -441,11 +455,13 @@ class _MhaDataStream(DataStream):
         fields += [(k, str(v)) for k, v in attributes.items() if str(v) and "\n" not in str(v) and " " not in k]
         fields += [("ElementType", _MHA_ELEMENT_TYPES[self._dtype.name]), ("ElementDataFile", "LOCAL")]
         header = "".join(f"{key} = {value}\n" for key, value in fields).encode("utf-8")
-        with open(path, "wb") as file:
+        with open(self._temporary_path, "wb") as file:
             file.write(header)
             # Reserve the pixel block up front (sparse where the filesystem allows it).
             file.truncate(len(header) + int(np.prod([*spatial, shape[0]], dtype=np.int64)) * self._dtype.itemsize)
-        self._memmap = np.memmap(path, dtype=self._dtype, mode="r+", offset=len(header), shape=(*spatial, shape[0]))
+        self._memmap = np.memmap(
+            self._temporary_path, dtype=self._dtype, mode="r+", offset=len(header), shape=(*spatial, shape[0])
+        )
 
     def write_slice(self, slices: tuple[slice, ...], data: np.ndarray) -> None:
         self._memmap[(*slices[1:], slices[0])] = np.moveaxis(data, 0, -1)
@@ -454,13 +470,22 @@ class _MhaDataStream(DataStream):
         self._memmap.flush()
         del self._memmap
         if not success:
-            os.remove(self.path)
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(self._temporary_path)
+            return
+        try:
+            os.replace(self._temporary_path, self.path)
+        except FileNotFoundError:
+            # A concurrent writer of the same entry finalized first; keep its identical result.
+            if not os.path.exists(self.path):
+                raise
 
 
 class _OmeZarrDataStream(DataStream):
-    def __init__(self, array: Any, store_path: Path) -> None:
+    def __init__(self, array: Any, store_path: Path, final_path: Path) -> None:
         self._array = array
         self._store_path = store_path
+        self._final_path = final_path
 
     def write_slice(self, slices: tuple[slice, ...], data: np.ndarray) -> None:
         self._array[slices] = data
@@ -468,6 +493,10 @@ class _OmeZarrDataStream(DataStream):
     def _close(self, success: bool) -> None:
         if not success:
             shutil.rmtree(self._store_path, ignore_errors=True)
+            return
+        if self._final_path.exists():
+            shutil.rmtree(self._final_path)
+        os.rename(self._store_path, self._final_path)
 
 
 class Dataset:
@@ -697,11 +726,14 @@ class Dataset:
                     self.h5.create_group(group)
                 h5_group = self.h5[group]
             name = name.split("/")[-1]
-            if name in h5_group:
-                del h5_group[name]
-            dataset = h5_group.create_dataset(name, shape=tuple(shape), dtype=dtype, chunks=None)
+            # Write under a temporary key and move on finalize: the final key never names a partial
+            # entry, and a replaced entry stays readable until its replacement is complete.
+            temporary_name = f"{name}.tmp"
+            if temporary_name in h5_group:
+                del h5_group[temporary_name]
+            dataset = h5_group.create_dataset(temporary_name, shape=tuple(shape), dtype=dtype, chunks=None)
             dataset.attrs.update({k: str(v) for k, v in attributes.items()})
-            return _H5DataStream(dataset)
+            return _H5DataStream(dataset, name)
 
         def is_exist(self, group: str, name: str | None = None) -> bool:
             if self.h5 is not None:
@@ -1258,7 +1290,9 @@ class Dataset:
             dimension = len(shape) - 1
             spacing = attributes.get_np_array("Spacing") if "Spacing" in attributes else np.ones(dimension)
             origin = attributes.get_np_array("Origin") if "Origin" in attributes else np.zeros(dimension)
-            store_path = self._path(name, writing=True)
+            final_path = self._path(name, writing=True)
+            store_path = Path(f"{final_path}.tmp")
+            shutil.rmtree(store_path, ignore_errors=True)
             array = create_ome_zarr_store(
                 store_path,
                 shape,
@@ -1267,7 +1301,7 @@ class Dataset:
                 origin=origin,
                 attributes=dict(attributes),
             )
-            return _OmeZarrDataStream(array, store_path)
+            return _OmeZarrDataStream(array, store_path, final_path)
 
         def get_names(self, group: str) -> list[str]:
             return self.get_group()

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -19,11 +19,11 @@
 from __future__ import annotations
 
 import ast
-import contextlib
 import copy
 import csv
 import functools
 import glob
+import itertools
 import math
 import os
 import re
@@ -32,7 +32,7 @@ import threading
 import warnings
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import torch
@@ -72,7 +72,10 @@ class _H5ReadPool:
     makes the cache effective — a per-read open rebuilds it empty every time. ``get``/``drop`` must be
     called under the file's lock; a write drops the file's reader so it never serves stale metadata;
     handles inherited across ``fork`` are dropped unused (closing them would flush another process's
-    state)."""
+    state). Pooled handles open with ``locking=False``: a held HDF5 read lock would block every other
+    process's write-open of the file for as long as the handle lives — the pool's whole lifetime.
+    Same-process access is serialized by the per-file thread lock; cross-process read-under-write
+    coherence is the store's own caveat, unchanged by the pool."""
 
     _MAX = 8
 
@@ -88,11 +91,14 @@ class _H5ReadPool:
                 self._pid = os.getpid()
             handle = self._handles.pop(filename, None)
             if handle is None or not handle.id.valid:
-                handle = h5py.File(filename, "r", **open_kwargs)
+                handle = h5py.File(filename, "r", locking=False, **open_kwargs)
             self._handles[filename] = handle
-            evicted = [self._handles.pop(oldest) for oldest in list(self._handles)[: -self._MAX]]
-        for stale in evicted:
-            self._close_idle(stale)
+            evicted = []
+            while len(self._handles) > self._MAX:
+                oldest = next(iter(self._handles))
+                evicted.append((oldest, self._handles.pop(oldest)))
+        for stale_name, stale in evicted:
+            self._close_idle(stale_name, stale)
         return handle
 
     def drop(self, filename: str) -> None:
@@ -101,16 +107,18 @@ class _H5ReadPool:
         if handle is not None and handle.id.valid:
             handle.close()
 
-    @staticmethod
-    def _close_idle(handle: Any) -> None:
+    def _close_idle(self, filename: str, handle: Any) -> None:
         # An evicted handle may be mid-read under its file's lock: close only when that lock is free,
-        # otherwise leave it open (it falls out of the pool and dies with the process).
-        lock = _get_h5_file_lock(handle.filename)
+        # otherwise put it back in the pool — an untracked open handle could never be dropped again.
+        lock = _get_h5_file_lock(filename)
         if lock.acquire(blocking=False):
             try:
                 handle.close()
             finally:
                 lock.release()
+        else:
+            with self._guard:
+                self._handles.setdefault(filename, handle)
 
 
 _h5_read_pool = _H5ReadPool()
@@ -370,7 +378,17 @@ class DataStream(ABC):
     The entry lives under a temporary name until the clean exit renames it into place: an existence
     probe (``is_dataset_exist``) or a concurrent reader never sees the entry while it is being written,
     a replaced entry stays readable until its replacement is complete, and a hard-killed writer leaves
-    only temporary debris, never a plausible-looking partial volume under the final name."""
+    only temporary debris, never a plausible-looking partial volume under the final name. The
+    temporary name is unique per stream (PID + sequence): two writers of the same entry (a case
+    landing on two workers) each own their temporary, and whichever finalizes last publishes — a
+    complete entry either way, never an interleaving of the two."""
+
+    _sequence = itertools.count()
+
+    @staticmethod
+    def temporary_suffix() -> str:
+        """The per-stream unique suffix a backend appends to its temporary name."""
+        return f"{os.getpid()}-{next(DataStream._sequence)}.tmp"
 
     _file: Dataset.File | None = None
 
@@ -385,9 +403,23 @@ class DataStream(ABC):
     def _close(self, success: bool) -> None:
         """Finalize the entry, or remove the partial one when ``success`` is False."""
 
+    def close(self) -> None:
+        """Finalize the entry under its final name."""
+        self._finish(True, None, None, None)
+
+    def abort(self, error: BaseException | None = None) -> None:
+        """Remove the partial entry."""
+        if error is None:
+            self._finish(False, None, None, None)
+        else:
+            self._finish(False, type(error), error, error.__traceback__)
+
     def __exit__(self, exc_type, value, traceback) -> None:
+        self._finish(exc_type is None, exc_type, value, traceback)
+
+    def _finish(self, success: bool, exc_type, value, traceback) -> None:
         try:
-            self._close(exc_type is None)
+            self._close(success)
         finally:
             if self._file is not None:
                 self._file.__exit__(exc_type, value, traceback)
@@ -434,7 +466,7 @@ class _MhaDataStream(DataStream):
 
     def __init__(self, path: str, shape: list[int], dtype: np.dtype, attributes: Attribute) -> None:
         self.path = path
-        self._temporary_path = f"{path}.tmp"
+        self._temporary_path = f"{path}.{self.temporary_suffix()}"
         spatial = list(shape[1:])
         # The header declares BinaryDataByteOrderMSB=False, so the map must be explicitly little-endian.
         self._dtype = np.dtype(dtype).newbyteorder("<")
@@ -469,16 +501,10 @@ class _MhaDataStream(DataStream):
     def _close(self, success: bool) -> None:
         self._memmap.flush()
         del self._memmap
-        if not success:
-            with contextlib.suppress(FileNotFoundError):
-                os.remove(self._temporary_path)
-            return
-        try:
+        if success:
             os.replace(self._temporary_path, self.path)
-        except FileNotFoundError:
-            # A concurrent writer of the same entry finalized first; keep its identical result.
-            if not os.path.exists(self.path):
-                raise
+        else:
+            os.remove(self._temporary_path)
 
 
 class _OmeZarrDataStream(DataStream):
@@ -496,7 +522,14 @@ class _OmeZarrDataStream(DataStream):
             return
         if self._final_path.exists():
             shutil.rmtree(self._final_path)
-        os.rename(self._store_path, self._final_path)
+        try:
+            os.rename(self._store_path, self._final_path)
+        except OSError:
+            # A concurrent writer of the same entry renamed its complete, identical store into place
+            # between the rmtree and this rename; keep it and drop ours.
+            if not self._final_path.exists():
+                raise
+            shutil.rmtree(self._store_path, ignore_errors=True)
 
 
 class Dataset:
@@ -593,8 +626,6 @@ class Dataset:
             self._lock.acquire()
             try:
                 if self.read:
-                    # Pooled: the chunk cache lives on the handle, and only a handle that survives
-                    # this enter/exit makes overlapping patch reads hit it.
                     self.h5 = _h5_read_pool.get(
                         self.filename,
                         rdcc_nbytes=self._READ_CHUNK_CACHE_BYTES,
@@ -602,11 +633,14 @@ class Dataset:
                     )
                 else:
                     _h5_read_pool.drop(self.filename)
+                    # locking=False on every KonfAI open (the HDF5 flag must agree across a file's
+                    # handles): same-process access is serialized by the per-file thread lock, and a
+                    # pooled reader must not hold a lock that blocks another process's write-open.
                     if not os.path.exists(self.filename):
                         Path(self.filename).parent.mkdir(parents=True, exist_ok=True)
-                        self.h5 = h5py.File(self.filename, "w")
+                        self.h5 = h5py.File(self.filename, "w", locking=False)
                     else:
-                        self.h5 = h5py.File(self.filename, "r+")
+                        self.h5 = h5py.File(self.filename, "r+", locking=False)
                     self.h5.attrs["Date"] = current_date()
             except BaseException:
                 self._lock.release()
@@ -696,19 +730,23 @@ class Dataset:
                     datas.append(np.asarray(transform.GetParameters()))
                 data = np.asarray(datas)
 
-            h5_group = self.h5
-            if len(name.split("/")) > 1:
-                group = "/".join(name.split("/")[:-1])
-                if group not in self.h5:
-                    self.h5.create_group(group)
-                h5_group = self.h5[group]
-
-            name = name.split("/")[-1]
+            h5_group, name = self._resolve_group(name)
             if name in h5_group:
                 del h5_group[name]
 
             dataset = h5_group.create_dataset(name, data=data, dtype=data.dtype, chunks=None)
             dataset.attrs.update({k: str(v) for k, v in attributes.items()})
+
+        def _resolve_group(self, name: str) -> tuple[h5py.Group, str]:
+            """The (created) parent group a slash-qualified entry name writes into, and its leaf name."""
+            h5 = cast(h5py.File, self.h5)
+            h5_group: h5py.Group = h5
+            if len(name.split("/")) > 1:
+                group = "/".join(name.split("/")[:-1])
+                if group not in h5:
+                    h5.create_group(group)
+                h5_group = h5[group]
+            return h5_group, name.split("/")[-1]
 
         def open_data_stream(
             self,
@@ -719,18 +757,8 @@ class Dataset:
         ) -> DataStream | None:
             if self.h5 is None:
                 return None
-            h5_group = self.h5
-            if len(name.split("/")) > 1:
-                group = "/".join(name.split("/")[:-1])
-                if group not in self.h5:
-                    self.h5.create_group(group)
-                h5_group = self.h5[group]
-            name = name.split("/")[-1]
-            # Write under a temporary key and move on finalize: the final key never names a partial
-            # entry, and a replaced entry stays readable until its replacement is complete.
-            temporary_name = f"{name}.tmp"
-            if temporary_name in h5_group:
-                del h5_group[temporary_name]
+            h5_group, name = self._resolve_group(name)
+            temporary_name = f"{name}.{DataStream.temporary_suffix()}"
             dataset = h5_group.create_dataset(temporary_name, shape=tuple(shape), dtype=dtype, chunks=None)
             dataset.attrs.update({k: str(v) for k, v in attributes.items()})
             return _H5DataStream(dataset, name)
@@ -753,7 +781,10 @@ class Dataset:
             group = groups.split("/")[0]
             if group == "":
                 names = [
-                    dataset.name.split("/")[-1] for dataset in h5_group.values() if isinstance(dataset, h5py.Dataset)
+                    dataset.name.split("/")[-1]
+                    for dataset in h5_group.values()
+                    # ``.tmp`` keys are in-flight (or hard-kill-orphaned) DataStream writes, not entries.
+                    if isinstance(dataset, h5py.Dataset) and not dataset.name.endswith(".tmp")
                 ]
             elif group == "*":
                 for k in h5_group.keys():
@@ -1265,14 +1296,11 @@ class Dataset:
                 attributes.update(image_attributes)
             if not isinstance(data, np.ndarray):
                 raise DatasetManagerError("OME-Zarr datasets can only store image arrays.")
-            dimension = data.ndim - 1
-            spacing = attributes.get_np_array("Spacing") if "Spacing" in attributes else np.ones(dimension)
-            origin = attributes.get_np_array("Origin") if "Origin" in attributes else np.zeros(dimension)
             write_ome_zarr(
                 self._path(name, writing=True),
                 data,
-                spacing=spacing,
-                origin=origin,
+                spacing=attributes.get_np_array("Spacing") if "Spacing" in attributes else None,
+                origin=attributes.get_np_array("Origin") if "Origin" in attributes else None,
                 attributes=dict(attributes),
             )
 
@@ -1287,18 +1315,14 @@ class Dataset:
 
             if len(shape) not in (3, 4):
                 return None
-            dimension = len(shape) - 1
-            spacing = attributes.get_np_array("Spacing") if "Spacing" in attributes else np.ones(dimension)
-            origin = attributes.get_np_array("Origin") if "Origin" in attributes else np.zeros(dimension)
             final_path = self._path(name, writing=True)
-            store_path = Path(f"{final_path}.tmp")
-            shutil.rmtree(store_path, ignore_errors=True)
+            store_path = Path(f"{final_path}.{DataStream.temporary_suffix()}")
             array = create_ome_zarr_store(
                 store_path,
                 shape,
                 dtype,
-                spacing=spacing,
-                origin=origin,
+                spacing=attributes.get_np_array("Spacing") if "Spacing" in attributes else None,
+                origin=attributes.get_np_array("Origin") if "Origin" in attributes else None,
                 attributes=dict(attributes),
             )
             return _OmeZarrDataStream(array, store_path, final_path)
@@ -1559,6 +1583,23 @@ class Dataset:
         """
         return self.file_format not in ("h5", "omezarr", "dicom")
 
+    def _write_target(self, group: str, name: str) -> tuple[Dataset.File, str]:
+        """The file a ``(group, name)`` write lands in and the entry name inside it, caches dropped.
+
+        A directory dataset routes any sub-directory prefix of ``group`` into the file path (one file
+        per case); a single store keeps one file and a ``group/name`` entry.
+        """
+        self._names_cache.clear()
+        self._infos_cache.clear()
+        if self.is_directory:
+            os.makedirs(self.filename, exist_ok=True)
+            s_group = group.split("/")
+            if len(s_group) > 1:
+                name = f"{'/'.join(s_group[:-1])}/{name}"
+                group = s_group[-1]
+            return Dataset.File(f"{self.filename}{name}", False, self.file_format, self.level), group
+        return Dataset.File(self.filename, False, self.file_format, self.level), f"{group}/{name}"
+
     def write(
         self,
         group: str,
@@ -1566,23 +1607,9 @@ class Dataset:
         data: sitk.Image | sitk.Transform | np.ndarray,
         attributes: Attribute | None = None,
     ) -> None:
-        self._names_cache.clear()
-        self._infos_cache.clear()
-        if attributes is None:
-            attributes = Attribute()
-        if self.is_directory:
-            os.makedirs(self.filename, exist_ok=True)
-        if self.is_directory:
-            s_group = group.split("/")
-            if len(s_group) > 1:
-                sub_directory = "/".join(s_group[:-1])
-                name = f"{sub_directory}/{name}"
-                group = s_group[-1]
-            with Dataset.File(f"{self.filename}{name}", False, self.file_format, self.level) as file:
-                file.data_to_file(group, data, attributes)
-        else:
-            with Dataset.File(self.filename, False, self.file_format, self.level) as file:
-                file.data_to_file(f"{group}/{name}", data, attributes)
+        target, entry = self._write_target(group, name)
+        with target as file:
+            file.data_to_file(entry, data, attributes if attributes is not None else Attribute())
 
     def can_stream_data(self, attributes: Attribute) -> bool:
         """Whether ``open_data_stream`` can serve this dataset's write format.
@@ -1608,21 +1635,9 @@ class Dataset:
         the volume and uses ``write``. The returned stream is a context manager: a clean exit
         finalizes the entry, an exception removes the partial one.
         """
-        self._names_cache.clear()
-        self._infos_cache.clear()
         if attributes is None:
             attributes = Attribute()
-        if self.is_directory:
-            os.makedirs(self.filename, exist_ok=True)
-            s_group = group.split("/")
-            if len(s_group) > 1:
-                name = f"{'/'.join(s_group[:-1])}/{name}"
-                group = s_group[-1]
-            file = Dataset.File(f"{self.filename}{name}", False, self.file_format, self.level)
-            entry = group
-        else:
-            file = Dataset.File(self.filename, False, self.file_format, self.level)
-            entry = f"{group}/{name}"
+        file, entry = self._write_target(group, name)
         backend = file.__enter__()
         try:
             stream = backend.open_data_stream(entry, shape, dtype, attributes)

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -64,6 +64,57 @@ def _get_h5_file_lock(filename: str) -> threading.RLock:
         return lock
 
 
+class _H5ReadPool:
+    """Pooled read handles, one per file per process, LRU-bounded.
+
+    The HDF5 chunk cache lives on the open handle, so reusing the handle across patch reads is what
+    makes the cache effective — a per-read open rebuilds it empty every time. ``get``/``drop`` must be
+    called under the file's lock; a write drops the file's reader so it never serves stale metadata;
+    handles inherited across ``fork`` are dropped unused (closing them would flush another process's
+    state)."""
+
+    _MAX = 8
+
+    def __init__(self) -> None:
+        self._handles: dict[str, Any] = {}
+        self._guard = threading.Lock()
+        self._pid = os.getpid()
+
+    def get(self, filename: str, **open_kwargs: Any) -> Any:
+        with self._guard:
+            if os.getpid() != self._pid:
+                self._handles.clear()
+                self._pid = os.getpid()
+            handle = self._handles.pop(filename, None)
+            if handle is None or not handle.id.valid:
+                handle = h5py.File(filename, "r", **open_kwargs)
+            self._handles[filename] = handle
+            evicted = [self._handles.pop(oldest) for oldest in list(self._handles)[: -self._MAX]]
+        for stale in evicted:
+            self._close_idle(stale)
+        return handle
+
+    def drop(self, filename: str) -> None:
+        with self._guard:
+            handle = self._handles.pop(filename, None)
+        if handle is not None and handle.id.valid:
+            handle.close()
+
+    @staticmethod
+    def _close_idle(handle: Any) -> None:
+        # An evicted handle may be mid-read under its file's lock: close only when that lock is free,
+        # otherwise leave it open (it falls out of the pool and dies with the process).
+        lock = _get_h5_file_lock(handle.filename)
+        if lock.acquire(blocking=False):
+            try:
+                handle.close()
+            finally:
+                lock.release()
+
+
+_h5_read_pool = _H5ReadPool()
+
+
 class Attribute(dict[str, Any]):
     """Metadata container storing repeated values with a stack-like naming scheme."""
 
@@ -488,6 +539,14 @@ class Dataset:
             pass
 
     class H5File(AbstractFile):
+        # Read-side HDF5 chunk cache, per opened dataset. The library default (1 MB) holds barely one
+        # medical-imaging chunk, so overlapping patch reads on a chunked (compressed) store
+        # re-decompress the same chunks once per patch. KonfAI writes its own h5 contiguous
+        # (unaffected); this serves third-party chunked stores read through the streamed patch path.
+        # nslots per the h5py guidance: a prime, well above the chunks the cache can hold.
+        _READ_CHUNK_CACHE_BYTES = 128 * 1024 * 1024
+        _READ_CHUNK_CACHE_SLOTS = 100003
+
         def __init__(self, filename: str, read: bool) -> None:
             self.h5: h5py.File | None = None
             self.filename = filename
@@ -505,15 +564,21 @@ class Dataset:
             self._lock.acquire()
             try:
                 if self.read:
-                    self.h5 = h5py.File(self.filename, "r")
+                    # Pooled: the chunk cache lives on the handle, and only a handle that survives
+                    # this enter/exit makes overlapping patch reads hit it.
+                    self.h5 = _h5_read_pool.get(
+                        self.filename,
+                        rdcc_nbytes=self._READ_CHUNK_CACHE_BYTES,
+                        rdcc_nslots=self._READ_CHUNK_CACHE_SLOTS,
+                    )
                 else:
+                    _h5_read_pool.drop(self.filename)
                     if not os.path.exists(self.filename):
                         Path(self.filename).parent.mkdir(parents=True, exist_ok=True)
                         self.h5 = h5py.File(self.filename, "w")
                     else:
                         self.h5 = h5py.File(self.filename, "r+")
                     self.h5.attrs["Date"] = current_date()
-                self.h5.__enter__()
             except BaseException:
                 self._lock.release()
                 self._lock = None
@@ -522,7 +587,7 @@ class Dataset:
 
         def __exit__(self, exc_type, value, traceback):
             try:
-                if self.h5 is not None:
+                if self.h5 is not None and not self.read:
                     self.h5.close()
             finally:
                 if self._lock is not None:

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -313,6 +313,20 @@ def image_to_data(image: sitk.Image) -> tuple[np.ndarray, Attribute]:
     return data, attributes
 
 
+def _flatten_transforms(transform: sitk.Transform) -> list[sitk.Transform]:
+    """The leaf transforms of a (possibly nested) composite, in application order.
+
+    ``CompositeTransform.GetNthTransform`` can itself return a composite, so a single-level walk
+    leaves a nested composite in the list and the serializer rejects it. Recurse to the leaves.
+    """
+    if isinstance(transform, sitk.CompositeTransform):
+        leaves: list[sitk.Transform] = []
+        for i in range(transform.GetNumberOfTransforms()):
+            leaves.extend(_flatten_transforms(transform.GetNthTransform(i)))
+        return leaves
+    return [transform]
+
+
 def get_infos(filename: str | Path) -> tuple[list[int], Attribute]:
     """Read shape and metadata from an image file without loading its full pixel data."""
     attributes = Attribute()
@@ -713,12 +727,7 @@ class Dataset:
                 data, attributes_tmp = image_to_data(data)
                 attributes.update(attributes_tmp)
             elif isinstance(data, sitk.Transform):
-                transforms = []
-                if isinstance(data, sitk.CompositeTransform):
-                    for i in range(data.GetNumberOfTransforms()):
-                        transforms.append(data.GetNthTransform(i))
-                else:
-                    transforms.append(data)
+                transforms = _flatten_transforms(data)
                 datas = []
                 for i, transform in enumerate(transforms):
                     if isinstance(transform, sitk.Euler3DTransform):
@@ -954,12 +963,7 @@ class Dataset:
             attributes = Attribute()
             if os.path.exists(f"{self.filename}{name}.itk.txt"):
                 data = sitk.ReadTransform(f"{self.filename}{name}.itk.txt")
-                transforms = []
-                if isinstance(data, sitk.CompositeTransform):
-                    for i in range(data.GetNumberOfTransforms()):
-                        transforms.append(data.GetNthTransform(i))
-                else:
-                    transforms.append(data)
+                transforms = _flatten_transforms(data)
                 datas = []
                 for i, transform in enumerate(transforms):
                     if isinstance(transform, sitk.Euler3DTransform):

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -391,6 +391,7 @@ class DataStream(ABC):
         return f"{os.getpid()}-{next(DataStream._sequence)}.tmp"
 
     _file: Dataset.File | None = None
+    _finished: bool = False
 
     def __enter__(self) -> DataStream:
         return self
@@ -418,6 +419,12 @@ class DataStream(ABC):
         self._finish(exc_type is None, exc_type, value, traceback)
 
     def _finish(self, success: bool, exc_type, value, traceback) -> None:
+        # Single-shot: a caller may both close() and, on the error path, abort() the same stream (or
+        # exit a ``with`` that already closed). Only the first call acts, so the backing file is exited
+        # once and a failed close is not overwritten by a second _close on already-released state.
+        if self._finished:
+            return
+        self._finished = True
         try:
             self._close(success)
         finally:

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -1449,6 +1449,17 @@ class Dataset:
             return True
         return self.file_format == "h5" and os.path.exists(f"{self.filename}.h5")
 
+    def concurrent_write_safe(self) -> bool:
+        """Whether writes to different entries land in disjoint files, so a background writer may
+        flush one entry while another thread writes elsewhere in the dataset.
+
+        Mirrors the backend dispatch in ``File.__enter__``: everything that is not a single-store
+        backend is a :class:`SitkFile` directory, one image file per ``(group, name)``. A single
+        store (one HDF5 file, one zarr hierarchy, a DICOM series) shares handles and metadata across
+        entries and must stay serial.
+        """
+        return self.file_format not in ("h5", "omezarr", "dicom")
+
     def write(
         self,
         group: str,

--- a/konfai/utils/ome_zarr.py
+++ b/konfai/utils/ome_zarr.py
@@ -173,6 +173,32 @@ def read_ome_zarr_data_slice(
     return np.asarray(patch), metadata
 
 
+def _spatial_geometry(
+    ndim: int,
+    shape_label: str,
+    spacing: Sequence[float] | None,
+    origin: Sequence[float] | None,
+) -> tuple[list[str], list[float], list[float]]:
+    """The NGFF spatial axes of a channel-first array with ``ndim`` dims, and its per-axis
+    scale/translation in axis order — geometry arrives ``(x, y, z)`` (SimpleITK order)."""
+    if ndim not in {3, 4}:
+        raise DatasetManagerError(f"OME-Zarr writing expects a C-Y-X or C-Z-Y-X array, got {shape_label}.")
+    spatial_axes = ["y", "x"] if ndim == 3 else ["z", "y", "x"]
+    dimension = len(spatial_axes)
+    spacing_xyz = list(spacing if spacing is not None else [1.0] * dimension)
+    origin_xyz = list(origin if origin is not None else [0.0] * dimension)
+    if len(spacing_xyz) != dimension or len(origin_xyz) != dimension:
+        raise DatasetManagerError(
+            f"OME-Zarr geometry must contain {dimension} spacing and origin values for {shape_label}."
+        )
+    coordinate = {"x": (spacing_xyz[0], origin_xyz[0]), "y": (spacing_xyz[1], origin_xyz[1])}
+    if dimension == 3:
+        coordinate["z"] = (spacing_xyz[2], origin_xyz[2])
+    scale_values = [float(coordinate[axis][0]) for axis in spatial_axes]
+    translation_values = [float(coordinate[axis][1]) for axis in spatial_axes]
+    return spatial_axes, scale_values, translation_values
+
+
 def write_ome_zarr(
     store_path: str | Path,
     data: np.ndarray,
@@ -186,24 +212,12 @@ def write_ome_zarr(
     _load_image.cache_clear()
     _require_ngff_zarr()
     array_data = np.asarray(data)
-    if array_data.ndim not in {3, 4}:
-        raise DatasetManagerError(f"OME-Zarr writing expects a C-Y-X or C-Z-Y-X array, got shape {array_data.shape}.")
-
-    spatial_axes = ["y", "x"] if array_data.ndim == 3 else ["z", "y", "x"]
+    spatial_axes, scale_values, translation_values = _spatial_geometry(
+        array_data.ndim, f"shape {array_data.shape}", spacing, origin
+    )
     dims = ["c", *spatial_axes]
-    dimension = len(spatial_axes)
-    spacing_xyz = list(spacing if spacing is not None else [1.0] * dimension)
-    origin_xyz = list(origin if origin is not None else [0.0] * dimension)
-    if len(spacing_xyz) != dimension or len(origin_xyz) != dimension:
-        raise DatasetManagerError(
-            f"OME-Zarr geometry must contain {dimension} spacing and origin values for shape {array_data.shape}."
-        )
-
-    coordinate = {"x": (spacing_xyz[0], origin_xyz[0]), "y": (spacing_xyz[1], origin_xyz[1])}
-    if dimension == 3:
-        coordinate["z"] = (spacing_xyz[2], origin_xyz[2])
-    scale = {"c": 1.0, **{axis: float(coordinate[axis][0]) for axis in spatial_axes}}
-    translation = {"c": 0.0, **{axis: float(coordinate[axis][1]) for axis in spatial_axes}}
+    scale = {"c": 1.0, **dict(zip(spatial_axes, scale_values, strict=True))}
+    translation = {"c": 0.0, **dict(zip(spatial_axes, translation_values, strict=True))}
 
     image = ngff_zarr.to_ngff_image(array_data, dims=dims, scale=scale, translation=translation)
     multiscales = ngff_zarr.to_multiscales(
@@ -236,23 +250,11 @@ def create_ome_zarr_store(
     """
     _load_image.cache_clear()
     _require_zarr()
-    if len(shape) not in {3, 4}:
-        raise DatasetManagerError(f"OME-Zarr writing expects a C-Y-X or C-Z-Y-X shape, got {list(shape)}.")
-
-    spatial_axes = ["y", "x"] if len(shape) == 3 else ["z", "y", "x"]
-    dimension = len(spatial_axes)
-    spacing_xyz = list(spacing if spacing is not None else [1.0] * dimension)
-    origin_xyz = list(origin if origin is not None else [0.0] * dimension)
-    if len(spacing_xyz) != dimension or len(origin_xyz) != dimension:
-        raise DatasetManagerError(
-            f"OME-Zarr geometry must contain {dimension} spacing and origin values for shape {list(shape)}."
-        )
-
-    coordinate = {"x": (spacing_xyz[0], origin_xyz[0]), "y": (spacing_xyz[1], origin_xyz[1])}
-    if dimension == 3:
-        coordinate["z"] = (spacing_xyz[2], origin_xyz[2])
-    scale = [1.0, *[float(coordinate[axis][0]) for axis in spatial_axes]]
-    translation = [0.0, *[float(coordinate[axis][1]) for axis in spatial_axes]]
+    spatial_axes, scale_values, translation_values = _spatial_geometry(
+        len(shape), f"shape {list(shape)}", spacing, origin
+    )
+    scale = [1.0, *scale_values]
+    translation = [0.0, *translation_values]
 
     if chunks is None:
         spatial_chunks = [min(extent, 128) for extent in shape[1:]]

--- a/konfai/utils/ome_zarr.py
+++ b/konfai/utils/ome_zarr.py
@@ -35,6 +35,7 @@ Optional dependencies: ``zarr`` + ``ngff-zarr`` (``pip install konfai[omezarr]``
 from __future__ import annotations
 
 from collections.abc import Sequence
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -88,8 +89,14 @@ def _read_konfai_attributes(store_path: str | Path) -> dict[str, Any]:
         return {}
 
 
-def _load_image(store_path: str | Path, level: int) -> Any:
-    """Return the ``NgffImage`` for ``level`` of an OME-Zarr store.
+@lru_cache(maxsize=8)
+def _load_image(store_path: str, level: int) -> Any:
+    """Return the ``NgffImage`` for ``level`` of an OME-Zarr store, memoised per (store, level).
+
+    A streamed run reads one patch per call, and re-parsing the NGFF metadata and rebuilding the
+    lazy array graph per patch is pure per-read overhead: the image object is lazy (no voxel data),
+    so a handful of them is cheap to keep. Every write path calls ``_load_image.cache_clear()`` —
+    a store just written must be re-read, never served from the memo.
 
     ``@N`` selects among the levels a store offers, so a single-level store has nothing to select: its
     one level is read whatever ``N`` says (as every other backend does -- ``SitkFile`` ignores
@@ -128,7 +135,7 @@ def read_ome_zarr_data_slice(
     timepoint: int = 0,
 ) -> tuple[np.ndarray, dict[str, Any]]:
     """Read a KonfAI channel-first ``C[Z]YX`` patch from an OME-Zarr store (lazy)."""
-    image = _load_image(store_path, level)
+    image = _load_image(str(store_path), level)
     dims = [str(axis).lower() for axis in image.dims]
     canonical_shape = _canonical_shape(dims, image.data.shape)
     if len(slices) != len(canonical_shape):
@@ -176,6 +183,7 @@ def write_ome_zarr(
     chunks: Sequence[int] | None = None,
 ) -> None:
     """Write one channel-first KonfAI array as a single-level OME-NGFF store."""
+    _load_image.cache_clear()
     _require_ngff_zarr()
     array_data = np.asarray(data)
     if array_data.ndim not in {3, 4}:
@@ -226,6 +234,7 @@ def create_ome_zarr_store(
     read back as zeros. Metadata (the 0.4 multiscales entry plus the KonfAI attribute sidecar) is
     complete from the start, so the store is readable at any point during the write.
     """
+    _load_image.cache_clear()
     _require_zarr()
     if len(shape) not in {3, 4}:
         raise DatasetManagerError(f"OME-Zarr writing expects a C-Y-X or C-Z-Y-X shape, got {list(shape)}.")
@@ -280,7 +289,7 @@ def create_ome_zarr_store(
 
 def get_ome_zarr_info(store_path: str | Path, level: int = 0) -> dict[str, Any]:
     """Return OME-Zarr metadata (raw axis-order shape) without reading pixel data."""
-    image = _load_image(store_path, level)
+    image = _load_image(str(store_path), level)
     dims = [str(axis).lower() for axis in image.dims]
     try:
         n_levels = len(ngff_zarr.from_ngff_zarr(str(store_path)).images)

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -663,6 +663,13 @@ def run_distributed_app(
         bound = sig.bind_partial(*args, **kwargs_fun)
         bound.apply_defaults()
         is_cluster = "resubmit" in kwargs
+        # The auto memory budget is a NODE budget, but build-time sizing (the evaluation auto-patch)
+        # runs while ``func(...)`` constructs the workflow -- before the spawn where world_size exists.
+        # The launcher therefore leaves the per-node rank count in the environment, and restores it
+        # after: a leak would silently shrink a later in-process run (tests, embedded Python).
+        local_ranks = len(list(bound.arguments.get("gpu") or [])) or int(bound.arguments.get("cpu") or 1)
+        previous_local_ranks = os.environ.get("KONFAI_LOCAL_RANKS")
+        os.environ["KONFAI_LOCAL_RANKS"] = str(max(1, local_ranks))
         try:
             execute_distributed_object(
                 func(*args, **kwargs_fun),
@@ -685,6 +692,11 @@ def run_distributed_app(
             )
         except KeyboardInterrupt:
             print("\n[KonfAI] Manual interruption (Ctrl+C)")
+        finally:
+            if previous_local_ranks is None:
+                os.environ.pop("KONFAI_LOCAL_RANKS", None)
+            else:
+                os.environ["KONFAI_LOCAL_RANKS"] = previous_local_ranks
 
     return wrapper
 

--- a/konfai/utils/utils.py
+++ b/konfai/utils/utils.py
@@ -123,6 +123,23 @@ def concretize_patch_size(
     return [resolve(d, p) for d, p in enumerate(patch_size)]
 
 
+def size_free_axes(
+    template: list[int] | None,
+    worst: list[int] | None,
+    multiple: list[int] | None,
+) -> list[int] | None:
+    """The up-front concrete patch for a free (``0``) axis config: the worst case with each free axis
+    rounded up to the model's ``multiple`` (its ``downsampling_factor``), so the first attempt is a
+    valid model input. ``None`` when there is nothing to size — no free axis, unknown worst case, or
+    every free extent is already a valid multiple (the raw path already works). Shared by the
+    prediction and training auto-patch loops so the rounding lives in one place.
+    """
+    if template is None or worst is None:
+        return None
+    sized = concretize_patch_size(template, worst, multiple)
+    return sized if sized != concretize_patch_size(template, worst) else None
+
+
 def resolve_overlap(overlap: OverlapSpec, patch_size: list[int], shape: list[int] | tuple[int, ...]) -> list[int]:
     """Resolve an overlap spec into per-axis voxels for a CONCRETE ``patch_size``.
 

--- a/konfai/utils/utils.py
+++ b/konfai/utils/utils.py
@@ -110,7 +110,8 @@ def concretize_patch_size(
     ``multiple`` (the model's per-axis ``downsampling_factor``) rounds a free axis UP to a valid input
     size for the network — 122 -> 128 for a factor 16 — so its encoder/decoder skips align. The rounded
     size may exceed the extent; the border padding (``pad_to_patch``) fills it and the accumulator crops
-    it back, exactly as it does for any patch larger than its case.
+    it back, exactly as it does for any patch larger than its case. A factor shorter than the patch rank
+    aligns to the TRAILING axes (a 2D model in a ``[1,0,0]`` slice regime constrains Y and X, not Z).
     """
     if patch_size is None:
         return list(shape)
@@ -126,10 +127,20 @@ def concretize_patch_size(
         if p != 0:
             return min(int(p), int(shape[d]))
         extent = int(shape[d])
-        m = int(multiple[d]) if multiple is not None and d < len(multiple) else 1
+        m = free_axis_rounding(multiple, d, len(patch_size))
         return ((extent + m - 1) // m) * m if m > 1 else extent
 
     return [resolve(d, p) for d, p in enumerate(patch_size)]
+
+
+def free_axis_rounding(multiple: list[int] | None, axis: int, rank: int) -> int:
+    """The rounding factor a free axis at spatial index ``axis`` (of ``rank`` axes) takes from the
+    model's per-axis ``multiple`` — trailing-aligned: a 2D model's ``[fy, fx]`` in a 3-axis patch
+    constrains Y and X and leaves Z at 1."""
+    if multiple is None:
+        return 1
+    aligned = axis - (rank - len(multiple))
+    return int(multiple[aligned]) if 0 <= aligned < len(multiple) else 1
 
 
 def size_free_axes(

--- a/konfai/utils/utils.py
+++ b/konfai/utils/utils.py
@@ -163,7 +163,10 @@ def resolve_overlap(overlap: OverlapSpec, patch_size: list[int], shape: list[int
             text = spec.strip()
             if not text.endswith("%"):
                 raise ConfigError(f"overlap: '{spec}' is not a percentage; use e.g. '20%', a voxel int or a fraction.")
-            spec = float(text[:-1]) / 100.0
+            try:
+                spec = float(text[:-1]) / 100.0
+            except ValueError:
+                raise ConfigError(f"overlap: '{spec}' is not a numeric percentage; use e.g. '20%'.") from None
         if isinstance(spec, float):
             if not 0.0 <= spec < 1.0:
                 raise ConfigError(f"overlap: fraction {spec} must be in [0, 1[.")

--- a/konfai/utils/utils.py
+++ b/konfai/utils/utils.py
@@ -27,6 +27,15 @@ import numpy as np
 from konfai.utils.errors import ConfigError, DatasetManagerError
 
 
+def env_flag(name: str, default: bool) -> bool:
+    """A ``KONFAI_*`` boolean switch: ``0``/``false`` is off, anything else set is on, unset is
+    ``default`` — one parser, so a switch read in two places accepts the same spellings."""
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() not in ("0", "false")
+
+
 def get_module(classpath: str, default_classpath: str) -> tuple[ModuleType, str]:
     """Import the module a classpath names and return it with the name to take from it.
 

--- a/konfai/utils/utils.py
+++ b/konfai/utils/utils.py
@@ -24,7 +24,7 @@ from types import ModuleType
 
 import numpy as np
 
-from konfai.utils.errors import DatasetManagerError
+from konfai.utils.errors import ConfigError, DatasetManagerError
 
 
 def get_module(classpath: str, default_classpath: str) -> tuple[ModuleType, str]:
@@ -153,14 +153,14 @@ def resolve_overlap(overlap: OverlapSpec, patch_size: list[int], shape: list[int
         if isinstance(spec, str):
             text = spec.strip()
             if not text.endswith("%"):
-                raise ValueError(f"overlap: '{spec}' is not a percentage; use e.g. '20%', a voxel int or a fraction.")
+                raise ConfigError(f"overlap: '{spec}' is not a percentage; use e.g. '20%', a voxel int or a fraction.")
             spec = float(text[:-1]) / 100.0
         if isinstance(spec, float):
             if not 0.0 <= spec < 1.0:
-                raise ValueError(f"overlap: fraction {spec} must be in [0, 1[.")
+                raise ConfigError(f"overlap: fraction {spec} must be in [0, 1[.")
             return int(size * spec)
         if spec < 0:
-            raise ValueError(f"overlap: {spec} must be >= 0 voxels.")
+            raise ConfigError(f"overlap: {spec} must be >= 0 voxels.")
         return int(spec)
 
     if overlap is None:
@@ -169,14 +169,14 @@ def resolve_overlap(overlap: OverlapSpec, patch_size: list[int], shape: list[int
         list(overlap) if isinstance(overlap, list) else [overlap] * len(patch_size)  # scalar broadcast
     )
     if len(specs) != len(patch_size):
-        raise ValueError(f"overlap: {len(specs)} entries for {len(patch_size)} axes; give one per axis or a scalar.")
+        raise ConfigError(f"overlap: {len(specs)} entries for {len(patch_size)} axes; give one per axis or a scalar.")
     resolved = []
     for spec, size, extent in zip(specs, patch_size, shape, strict=True):
         # No overlap on an axis that is not tiled (one patch spans it) nor on a length-1 patch axis
         # (2D slicing: nothing to blend along a single-voxel patch).
         voxels = one(spec, size) if 1 < size < extent else 0
         if voxels >= size:
-            raise ValueError(f"overlap: {voxels} voxels must be smaller than the patch size {size}.")
+            raise ConfigError(f"overlap: {voxels} voxels must be smaller than the patch size {size}.")
         resolved.append(voxels)
     return resolved
 
@@ -275,7 +275,7 @@ def get_patch_slices_from_shape(
 
     for dim in range(len(shape)):
         if overlap[dim] >= patch_size[dim]:
-            raise ValueError(
+            raise ConfigError(
                 f"Overlap must be less than patch size, got overlap={overlap[dim]}",
                 f" ≥ patch_size={patch_size[dim]} at dim={dim}",
             )

--- a/konfai/utils/utils.py
+++ b/konfai/utils/utils.py
@@ -247,14 +247,15 @@ def resolve_patch(
 
 
 def get_patch_slices_from_shape(
-    patch_size: list[int], shape: list[int], overlap_tmp: OverlapSpec
+    patch_size: list[int], shape: list[int], overlap_tmp: OverlapSpec, multiple: list[int] | None = None
 ) -> tuple[list[tuple[slice, ...]], list[tuple[int, bool]]]:
 
-    has_free_axis = patch_size is not None and any(p == 0 for p in patch_size) and not all(p == 0 for p in patch_size)
-    if patch_size is None or all(p == 0 for p in patch_size):
-        patch_size = shape
-    else:
-        patch_size = concretize_patch_size(patch_size, shape)
+    # A free (``0``) axis concretizes to THIS case's extent, rounded up to the model's ``multiple`` so a
+    # small case still reaches the network at a valid input size -- the up-front worst-case sizing only
+    # guarantees the largest case, and a heterogeneous smaller one would otherwise arrive non-divisible.
+    template = [0] * len(shape) if patch_size is None else patch_size
+    has_free_axis = any(p == 0 for p in template) and not all(p == 0 for p in template)
+    patch_size = concretize_patch_size(template, shape, multiple)
     if len(shape) != len(patch_size):
         raise DatasetManagerError(
             f"Dimension mismatch: 'patch_size' has {len(patch_size)} dimensions, but 'shape' has {len(shape)}.",

--- a/konfai/utils/utils.py
+++ b/konfai/utils/utils.py
@@ -88,11 +88,20 @@ DEFAULT_OVERLAP_FRACTION = 0.2
 OverlapSpec = int | float | str | list["int | float | str"] | None
 
 
-def concretize_patch_size(patch_size: list[int] | None, shape: list[int] | tuple[int, ...]) -> list[int]:
+def concretize_patch_size(
+    patch_size: list[int] | None,
+    shape: list[int] | tuple[int, ...],
+    multiple: list[int] | None = None,
+) -> list[int]:
     """Resolve the per-axis patch convention onto a concrete shape: ``0`` = free axis -> full extent.
 
     ``[0,0,0]`` (or ``None``) is the whole volume; ``[1,0,0]`` is a full 2D slice; a positive entry is
     fixed by the user and passes through (clamped to the extent so a patch never exceeds the volume).
+
+    ``multiple`` (the model's per-axis ``downsampling_factor``) rounds a free axis UP to a valid input
+    size for the network — 122 -> 128 for a factor 16 — so its encoder/decoder skips align. The rounded
+    size may exceed the extent; the border padding (``pad_to_patch``) fills it and the accumulator crops
+    it back, exactly as it does for any patch larger than its case.
     """
     if patch_size is None:
         return list(shape)
@@ -103,7 +112,15 @@ def concretize_patch_size(patch_size: list[int] | None, shape: list[int] | tuple
             f"shape: {shape}",
             "Both must have the same number of dimensions (e.g., 3D patch for 3D volume).",
         )
-    return [int(shape[d]) if p == 0 else min(int(p), int(shape[d])) for d, p in enumerate(patch_size)]
+
+    def resolve(d: int, p: int) -> int:
+        if p != 0:
+            return min(int(p), int(shape[d]))
+        extent = int(shape[d])
+        m = int(multiple[d]) if multiple is not None and d < len(multiple) else 1
+        return ((extent + m - 1) // m) * m if m > 1 else extent
+
+    return [resolve(d, p) for d, p in enumerate(patch_size)]
 
 
 def resolve_overlap(overlap: OverlapSpec, patch_size: list[int], shape: list[int] | tuple[int, ...]) -> list[int]:

--- a/tests/integration/test_konfai_streamed_evaluation.py
+++ b/tests/integration/test_konfai_streamed_evaluation.py
@@ -23,7 +23,6 @@ feature stands on -- and that the budget run actually took the patched path.
 """
 
 import json
-import os
 import subprocess
 import sys
 import textwrap
@@ -34,15 +33,9 @@ import pytest
 
 SimpleITK = pytest.importorskip("SimpleITK")
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+from test_konfai_core_workflows import _subprocess_env  # noqa: E402
+
 TRAIN_NAME = "STREAMED_EVAL_01"
-
-
-def _subprocess_env() -> dict[str, str]:
-    env = os.environ.copy()
-    pythonpath = env.get("PYTHONPATH")
-    env["PYTHONPATH"] = str(REPO_ROOT) if not pythonpath else f"{REPO_ROOT}{os.pathsep}{pythonpath}"
-    return env
 
 
 EVALUATION_TEMPLATE = """Evaluator:

--- a/tests/integration/test_konfai_streamed_prediction.py
+++ b/tests/integration/test_konfai_streamed_prediction.py
@@ -21,9 +21,9 @@ when the gate refuses.
 
 The geometry variants exercise the write dispatcher end to end, one per region kind and then in
 composition: a ``Canonical`` inverse (ORIENTATION — in-slab mirrors), a ``Padding`` inverse (CROP), a
-``ResampleToResolution`` inverse on a uint8 chain (RESCALE, streamed through in nearest mode) and on a
-float chain (demoted to the buffered tail, since interpolation is only byte-identical whole-volume),
-a two-inverse pipe, and the full three-inverse stack (crop + rescale + reorient composed, streamed
+``ResampleToResolution`` inverse on a uint8 chain (RESCALE, streamed in nearest mode, byte-exact) and on
+a float chain (RESCALE, streamed in linear mode, matching the reference to float-rounding), a
+two-inverse pipe, and the full three-inverse stack (crop + rescale + reorient composed, streamed
 end to end). The TTA variants exercise the slab-synchronized cross-copy reduce: an in-plane flip
 streams (each copy's window reduced slab by slab), while a slab-axis flip must refuse and complete
 whole-volume. Every variant is compared voxel for voxel against its own kill-switch reference."""
@@ -148,8 +148,8 @@ _VARIANT_TRANSFORMS = {
 }
 
 # ResampleLabel/GeometryStack cast to uint8 before the reduction, so the tensor reaching the RESCALE
-# stage resamples in nearest mode — the exactness the streamed resample requires. ResampleFloat keeps
-# the float chain: the dispatcher must demote it to the buffered tail and stay byte-identical.
+# stage resamples in nearest mode (byte-exact). ResampleFloat keeps the float chain, so it resamples in
+# linear mode and matches the reference to float-rounding.
 _UINT8_BEFORE_REDUCTION = """        before_reduction_transforms:
           TensorCast:
             dtype: uint8
@@ -164,7 +164,7 @@ _VARIANT_USES_STREAMED_WRITER = {
     "Canonical": True,
     "Padding": True,
     "ResampleLabel": True,
-    "ResampleFloat": False,
+    "ResampleFloat": True,
     "GeometryPair": True,
     "GeometryStack": True,
     "TTA": True,
@@ -258,15 +258,20 @@ def test_streamed_prediction_is_voxel_identical_to_reference(
         reference_array = SimpleITK.GetArrayFromImage(reference)
         streamed_array = SimpleITK.GetArrayFromImage(streamed)
         assert streamed_array.dtype == reference_array.dtype, (variant, case)
-        np.testing.assert_array_equal(streamed_array, reference_array, err_msg=f"{variant}/{case}")
+        if variant == "ResampleFloat":
+            # A float rescale streams its linear interpolation, matching the whole-volume reference to
+            # float-rounding rather than bit for bit.
+            np.testing.assert_allclose(streamed_array, reference_array, atol=1e-2, err_msg=f"{variant}/{case}")
+        else:
+            np.testing.assert_array_equal(streamed_array, reference_array, err_msg=f"{variant}/{case}")
 
 
 @pytest.mark.parametrize("variant", _ALL_VARIANTS)
 def test_streamed_prediction_takes_the_expected_writer(streamed_experiment: dict[str, Path], variant: str) -> None:
     """SimpleITK always writes ``CenterOfRotation`` into a MetaImage header; the streamed region writer
     never does. Its absence proves the variant streamed to the sink (for TTA: the slab-synchronized
-    cross-copy reduce); its presence proves the buffered (chain-split / demoted) and refused (TTAZ —
-    a slab-axis flip) variants assembled and wrote classically."""
+    cross-copy reduce); its presence proves a refused variant (TTAZ — a slab-axis flip that cannot act
+    slab by slab) assembled the whole volume and wrote it classically."""
     experiment_dir = streamed_experiment["experiment_dir"]
     case = _case_names(streamed_experiment["dataset_dir"])[0]
     streamed_header = _prediction_path(experiment_dir / f"Predictions_{variant}_streamed", case).read_bytes()[:2048]

--- a/tests/integration/test_konfai_streamed_prediction.py
+++ b/tests/integration/test_konfai_streamed_prediction.py
@@ -54,11 +54,10 @@ from konfai.trainer import train
 def run_prediction(prediction_file: Path, predictions_dir: Path, disable_streaming: bool = False) -> None:
     # Streaming has no config knob -- it is automatic. The whole-volume reference is obtained through the
     # global ops kill-switch KONFAI_STREAMED_WRITES=0, pinned in both directions so an inherited
-    # value cannot leak into either run. The TTA
-    # worth gate would route these toy volumes whole-volume, so zero its threshold to exercise the
-    # streamed reduce.
+    # value cannot leak into either run. The worth gate would route these toy volumes whole-volume,
+    # so zero its threshold to exercise the streamed machinery.
     os.environ["KONFAI_STREAMED_WRITES"] = "0" if disable_streaming else "1"
-    os.environ["KONFAI_STREAMED_TTA_THRESHOLD"] = "0"
+    os.environ["KONFAI_STREAM_WORTH_THRESHOLD"] = "0"
     root = Path.cwd()
     checkpoints = sorted((root / "Checkpoints" / "__TRAIN_NAME__").glob("*.pt"))
     if not checkpoints:

--- a/tests/integration/test_konfai_streamed_prediction.py
+++ b/tests/integration/test_konfai_streamed_prediction.py
@@ -53,7 +53,8 @@ from konfai.trainer import train
 
 def run_prediction(prediction_file: Path, predictions_dir: Path, disable_streaming: bool = False) -> None:
     # Streaming has no config knob -- it is automatic. The whole-volume reference is obtained through the
-    # global ops kill-switch KONFAI_STREAMED_WRITES=0; the streamed run just leaves it unset. The TTA
+    # global ops kill-switch KONFAI_STREAMED_WRITES=0, pinned in both directions so an inherited
+    # value cannot leak into either run. The TTA
     # worth gate would route these toy volumes whole-volume, so zero its threshold to exercise the
     # streamed reduce.
     os.environ["KONFAI_STREAMED_WRITES"] = "0" if disable_streaming else "1"

--- a/tests/integration/test_konfai_streamed_prediction.py
+++ b/tests/integration/test_konfai_streamed_prediction.py
@@ -17,14 +17,16 @@
 """Streamed prediction writes (automatic, no config knob): the slab-by-slab path must be voxel-identical
 to the assembled-volume path (obtained via the ``KONFAI_STREAMED_WRITES=0`` kill-switch), must actually
 take the streamed writer (its hand-written MetaImage header is observable), and must fall back safely
-when the gate refuses (here: TTA).
+when the gate refuses.
 
 The geometry variants exercise the write dispatcher end to end, one per region kind and then in
 composition: a ``Canonical`` inverse (ORIENTATION — in-slab mirrors), a ``Padding`` inverse (CROP), a
 ``ResampleToResolution`` inverse on a uint8 chain (RESCALE, streamed through in nearest mode) and on a
 float chain (demoted to the buffered tail, since interpolation is only byte-identical whole-volume),
 a two-inverse pipe, and the full three-inverse stack (crop + rescale + reorient composed, streamed
-end to end). Every variant is compared voxel for voxel against its own kill-switch reference."""
+end to end). The TTA variants exercise the slab-synchronized cross-copy reduce: an in-plane flip
+streams (each copy's window reduced slab by slab), while a slab-axis flip must refuse and complete
+whole-volume. Every variant is compared voxel for voxel against its own kill-switch reference."""
 
 import subprocess
 import sys
@@ -82,14 +84,17 @@ def main() -> None:
         statistics_dir=root / "Statistics",
     )
     # Same config both ways -- only the kill-switch differs -- so the outputs must match bit for bit.
-    for variant in ["", "Canonical", "Padding", "ResampleLabel", "ResampleFloat", "GeometryPair", "GeometryStack"]:
+    # TTA (in-plane flip) streams through the slab-synchronized reduce; TTAZ (slab-axis flip) must
+    # refuse and complete whole-volume.
+    for variant in [
+        "", "Canonical", "Padding", "ResampleLabel", "ResampleFloat", "GeometryPair", "GeometryStack",
+        "TTA", "TTAZ", "TTAStack",
+    ]:
         run_prediction(
             root / f"Prediction{variant}.yml", root / f"Predictions_{variant or 'base'}_reference",
             disable_streaming=True,
         )
         run_prediction(root / f"Prediction{variant}.yml", root / f"Predictions_{variant or 'base'}_streamed")
-    # TTA makes the finalize chain non-local, so streaming refuses and the run completes whole-volume.
-    run_prediction(root / "PredictionTTA.yml", root / "Predictions_streamed_tta")
 
 
 if __name__ == "__main__":
@@ -162,13 +167,40 @@ _VARIANT_USES_STREAMED_WRITER = {
     "ResampleFloat": False,
     "GeometryPair": True,
     "GeometryStack": True,
+    "TTA": True,
+    "TTAZ": False,
+    "TTAStack": True,
 }
+
+_ALL_VARIANTS = tuple(_VARIANT_USES_STREAMED_WRITER)
+
+# TTA copies concatenated, then InferenceStack (SLAB: per-voxel member mean + a per-region side write
+# of the stack) — the streamed prefix must feed it every slab's place and the stack must still match.
+_STACK_AFTER_REDUCTION_BLOCK = """\
+        after_reduction_transforms:
+          InferenceStack:
+            dataset: ''
+            name: stack
+            mode: mean"""
 
 
 def _write_streamed_prediction_configs(experiment_dir: Path) -> None:
     base = (experiment_dir / "Prediction.yml").read_text(encoding="utf-8")
+    # The in-plane flip (y and x, never z) is slab-parallel, so the case streams; flipping the slab
+    # axis instead mirrors the slab order, which the gate must refuse.
     tta = _replace_once(base, "    augmentations: None", TTA_AUGMENTATIONS_BLOCK)
     (experiment_dir / "PredictionTTA.yml").write_text(tta, encoding="utf-8")
+    z_flip_block = TTA_AUGMENTATIONS_BLOCK.replace(
+        "- 0\n            - 1\n            - 1", "- 1\n            - 0\n            - 0"
+    )
+    assert z_flip_block != TTA_AUGMENTATIONS_BLOCK, "the TTA block does not match the expected f_prob layout"
+    (experiment_dir / "PredictionTTAZ.yml").write_text(
+        _replace_once(base, "    augmentations: None", z_flip_block), encoding="utf-8"
+    )
+    tta_stack = _replace_once(tta, "        after_reduction_transforms: None", _STACK_AFTER_REDUCTION_BLOCK)
+    tta_stack = _replace_once(tta_stack, "        reduction: Mean", "        reduction: Concat")
+    tta_stack = _replace_once(tta_stack, "        Mean: {}", "        Concat: {}")
+    (experiment_dir / "PredictionTTAStack.yml").write_text(tta_stack, encoding="utf-8")
     for variant, transforms_block in _VARIANT_TRANSFORMS.items():
         config = _replace_once(base, "            transforms: None", transforms_block)
         if variant in _UINT8_VARIANTS:
@@ -178,8 +210,8 @@ def _write_streamed_prediction_configs(experiment_dir: Path) -> None:
 
 @pytest.fixture(scope="module")
 def streamed_experiment(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
-    """Train once, then predict the assembled reference (kill-switch), the automatic streamed run, and a
-    TTA run that must fall back to the whole-volume path."""
+    """Train once, then predict every variant twice: the assembled reference (kill-switch) and the
+    automatic streamed run."""
     experiment_dir = tmp_path_factory.mktemp("streamed") / "experiment"
     paths = _prepare_experiment_dir(experiment_dir, TRAIN_NAME)
     _write_streamed_prediction_configs(experiment_dir)
@@ -195,7 +227,6 @@ def streamed_experiment(tmp_path_factory: pytest.TempPathFactory) -> dict[str, P
     return {
         "dataset_dir": paths["dataset_dir"],
         "experiment_dir": experiment_dir,
-        "streamed_tta": experiment_dir / "Predictions_streamed_tta",
     }
 
 
@@ -211,7 +242,7 @@ def _prediction_path(predictions_dir: Path, case: str) -> Path:
     return path
 
 
-@pytest.mark.parametrize("variant", ["base", *_VARIANT_TRANSFORMS])
+@pytest.mark.parametrize("variant", _ALL_VARIANTS)
 def test_streamed_prediction_is_voxel_identical_to_reference(
     streamed_experiment: dict[str, Path], variant: str
 ) -> None:
@@ -230,11 +261,12 @@ def test_streamed_prediction_is_voxel_identical_to_reference(
         np.testing.assert_array_equal(streamed_array, reference_array, err_msg=f"{variant}/{case}")
 
 
-@pytest.mark.parametrize("variant", ["base", *_VARIANT_TRANSFORMS])
+@pytest.mark.parametrize("variant", _ALL_VARIANTS)
 def test_streamed_prediction_takes_the_expected_writer(streamed_experiment: dict[str, Path], variant: str) -> None:
     """SimpleITK always writes ``CenterOfRotation`` into a MetaImage header; the streamed region writer
-    never does. Its absence proves the variant streamed to the sink; its presence proves the buffered
-    (chain-split / demoted) variants assembled and wrote classically."""
+    never does. Its absence proves the variant streamed to the sink (for TTA: the slab-synchronized
+    cross-copy reduce); its presence proves the buffered (chain-split / demoted) and refused (TTAZ —
+    a slab-axis flip) variants assembled and wrote classically."""
     experiment_dir = streamed_experiment["experiment_dir"]
     case = _case_names(streamed_experiment["dataset_dir"])[0]
     streamed_header = _prediction_path(experiment_dir / f"Predictions_{variant}_streamed", case).read_bytes()[:2048]
@@ -243,10 +275,26 @@ def test_streamed_prediction_takes_the_expected_writer(streamed_experiment: dict
     assert b"CenterOfRotation" in reference_header, variant
 
 
-def test_streamed_request_with_tta_falls_back_to_whole_volume_path(streamed_experiment: dict[str, Path]) -> None:
+def test_streamed_tta_output_shape_and_values_are_sane(streamed_experiment: dict[str, Path]) -> None:
     for case in _case_names(streamed_experiment["dataset_dir"]):
-        path = _prediction_path(streamed_experiment["streamed_tta"], case)
-        assert b"CenterOfRotation" in path.read_bytes()[:2048], "expected the whole-volume writer"
+        path = _prediction_path(streamed_experiment["experiment_dir"] / "Predictions_TTA_streamed", case)
         array = SimpleITK.GetArrayFromImage(SimpleITK.ReadImage(str(path)))
         assert array.shape == (3, 16, 16), case
         assert np.isfinite(array).all(), case
+
+
+def test_streamed_inference_stack_sidecar_is_voxel_identical_to_reference(
+    streamed_experiment: dict[str, Path],
+) -> None:
+    """The per-member stack InferenceStack persists is an output too: written region by region on the
+    streamed path, it must hold the same voxels as the whole-volume write."""
+    experiment_dir = streamed_experiment["experiment_dir"]
+    for case in _case_names(streamed_experiment["dataset_dir"]):
+        stacks = {}
+        for kind in ("streamed", "reference"):
+            path = (
+                experiment_dir / f"Predictions_TTAStack_{kind}" / TRAIN_NAME / "Dataset" / case / "InferenceStack.mha"
+            )
+            assert path.exists(), f"missing InferenceStack sidecar: {path}"
+            stacks[kind] = SimpleITK.GetArrayFromImage(SimpleITK.ReadImage(str(path)))
+        np.testing.assert_array_equal(stacks["streamed"], stacks["reference"], err_msg=case)

--- a/tests/integration/test_konfai_streamed_prediction.py
+++ b/tests/integration/test_konfai_streamed_prediction.py
@@ -53,8 +53,11 @@ from konfai.trainer import train
 
 def run_prediction(prediction_file: Path, predictions_dir: Path, disable_streaming: bool = False) -> None:
     # Streaming has no config knob -- it is automatic. The whole-volume reference is obtained through the
-    # global ops kill-switch KONFAI_STREAMED_WRITES=0; the streamed run just leaves it unset.
+    # global ops kill-switch KONFAI_STREAMED_WRITES=0; the streamed run just leaves it unset. The TTA
+    # worth gate would route these toy volumes whole-volume, so zero its threshold to exercise the
+    # streamed reduce.
     os.environ["KONFAI_STREAMED_WRITES"] = "0" if disable_streaming else "1"
+    os.environ["KONFAI_STREAMED_TTA_THRESHOLD"] = "0"
     root = Path.cwd()
     checkpoints = sorted((root / "Checkpoints" / "__TRAIN_NAME__").glob("*.pt"))
     if not checkpoints:

--- a/tests/unit/test_async_writes.py
+++ b/tests/unit/test_async_writes.py
@@ -51,11 +51,13 @@ def test_concurrent_write_safety_is_declared_per_backend(tmp_path) -> None:
 
 
 def test_async_streamed_writes_match_the_inline_reference(tmp_path, monkeypatch) -> None:
-    # A per-file destination goes through the background writer; the kill-switch forces the inline
-    # path on the same store. Same operations, same order — the files must match bit for bit.
+    # A per-file destination goes through the background writer (forced here — the automatic gate
+    # also requires a GPU-placed output); the kill-switch runs the same store inline. Same
+    # operations, same order — the files must match bit for bit.
     used: list[int] = []
     submit = _AsyncWriter.submit
     monkeypatch.setattr(_AsyncWriter, "submit", lambda self, op: (used.append(1), submit(self, op))[1])
+    monkeypatch.setenv("KONFAI_ASYNC_WRITES", "1")
     asynchronous, whole_volume = _drive_tta(
         tmp_path / "async", monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=True, file_format="mha"
     )
@@ -67,9 +69,16 @@ def test_async_streamed_writes_match_the_inline_reference(tmp_path, monkeypatch)
     assert torch.equal(asynchronous, inline)
 
 
-def test_single_store_destination_stays_inline(tmp_path, monkeypatch) -> None:
+def test_async_gate_stays_inline_for_single_stores_and_cpu_outputs(tmp_path, monkeypatch) -> None:
     used: list[int] = []
     submit = _AsyncWriter.submit
     monkeypatch.setattr(_AsyncWriter, "submit", lambda self, op: (used.append(1), submit(self, op))[1])
-    _drive_tta(tmp_path, monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=True, file_format="h5")
+    # Even forced, a single-store destination never crosses threads.
+    monkeypatch.setenv("KONFAI_ASYNC_WRITES", "1")
+    _drive_tta(tmp_path / "h5", monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=True, file_format="h5")
     assert not used, "an h5 store must never be written from the background thread"
+    # Automatic mode on a CPU-placed output stays inline: the blend already saturates the memory
+    # bandwidth the writer would consume.
+    monkeypatch.delenv("KONFAI_ASYNC_WRITES", raising=False)
+    _drive_tta(tmp_path / "cpu", monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=True, file_format="mha")
+    assert not used, "a CPU-only output must stay inline in automatic mode"

--- a/tests/unit/test_async_writes.py
+++ b/tests/unit/test_async_writes.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The background writer: disk writes overlap the prediction loop, byte-identically.
+
+Writes are submitted to one worker per output dataset — in order, bounded queue, failures kept and
+re-raised — but only when the destination serves disjoint files per entry
+(``Dataset.concurrent_write_safe``): a single-store backend (h5, zarr) stays inline, so no store is
+ever written from two threads. Pure ``threading``/``queue``, no fork and no signals, so the behaviour
+is the same on Linux, macOS and Windows."""
+
+import pytest
+import torch
+from konfai.data.augmentation import Flip
+from konfai.predictor import _AsyncWriter
+from konfai.utils.dataset import Dataset
+from konfai.utils.errors import PredictorError
+from test_streamed_tta import _drive_tta
+
+
+def test_async_writer_runs_in_order_and_surfaces_failures() -> None:
+    writer = _AsyncWriter()
+    done: list[int] = []
+    writer.submit(lambda: done.append(1))
+    writer.submit(lambda: (_ for _ in ()).throw(PredictorError("destination died")))
+    # Operations submitted after a failure drain unexecuted; the failure surfaces at the latest at
+    # close(), so a run can never end with a write silently missing.
+    writer.submit(lambda: done.append(2))
+    with pytest.raises(PredictorError, match="destination died"):
+        writer.close()
+    assert done == [1]
+
+
+def test_concurrent_write_safety_is_declared_per_backend(tmp_path) -> None:
+    assert Dataset(f"{tmp_path}/a", "mha").concurrent_write_safe()
+    assert not Dataset(f"{tmp_path}/a.h5", "h5").concurrent_write_safe()
+    assert not Dataset(f"{tmp_path}/a", "omezarr").concurrent_write_safe()
+
+
+def test_async_streamed_writes_match_the_inline_reference(tmp_path, monkeypatch) -> None:
+    # A per-file destination goes through the background writer; the kill-switch forces the inline
+    # path on the same store. Same operations, same order — the files must match bit for bit.
+    used: list[int] = []
+    submit = _AsyncWriter.submit
+    monkeypatch.setattr(_AsyncWriter, "submit", lambda self, op: (used.append(1), submit(self, op))[1])
+    asynchronous, whole_volume = _drive_tta(
+        tmp_path / "async", monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=True, file_format="mha"
+    )
+    assert not whole_volume and used, "the mha destination should have taken the background writer"
+    monkeypatch.setenv("KONFAI_ASYNC_WRITES", "0")
+    inline, _ = _drive_tta(
+        tmp_path / "inline", monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=True, file_format="mha"
+    )
+    assert torch.equal(asynchronous, inline)
+
+
+def test_single_store_destination_stays_inline(tmp_path, monkeypatch) -> None:
+    used: list[int] = []
+    submit = _AsyncWriter.submit
+    monkeypatch.setattr(_AsyncWriter, "submit", lambda self, op: (used.append(1), submit(self, op))[1])
+    _drive_tta(tmp_path, monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=True, file_format="h5")
+    assert not used, "an h5 store must never be written from the background thread"

--- a/tests/unit/test_async_writes.py
+++ b/tests/unit/test_async_writes.py
@@ -36,10 +36,11 @@ def test_async_writer_runs_in_order_and_surfaces_failures() -> None:
     done: list[int] = []
     writer.submit(lambda: done.append(1))
     writer.submit(lambda: (_ for _ in ()).throw(PredictorError("destination died")))
-    # Operations submitted after a failure drain unexecuted; the failure surfaces at the latest at
-    # close(), so a run can never end with a write silently missing.
-    writer.submit(lambda: done.append(2))
+    # Operations submitted after a failure drain unexecuted; the failure surfaces at the LATEST at
+    # close(), possibly earlier at this submit if the worker already recorded it -- accept it wherever
+    # it lands, so a run can never end with a write silently missing.
     with pytest.raises(PredictorError, match="destination died"):
+        writer.submit(lambda: done.append(2))
         writer.close()
     assert done == [1]
 

--- a/tests/unit/test_auto_patching.py
+++ b/tests/unit/test_auto_patching.py
@@ -127,6 +127,43 @@ class TestPatchGrid:
         assert all(s[0].stop <= 37 and s[1].stop <= 41 and s[2].stop <= 29 for s in fixed)
 
 
+class TestFreeAxisReachesTheModelAsAValidMultiple:
+    """The up-front sizing rounds the WORST case to the model multiple; a smaller heterogeneous case
+    must still round on its OWN grid, or it reaches the network at a non-divisible extent and crashes
+    the encoder/decoder skips. The rounding lives on the per-case read, keyed by ``free_axis_multiple``."""
+
+    def test_whole_volume_free_axis_stays_a_single_clamped_patch(self):
+        # The grid is unchanged: one whole-volume patch whose slice is clamped to the extent. The
+        # round-up to the multiple is a PADDING target, not extra patches.
+        slices, nb = get_patch_slices_from_shape([0, 0, 0], [122, 250, 250], None, [16, 16, 16])
+        assert slices == [(slice(0, 122), slice(0, 250), slice(0, 250))]
+        assert all(count == 1 for count, _ in nb)
+
+    def test_small_case_is_padded_up_to_the_model_multiple(self):
+        import torch
+        from konfai.data.patching import DatasetPatch
+
+        patch = DatasetPatch(patch_size=[0, 0, 0], overlap=0)
+        patch.free_axis_multiple = [16, 16, 16]
+        patch.load([122, 250, 250], 0)
+        data = torch.zeros(1, 122, 250, 250)  # [C, Z, Y, X]
+        plan = patch.get_read_plan(data.shape, 0, 0, is_input=True)
+        model_input = patch.apply_read_plan(data[tuple(plan.data_slices)], plan)
+        assert list(model_input.shape) == [1, 128, 256, 256]
+
+    def test_no_multiple_leaves_the_extent_raw(self):
+        # Evaluation has no model, so no multiple: the free axis stays at its raw extent (unchanged).
+        import torch
+        from konfai.data.patching import DatasetPatch
+
+        patch = DatasetPatch(patch_size=[0, 0, 0], overlap=0)  # free_axis_multiple stays None
+        patch.load([122, 250, 250], 0)
+        data = torch.zeros(1, 122, 250, 250)
+        plan = patch.get_read_plan(data.shape, 0, 0, is_input=True)
+        model_input = patch.apply_read_plan(data[tuple(plan.data_slices)], plan)
+        assert list(model_input.shape) == [1, 122, 250, 250]
+
+
 class TestResolvePatch:
     def test_whole_volume_when_it_fits(self):
         # 64^3 float32 single channel = 1 MiB; a 100 MiB budget swallows it whole.

--- a/tests/unit/test_auto_patching.py
+++ b/tests/unit/test_auto_patching.py
@@ -46,6 +46,15 @@ class TestConcretize:
     def test_none_is_the_whole_volume(self):
         assert concretize_patch_size(None, [10, 20, 30]) == [10, 20, 30]
 
+    def test_free_axis_rounds_up_to_the_model_multiple(self):
+        # A free axis is sized to a valid model input: the extent rounded UP to the downsampling factor
+        # (122 -> 128 for factor 8), which may exceed the extent (padding fills it, cropped back).
+        assert concretize_patch_size([0, 128, 128], [122, 130, 130], multiple=[8, 1, 1]) == [128, 128, 128]
+        assert concretize_patch_size([96, 0, 0], [200, 220, 240], multiple=[32, 32, 32]) == [96, 224, 256]
+        # An already-valid extent is unchanged; a fixed axis is never rounded (only clamped).
+        assert concretize_patch_size([0, 0, 0], [64, 128, 256], multiple=[32, 32, 32]) == [64, 128, 256]
+        assert concretize_patch_size([48, 0, 0], [50, 100, 100], multiple=[16, 16, 16]) == [48, 112, 112]
+
 
 class TestResolveOverlap:
     def test_default_is_a_fifth_of_the_patch_per_axis(self):

--- a/tests/unit/test_auto_patching.py
+++ b/tests/unit/test_auto_patching.py
@@ -24,6 +24,7 @@ single patch spans.
 
 import numpy as np
 import pytest
+from konfai.utils.errors import ConfigError
 from konfai.utils.utils import (
     concretize_patch_size,
     get_patch_slices_from_shape,
@@ -80,15 +81,15 @@ class TestResolveOverlap:
         assert resolve_overlap(16, [1, 128, 128], [300, 512, 512]) == [0, 16, 16]
 
     def test_overlap_not_smaller_than_patch_is_refused(self):
-        with pytest.raises(ValueError, match="smaller than the patch"):
+        with pytest.raises(ConfigError, match="smaller than the patch"):
             resolve_overlap(64, [64, 64, 64], [512, 512, 512])
 
     def test_bad_forms_are_refused(self):
-        with pytest.raises(ValueError, match="percentage"):
+        with pytest.raises(ConfigError, match="percentage"):
             resolve_overlap("big", [64, 64, 64], [512, 512, 512])
-        with pytest.raises(ValueError, match=r"\[0, 1\["):
+        with pytest.raises(ConfigError, match=r"\[0, 1\["):
             resolve_overlap(1.5, [64, 64, 64], [512, 512, 512])
-        with pytest.raises(ValueError, match="one per axis"):
+        with pytest.raises(ConfigError, match="one per axis"):
             resolve_overlap([1, 2], [64, 64, 64], [512, 512, 512])
 
 

--- a/tests/unit/test_auto_patching.py
+++ b/tests/unit/test_auto_patching.py
@@ -87,6 +87,10 @@ class TestResolveOverlap:
     def test_bad_forms_are_refused(self):
         with pytest.raises(ConfigError, match="percentage"):
             resolve_overlap("big", [64, 64, 64], [512, 512, 512])
+        # A "%"-suffixed but non-numeric value must still raise ConfigError, not a bare ValueError
+        # from float("big").
+        with pytest.raises(ConfigError, match="numeric percentage"):
+            resolve_overlap("big%", [64, 64, 64], [512, 512, 512])
         with pytest.raises(ConfigError, match=r"\[0, 1\["):
             resolve_overlap(1.5, [64, 64, 64], [512, 512, 512])
         with pytest.raises(ConfigError, match="one per axis"):

--- a/tests/unit/test_auto_patching.py
+++ b/tests/unit/test_auto_patching.py
@@ -163,6 +163,25 @@ class TestFreeAxisReachesTheModelAsAValidMultiple:
         model_input = patch.apply_read_plan(data[tuple(plan.data_slices)], plan)
         assert list(model_input.shape) == [1, 122, 250, 250]
 
+    def test_a_2d_multiple_aligns_to_the_trailing_axes(self):
+        # A 2D model's factor has two entries but the slice regime's patch has three axes: the factor
+        # constrains Y and X (the axes the model sees), never Z — front-indexing would leave X raw and
+        # round Y by the X factor.
+        import torch
+        from konfai.data.patching import DatasetPatch
+
+        assert concretize_patch_size([1, 0, 0], [10, 250, 250], multiple=[8, 8]) == [1, 256, 256]
+        assert concretize_patch_size([1, 0, 0], [10, 248, 250], multiple=[4, 16]) == [1, 248, 256]
+
+        patch = DatasetPatch(patch_size=[1, 0, 0], overlap=0)
+        patch.free_axis_multiple = [4, 4]
+        patch.load([3, 250, 250], 0)
+        data = torch.zeros(1, 3, 250, 250)
+        plan = patch.get_read_plan(data.shape, 0, 0, is_input=True)
+        model_input = patch.apply_read_plan(data[tuple(plan.data_slices)], plan)
+        # apply_read_plan squeezes the length-1 patch axis: a full 2D slice, both axes rounded to 252.
+        assert list(model_input.shape) == [1, 252, 252]
+
 
 class TestResolvePatch:
     def test_whole_volume_when_it_fits(self):

--- a/tests/unit/test_data_manager.py
+++ b/tests/unit/test_data_manager.py
@@ -85,6 +85,43 @@ def test_train_split_single_process_keeps_everything(monkeypatch: pytest.MonkeyP
 
 
 # --------------------------------------------------------------------------------------
+# Data._split — PREDICTION/EVALUATION shards must keep every case whole on one rank
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("state", [State.PREDICTION, State.EVALUATION])
+@pytest.mark.parametrize("world_size", [2, 3])
+def test_prediction_split_keeps_every_case_on_one_rank(
+    monkeypatch: pytest.MonkeyPatch, state: State, world_size: int
+) -> None:
+    # The streamed write (and the TTA aligner) reassemble a case from ALL its patches: a case split
+    # across ranks would leave every rank's accumulator forever incomplete.
+    monkeypatch.setenv("KONFAI_STATE", str(state))
+    mapping = [(case, a, p) for case in range(5) for a in range(2) for p in range(3)]
+
+    shards = Data._split(mapping, world_size)
+
+    assert sorted(entry for shard in shards for entry in shard) == sorted(mapping)
+    owner: dict[int, int] = {}
+    for rank, shard in enumerate(shards):
+        for entry in shard:
+            assert owner.setdefault(entry[0], rank) == rank, f"case {entry[0]} split across ranks"
+
+
+def test_prediction_split_more_ranks_than_cases_leaves_spare_ranks_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KONFAI_STATE", str(State.PREDICTION))
+    mapping = [(case, 0, p) for case in range(2) for p in range(4)]
+
+    shards = Data._split(mapping, 4)
+
+    assert sorted(entry for shard in shards for entry in shard) == sorted(mapping)
+    non_empty = [shard for shard in shards if shard]
+    assert len(non_empty) == 2
+    for shard in non_empty:
+        assert len({entry[0] for entry in shard}) == 1  # one whole case per busy rank
+
+
+# --------------------------------------------------------------------------------------
 # DataTrain train/validation split — reproducible and seeded from sorted names
 # --------------------------------------------------------------------------------------
 

--- a/tests/unit/test_data_stream.py
+++ b/tests/unit/test_data_stream.py
@@ -145,6 +145,70 @@ def test_mha_float16_is_stored_as_float32_matching_the_whole_volume_path(tmp_pat
     np.testing.assert_array_equal(result, volume.astype(np.float32))
 
 
+@pytest.mark.parametrize("file_format", FORMATS)
+def test_entry_is_invisible_until_the_stream_finalizes(tmp_path: Path, file_format: str) -> None:
+    """The entry must not exist under its final name while the stream is open: an existence probe
+    taken mid-write (another worker resolving the same case) would otherwise stream from a partial
+    volume."""
+    _skip_unavailable(file_format)
+    volume = _volume()
+    dataset = Dataset(tmp_path / "streamed", file_format)
+    stream = dataset.open_data_stream("CT", "CASE_001", list(volume.shape), volume.dtype, _image_attributes())
+    assert stream is not None
+    with stream:
+        stream.write_slice(
+            (slice(0, volume.shape[0]), slice(0, 2), slice(0, 5), slice(0, 4)),
+            volume[:, 0:2],
+        )
+        assert not Dataset(tmp_path / "streamed", file_format).is_dataset_exist("CT", "CASE_001")
+        for start in range(2, volume.shape[1], 2):
+            region = slice(start, min(start + 2, volume.shape[1]))
+            slices = (slice(0, volume.shape[0]), region, *(slice(0, extent) for extent in volume.shape[2:]))
+            stream.write_slice(slices, volume[:, region])
+    assert dataset.is_dataset_exist("CT", "CASE_001")
+    result, _ = dataset.read_data("CT", "CASE_001")
+    np.testing.assert_array_equal(result, volume)
+
+
+@pytest.mark.parametrize("file_format", FORMATS)
+def test_replaced_entry_stays_readable_until_its_replacement_is_complete(tmp_path: Path, file_format: str) -> None:
+    _skip_unavailable(file_format)
+    first = _volume()
+    second = first + 1
+    dataset = Dataset(tmp_path / "streamed", file_format)
+    _write_by_slabs(dataset, first, _image_attributes())
+    stream = dataset.open_data_stream("CT", "CASE_001", list(second.shape), second.dtype, _image_attributes())
+    assert stream is not None
+    with stream:
+        stream.write_slice(
+            (slice(0, second.shape[0]), slice(0, 2), slice(0, 5), slice(0, 4)),
+            second[:, 0:2],
+        )
+        mid_write, _ = dataset.read_data("CT", "CASE_001")
+        np.testing.assert_array_equal(mid_write, first)
+        for start in range(2, second.shape[1], 2):
+            region = slice(start, min(start + 2, second.shape[1]))
+            slices = (slice(0, second.shape[0]), region, *(slice(0, extent) for extent in second.shape[2:]))
+            stream.write_slice(slices, second[:, region])
+    result, _ = dataset.read_data("CT", "CASE_001")
+    np.testing.assert_array_equal(result, second)
+
+
+@pytest.mark.parametrize("file_format", FORMATS)
+def test_aborted_stream_leaves_an_existing_entry_untouched(tmp_path: Path, file_format: str) -> None:
+    _skip_unavailable(file_format)
+    first = _volume()
+    dataset = Dataset(tmp_path / "streamed", file_format)
+    _write_by_slabs(dataset, first, _image_attributes())
+    stream = dataset.open_data_stream("CT", "CASE_001", list(first.shape), first.dtype, _image_attributes())
+    assert stream is not None
+    with pytest.raises(RuntimeError, match="boom"):
+        with stream:
+            raise RuntimeError("boom")
+    result, _ = dataset.read_data("CT", "CASE_001")
+    np.testing.assert_array_equal(result, first)
+
+
 def test_can_stream_data_matches_open_support(tmp_path: Path) -> None:
     geometry = _image_attributes()
     assert Dataset(tmp_path / "a", "mha").can_stream_data(geometry)

--- a/tests/unit/test_data_stream.py
+++ b/tests/unit/test_data_stream.py
@@ -200,31 +200,36 @@ def test_two_concurrent_streams_of_one_entry_publish_a_complete_volume(tmp_path:
     each owns its own, and whichever finalizes last publishes a COMPLETE volume — never an
     interleaving where one writer's open truncated the other's in-flight file."""
     _skip_unavailable(file_format)
-    volume = _volume()
+    # DISTINCT volumes: if the two temporaries interleaved into one final file, the result would equal
+    # neither whole -- writing the same values both times could not tell an interleaving from a clean
+    # publish. ``first`` finalizes last (its ``with`` closes after ``second``'s), so it must win whole.
+    volume_a = _volume()
+    volume_b = volume_a + 100
     dataset = Dataset(tmp_path / "streamed", file_format)
-    shape, dtype = list(volume.shape), volume.dtype
+    shape, dtype = list(volume_a.shape), volume_a.dtype
     first = dataset.open_data_stream("CT", "CASE_001", shape, dtype, _image_attributes())
     assert first is not None
     with first:
         first.write_slice(
-            (slice(0, volume.shape[0]), slice(0, 3), slice(0, 5), slice(0, 4)),
-            volume[:, 0:3],
+            (slice(0, volume_a.shape[0]), slice(0, 3), slice(0, 5), slice(0, 4)),
+            volume_a[:, 0:3],
         )
-        # A second writer starts while the first is mid-write.
+        # A second writer starts while the first is mid-write, with its own values.
         second = dataset.open_data_stream("CT", "CASE_001", shape, dtype, _image_attributes())
         assert second is not None
         with second:
-            for start in range(0, volume.shape[1], 2):
-                region = slice(start, min(start + 2, volume.shape[1]))
-                slices = (slice(0, volume.shape[0]), region, *(slice(0, extent) for extent in volume.shape[2:]))
-                second.write_slice(slices, volume[:, region])
-        for start in range(3, volume.shape[1], 2):
-            region = slice(start, min(start + 2, volume.shape[1]))
-            slices = (slice(0, volume.shape[0]), region, *(slice(0, extent) for extent in volume.shape[2:]))
-            first.write_slice(slices, volume[:, region])
+            for start in range(0, volume_b.shape[1], 2):
+                region = slice(start, min(start + 2, volume_b.shape[1]))
+                slices = (slice(0, volume_b.shape[0]), region, *(slice(0, extent) for extent in volume_b.shape[2:]))
+                second.write_slice(slices, volume_b[:, region])
+        for start in range(3, volume_a.shape[1], 2):
+            region = slice(start, min(start + 2, volume_a.shape[1]))
+            slices = (slice(0, volume_a.shape[0]), region, *(slice(0, extent) for extent in volume_a.shape[2:]))
+            first.write_slice(slices, volume_a[:, region])
 
     result, _ = dataset.read_data("CT", "CASE_001")
-    np.testing.assert_array_equal(result, volume)
+    # A complete volume, never a per-slab mixture of the two.
+    np.testing.assert_array_equal(result, volume_a)
 
 
 def test_h5_stream_temporary_key_is_invisible_to_name_listing(tmp_path: Path) -> None:
@@ -260,6 +265,25 @@ def test_aborted_stream_leaves_an_existing_entry_untouched(tmp_path: Path, file_
             raise RuntimeError("boom")
     result, _ = dataset.read_data("CT", "CASE_001")
     np.testing.assert_array_equal(result, first)
+
+
+@pytest.mark.parametrize("file_format", FORMATS)
+def test_abort_after_close_is_a_noop(tmp_path: Path, file_format: str) -> None:
+    """The finalize lifecycle is single-shot: streamed Save materialization close()s, then abort()s on
+    the error path. The second call must not re-run _close on already-released state (which would try
+    to remove the entry it just published, or double-exit the backing file)."""
+    _skip_unavailable(file_format)
+    volume = _volume()
+    dataset = Dataset(tmp_path / "streamed", file_format)
+    stream = dataset.open_data_stream("CT", "CASE_001", list(volume.shape), volume.dtype, _image_attributes())
+    assert stream is not None
+    for start in range(0, volume.shape[1], 2):
+        region = slice(start, min(start + 2, volume.shape[1]))
+        stream.write_slice((slice(0, volume.shape[0]), region, *(slice(0, e) for e in volume.shape[2:])), volume[:, region])
+    stream.close()
+    stream.abort(RuntimeError("late"))  # must be inert, not undo the publish
+    result, _ = dataset.read_data("CT", "CASE_001")
+    np.testing.assert_array_equal(result, volume)
 
 
 def test_can_stream_data_matches_open_support(tmp_path: Path) -> None:

--- a/tests/unit/test_data_stream.py
+++ b/tests/unit/test_data_stream.py
@@ -194,6 +194,59 @@ def test_replaced_entry_stays_readable_until_its_replacement_is_complete(tmp_pat
     np.testing.assert_array_equal(result, second)
 
 
+@pytest.mark.parametrize("file_format", ["mha", "omezarr"])
+def test_two_concurrent_streams_of_one_entry_publish_a_complete_volume(tmp_path: Path, file_format: str) -> None:
+    """Two writers of the same entry (a case landing on two workers) must not share a temporary:
+    each owns its own, and whichever finalizes last publishes a COMPLETE volume — never an
+    interleaving where one writer's open truncated the other's in-flight file."""
+    _skip_unavailable(file_format)
+    volume = _volume()
+    dataset = Dataset(tmp_path / "streamed", file_format)
+    shape, dtype = list(volume.shape), volume.dtype
+    first = dataset.open_data_stream("CT", "CASE_001", shape, dtype, _image_attributes())
+    assert first is not None
+    with first:
+        first.write_slice(
+            (slice(0, volume.shape[0]), slice(0, 3), slice(0, 5), slice(0, 4)),
+            volume[:, 0:3],
+        )
+        # A second writer starts while the first is mid-write.
+        second = dataset.open_data_stream("CT", "CASE_001", shape, dtype, _image_attributes())
+        assert second is not None
+        with second:
+            for start in range(0, volume.shape[1], 2):
+                region = slice(start, min(start + 2, volume.shape[1]))
+                slices = (slice(0, volume.shape[0]), region, *(slice(0, extent) for extent in volume.shape[2:]))
+                second.write_slice(slices, volume[:, region])
+        for start in range(3, volume.shape[1], 2):
+            region = slice(start, min(start + 2, volume.shape[1]))
+            slices = (slice(0, volume.shape[0]), region, *(slice(0, extent) for extent in volume.shape[2:]))
+            first.write_slice(slices, volume[:, region])
+
+    result, _ = dataset.read_data("CT", "CASE_001")
+    np.testing.assert_array_equal(result, volume)
+
+
+def test_h5_stream_temporary_key_is_invisible_to_name_listing(tmp_path: Path) -> None:
+    pytest.importorskip("h5py")
+    volume = _volume()
+    dataset = Dataset(tmp_path / "streamed", "h5")
+    dataset.write("CT", "CASE_000", volume, _image_attributes())
+    stream = dataset.open_data_stream("CT", "CASE_001", list(volume.shape), volume.dtype, _image_attributes())
+    assert stream is not None
+    with stream:
+        stream.write_slice(
+            (slice(0, volume.shape[0]), slice(0, 2), slice(0, 5), slice(0, 4)),
+            volume[:, 0:2],
+        )
+        assert Dataset(tmp_path / "streamed", "h5").get_names("CT") == ["CASE_000"]
+        for start in range(2, volume.shape[1], 2):
+            region = slice(start, min(start + 2, volume.shape[1]))
+            slices = (slice(0, volume.shape[0]), region, *(slice(0, extent) for extent in volume.shape[2:]))
+            stream.write_slice(slices, volume[:, region])
+    assert sorted(dataset.get_names("CT")) == ["CASE_000", "CASE_001"]
+
+
 @pytest.mark.parametrize("file_format", FORMATS)
 def test_aborted_stream_leaves_an_existing_entry_untouched(tmp_path: Path, file_format: str) -> None:
     _skip_unavailable(file_format)

--- a/tests/unit/test_data_stream.py
+++ b/tests/unit/test_data_stream.py
@@ -279,7 +279,9 @@ def test_abort_after_close_is_a_noop(tmp_path: Path, file_format: str) -> None:
     assert stream is not None
     for start in range(0, volume.shape[1], 2):
         region = slice(start, min(start + 2, volume.shape[1]))
-        stream.write_slice((slice(0, volume.shape[0]), region, *(slice(0, e) for e in volume.shape[2:])), volume[:, region])
+        stream.write_slice(
+            (slice(0, volume.shape[0]), region, *(slice(0, e) for e in volume.shape[2:])), volume[:, region]
+        )
     stream.close()
     stream.abort(RuntimeError("late"))  # must be inert, not undo the publish
     result, _ = dataset.read_data("CT", "CASE_001")

--- a/tests/unit/test_dataset_streaming.py
+++ b/tests/unit/test_dataset_streaming.py
@@ -80,6 +80,45 @@ def test_dataset_read_data_slice_h5_reads_only_requested_region(tmp_path: Path) 
     np.testing.assert_array_equal(patch, volume[:, 1:3, 2:5])
 
 
+def test_h5_read_handle_is_pooled_across_reads(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The chunk cache lives on the open handle: repeated patch reads must reuse one handle, not
+    rebuild an empty cache per read."""
+    import h5py
+
+    dataset = Dataset(tmp_path / "Pooled", "h5")
+    volume = np.arange(1 * 6 * 5, dtype=np.float32).reshape(1, 6, 5)
+    dataset.write("CT", "CASE_000", volume, _image_attributes([1.0, 2.0], [0.5, 1.5]))
+
+    real_file = h5py.File
+    read_opens = 0
+
+    def counting(name, mode="r", *args, **kwargs):
+        nonlocal read_opens
+        if mode == "r":
+            read_opens += 1
+        return real_file(name, mode, *args, **kwargs)
+
+    monkeypatch.setattr(h5py, "File", counting)
+    for start in range(3):
+        patch, _ = dataset.read_data_slice("CT", "CASE_000", (slice(None), slice(start, start + 2), slice(0, 5)))
+        np.testing.assert_array_equal(patch, volume[:, start : start + 2])
+    assert read_opens == 1
+
+
+def test_h5_write_invalidates_the_pooled_reader(tmp_path: Path) -> None:
+    dataset = Dataset(tmp_path / "Invalidated", "h5")
+    attrs = _image_attributes([1.0, 2.0], [0.5, 1.5])
+    volume = np.zeros((1, 4, 5), dtype=np.float32)
+    dataset.write("CT", "CASE_000", volume, attrs)
+    first, _ = dataset.read_data_slice("CT", "CASE_000", (slice(None), slice(0, 4), slice(0, 5)))
+    np.testing.assert_array_equal(first, volume)
+
+    replacement = volume + 7
+    dataset.write("CT", "CASE_000", replacement, attrs)
+    second, _ = dataset.read_data_slice("CT", "CASE_000", (slice(None), slice(0, 4), slice(0, 5)))
+    np.testing.assert_array_equal(second, replacement)
+
+
 def test_dataset_read_data_statistics_h5_returns_global_stats_without_loading_full_array(tmp_path: Path) -> None:
     dataset = Dataset(tmp_path / "Volumes", "h5")
     volume = np.arange(1 * 4 * 5, dtype=np.float32).reshape(1, 4, 5)

--- a/tests/unit/test_downsampling_factor.py
+++ b/tests/unit/test_downsampling_factor.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-"""``Network.downsampling_factor`` reads the per-axis input divisor off the graph (the product of the
-encoder's downsampling strides), used to size a free patch axis to a valid extent for the model."""
+"""``Network.downsampling_factor`` reads the per-axis input divisor off the graph -- the coarsest
+downsampling the branch register reaches -- used to size a free patch axis to a valid extent for the
+model. Parallel branches (a residual shortcut beside the main path) reduce the same level once."""
 
 import pytest
 import torch
+from konfai.models.python.classification.resnet import ResBlock
 from konfai.models.python.segmentation.plainconvunet import PlainConvUNet
 from konfai.network.network import Network
 
@@ -65,3 +67,19 @@ def test_downsampling_factor_ignores_the_residual_avgpool_and_transpose_upsample
             self.add_module("up", torch.nn.ConvTranspose3d(4, 4, 2, stride=2))  # must NOT count
 
     assert _OneLevel().downsampling_factor() == [2, 2, 2]
+
+
+def test_downsampling_factor_counts_a_parallel_strided_shortcut_once():
+    """A torchvision-style residual block (KonfAI ``ResBlock``) strides its main conv AND its
+    projection shortcut in parallel -- both reduce the SAME level, merged by the residual ``Add``. A
+    flat ``modules()`` walk multiplies the two strides and double-counts the level; the branch trace
+    follows the two parallel branches to their merge and counts it once. Two strided blocks reduce by
+    2 each -> [4, 4, 4], not the [16, 16, 16] the double-count would report."""
+
+    class _TwoStridedResiduals(Network):
+        def __init__(self) -> None:
+            super().__init__()
+            self.add_module("Block_0", ResBlock(1, 4, downsample=True, dim=3))
+            self.add_module("Block_1", ResBlock(4, 8, downsample=True, dim=3))
+
+    assert _TwoStridedResiduals().downsampling_factor() == [4, 4, 4]

--- a/tests/unit/test_downsampling_factor.py
+++ b/tests/unit/test_downsampling_factor.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""``Network.downsampling_factor`` reads the per-axis input divisor off the graph (the product of the
+encoder's downsampling strides), used to size a free patch axis to a valid extent for the model."""
+
+import pytest
+import torch
+from konfai.models.python.segmentation.plainconvunet import PlainConvUNet
+from konfai.network.network import Network
+
+# (id, strides, expected per-axis divisor). The divisor is the product of the encoder strides per axis.
+CONFIGS = [
+    ("isotropic_5stage", [1, 2, 2, 2, 2], [16, 16, 16]),
+    ("anisotropic_totalseg", [1, [1, 2, 2], [2, 2, 2], [2, 2, 2]], [4, 8, 8]),
+    ("shallow", [1, 2], [2, 2, 2]),
+]
+
+
+@pytest.mark.parametrize("name, strides, expected", CONFIGS, ids=[c[0] for c in CONFIGS])
+def test_downsampling_factor_reads_encoder_strides(name, strides, expected):
+    model = PlainConvUNet(
+        dim=3,
+        in_channels=1,
+        n_stages=len(strides),
+        features_per_stage=[8 * 2**i for i in range(len(strides))],
+        strides=strides,
+        num_classes=2,
+    )
+    assert model.downsampling_factor() == expected
+
+
+def test_downsampling_factor_none_without_downsampling():
+    """A model that never downsamples imposes no divisibility constraint."""
+
+    class _Flat(Network):
+        def __init__(self) -> None:
+            super().__init__()
+            self.add_module("conv", torch.nn.Conv3d(1, 4, 3, padding=1))
+
+    assert _Flat().downsampling_factor() is None
+
+
+def test_downsampling_factor_ignores_the_residual_avgpool_and_transpose_upsample():
+    """Only MaxPool and stride>1 Conv shrink the skip path; a residual AvgPool and a decoder
+    ConvTranspose must not inflate the factor (they would double-count one level)."""
+
+    class _OneLevel(Network):
+        def __init__(self) -> None:
+            super().__init__()
+            self.add_module("down", torch.nn.Conv3d(1, 4, 3, stride=2, padding=1))  # counts
+            self.add_module("residual", torch.nn.AvgPool3d(2, stride=2))  # must NOT count
+            self.add_module("up", torch.nn.ConvTranspose3d(4, 4, 2, stride=2))  # must NOT count
+
+    assert _OneLevel().downsampling_factor() == [2, 2, 2]

--- a/tests/unit/test_downsampling_factor.py
+++ b/tests/unit/test_downsampling_factor.py
@@ -21,6 +21,7 @@ import pytest
 import torch
 from konfai.models.python.classification.resnet import ResBlock
 from konfai.models.python.segmentation.plainconvunet import PlainConvUNet
+from konfai.network import blocks
 from konfai.network.network import Network
 
 # (id, strides, expected per-axis divisor). The divisor is the product of the encoder strides per axis.
@@ -55,18 +56,34 @@ def test_downsampling_factor_none_without_downsampling():
     assert _Flat().downsampling_factor() is None
 
 
-def test_downsampling_factor_ignores_the_residual_avgpool_and_transpose_upsample():
-    """Only MaxPool and stride>1 Conv shrink the skip path; a residual AvgPool and a decoder
-    ConvTranspose must not inflate the factor (they would double-count one level)."""
+def test_downsampling_factor_counts_a_main_path_avgpool_but_not_the_decoder_upsample():
+    """AvgPool IS a downsampler (a model may pool on its main path instead of striding); it must count,
+    or the factor undercounts and the model receives a non-divisible extent. A decoder ConvTranspose
+    grows the grid and must not count."""
 
     class _OneLevel(Network):
         def __init__(self) -> None:
             super().__init__()
-            self.add_module("down", torch.nn.Conv3d(1, 4, 3, stride=2, padding=1))  # counts
-            self.add_module("residual", torch.nn.AvgPool3d(2, stride=2))  # must NOT count
+            self.add_module("down", torch.nn.AvgPool3d(2, stride=2))  # main-path pool: counts
+            self.add_module("conv", torch.nn.Conv3d(1, 4, 3, padding=1))
             self.add_module("up", torch.nn.ConvTranspose3d(4, 4, 2, stride=2))  # must NOT count
 
     assert _OneLevel().downsampling_factor() == [2, 2, 2]
+
+
+def test_downsampling_factor_does_not_inflate_a_parallel_residual_avgpool():
+    """A residual shortcut's AvgPool runs PARALLEL to the strided main conv (KonfAI's ResNet-D block):
+    both reduce the same level, merged by the ``Add``. Counting AvgPool must not double-count here — the
+    branch-aware max sees the two parallel /2 branches as one /2, not /4."""
+
+    class _ResDBlock(Network):
+        def __init__(self) -> None:
+            super().__init__()
+            self.add_module("Main", torch.nn.Conv3d(1, 4, 3, stride=2, padding=1))  # branch 0: /2
+            self.add_module("SkipPool", torch.nn.AvgPool3d(2, stride=2), in_branch=[1], out_branch=[1])  # /2
+            self.add_module("Add", blocks.Add(), in_branch=[0, 1])
+
+    assert _ResDBlock().downsampling_factor() == [2, 2, 2]
 
 
 def test_downsampling_factor_counts_a_parallel_strided_shortcut_once():
@@ -118,3 +135,28 @@ def test_downsampling_factor_aligns_mixed_dimensionalities_to_the_trailing_axes(
             self.add_module("slice_pool", torch.nn.MaxPool2d(2))  # 2D stride 2 -> trailing [1, 2, 2]
 
     assert _Mixed().downsampling_factor() == [4, 8, 8]
+
+
+def test_downsampling_factor_seeds_a_nested_block_from_all_its_inputs():
+    """A nested routed block reading several branches at DIFFERENT factors must see each at its own
+    resolution: if it downsamples a non-first input, seeding every internal branch from the first input
+    would undercount that deeper level. Here a block takes a /2 branch and a /8 branch and pools the /8
+    one further to /16 -- that /16 is the graph's coarsest level and must surface."""
+
+    class _Deeper(Network):
+        def __init__(self) -> None:
+            super().__init__()
+            # Build two branches at different depths: branch 0 at /2, branch 'deep' at /8.
+            self.add_module("Shallow", torch.nn.Conv3d(1, 4, 3, stride=2, padding=1), out_branch=["shallow"])
+            self.add_module("Deep", torch.nn.Conv3d(1, 4, 3, stride=8, padding=1), out_branch=["deep"])
+
+            class _Fuse(Network):
+                def __init__(self) -> None:
+                    super().__init__()
+                    # Reads [shallow (/2), deep (/8)]; pools the SECOND input (branch '1') to /16.
+                    self.add_module("PoolDeep", torch.nn.MaxPool3d(2), in_branch=[1], out_branch=[1])
+                    self.add_module("Merge", blocks.Add(), in_branch=[1, 0])
+
+            self.add_module("Fuse", _Fuse(), in_branch=["shallow", "deep"], out_branch=["fused"])
+
+    assert _Deeper().downsampling_factor() == [16, 16, 16]

--- a/tests/unit/test_downsampling_factor.py
+++ b/tests/unit/test_downsampling_factor.py
@@ -83,3 +83,38 @@ def test_downsampling_factor_counts_a_parallel_strided_shortcut_once():
             self.add_module("Block_1", ResBlock(4, 8, downsample=True, dim=3))
 
     assert _TwoStridedResiduals().downsampling_factor() == [4, 4, 4]
+
+
+def test_downsampling_factor_sees_inside_an_opaque_wrapped_module():
+    """A third-party net added as ONE plain leaf (the smp/torchvision wrapping pattern) hides its graph
+    from the branch trace; its internal strides must still count — a lost factor disables the free-axis
+    rounding entirely and the model crashes on a non-divisible extent."""
+
+    class _Wrapped(Network):
+        def __init__(self) -> None:
+            super().__init__()
+            self.add_module(
+                "Model",
+                torch.nn.Sequential(
+                    torch.nn.Conv2d(1, 8, 3, stride=2, padding=1),
+                    torch.nn.Conv2d(8, 16, 3, stride=2, padding=1),
+                    torch.nn.ConvTranspose2d(16, 8, 2, stride=2),
+                ),
+            )
+
+    assert _Wrapped().downsampling_factor() == [4, 4]
+
+
+def test_downsampling_factor_aligns_mixed_dimensionalities_to_the_trailing_axes():
+    """A leaf of lower dimensionality (a 2D side head in a 3D graph) acts on the LAST axes: it must
+    neither crash the computation nor lock the factor's rank to 2."""
+
+    class _Mixed(Network):
+        def __init__(self) -> None:
+            super().__init__()
+            self.add_module("head2d", torch.nn.Conv2d(1, 4, 3, stride=1, padding=1))  # stride 1: inert
+            self.add_module("down_a", torch.nn.Conv3d(1, 4, 3, stride=2, padding=1))
+            self.add_module("down_b", torch.nn.Conv3d(4, 8, 3, stride=2, padding=1))
+            self.add_module("slice_pool", torch.nn.MaxPool2d(2))  # 2D stride 2 -> trailing [1, 2, 2]
+
+    assert _Mixed().downsampling_factor() == [4, 8, 8]

--- a/tests/unit/test_imaging_formats.py
+++ b/tests/unit/test_imaging_formats.py
@@ -34,6 +34,25 @@ def _image_attributes() -> Attribute:
     return attributes
 
 
+def test_flatten_transforms_recurses_into_nested_composites() -> None:
+    """The transform serializer walks a composite to its leaves. SimpleITK keeps a nested composite
+    nested (``GetNthTransform`` returns it as-is), so a single-level walk would hand that composite to
+    the per-leaf type switch, which rejects it -- the recursion is what keeps a nested chain storable."""
+    sitk = pytest.importorskip("SimpleITK")
+    from konfai.utils.dataset import _flatten_transforms
+
+    inner = sitk.CompositeTransform([sitk.Euler3DTransform(), sitk.AffineTransform(3)])
+    outer = sitk.CompositeTransform(3)
+    outer.AddTransform(sitk.Euler3DTransform())
+    outer.AddTransform(inner)  # the nested composite SimpleITK preserves verbatim
+
+    assert isinstance(outer.GetNthTransform(1), sitk.CompositeTransform)  # premise: nesting survives
+    leaves = _flatten_transforms(outer)
+    assert [type(t).__name__ for t in leaves] == ["Euler3DTransform", "Euler3DTransform", "AffineTransform"]
+    assert all(not isinstance(t, sitk.CompositeTransform) for t in leaves)
+    assert len(_flatten_transforms(sitk.Euler3DTransform())) == 1  # a lone transform is its own single leaf
+
+
 # ---------------------------------------------------------------------------
 # DICOM tests (no real DICOM files — uses unittest.mock)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mask_streaming.py
+++ b/tests/unit/test_mask_streaming.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""``Mask`` streams slab by slab: ``stream_slab`` reads only the aligned mask region and reassembles
+byte-identically to the whole-volume ``__call__``, so a finalize ``Mask`` keeps the case on the
+streamed path."""
+
+import numpy as np
+import pytest
+import torch
+
+sitk = pytest.importorskip("SimpleITK")
+
+from konfai.data.transform import Attribute, LocalityKind, Mask  # noqa: E402
+
+
+def _write_mask(path, z, y, x, seed=0):
+    rng = np.random.default_rng(seed)
+    arr = (rng.random((z, y, x)) > 0.4).astype(np.uint8)
+    sitk.WriteImage(sitk.GetImageFromArray(arr), str(path))
+
+
+@pytest.mark.parametrize("slab", [1, 4, 5])
+def test_mask_stream_slab_reassembles_like_whole_volume(tmp_path, slab):
+    # Single-channel output (the real case: a masked sCT); a [1,Z,Y,X] mask indexes a 1-channel volume.
+    z, y, x = 12, 8, 7
+    path = tmp_path / "mask.mha"
+    _write_mask(path, z, y, x)
+    torch.manual_seed(1)
+    volume = torch.randn(1, z, y, x)
+
+    # SLAB declaration is what routes it through the streamed-write dispatcher.
+    m = Mask(path=str(path), value_outside=-999)
+    assert m.patch_locality(Attribute()).kind is LocalityKind.SLAB
+
+    whole = m("case", volume.clone(), Attribute())
+
+    streamed = volume.clone()
+    for z0 in range(0, z, slab):
+        z1 = min(z0 + slab, z)
+        rows = m.stream_slab("case", streamed[:, z0:z1].clone(), slice(z0, z1), [z, y, x], Attribute())
+        streamed[:, z0:z1] = rows
+
+    assert torch.equal(streamed, whole)
+
+
+def test_mask_stream_slab_masks_the_right_voxels(tmp_path):
+    # A concrete check the region is aligned, not just self-consistent: outside the mask -> value_outside,
+    # inside -> untouched, and the streamed slabs land on the same voxels as the whole-volume call.
+    z, y, x = 6, 5, 4
+    path = tmp_path / "m.mha"
+    _write_mask(path, z, y, x, seed=3)
+    mask = torch.as_tensor(sitk.GetArrayFromImage(sitk.ReadImage(str(path)))).unsqueeze(0)
+    m = Mask(path=str(path), value_outside=-1)
+    out = torch.ones(1, z, y, x) * 7.0
+    for z0 in range(0, z, 2):
+        out[:, z0 : z0 + 2] = m.stream_slab("c", out[:, z0 : z0 + 2].clone(), slice(z0, z0 + 2), [z, y, x], Attribute())
+    assert torch.equal(out[mask == 0], torch.full_like(out[mask == 0], -1.0))
+    assert torch.equal(out[mask != 0], torch.full_like(out[mask != 0], 7.0))

--- a/tests/unit/test_memory_budget.py
+++ b/tests/unit/test_memory_budget.py
@@ -18,6 +18,7 @@
 estimates the dataset size from headers alone, and -- for ``"auto"`` -- reads the cgroup limit rather
 than the host so a container/SLURM job is not OOM-killed."""
 
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -225,6 +226,71 @@ def test_budget_is_per_rank_so_world_size_flips_the_decision() -> None:
     sharded = _make_train(half)
     sharded._resolve_cache_regime(world_size=4)
     assert sharded.use_cache is True
+
+
+# --------------------------------------------------------------------------------------
+# The evaluation auto-patch -- an AUTO budget is a NODE budget, split across the local ranks
+# --------------------------------------------------------------------------------------
+
+
+def _metric_sizing_budget(
+    monkeypatch: pytest.MonkeyPatch, memory_budget: str | float | None, local_ranks: str | None
+) -> float:
+    """Drive DataMetric._maybe_auto_patch over a fake one-case dataset and capture the budget it
+    actually hands to resolve_patch."""
+    data = DataMetric(memory_budget=memory_budget)
+    data.datasets = {
+        "f": SimpleNamespace(get_names=lambda group: ["case"], get_infos=lambda group, name: ([1, 64, 64, 64], None))
+    }
+    monkeypatch.setattr(DataMetric, "_resolve_dataset_sources", lambda self: {"CT": [("f", False)]}, raising=False)
+    monkeypatch.setattr(data_manager, "available_memory_bytes", lambda: (100 * 2**30, "host"))
+    captured: dict[str, float] = {}
+
+    def capture(template, shape, channels, element_bytes, budget, **kwargs):
+        captured["budget"] = budget
+        return list(shape)  # "fits whole": the sizing exits without installing a patch
+
+    monkeypatch.setattr(data_manager, "resolve_patch", capture)
+    if local_ranks is None:
+        monkeypatch.delenv("KONFAI_LOCAL_RANKS", raising=False)
+    else:
+        monkeypatch.setenv("KONFAI_LOCAL_RANKS", local_ranks)
+    data._maybe_auto_patch()
+    return captured["budget"]
+
+
+def test_eval_auto_budget_is_divided_by_the_local_ranks(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 4 ranks evaluating on one node share its RAM: each sizes its patch from a quarter of the
+    # auto budget, or together they over-commit the host 4-fold.
+    node_auto = 100 * 2**30 * _AUTO_MEMORY_SAFETY_FRACTION
+    assert _metric_sizing_budget(monkeypatch, None, "4") == node_auto // 4
+    # Without the launcher's hint (direct API use), today's undivided behaviour is preserved.
+    assert _metric_sizing_budget(monkeypatch, None, None) == node_auto
+
+
+def test_eval_explicit_budget_is_per_rank_and_never_divided(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert _metric_sizing_budget(monkeypatch, "1GiB", "4") == float(2**30)
+
+
+def test_run_distributed_app_exports_and_restores_local_ranks(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The wrapper leaves the per-node rank count in the environment while the workflow is built
+    # (the KeyboardInterrupt escapes the factory before any spawn), and restores it after -- a
+    # leak would silently shrink a later in-process run's patches.
+    captured: list[str] = []
+
+    @runtime.run_distributed_app
+    def factory(config=None, gpu: list[int] = [], cpu: int = 1):
+        captured.append(os.environ["KONFAI_LOCAL_RANKS"])
+        raise KeyboardInterrupt
+
+    monkeypatch.delenv("KONFAI_LOCAL_RANKS", raising=False)
+    factory(gpu=[0, 1])
+    factory(gpu=[], cpu=3)
+    assert captured == ["2", "3"]
+    assert "KONFAI_LOCAL_RANKS" not in os.environ
+    monkeypatch.setenv("KONFAI_LOCAL_RANKS", "7")
+    factory(gpu=[0])
+    assert captured[-1] == "1" and os.environ["KONFAI_LOCAL_RANKS"] == "7"
 
 
 def test_auto_budget_uses_detected_memory(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_memory_budget.py
+++ b/tests/unit/test_memory_budget.py
@@ -26,6 +26,7 @@ from konfai.data import data_manager
 from konfai.data.augmentation import DataAugmentationsList
 from konfai.data.data_manager import (
     _AUTO_MEMORY_SAFETY_FRACTION,
+    DataMetric,
     DataPrediction,
     DataTrain,
     _parse_memory_budget_bytes,
@@ -199,15 +200,18 @@ def test_none_budget_means_auto_for_training(monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_one_pass_workflows_never_cache_whatever_the_budget() -> None:
-    # Prediction and evaluation read each case exactly once: a cache is never re-read, so even a
+    # Prediction AND evaluation read each case exactly once: a cache is never re-read, so even a
     # budget the dataset comfortably fits keeps them on the stream/buffer path.
-    prediction = DataPrediction(augmentations=None, memory_budget=f"{_DATASET_BYTES * 100}b")
-    prediction._prepared_data = {"CT": [SimpleNamespace(base_shape=[1, 2, 2, 2])]}  # type: ignore[assignment]
-    prediction._prepared_validation_data = {}
-    prediction._prepared_train_names = ["case_a"]
-    prediction._prepared_validation_names = []
-    prediction._resolve_cache_regime(world_size=1)
-    assert prediction.use_cache is False
+    for data in (
+        DataPrediction(augmentations=None, memory_budget=f"{_DATASET_BYTES * 100}b"),
+        DataMetric(memory_budget=f"{_DATASET_BYTES * 100}b"),
+    ):
+        data._prepared_data = {"CT": [SimpleNamespace(base_shape=[1, 2, 2, 2])]}  # type: ignore[assignment]
+        data._prepared_validation_data = {}
+        data._prepared_train_names = ["case_a"]
+        data._prepared_validation_names = []
+        data._resolve_cache_regime(world_size=1)
+        assert data.use_cache is False, type(data).__name__
 
 
 def test_budget_is_per_rank_so_world_size_flips_the_decision() -> None:

--- a/tests/unit/test_memory_budget.py
+++ b/tests/unit/test_memory_budget.py
@@ -272,6 +272,12 @@ def test_eval_explicit_budget_is_per_rank_and_never_divided(monkeypatch: pytest.
     assert _metric_sizing_budget(monkeypatch, "1GiB", "4") == float(2**30)
 
 
+def test_a_garbled_local_ranks_variable_keeps_the_undivided_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A user-exported junk value must not crash the build: any unparsable content falls back to 1.
+    node_auto = 100 * 2**30 * _AUTO_MEMORY_SAFETY_FRACTION
+    assert _metric_sizing_budget(monkeypatch, None, "two") == node_auto
+
+
 def test_run_distributed_app_exports_and_restores_local_ranks(monkeypatch: pytest.MonkeyPatch) -> None:
     # The wrapper leaves the per-node rank count in the environment while the workflow is built
     # (the KeyboardInterrupt escapes the factory before any spawn), and restores it after -- a
@@ -291,6 +297,18 @@ def test_run_distributed_app_exports_and_restores_local_ranks(monkeypatch: pytes
     monkeypatch.setenv("KONFAI_LOCAL_RANKS", "7")
     factory(gpu=[0])
     assert captured[-1] == "1" and os.environ["KONFAI_LOCAL_RANKS"] == "7"
+
+    # A genuine factory failure (not the swallowed KeyboardInterrupt) must restore the variable too —
+    # the restore lives in a finally, not in the interrupt handler.
+    monkeypatch.delenv("KONFAI_LOCAL_RANKS", raising=False)
+
+    @runtime.run_distributed_app
+    def broken(config=None, gpu: list[int] = [], cpu: int = 1):
+        raise ValueError("factory died")
+
+    with pytest.raises(ValueError, match="factory died"):
+        broken(gpu=[0, 1])
+    assert "KONFAI_LOCAL_RANKS" not in os.environ
 
 
 def test_auto_budget_uses_detected_memory(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_patching.py
+++ b/tests/unit/test_patching.py
@@ -20,7 +20,7 @@ import itertools
 
 import pytest
 import torch
-from konfai.data.patching import Accumulator, Cosinus, Gaussian, Mean, StreamingAccumulator
+from konfai.data.patching import Accumulator, Cosinus, Gaussian, Mean, StreamingAccumulator, blend_overlap
 from konfai.utils.errors import PatchError
 from konfai.utils.utils import get_patch_slices_from_shape
 
@@ -125,6 +125,42 @@ def test_accumulator_gpu_blend_matches_cpu(combine_cls):
 # --------------------------------------------------------------------------------------
 # Blending windows (Mean / Cosinus)
 # --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("combine_cls", [None, Gaussian])
+@pytest.mark.parametrize("free_axis", [0, 1, 2])
+def test_free_axis_reassembles_like_its_concrete_extent(free_axis, combine_cls):
+    """A free (``0``) axis spans the full extent and must reassemble identically to the concrete-extent
+    patch: the Accumulator must not collapse the axis to a zero-width slice, and the blend window must
+    broadcast at any axis position (a *trailing* free axis is what a rank-collapsed window misaligns)."""
+    torch.manual_seed(0)
+    # 8 = 4 + 2 + 2 tiles at step (patch-overlap)=2, so every tiled patch is full patch_size (the model
+    # emits full-size patches; the Accumulator crops the border tail only after blending).
+    full = torch.rand(1, 1, 8, 8, 8)
+    spatial = list(full.shape[2:])
+    free = [4, 4, 4]
+    free[free_axis] = 0  # one free axis (single full-extent patch); the other two tile with overlap
+    concrete = [p if p > 0 else spatial[i] for i, p in enumerate(free)]
+    # A free axis is a single patch spanning the extent -> no taper. The concrete reference mirrors that
+    # with overlap 0 on that axis (the free version zeroes it itself via the size-1 kept entry).
+    concrete_overlap = [2, 2, 2]
+    concrete_overlap[free_axis] = 0
+
+    def assemble(patch_size: list[int], overlap: int | list[int]) -> torch.Tensor:
+        slices, _ = get_patch_slices_from_shape(patch_size, spatial, overlap)
+        combine = None
+        if combine_cls is not None:
+            combine = combine_cls()
+            kept = [i if i > 1 else 1 for i in patch_size]  # the ModelPatch.init blend-window contract
+            combine.set_patch_config(kept, blend_overlap(overlap, kept))
+        acc = Accumulator(slices, patch_size, patch_combine=combine, batch=True)
+        for i, sl in enumerate(slices):
+            acc.add_layer(i, full[(slice(None), slice(None), *sl)].clone())
+        return acc.assemble()
+
+    out = assemble(free, 2)
+    assert out.shape == full.shape, out.shape
+    assert torch.equal(out, assemble(concrete, concrete_overlap))
 
 
 @pytest.mark.parametrize("combine_cls", [Mean, Cosinus])

--- a/tests/unit/test_predictor_memory.py
+++ b/tests/unit/test_predictor_memory.py
@@ -260,6 +260,9 @@ def test_predictor_runs_prediction_logging_once_per_batch_even_with_multiple_out
             assert layer.shape == (1, 2, 2)
             self.writes += 1
 
+        def finalize_writes(self) -> None:
+            pass
+
     class DummyCompositeModule:
         @staticmethod
         def set_state(state) -> None:

--- a/tests/unit/test_read_chunk_cache.py
+++ b/tests/unit/test_read_chunk_cache.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read-side caching of chunked stores.
+
+Overlapping patch reads revisit the same chunks: the HDF5 read handle carries a chunk cache sized for
+imaging chunks (the library default holds barely one), and the OME-Zarr image handle is memoised per
+(store, level) so a streamed run parses the NGFF metadata once, not once per patch — invalidated by
+every write path, because a store just written must be re-read."""
+
+import numpy as np
+import pytest
+from konfai.utils.dataset import Attribute, Dataset
+
+h5py = pytest.importorskip("h5py")
+
+
+def test_h5_read_handle_carries_an_imaging_sized_chunk_cache(tmp_path) -> None:
+    dataset = Dataset(f"{tmp_path}/store.h5", "h5")
+    dataset.write("group", "CASE_000", np.zeros((1, 4, 4, 4), dtype=np.float32), Attribute())
+    with Dataset.File(f"{tmp_path}/store.h5", True, "h5") as backend:
+        _, nslots, nbytes, _ = backend.h5.id.get_access_plist().get_cache()
+    assert nbytes == Dataset.H5File._READ_CHUNK_CACHE_BYTES
+    assert nslots == Dataset.H5File._READ_CHUNK_CACHE_SLOTS
+
+
+def test_ome_zarr_image_is_memoised_per_store_and_invalidated_by_writes(tmp_path) -> None:
+    pytest.importorskip("ngff_zarr")
+    from konfai.utils.ome_zarr import _load_image, read_ome_zarr_data_slice, write_ome_zarr
+
+    store = tmp_path / "case.ome.zarr"
+    write_ome_zarr(store, np.ones((1, 4, 4, 4), dtype=np.float32))
+    first = _load_image(str(store), 0)
+    assert _load_image(str(store), 0) is first, "the image handle must be memoised per (store, level)"
+
+    write_ome_zarr(store, np.full((1, 4, 4, 4), 7.0, dtype=np.float32))
+    data, _ = read_ome_zarr_data_slice(store, tuple(slice(None) for _ in range(4)))
+    assert float(data.max()) == 7.0, "a write must invalidate the memo so the new voxels are read"

--- a/tests/unit/test_save_streaming.py
+++ b/tests/unit/test_save_streaming.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""An unsatisfied ``Save`` whose prefix streams keeps the case streaming: the cache is materialized
+slab by slab (the sweep) at first data access, after which the case streams from it exactly as if
+the cache had always existed. The swept cache must equal the classically written one, the regime
+probe must never write, and every failure must fall back to the whole-volume path."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from konfai.data.patching import DatasetManager, DatasetPatch
+from konfai.data.transform import Clip, Permute, Save, Standardize, Transform
+from konfai.utils.dataset import Attribute, Dataset
+
+pytest.importorskip("SimpleITK")
+
+
+def _image_attributes() -> Attribute:
+    attributes = Attribute()
+    attributes["Origin"] = np.asarray([10.0, 20.0, 30.0])
+    attributes["Spacing"] = np.asarray([0.5, 1.5, 2.0])
+    attributes["Direction"] = np.eye(3, dtype=np.float64).reshape(-1)
+    return attributes
+
+
+def _source(tmp_path: Path) -> Dataset:
+    rng = np.random.default_rng(0)
+    volume = (rng.random((1, 12, 10, 8)) * 100).astype(np.float32)
+    dataset = Dataset(tmp_path / "source", "mha")
+    dataset.write("CT", "CASE_000", volume, _image_attributes())
+    return dataset
+
+
+def _manager(source: Dataset, transforms: list[Transform], patch_size: list[int] | None = None) -> DatasetManager:
+    return DatasetManager(
+        index=0,
+        group_src="CT",
+        group_dest="CT",
+        name="CASE_000",
+        dataset=source,
+        patch=DatasetPatch(patch_size if patch_size is not None else [4, 5, 4]),
+        transforms=transforms,
+        data_augmentations_list=[],
+    )
+
+
+def _whole_volume_patches(manager: DatasetManager, transforms: list[Transform]) -> list[torch.Tensor]:
+    reference = _manager(manager.dataset, transforms)
+    reference.load(transforms, [], load_augmentations=False)
+    return [
+        reference.patch.get_data(reference._get_tensor(0), index, 0, True)
+        for index in range(reference.patch.get_size(0))
+    ]
+
+
+def test_regime_probe_answers_yes_without_writing_the_cache(tmp_path: Path) -> None:
+    source = _source(tmp_path)
+    cache = Dataset(tmp_path / "cache", "mha")
+    manager = _manager(source, [Clip(0.0, 50.0), Save(str(tmp_path / "cache"))])
+
+    assert manager.can_stream_patch(0)
+    assert not cache.is_dataset_exist("CT", "CASE_000")
+
+
+def test_sweep_writes_the_same_cache_as_the_whole_volume_load(tmp_path: Path) -> None:
+    source = _source(tmp_path)
+    classic = [Clip(0.0, 50.0), Save(str(tmp_path / "cache_classic"))]
+    swept = [Clip(0.0, 50.0), Save(str(tmp_path / "cache_swept"))]
+
+    _manager(source, classic).load(classic, [], load_augmentations=False)
+    manager = _manager(source, swept)
+    patch = manager.get_data(0, 0, [], True)
+
+    # The case streamed: the volume was never assembled, and the source boundary is the swept cache.
+    assert not manager.loaded
+    stream_source = manager._resolve_patch_stream_source(0)
+    assert stream_source is not None and not stream_source.pending_sweeps
+    assert Path(stream_source.dataset.filename).name == "cache_swept"
+
+    expected, expected_attributes = Dataset(tmp_path / "cache_classic", "mha").read_data("CT", "CASE_000")
+    result, result_attributes = Dataset(tmp_path / "cache_swept", "mha").read_data("CT", "CASE_000")
+    np.testing.assert_array_equal(result, expected)
+    for key in ("Origin", "Spacing", "Direction"):
+        np.testing.assert_allclose(
+            result_attributes.get_np_array(key), expected_attributes.get_np_array(key), err_msg=key
+        )
+    assert torch.equal(patch, _whole_volume_patches(manager, classic)[0])
+
+
+def test_streamed_patches_after_the_sweep_match_the_whole_volume_path(tmp_path: Path) -> None:
+    source = _source(tmp_path)
+    transforms = [Clip(0.0, 50.0), Save(str(tmp_path / "cache"))]
+    manager = _manager(source, transforms)
+    reference = _whole_volume_patches(manager, [Clip(0.0, 50.0)])
+
+    for index in range(manager.patch.get_size(0)):
+        assert torch.equal(manager.get_data(index, 0, [], True), reference[index]), index
+    assert not manager.loaded
+
+
+def test_sweep_composes_region_stages_before_the_save(tmp_path: Path) -> None:
+    # A Permute is an ORIENTATION stage: the sweep's slabs of the Save space pull remapped source
+    # regions, and the materialized cache must still equal the whole-volume pass byte for byte.
+    source = _source(tmp_path)
+    classic = [Permute("2|1|0"), Clip(0.0, 50.0), Save(str(tmp_path / "cache_classic"))]
+    swept = [Permute("2|1|0"), Clip(0.0, 50.0), Save(str(tmp_path / "cache_swept"))]
+
+    _manager(source, classic).load(classic, [], load_augmentations=False)
+    manager = _manager(source, swept)
+    manager.get_data(0, 0, [], True)
+    assert not manager.loaded
+
+    expected, _ = Dataset(tmp_path / "cache_classic", "mha").read_data("CT", "CASE_000")
+    result, _ = Dataset(tmp_path / "cache_swept", "mha").read_data("CT", "CASE_000")
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_save_unlocks_a_global_statistic_after_a_value_changing_stage(tmp_path: Path) -> None:
+    """[Clip, Standardize] cannot stream (the stored volume's statistic is not Standardize's input),
+    but [Clip, Save, Standardize] can: the statistic seeds from the materialized post-Clip cache."""
+    source = _source(tmp_path)
+    assert not _manager(source, [Clip(0.0, 50.0), Standardize(inverse=False)]).can_stream_patch(0)
+
+    transforms = [Clip(0.0, 50.0), Save(str(tmp_path / "cache")), Standardize(inverse=False)]
+    manager = _manager(source, transforms)
+    assert manager.can_stream_patch(0)
+    reference = _whole_volume_patches(manager, [Clip(0.0, 50.0), Standardize(inverse=False)])
+
+    for index in range(manager.patch.get_size(0)):
+        got = manager.get_data(index, 0, [], True)
+        np.testing.assert_allclose(got.numpy(), reference[index].numpy(), rtol=1e-6, err_msg=str(index))
+    assert not manager.loaded
+
+
+def test_two_saves_materialize_in_order(tmp_path: Path) -> None:
+    source = _source(tmp_path)
+    first, second = str(tmp_path / "cache_first"), str(tmp_path / "cache_second")
+    classic_first, classic_second = str(tmp_path / "classic_first"), str(tmp_path / "classic_second")
+    classic = [Clip(0.0, 50.0), Save(classic_first), Clip(10.0, 40.0), Save(classic_second)]
+    swept = [Clip(0.0, 50.0), Save(first), Clip(10.0, 40.0), Save(second)]
+
+    _manager(source, classic).load(classic, [], load_augmentations=False)
+    manager = _manager(source, swept)
+    manager.get_data(0, 0, [], True)
+    assert not manager.loaded
+
+    for swept_cache, classic_cache in ((first, classic_first), (second, classic_second)):
+        expected, _ = Dataset(Path(classic_cache), "mha").read_data("CT", "CASE_000")
+        result, _ = Dataset(Path(swept_cache), "mha").read_data("CT", "CASE_000")
+        np.testing.assert_array_equal(result, expected, err_msg=swept_cache)
+
+
+def test_unstreamable_destination_keeps_the_whole_volume_path(tmp_path: Path) -> None:
+    # nii.gz cannot serve region writes: the Save stays on the whole-volume path, as before the sweep.
+    source = _source(tmp_path)
+    manager = _manager(source, [Clip(0.0, 50.0), Save(f"{tmp_path / 'cache'}:nii.gz")])
+    assert not manager.can_stream_patch(0)
+
+
+def test_failed_sweep_falls_back_to_the_whole_volume_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from konfai.utils import dataset as dataset_module
+
+    source = _source(tmp_path)
+    transforms = [Clip(0.0, 50.0), Save(str(tmp_path / "cache"))]
+    manager = _manager(source, transforms)
+    reference = _whole_volume_patches(manager, [Clip(0.0, 50.0)])
+
+    def broken_write(self, slices, data):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(dataset_module._MhaDataStream, "write_slice", broken_write)
+    with pytest.warns(UserWarning, match="falling back to the whole-volume path"):
+        patch = manager.get_data(0, 0, [], True)
+    monkeypatch.undo()
+
+    assert manager._sweep_failed
+    assert torch.equal(patch, reference[0])
+    # The aborted sweep left no debris; the whole-volume fallback wrote the cache classically.
+    assert not list((tmp_path / "cache").glob("**/*.tmp"))
+    assert Dataset(tmp_path / "cache", "mha").is_dataset_exist("CT", "CASE_000")
+
+
+def test_kill_switch_keeps_the_whole_volume_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KONFAI_STREAMED_WRITES", "0")
+    source = _source(tmp_path)
+    manager = _manager(source, [Clip(0.0, 50.0), Save(str(tmp_path / "cache"))])
+    assert not manager.can_stream_patch(0)

--- a/tests/unit/test_save_streaming.py
+++ b/tests/unit/test_save_streaming.py
@@ -114,6 +114,59 @@ def test_streamed_patches_after_the_sweep_match_the_whole_volume_path(tmp_path: 
     assert not manager.loaded
 
 
+def test_multi_slab_sweep_writes_the_same_cache_as_the_whole_volume_load(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Three slabs instead of one: slab targets at non-zero offsets, the header written on the first
+    slab only, and a region stage composed across slab boundaries."""
+    from konfai.data import patching as patching_module
+
+    monkeypatch.setattr(patching_module, "_SWEEP_SLAB_ROWS", 4)
+    source = _source(tmp_path)
+    classic = [Permute("2|1|0"), Clip(0.0, 50.0), Save(str(tmp_path / "cache_classic"))]
+    swept = [Permute("2|1|0"), Clip(0.0, 50.0), Save(str(tmp_path / "cache_swept"))]
+
+    _manager(source, classic).load(classic, [], load_augmentations=False)
+    manager = _manager(source, swept)
+    manager.get_data(0, 0, [], True)
+    assert not manager.loaded
+
+    expected, expected_attributes = Dataset(tmp_path / "cache_classic", "mha").read_data("CT", "CASE_000")
+    result, result_attributes = Dataset(tmp_path / "cache_swept", "mha").read_data("CT", "CASE_000")
+    np.testing.assert_array_equal(result, expected)
+    assert set(result_attributes.keys()) == set(expected_attributes.keys())
+
+
+def test_failed_multi_slab_sweep_leaves_no_partial_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failure after the first slab is written must remove the partial entry, not publish it."""
+    from konfai.data import patching as patching_module
+    from konfai.utils import dataset as dataset_module
+
+    monkeypatch.setattr(patching_module, "_SWEEP_SLAB_ROWS", 4)
+    source = _source(tmp_path)
+    manager = _manager(source, [Clip(0.0, 50.0), Save(str(tmp_path / "cache"))])
+    reference = _whole_volume_patches(manager, [Clip(0.0, 50.0)])
+
+    calls = 0
+    real_write = dataset_module._MhaDataStream.write_slice
+
+    def failing_after_first(self, slices, data):
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            raise OSError("disk full")
+        real_write(self, slices, data)
+
+    monkeypatch.setattr(dataset_module._MhaDataStream, "write_slice", failing_after_first)
+    with pytest.warns(UserWarning, match="falling back to the whole-volume path"):
+        patch = manager.get_data(0, 0, [], True)
+    monkeypatch.setattr(dataset_module._MhaDataStream, "write_slice", real_write)
+
+    assert calls > 1
+    assert torch.equal(patch, reference[0])
+    assert not list((tmp_path / "cache").glob("**/*.tmp"))
+
+
 def test_sweep_composes_region_stages_before_the_save(tmp_path: Path) -> None:
     # A Permute is an ORIENTATION stage: the sweep's slabs of the Save space pull remapped source
     # regions, and the materialized cache must still equal the whole-volume pass byte for byte.

--- a/tests/unit/test_streamed_tta.py
+++ b/tests/unit/test_streamed_tta.py
@@ -402,18 +402,19 @@ def test_streamed_inference_stack_aborts_its_sink_when_the_case_dies(monkeypatch
     # A case that dies between slabs must not leave the stack's region sink open: the dispatcher's
     # error path calls stream_abort, which closes and drops whatever the stage held for the case.
     class _Sink:
-        closed = False
+        aborted = False
 
         def write_slice(self, target, array):
             del target, array
 
-        def __exit__(self, *exc):
-            _Sink.closed = True
+        def abort(self, error=None):
+            # The partial stack must be REMOVED, never finalized under its final name.
+            _Sink.aborted = True
 
     stack = InferenceStack("", "stack", mode="Seg")
     stack._stack_sinks["CASE_000"] = cast(Dataset, _Sink())  # type: ignore[assignment]
     stack.stream_abort("CASE_000")
-    assert _Sink.closed and not stack._stack_sinks
+    assert _Sink.aborted and not stack._stack_sinks
     stack._stack_buffers["CASE_000"] = [np.zeros((1, 1, 1, 1), dtype=np.float32)]
     stack.stream_abort("CASE_000")
     assert not stack._stack_buffers

--- a/tests/unit/test_streamed_tta.py
+++ b/tests/unit/test_streamed_tta.py
@@ -88,6 +88,7 @@ def _drive_tta(
     patch_combine=None,
     case_index: int = 0,
     file_format: str = "h5",
+    worth_gate: bool = False,
 ):
     """Push one TTA case (identity copy + one augmented copy) patch by patch through ``add_layer``
     against an h5 sink, interleaved along the slab axis exactly as the prediction mapping orders it,
@@ -99,6 +100,12 @@ def _drive_tta(
     monkeypatch.setenv("KONFAI_STREAMED_WRITES", "1" if streamed else "0")
     monkeypatch.setenv("KONFAI_config_file", "unused.yml")
     monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
+    # Toy volumes are far below the production worth-streaming threshold: zero it so these tests
+    # exercise the streamed machinery; ``worth_gate`` keeps the production threshold instead.
+    if worth_gate:
+        monkeypatch.delenv("KONFAI_STREAMED_TTA_THRESHOLD", raising=False)
+    else:
+        monkeypatch.setenv("KONFAI_STREAMED_TTA_THRESHOLD", "0")
 
     attribute = _geometry_attribute()
     volume = torch.from_numpy(np.random.default_rng(0).standard_normal((C, *SHAPE)).astype(np.float32)).to(dtype)
@@ -222,6 +229,17 @@ def test_streamed_tta_composes_with_a_region_pipe(tmp_path, monkeypatch) -> None
     reference, _ = _drive_tta(
         tmp_path / "reference", monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=False, **kwargs
     )
+    assert torch.equal(streamed, reference)
+
+
+def test_light_tta_case_takes_the_whole_volume_path_by_the_worth_gate(tmp_path, monkeypatch) -> None:
+    # A TTA case whose assembled accumulators are a sliver of allocatable memory has nothing for the
+    # slab-synchronized reduce to save: the worth gate routes it whole-volume, output unchanged.
+    streamed, whole_volume = _drive_tta(
+        tmp_path / "gated", monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=True, worth_gate=True
+    )
+    assert whole_volume, "a toy TTA case should not pay the streamed reduce"
+    reference, _ = _drive_tta(tmp_path / "reference", monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=False)
     assert torch.equal(streamed, reference)
 
 

--- a/tests/unit/test_streamed_tta.py
+++ b/tests/unit/test_streamed_tta.py
@@ -87,6 +87,7 @@ def _drive_tta(
     dtype: torch.dtype = torch.float32,
     patch_combine=None,
     case_index: int = 0,
+    file_format: str = "h5",
 ):
     """Push one TTA case (identity copy + one augmented copy) patch by patch through ``add_layer``
     against an h5 sink, interleaved along the slab axis exactly as the prediction mapping orders it,
@@ -135,7 +136,7 @@ def _drive_tta(
 
     output_dataset = OutSameAsGroupDataset(
         same_as_group="src:dest",
-        dataset_filename=f"{tmp_path}/output.h5:h5",
+        dataset_filename=f"{tmp_path}/output.h5:h5" if file_format == "h5" else f"{tmp_path}/output:{file_format}",
         group="out",
         patch_combine=None,
         reduction="Mean",
@@ -159,7 +160,9 @@ def _drive_tta(
             output_dataset.write_prediction(0, "CASE_000", result)
             whole_volume = True
 
-    data, _ = Dataset(f"{tmp_path}/output.h5", "h5").read_data("out", "CASE_000")
+    output_dataset.finalize_writes()
+    store = f"{tmp_path}/output.h5" if file_format == "h5" else f"{tmp_path}/output"
+    data, _ = Dataset(store, file_format).read_data("out", "CASE_000")
     return torch.from_numpy(data), whole_volume
 
 

--- a/tests/unit/test_streamed_tta.py
+++ b/tests/unit/test_streamed_tta.py
@@ -52,12 +52,14 @@ def _geometry_attribute() -> Attribute:
     return attribute
 
 
-def _augmentations(augmentation, nb: int = 1, shape: list[int] | None = None) -> DataAugmentationsList:
-    """A one-augmentation list with its draw made for case 0 (prob 1, so every copy is selected)."""
+def _augmentations(
+    augmentation, nb: int = 1, shape: list[int] | None = None, case_index: int = 0
+) -> DataAugmentationsList:
+    """A one-augmentation list with its draw made for ``case_index`` (prob 1, so every copy is selected)."""
     augmentation.load(1.0)
     augmentations = DataAugmentationsList(nb=nb, data_augmentations={})
     augmentations.data_augmentations = [augmentation]
-    augmentation.state_init(0, [list(shape or SHAPE) for _ in range(nb)], [Attribute() for _ in range(nb)])
+    augmentation.state_init(case_index, [list(shape or SHAPE) for _ in range(nb)], [Attribute() for _ in range(nb)])
     return augmentations
 
 
@@ -84,6 +86,7 @@ def _drive_tta(
     after=(),
     dtype: torch.dtype = torch.float32,
     patch_combine=None,
+    case_index: int = 0,
 ):
     """Push one TTA case (identity copy + one augmented copy) patch by patch through ``add_layer``
     against an h5 sink, interleaved along the slab axis exactly as the prediction mapping orders it,
@@ -100,8 +103,8 @@ def _drive_tta(
     volume = torch.from_numpy(np.random.default_rng(0).standard_normal((C, *SHAPE)).astype(np.float32)).to(dtype)
     for transform in transforms:
         volume = transform("CASE_000", volume, attribute)
-    augmentations = _augmentations(augmentation, shape=list(volume.shape[1:]))
-    copies = [volume, augmentation.compute("CASE_000", 0, 0, volume)]
+    augmentations = _augmentations(augmentation, shape=list(volume.shape[1:]), case_index=case_index)
+    copies = [volume, augmentation.compute("CASE_000", case_index, 0, volume)]
     patch_slices, _ = get_patch_slices_from_shape(PATCH_SIZE, list(volume.shape[1:]), OVERLAP)
     patches = [_make_patches(copy, patch_slices) for copy in copies]
 
@@ -114,7 +117,7 @@ def _drive_tta(
             return patch_slices
 
     class DummyManager:
-        index = 0
+        index = case_index
         name = "CASE_000"
         patch = DummyPatch()
         shapes: ClassVar[list[list[int]]] = [list(volume.shape[1:]), list(volume.shape[1:])]
@@ -358,15 +361,64 @@ def test_streamed_inference_stack_buffers_when_the_sink_refuses_regions(tmp_path
     assert stack_data.shape == (2, *SHAPE)
 
 
+def test_streamed_tta_binds_the_draw_by_the_manager_case_index(tmp_path, monkeypatch) -> None:
+    # A DDP shard remaps case indices to loader-local ones, but the draw was made under the manager's
+    # own index — the only key ``who_index`` holds. Both paths must un-augment through it: with the
+    # local index (0 here) the state lookup has no entry at all.
+    streamed, whole_volume = _drive_tta(
+        tmp_path / "streamed", monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=True, case_index=7
+    )
+    assert not whole_volume
+    reference, _ = _drive_tta(
+        tmp_path / "reference", monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=False, case_index=7
+    )
+    assert torch.equal(streamed, reference)
+
+
+def test_streamed_inference_stack_aborts_its_sink_when_the_case_dies(monkeypatch) -> None:
+    # A case that dies between slabs must not leave the stack's region sink open: the dispatcher's
+    # error path calls stream_abort, which closes and drops whatever the stage held for the case.
+    class _Sink:
+        closed = False
+
+        def write_slice(self, target, array):
+            del target, array
+
+        def __exit__(self, *exc):
+            _Sink.closed = True
+
+    stack = InferenceStack("", "stack", mode="Seg")
+    stack._stack_sinks["CASE_000"] = cast(Dataset, _Sink())  # type: ignore[assignment]
+    stack.stream_abort("CASE_000")
+    assert _Sink.closed and not stack._stack_sinks
+    stack._stack_buffers["CASE_000"] = [np.zeros((1, 1, 1, 1), dtype=np.float32)]
+    stack.stream_abort("CASE_000")
+    assert not stack._stack_buffers
+
+
 def test_interleaved_case_entries_order_copies_by_slab_start() -> None:
     patch = DatasetPatch(patch_size=list(PATCH_SIZE), overlap=OVERLAP)
     patch.load(list(SHAPE), 0)
     patch.load(list(SHAPE), 1)
     entries = [(a, p) for a in range(2) for p in range(patch.get_size(0))]
-    ordered = _interleaved_case_entries(patch, entries)
+    ordered = _interleaved_case_entries([patch, patch], entries)
     assert sorted(ordered) == sorted(entries), "the interleave must be a permutation of the case"
     starts = [patch.get_patch_slices(a)[p][0].start for a, p in ordered]
     assert starts == sorted(starts), "arrival must be non-decreasing along the slab axis"
     for a in range(2):
         within_copy = [p for entry_a, p in ordered if entry_a == a]
         assert within_copy == sorted(within_copy), "within a copy the patch order must be untouched"
+
+
+def test_interleaved_case_entries_keep_the_plain_order_when_groups_disagree() -> None:
+    # One shared arrival order must serve every destination group: when their grids disagree on the
+    # slab starts (or one cannot even index an entry), the interleave silently steps aside — it is a
+    # memory bound, never a correctness requirement.
+    patch = DatasetPatch(patch_size=list(PATCH_SIZE), overlap=OVERLAP)
+    patch.load(list(SHAPE), 0)
+    patch.load(list(SHAPE), 1)
+    other = DatasetPatch(patch_size=[3, 4, 3], overlap=OVERLAP)
+    other.load(list(SHAPE), 0)
+    other.load(list(SHAPE), 1)
+    entries = [(a, p) for a in range(2) for p in range(patch.get_size(0))]
+    assert _interleaved_case_entries([patch, other], entries) == entries

--- a/tests/unit/test_streamed_tta.py
+++ b/tests/unit/test_streamed_tta.py
@@ -1,0 +1,372 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Streamed test-time augmentation: the slab-synchronized cross-copy reduce.
+
+A TTA case streams when every copy's un-augment acts slab by slab (a draw whose declared remap fixes
+the slab axis): each copy keeps its own sliding-window accumulator, a :class:`SlabAligner` holds the
+copies' finalized slabs until the slowest frontier passes, and the joint interval runs the SAME
+per-copy head and reduction call as the whole-volume ``get_output`` — which is why the streamed
+output must equal the assembled one bit for bit, for every reduction (Mean, Median, Concat), blend,
+and dtype. A draw that moves the slab axis (a z-flip) must refuse and fall back, transparently."""
+
+from types import SimpleNamespace
+from typing import ClassVar, cast
+
+import numpy as np
+import pytest
+import torch
+from konfai.data.augmentation import Brightness, DataAugmentationsList, Flip, Permute
+from konfai.data.data_manager import DatasetIter, _interleaved_case_entries
+from konfai.data.patching import DatasetPatch, Gaussian, SlabAligner
+from konfai.data.transform import Flip as FlipTransform
+from konfai.data.transform import InferenceStack, LocalityKind, Sum
+from konfai.predictor import Concat, Mean, Median, OutSameAsGroupDataset, Reduction
+from konfai.utils.dataset import Attribute, Dataset
+from konfai.utils.utils import get_patch_slices_from_shape
+
+SHAPE = [6, 4, 3]
+PATCH_SIZE = [2, 4, 3]
+OVERLAP = 1
+C = 2
+
+
+def _geometry_attribute() -> Attribute:
+    attribute = Attribute()
+    attribute["Origin"] = np.zeros(3)
+    attribute["Spacing"] = np.ones(3)
+    attribute["Direction"] = np.eye(3).flatten()
+    return attribute
+
+
+def _augmentations(augmentation, nb: int = 1, shape: list[int] | None = None) -> DataAugmentationsList:
+    """A one-augmentation list with its draw made for case 0 (prob 1, so every copy is selected)."""
+    augmentation.load(1.0)
+    augmentations = DataAugmentationsList(nb=nb, data_augmentations={})
+    augmentations.data_augmentations = [augmentation]
+    augmentation.state_init(0, [list(shape or SHAPE) for _ in range(nb)], [Attribute() for _ in range(nb)])
+    return augmentations
+
+
+def _make_patches(volume: torch.Tensor, patch_slices) -> list[torch.Tensor]:
+    """Cut ``volume`` into model-sized patches, border patches zero-padded up to the patch extent."""
+    patches = []
+    for patch_slice in patch_slices:
+        patch = volume[(slice(None), *patch_slice)]
+        padding = []
+        for dim, s in reversed(list(enumerate(patch_slice))):
+            padding += [0, PATCH_SIZE[dim] - (s.stop - s.start)]
+        patches.append(torch.nn.functional.pad(patch, padding) if any(padding) else patch)
+    return patches
+
+
+def _drive_tta(
+    tmp_path,
+    monkeypatch,
+    *,
+    augmentation,
+    streamed: bool,
+    reduction: Reduction | None = None,
+    transforms=(),
+    after=(),
+    dtype: torch.dtype = torch.float32,
+    patch_combine=None,
+):
+    """Push one TTA case (identity copy + one augmented copy) patch by patch through ``add_layer``
+    against an h5 sink, interleaved along the slab axis exactly as the prediction mapping orders it,
+    and read the written entry back.
+
+    The forward ``transforms`` run once on the volume (stacking the attribute as the input pipeline
+    would) and the result plays the model output; the augmented copy is the augmentation's own
+    ``compute`` of it. Returns the written tensor and whether the whole-volume path produced it."""
+    monkeypatch.setenv("KONFAI_STREAMED_WRITES", "1" if streamed else "0")
+    monkeypatch.setenv("KONFAI_config_file", "unused.yml")
+    monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
+
+    attribute = _geometry_attribute()
+    volume = torch.from_numpy(np.random.default_rng(0).standard_normal((C, *SHAPE)).astype(np.float32)).to(dtype)
+    for transform in transforms:
+        volume = transform("CASE_000", volume, attribute)
+    augmentations = _augmentations(augmentation, shape=list(volume.shape[1:]))
+    copies = [volume, augmentation.compute("CASE_000", 0, 0, volume)]
+    patch_slices, _ = get_patch_slices_from_shape(PATCH_SIZE, list(volume.shape[1:]), OVERLAP)
+    patches = [_make_patches(copy, patch_slices) for copy in copies]
+
+    class DummyPatch:
+        patch_size: ClassVar[list[int]] = list(PATCH_SIZE)
+
+        @staticmethod
+        def get_patch_slices(index_augmentation: int):
+            del index_augmentation
+            return patch_slices
+
+    class DummyManager:
+        index = 0
+        name = "CASE_000"
+        patch = DummyPatch()
+        shapes: ClassVar[list[list[int]]] = [list(volume.shape[1:]), list(volume.shape[1:])]
+        cache_attributes: ClassVar[list[Attribute]] = [Attribute(), Attribute()]
+
+    class DummyDatasetIter:
+        data_augmentations_list: ClassVar[list[DataAugmentationsList]] = [augmentations]
+        groups_src: ClassVar[dict] = {
+            "src": {"dest": SimpleNamespace(transforms=list(transforms), patch_transforms=[])}
+        }
+
+        @staticmethod
+        def get_dataset_from_index(group_dest: str, index: int):
+            return DummyManager()
+
+    output_dataset = OutSameAsGroupDataset(
+        same_as_group="src:dest",
+        dataset_filename=f"{tmp_path}/output.h5:h5",
+        group="out",
+        patch_combine=None,
+        reduction="Mean",
+    )
+    output_dataset.reduction = reduction if reduction is not None else Mean()
+    output_dataset.nb_data_augmentation = 2
+    output_dataset.after_reduction_transforms = list(after)
+    for transform in output_dataset.after_reduction_transforms:
+        transform.set_datasets([output_dataset])
+    if patch_combine is not None:
+        patch_combine.set_patch_config(list(PATCH_SIZE), OVERLAP)
+        output_dataset.patch_combine = patch_combine
+
+    dataset_iter = cast(DatasetIter, DummyDatasetIter())
+    order = sorted((patch_slices[p][0].start, a, p) for a in range(2) for p in range(len(patch_slices)))
+    whole_volume = False
+    for _, a, p in order:
+        output_dataset.add_layer(0, a, p, patches[a][p].clone(), dataset_iter, Attribute(attribute), [C])
+        if output_dataset.is_done(0):
+            result = output_dataset.get_output(0, [C], dataset_iter)
+            output_dataset.write_prediction(0, "CASE_000", result)
+            whole_volume = True
+
+    data, _ = Dataset(f"{tmp_path}/output.h5", "h5").read_data("out", "CASE_000")
+    return torch.from_numpy(data), whole_volume
+
+
+# --------------------------------------------------------------------------------------
+# Byte-identity: the slab-synchronized reduce equals the whole-volume path, per reduction.
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("reduction", "dtype", "patch_combine"),
+    [
+        (Mean(), torch.float32, Gaussian()),
+        (Mean(), torch.float16, None),
+        (Median(), torch.float32, Gaussian()),
+        (Median(), torch.float16, None),
+    ],
+)
+def test_streamed_tta_flip_matches_whole_volume(tmp_path, monkeypatch, reduction, dtype, patch_combine) -> None:
+    # An in-plane flip (y and x, never z): the copies' un-augment is slab-parallel, so the case must
+    # stream (the whole-volume path never fires) and still match the assembled reference bit for bit.
+    kwargs = {"reduction": reduction, "dtype": dtype, "patch_combine": patch_combine}
+    streamed, whole_volume = _drive_tta(
+        tmp_path / "streamed", monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=True, **kwargs
+    )
+    assert not whole_volume, "the TTA case should have streamed"
+    reference, whole_volume = _drive_tta(
+        tmp_path / "reference", monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=False, **kwargs
+    )
+    assert whole_volume
+    assert streamed.dtype == reference.dtype
+    assert torch.equal(streamed, reference)
+
+
+def test_streamed_tta_concat_layout_matches_whole_volume(tmp_path, monkeypatch) -> None:
+    # reduce=Concat keeps the copies as leading blocks for after_reduction to merge (the documented
+    # contract): the streamed prefix must hand Sum the same [T, C, ...] layout, slab by slab.
+    kwargs = {"reduction": Concat(), "after": [Sum(dim=0)]}
+    streamed, whole_volume = _drive_tta(
+        tmp_path / "streamed", monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=True, **kwargs
+    )
+    assert not whole_volume
+    reference, _ = _drive_tta(
+        tmp_path / "reference", monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=False, **kwargs
+    )
+    assert torch.equal(streamed, reference)
+
+
+def test_streamed_tta_composes_with_a_region_pipe(tmp_path, monkeypatch) -> None:
+    # TTA reduce feeding the write dispatcher's region pipe: the forward Flip on the slab axis leaves
+    # a z-mirror inverse in the finalize chain, streamed AFTER the cross-copy reduction. Both layers
+    # of the machinery compose without either knowing about the other.
+    kwargs = {"transforms": [FlipTransform("0", inverse=True)]}
+    streamed, whole_volume = _drive_tta(
+        tmp_path / "streamed", monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=True, **kwargs
+    )
+    assert not whole_volume
+    reference, _ = _drive_tta(
+        tmp_path / "reference", monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=False, **kwargs
+    )
+    assert torch.equal(streamed, reference)
+
+
+def test_streamed_tta_slab_axis_flip_falls_back_to_whole_volume(tmp_path, monkeypatch) -> None:
+    # A z-flip mirrors the slab order: finalizing output slab 0 would need the copy's LAST patch, so
+    # the gate must refuse and the case must complete through the whole-volume path, transparently.
+    streamed, whole_volume = _drive_tta(
+        tmp_path / "streamed", monkeypatch, augmentation=Flip(f_prob=[1, 0, 0]), streamed=True
+    )
+    assert whole_volume, "a slab-axis flip must fall back to the whole-volume path"
+    reference, _ = _drive_tta(tmp_path / "reference", monkeypatch, augmentation=Flip(f_prob=[1, 0, 0]), streamed=False)
+    assert torch.equal(streamed, reference)
+
+
+# --------------------------------------------------------------------------------------
+# The gate: slab-parallelism is read from the augmentation's own declarations.
+# --------------------------------------------------------------------------------------
+
+
+def _gate(augmentation, nb: int = 1) -> bool:
+    augmentations = _augmentations(augmentation, nb=nb)
+
+    class DummyManager:
+        index = 0
+        shapes: ClassVar[list[list[int]]] = [list(SHAPE)] * (nb + 1)
+
+    class DummyDatasetIter:
+        data_augmentations_list: ClassVar[list[DataAugmentationsList]] = [augmentations]
+
+        @staticmethod
+        def get_dataset_from_index(group_dest: str, index: int):
+            return DummyManager()
+
+    output_dataset = OutSameAsGroupDataset.__new__(OutSameAsGroupDataset)
+    output_dataset.nb_data_augmentation = nb + 1
+    output_dataset.group_dest = "dest"
+    return output_dataset._tta_streamable(cast(DatasetIter, DummyDatasetIter()), 0, _geometry_attribute())
+
+
+def test_gate_reads_the_draw_declarations() -> None:
+    # In-plane flips fix every slab; a z-flip mirrors them; Permute always moves the slab axis
+    # (its two generators both displace z); a per-voxel colour draw inverts per voxel.
+    assert _gate(Flip(f_prob=[0, 1, 1]))
+    assert not _gate(Flip(f_prob=[1, 0, 0]))
+    assert not _gate(Permute(prob_permute=None), nb=2)
+    assert _gate(Brightness(b_std=0.5))
+
+
+# --------------------------------------------------------------------------------------
+# SlabAligner: pure interval arithmetic over ordered emitters.
+# --------------------------------------------------------------------------------------
+
+
+def test_aligner_single_stream_passes_slabs_through() -> None:
+    aligner = SlabAligner(1)
+    slab = torch.arange(2 * 3 * 4, dtype=torch.float32).reshape(2, 3, 4)
+    emitted = aligner.push(0, [(slice(0, 3), slab)], finished=False)
+    assert len(emitted) == 1
+    interval, rows = emitted[0]
+    assert interval == slice(0, 3) and list(rows) == [0]
+    assert torch.equal(rows[0], slab), "a lone stream's rows must be the slab itself"
+    assert not aligner.complete
+    aligner.push(0, [], finished=True)
+    assert aligner.complete
+
+
+def test_aligner_joint_intervals_carry_every_stream_and_stay_bounded() -> None:
+    z = 8
+    streams = [torch.randn(1, z, 2), torch.randn(1, z, 2)]
+    partitions = {0: [2, 5, 8], 1: [1, 3, 4, 8]}  # deliberately skewed emission boundaries
+    aligner = SlabAligner(2)
+    outputs = {0: [], 1: []}
+    consumed = 0
+    for step in range(max(len(p) for p in partitions.values())):
+        for stream, cuts in partitions.items():
+            if step >= len(cuts):
+                continue
+            start = 0 if step == 0 else cuts[step - 1]
+            stop = cuts[step]
+            emitted = aligner.push(stream, [(slice(start, stop), streams[stream][:, start:stop])], finished=stop == z)
+            for interval, rows in emitted:
+                assert interval.start == consumed, "intervals must tile the axis in order"
+                assert sorted(rows) == [0, 1]
+                for key, block in rows.items():
+                    outputs[key].append(block)
+                consumed = interval.stop
+            # Nothing beyond the slowest frontier is buffered once emitted rows are pruned.
+            for pending in aligner._pending.values():
+                assert all(start + slab.shape[1] > consumed for start, slab in pending)
+    assert consumed == z and aligner.complete
+    for key, stream_volume in enumerate(streams):
+        assert torch.equal(torch.cat(outputs[key], dim=1), stream_volume)
+
+
+# --------------------------------------------------------------------------------------
+# The prediction mapping: copies advance together along the slab axis.
+# --------------------------------------------------------------------------------------
+
+
+def test_streamed_inference_stack_writes_the_stack_region_by_region(tmp_path, monkeypatch) -> None:
+    # InferenceStack declares SLAB: per-voxel member reduction plus a per-region side write of the
+    # stack. Fed through the streamed prefix it must produce the same main output AND the same stack
+    # entry as the whole-volume call — here on a TTA Concat chain, where the stack holds both copies.
+    def run(where: str, streamed: bool):
+        stack = InferenceStack("", "stack", mode="Seg")
+        streamed_out, whole_volume = _drive_tta(
+            tmp_path / where,
+            monkeypatch,
+            augmentation=Flip(f_prob=[0, 1, 1]),
+            streamed=streamed,
+            reduction=Concat(),
+            after=[stack],
+        )
+        stack_data, _ = Dataset(f"{tmp_path / where}/output.h5", "h5").read_data("InferenceStack", "CASE_000")
+        return streamed_out, torch.from_numpy(stack_data), whole_volume
+
+    assert InferenceStack("", "stack").patch_locality(Attribute()).kind is LocalityKind.SLAB
+    got, got_stack, whole_volume = run("streamed", streamed=True)
+    assert not whole_volume, "a SLAB stage must not force the whole-volume path"
+    want, want_stack, _ = run("reference", streamed=False)
+    assert torch.equal(got, want)
+    assert torch.equal(got_stack, want_stack)
+
+
+def test_streamed_inference_stack_buffers_when_the_sink_refuses_regions(tmp_path, monkeypatch) -> None:
+    # A destination that cannot serve region writes must not lose the stack: the SLAB stage buffers
+    # and writes classically at the last slab — the whole-volume path's memory, never a missing file.
+    stack = InferenceStack(f"{tmp_path}/stack_only.h5:h5", "stack", mode="Seg")
+    stack.dataset.open_data_stream = lambda *args, **kwargs: None  # type: ignore[union-attr,method-assign]
+    _, whole_volume = _drive_tta(
+        tmp_path / "streamed",
+        monkeypatch,
+        augmentation=Flip(f_prob=[0, 1, 1]),
+        streamed=True,
+        reduction=Concat(),
+        after=[stack],
+    )
+    assert not whole_volume
+    stack_data, _ = Dataset(f"{tmp_path}/stack_only.h5", "h5").read_data("InferenceStack", "CASE_000")
+    assert stack_data.shape == (2, *SHAPE)
+
+
+def test_interleaved_case_entries_order_copies_by_slab_start() -> None:
+    patch = DatasetPatch(patch_size=list(PATCH_SIZE), overlap=OVERLAP)
+    patch.load(list(SHAPE), 0)
+    patch.load(list(SHAPE), 1)
+    entries = [(a, p) for a in range(2) for p in range(patch.get_size(0))]
+    ordered = _interleaved_case_entries(patch, entries)
+    assert sorted(ordered) == sorted(entries), "the interleave must be a permutation of the case"
+    starts = [patch.get_patch_slices(a)[p][0].start for a, p in ordered]
+    assert starts == sorted(starts), "arrival must be non-decreasing along the slab axis"
+    for a in range(2):
+        within_copy = [p for entry_a, p in ordered if entry_a == a]
+        assert within_copy == sorted(within_copy), "within a copy the patch order must be untouched"

--- a/tests/unit/test_streamed_tta.py
+++ b/tests/unit/test_streamed_tta.py
@@ -232,15 +232,17 @@ def test_streamed_tta_composes_with_a_region_pipe(tmp_path, monkeypatch) -> None
     assert torch.equal(streamed, reference)
 
 
-def test_light_tta_case_takes_the_whole_volume_path_by_the_worth_gate(tmp_path, monkeypatch) -> None:
+def test_light_tta_case_takes_the_whole_volume_path_by_the_worth_gate(tmp_path, monkeypatch, capsys) -> None:
     # A TTA case whose assembled accumulators are a sliver of allocatable memory has nothing for the
-    # slab-synchronized reduce to save: the worth gate routes it whole-volume, output unchanged.
+    # slab-synchronized reduce to save: the worth gate routes it whole-volume, output unchanged, and
+    # the fallback is said once (a silent one would hide that a large case pays it).
     streamed, whole_volume = _drive_tta(
         tmp_path / "gated", monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=True, worth_gate=True
     )
     assert whole_volume, "a toy TTA case should not pay the streamed reduce"
     reference, _ = _drive_tta(tmp_path / "reference", monkeypatch, augmentation=Flip(f_prob=[0, 1, 1]), streamed=False)
     assert torch.equal(streamed, reference)
+    assert capsys.readouterr().out.count("takes the whole-volume path") == 1
 
 
 def test_streamed_tta_slab_axis_flip_falls_back_to_whole_volume(tmp_path, monkeypatch) -> None:

--- a/tests/unit/test_streamed_tta.py
+++ b/tests/unit/test_streamed_tta.py
@@ -103,9 +103,9 @@ def _drive_tta(
     # Toy volumes are far below the production worth-streaming threshold: zero it so these tests
     # exercise the streamed machinery; ``worth_gate`` keeps the production threshold instead.
     if worth_gate:
-        monkeypatch.delenv("KONFAI_STREAMED_TTA_THRESHOLD", raising=False)
+        monkeypatch.delenv("KONFAI_STREAM_WORTH_THRESHOLD", raising=False)
     else:
-        monkeypatch.setenv("KONFAI_STREAMED_TTA_THRESHOLD", "0")
+        monkeypatch.setenv("KONFAI_STREAM_WORTH_THRESHOLD", "0")
 
     attribute = _geometry_attribute()
     volume = torch.from_numpy(np.random.default_rng(0).standard_normal((C, *SHAPE)).astype(np.float32)).to(dtype)

--- a/tests/unit/test_streamed_write_dispatcher.py
+++ b/tests/unit/test_streamed_write_dispatcher.py
@@ -48,7 +48,7 @@ from konfai.data.transform import (
     Transform,
     TransformInverse,
 )
-from konfai.predictor import Mean, OutSameAsGroupDataset, Reduction
+from konfai.predictor import Mean, OutSameAsGroupDataset, Reduction, _FinalizeStage
 from konfai.utils.dataset import Attribute
 from konfai.utils.errors import PatchError
 
@@ -149,6 +149,42 @@ def test_stream_orientation_canonical_inverse_matches_whole_volume(seed: int) ->
         _partitions(Z, rng),
     )
     assert torch.equal(got, reference)
+
+
+def test_forward_orientation_records_case_geometry_from_the_volume_not_the_slab() -> None:
+    # A FORWARD orientation in the write pipe records the output origin from the extent it is handed;
+    # streamed, that is a slab window, so it must be given the FULL volume extent instead (Canonical
+    # documents "the extent is the VOLUME's, never a patch's"). Without the fix the sink origin was
+    # derived from the slab height and diverged from the whole-volume path.
+    ds = _output_dataset()
+    canonical = Canonical()
+    stage = _FinalizeStage(transform=canonical, inverted=False)
+    in_shape = [Z, Y, X]
+    direction = np.array([[1.0, 0, 0], [0, 0, 1], [0, 1, 0]]).flatten()  # swap y/z: origin then depends on the z-extent
+
+    def _attr() -> Attribute:
+        attribute = Attribute()
+        attribute["Direction"] = direction
+        attribute["Spacing"] = np.ones(3)
+        attribute["Origin"] = np.array([7.0, 5.0, 3.0])
+        return attribute
+
+    reference = _attr()
+    canonical.write_stream_cache_attribute(reference, in_shape)  # the whole-volume path's geometry
+
+    slab_derived = _attr()
+    canonical.write_stream_cache_attribute(slab_derived, [2, Y, X])  # what the slab shape would produce
+
+    got = _attr()
+    target = (slice(0, 2), slice(0, Y), slice(0, X))  # a 2-row slab, height != Z
+    ds._apply_pipe_stage(
+        stage, LocalityKind.ORIENTATION, torch.zeros(C, 2, Y, X), target, list(target), in_shape, in_shape, got, "case"
+    )
+
+    assert np.allclose(got.get_np_array("Origin"), reference.get_np_array("Origin"))
+    assert not np.allclose(
+        reference.get_np_array("Origin"), slab_derived.get_np_array("Origin")
+    )  # the test distinguishes
 
 
 @pytest.mark.parametrize("seed", range(4))

--- a/tests/unit/test_streamed_write_dispatcher.py
+++ b/tests/unit/test_streamed_write_dispatcher.py
@@ -204,6 +204,36 @@ def test_stream_rescale_nearest_is_byte_identical_to_the_whole_volume_inverse(se
 
 
 @pytest.mark.parametrize("seed", range(4))
+def test_stream_rescale_linear_matches_the_whole_volume_inverse_to_float_rounding(seed: int) -> None:
+    # A float (linear) rescale is not byte-identical to F.interpolate windowed, but resample_region
+    # computes the same linear taps, so the streamed inverse matches the whole-volume one to
+    # ~float-rounding (KONFAI_STREAM_LINEAR_RESAMPLE trades exactly this for a bounded window).
+    rng = np.random.default_rng(seed)
+    volume = torch.from_numpy(rng.standard_normal((C, Z, Y, X)).astype(np.float32)) * 100.0
+    resample = ResampleToResolution([1.0, 1.0, 1.0])
+    attribute = Attribute()
+    attribute["Spacing"] = torch.tensor([1.0, 1.0, 1.0])
+    attribute["Size"] = np.asarray([12, 9, 7])
+    attribute["Size"] = np.asarray([Z, Y, X])
+    in_shape = [Z, Y, X]
+    out_shape = resample.inverse_transform_shape(in_shape, attribute)
+    scales = [in_shape[k] / out_shape[k] for k in range(3)]
+    reference = resample.inverse("case", volume.clone(), Attribute(attribute))
+    got = _run_stream(
+        lambda target: resample.stream_region_target(target, in_shape, Attribute(attribute)),
+        lambda window, target, source: resample.resample_region(
+            window, target, [s.start for s in source], scales, in_shape
+        ),
+        in_shape,
+        out_shape,
+        volume,
+        _partitions(Z, rng),
+    )
+    assert got.shape == reference.shape
+    torch.testing.assert_close(got, reference, atol=1e-2, rtol=0)  # ~1e-4 relative on values ~100
+
+
+@pytest.mark.parametrize("seed", range(4))
 def test_stream_halo_dilate_matches_whole_volume(seed: int) -> None:
     # A forward HALO stage (Dilate) rides the same window: the pull enlarges by the declared radius,
     # the stage runs on the window, and the halo is cropped back — seams must agree bit for bit.

--- a/tests/unit/test_streamed_write_dispatcher.py
+++ b/tests/unit/test_streamed_write_dispatcher.py
@@ -539,8 +539,7 @@ def test_add_layer_streams_a_flip_inverse_through_the_region_stage(tmp_path, mon
 
 def test_add_layer_streams_a_stat_inverse_riding_the_pipe(tmp_path, monkeypatch) -> None:
     # The common synthesis finalize: the forward Normalize stacked Min/Max, so its inverse is a
-    # per-voxel affine map riding the pipe behind the flip's region — the case the all-POINTWISE gate
-    # used to refuse outright.
+    # per-voxel affine map riding the pipe behind the flip's region.
     volume = torch.from_numpy(np.random.default_rng(2).standard_normal((1, 6, 4, 3)).astype(np.float32))
     transforms = [Normalize(inverse=True), Flip("0", inverse=True)]
     streamed = _drive_prediction(tmp_path / "streamed", transforms, volume, monkeypatch, streamed=True)

--- a/tests/unit/test_streamed_write_dispatcher.py
+++ b/tests/unit/test_streamed_write_dispatcher.py
@@ -358,13 +358,13 @@ def _geometry_attribute() -> Attribute:
 
 def test_plan_all_pointwise_streams_direct() -> None:
     plan = _output_dataset(final=[TensorCast("float32", inverse=False)])._plan_stream(
-        _dataset_iter([]), _geometry_attribute()
+        _dataset_iter([]), 0, _geometry_attribute()
     )
     assert plan is not None and plan.mode == "direct"
 
 
 def test_plan_one_geometry_inverse_streams_through_the_region_stage() -> None:
-    plan = _output_dataset()._plan_stream(_dataset_iter([Flip("0", inverse=True)]), _geometry_attribute())
+    plan = _output_dataset()._plan_stream(_dataset_iter([Flip("0", inverse=True)]), 0, _geometry_attribute())
     assert plan is not None and plan.mode == "region"
     assert plan.pipe_start == 0 and plan.stages[0].inverted
 
@@ -374,6 +374,7 @@ def test_plan_several_region_stages_compose_into_one_streamed_pipe() -> None:
     # geometry chain still streams to the write — no chain is one region too many.
     plan = _output_dataset()._plan_stream(
         _dataset_iter([Flip("0", inverse=True), Padding([0, 0, 0, 0, 2, 1], inverse=True)]),
+        0,
         _geometry_attribute(),
     )
     assert plan is not None and plan.mode == "region"
@@ -384,7 +385,7 @@ def test_plan_whole_volume_stage_falls_to_the_buffered_tail_and_swallows_the_reg
     # [region, WHOLE_VOLUME]: the tail must start at the region stage, not after it — a buffered head
     # is pointwise-only so the buffer sits on the accumulator grid.
     plan = _output_dataset(final=[Softmax(1)])._plan_stream(
-        _dataset_iter([Flip("0", inverse=True)]), _geometry_attribute()
+        _dataset_iter([Flip("0", inverse=True)]), 0, _geometry_attribute()
     )
     assert plan is not None and plan.mode == "buffered"
     assert plan.pipe_start is None and plan.tail_start == 0
@@ -396,9 +397,9 @@ def test_plan_seeded_global_stat_counts_as_pointwise_and_unseeded_does_not() -> 
     seeded = _geometry_attribute()
     seeded["Min"] = 0.0
     seeded["Max"] = 1.0
-    plan = _output_dataset(final=[Normalize(inverse=False)])._plan_stream(_dataset_iter([]), seeded)
+    plan = _output_dataset(final=[Normalize(inverse=False)])._plan_stream(_dataset_iter([]), 0, seeded)
     assert plan is not None and plan.mode == "direct"
-    plan = _output_dataset(final=[Normalize(inverse=False)])._plan_stream(_dataset_iter([]), _geometry_attribute())
+    plan = _output_dataset(final=[Normalize(inverse=False)])._plan_stream(_dataset_iter([]), 0, _geometry_attribute())
     assert plan is not None and plan.mode == "buffered" and plan.tail_start == 0
 
 
@@ -408,15 +409,15 @@ def test_plan_refuses_tta_custom_reduction_and_non_pointwise_before_reduction() 
             return tensors[0]
 
     attribute = _geometry_attribute()
-    assert _output_dataset(nb_data_augmentation=2)._plan_stream(_dataset_iter([]), attribute) is None
-    assert _output_dataset(reduction=_CustomReduction())._plan_stream(_dataset_iter([]), attribute) is None
-    assert _output_dataset(before=[Softmax(1)])._plan_stream(_dataset_iter([]), attribute) is None
+    assert _output_dataset(nb_data_augmentation=2)._plan_stream(_dataset_iter([]), 0, attribute) is None
+    assert _output_dataset(reduction=_CustomReduction())._plan_stream(_dataset_iter([]), 0, attribute) is None
+    assert _output_dataset(before=[Softmax(1)])._plan_stream(_dataset_iter([]), 0, attribute) is None
 
 
 def test_plan_non_region_writable_format_buffers_and_writes_classically() -> None:
     # nrrd cannot serve region writes: the pointwise chain still streams the accumulator into a buffer
     # (the windowed-accumulator win survives), and the volume is written through the classic writer.
-    plan = _output_dataset(file_format="nrrd")._plan_stream(_dataset_iter([]), _geometry_attribute())
+    plan = _output_dataset(file_format="nrrd")._plan_stream(_dataset_iter([]), 0, _geometry_attribute())
     assert plan is not None and plan.mode == "buffered" and plan.tail_start == len(plan.stages)
 
 

--- a/tests/unit/test_streamed_write_dispatcher.py
+++ b/tests/unit/test_streamed_write_dispatcher.py
@@ -185,6 +185,9 @@ def test_forward_orientation_records_case_geometry_from_the_volume_not_the_slab(
     assert not np.allclose(
         reference.get_np_array("Origin"), slab_derived.get_np_array("Origin")
     )  # the test distinguishes
+    # The whole stack must match, not just the top Origin: a bug that pushed the slab geometry and then
+    # the full-volume one would leave a stale entry lower in the stack for the later inverse pop to hit.
+    assert got == reference
 
 
 @pytest.mark.parametrize("seed", range(4))

--- a/tests/unit/test_streamed_write_dispatcher.py
+++ b/tests/unit/test_streamed_write_dispatcher.py
@@ -468,6 +468,8 @@ def _drive_prediction(tmp_path, transforms, volume, monkeypatch, streamed=True, 
     monkeypatch.setenv("KONFAI_STREAMED_WRITES", "1" if streamed else "0")
     monkeypatch.setenv("KONFAI_config_file", "unused.yml")
     monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
+    # Toy volumes sit far below the worth gate: zero it so the streamed machinery is exercised.
+    monkeypatch.setenv("KONFAI_STREAM_WORTH_THRESHOLD", "0")
 
     attribute = _geometry_attribute()
     model_volume = volume.clone()
@@ -489,6 +491,7 @@ def _drive_prediction(tmp_path, transforms, volume, monkeypatch, streamed=True, 
     class DummyManager:
         name = "CASE_000"
         patch = DummyPatch()
+        shapes: ClassVar[list[list[int]]] = [list(model_volume.shape[1:])]
         cache_attributes: ClassVar[list[Attribute]] = [Attribute()]
 
     class DummyDatasetIter:

--- a/tests/unit/test_trainer.py
+++ b/tests/unit/test_trainer.py
@@ -239,6 +239,29 @@ def test_broadcast_stop_adopts_rank_zero_decision(tmp_path: Path, monkeypatch) -
     assert trainer._broadcast_stop(True) is False  # a non-zero rank keeps going when rank 0 does
 
 
+# ---- OOM shrink rendezvous agreement ----
+
+
+def test_agreed_patch_takes_the_per_axis_min_of_the_proposals() -> None:
+    # Ranks at their floor propose None and abstain; the survivors agree on the per-axis MIN so
+    # every rank trains the same grid.
+    assert trainer_module._agreed_patch([None, [1, 16, 16], [1, 12, 24]], [0, 0, 0]) == [1, 12, 16]
+
+
+def test_agreed_patch_is_none_when_every_rank_is_at_the_floor() -> None:
+    assert trainer_module._agreed_patch([None, None], [0, 0, 0]) is None
+
+
+def test_agreed_patch_diagnoses_a_crossed_collective_instead_of_a_type_error() -> None:
+    # An asymmetric OOM pairs this rendezvous with a still-training rank's own collective: the
+    # gathered payload is then not a candidate list. That must fail as a diagnosis, not as an
+    # opaque TypeError from min() or ValueError from zip().
+    with pytest.raises(TrainerError, match="not a patch candidate"):
+        trainer_module._agreed_patch([{"loss": 0.5}, [1, 16, 16]], [0, 0, 0])
+    with pytest.raises(TrainerError, match="not a patch candidate"):
+        trainer_module._agreed_patch([[1, 16], [1, 16, 16]], [0, 0, 0])  # wrong length = same diagnosis
+
+
 # ---- EarlyStopping ----
 
 

--- a/tests/unit/test_transform_locality_contract.py
+++ b/tests/unit/test_transform_locality_contract.py
@@ -265,12 +265,14 @@ def _kind_of(case: _Case) -> LocalityKind:
     return case.transform.patch_locality(_attributes(case.group)).kind
 
 
+# The kinds the READ dispatcher cannot honour: WHOLE_VOLUME by definition, and SLAB because its side
+# effect needs the slab's place in the written OUTPUT, which a patch read has no notion of.
+_READ_REFUSED_KINDS = (LocalityKind.WHOLE_VOLUME, LocalityKind.SLAB)
+
+
 def _streamable_cases() -> list[_Case]:
     return [
-        case
-        for cls in _builtin_transforms()
-        for case in _cases_of(cls)
-        if _kind_of(case) is not LocalityKind.WHOLE_VOLUME
+        case for cls in _builtin_transforms() for case in _cases_of(cls) if _kind_of(case) not in _READ_REFUSED_KINDS
     ]
 
 
@@ -307,10 +309,18 @@ def test_no_declaration_writes_to_the_case_metadata() -> None:
 
 
 def test_every_locality_kind_is_exercised() -> None:
-    # The property below is only as good as the kinds it reaches: every streamable kind must have at
-    # least one built-in standing for it, so a regression in one kind's dispatch cannot pass unseen.
+    # The property below is only as good as the kinds it reaches: every read-streamable kind must have
+    # at least one built-in standing for it, so a regression in one kind's dispatch cannot pass unseen.
     kinds = {_kind_of(case) for case in _streamable_cases()}
-    assert kinds == set(LocalityKind) - {LocalityKind.WHOLE_VOLUME}
+    assert kinds == set(LocalityKind) - set(_READ_REFUSED_KINDS)
+
+
+def test_slab_declaration_refuses_the_read_path(dataset: Dataset) -> None:
+    # SLAB is a write-side contract (stream_slab gets the region); a read chain carrying it must fall
+    # back to the whole volume rather than run the stage without its side effect's context.
+    case = _CASES["InferenceStack"][0]
+    assert _kind_of(case) is LocalityKind.SLAB
+    assert not _manager(dataset, case).can_stream_patch(0)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_vram_sizing.py
+++ b/tests/unit/test_vram_sizing.py
@@ -167,6 +167,7 @@ def _predictor(out_channels, nb_augmentation, reduction, margined, candidate=Non
     predictor = Predictor.__new__(Predictor)
     predictor._vram_patch_template = [0, 0, 0]
     predictor._vram_patch_candidate = candidate
+    predictor._downsampling_factor = None
     predictor.dataset = _Data([100, 100, 100])
     predictor.model = _Model(out_channels)
     predictor.combine = Mean()


### PR DESCRIPTION
Top of the streaming stack (on #53 `refactor/loading-regime`). Everything after the loading-regime refactor, integrated, adversarially reviewed and re-benchmarked.

## What lands here
- **Streamed TTA** — per-copy sliding windows + a `SlabAligner` joint reduce, bit-exact for Mean/Median/Concat; `InferenceStack` becomes a `SLAB` side-write; the prediction mapping interleaves patches along the slab axis.
- **Perf cluster** — single-window `StreamingAccumulator` (the double-buffer slide cost +3.2 GB VRAM for no GPU-time gain), overlapped disk writes, pooled h5 read handles.
- **Free-axis auto-sizing** — `Network.downsampling_factor()` reads the model's input divisor off the graph; a free (`0`) patch axis sizes itself to a valid multiple in predict AND train; the accumulator/blend free-axis bugs are fixed (byte-identical, `[96,0,0]` == `[96,224,256]` e2e).
- **More of the finalize chain streams** — `Mask` (SLAB), the **linear resample inverse by default** (`KONFAI_STREAM_LINEAR_RESAMPLE=0` for bit-exactness), and an unsatisfied `Save` cache materialized slab by slab (`[Clip, Save, Standardize]` now streams).
- **Correctness/robustness** — `DataStream` entries invisible until finalize (per-stream temporary + rename, all three backends), `locking=False` on every h5 open so a pooled reader never blocks another process's write, one generic worth rule (`_worth_streaming`) that keeps a memory-light case (2.5D) on the whole-volume path.

## Verification
- Two adversarial review passes (correctness: 2 reproduced concurrency races fixed; elegance: shared paths deduplicated).
- Full core suite (unit + integration) green; mypy + ruff clean.
- Re-benchmark (RTX PRO 5000, main vs branch): TotalSeg-L & MRSeg-L go from RAM-killed to completing (19.3 GB / 6.2 GB); TotalSeg-M / MRSeg-M cut VRAM ~4-6 GB at neutral wall; ImpactSynth stays on the assembled path, byte-identical. Boundary flips only from the linear default (~0.006%).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added slab-based streaming for masks and streamed TTA reductions, including improved multi-copy prediction ordering.
  * Streamed “Save” can materialize via sweep-based caching when supported; streamed disk writes can run asynchronously with `finalize_writes()` ensuring completion.
  * Added model downsampling-factor analysis to improve free-axis sizing and OOM recovery behavior.
* **Bug Fixes**
  * Improved streaming readiness and region-write lifecycle handling; clearer guidance for worker crashes.
  * Enhanced linear (float) resampling streaming accuracy, with `KONFAI_STREAM_LINEAR_RESAMPLE=0` for exact whole-volume resampling.
* **Documentation**
  * Updated memory budgeting and streaming-regime guidance, plus float resampling caveats.
* **Chores**
  * Expanded streaming, caching, async-write, patching, and downsampling-factor test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->