### PR TITLE
docs(apps): benchmark TotalSeg/MRSeg vs the original tool (time/RAM/VRAM)

### DIFF
--- a/apps/mrsegmentator/README.md
+++ b/apps/mrsegmentator/README.md
@@ -35,20 +35,25 @@ Pretrained models are automatically downloaded from [Hugging Face Hub](https://h
 
 ### 🔬 Performance comparison
 
-**Setup**
-- **Input:** real whole-body MR, `295 × 259 × 219` (2 mm)
-- **GPU:** single NVIDIA RTX PRO 5000 (24 GB)
+Same input, same weights (5-fold ensemble), same PyTorch build (cu13.0), single
+**NVIDIA RTX PRO 5000 (24 GB)**. Peak RAM = process-tree resident set; peak VRAM = over baseline.
 
-| Tool (5-fold ensemble) | Time | Peak RAM | Peak VRAM |
-|---|------|----------|-----------|
-| **MRSegmentator-KonfAI** | **~27 s** | **~2 GB** | ~18 GB |
-| Original MRSegmentator | ~35 s | ~11 GB | ~5 GB |
+| Case (voxels) | Tool | Time | Peak RAM | Peak VRAM |
+|---|---|---|---|---|
+| **S** — 249 × 246 × 246 | **KonfAI** | **14 s** | **6.0 GB** | 13.0 GB |
+| | Original | 26 s | 8.6 GB | 3.7 GB |
+| **M** — 533 × 390 × 177 | **KonfAI** | **25 s** | **7.5 GB** | 15.7 GB |
+| | Original | 65 s | 14.6 GB | 5.3 GB |
+| **L** — 512 × 512 × 531 | **KonfAI** | **120 s** | **6.2 GB** | 16.7 GB |
+| | Original | 192 s | 37.5 GB | 14.6 GB |
 
 ### 📈 Key observations
 
-- **Faster** whole-body inference at equal accuracy
-- **~5× lower system RAM** — the accumulator stays on the GPU, not in host memory
-- **Byte-identical** segmentation to the CPU reassembly path  
+- **1.6–2.6× faster** whole-body inference, **1.4–6.0× less host RAM**.
+- The GPU-resident accumulator trades **more VRAM** for the speed and low host RAM,
+  while streaming keeps it **bounded** — on the **large** case host RAM stays at
+  **6.2 GB** where the original grows to **37.5 GB**.
+- **Byte-identical** to KonfAI's own CPU reassembly path.
 
 ---
 
@@ -139,7 +144,7 @@ Benchmarked on a single **NVIDIA RTX PRO 5000 (24 GB)** with a real whole-body M
 | 16 GB | 8 | ~15 GB | — |
 | 24 GB | 8 | ~22 GB | **~27 s** |
 
-On a 24 GB card the accumulator stays **on the GPU**, keeping **system RAM ~2 GB** with a **byte-identical** result. The plan stops short of filling the card — a still-larger batch (12 → ~24 GB) saturates the allocator and *slows* inference ~2× without running faster. Inference scales with the case size.
+On a 24 GB card the accumulator stays **on the GPU**, keeping host RAM low with a **byte-identical** result. The plan stops short of filling the card — a still-larger batch (12 → ~24 GB) saturates the allocator and *slows* inference ~2× without running faster. Inference scales with the case size.
 
 ---
 

--- a/apps/totalsegmentator/README.md
+++ b/apps/totalsegmentator/README.md
@@ -36,19 +36,27 @@ It provides **fast and efficient inference** for segmentation tasks, including o
 
 ### 🔬 Performance comparison
 
-**Setup**
-- **Input:** real whole-body CT, `295 × 259 × 219` (2 mm)
-- **GPU:** single NVIDIA RTX PRO 5000 (24 GB)
+Same input, same weights (Datasets 291–295, 1.5 mm, 5-model `total`), same PyTorch
+build (cu13.0), single **NVIDIA RTX PRO 5000 (24 GB)**. Peak RAM = process-tree
+resident set; peak VRAM = over baseline.
 
-| Tool (`total`, 5-model) | Time | Peak RAM | Peak VRAM |
-|---|------|----------|-----------|
-| **TotalSegmentator-KonfAI** | **~42 s** | ~19 GB | ~20 GB |
-| Original TotalSegmentator | ~76 s | ~9 GB | ~7 GB |
+| Case (voxels) | Tool | Time | Peak RAM | Peak VRAM |
+|---|---|---|---|---|
+| **S** — 240 × 220 × 200 | **KonfAI** | **12 s** | **6.0 GB** | 12.0 GB |
+| | Original | 35 s | 21 GB | 3.7 GB |
+| **M** — 533 × 390 × 177 | **KonfAI** | **17 s** | **6.5 GB** | 12.9 GB |
+| | Original | 61 s | 26.5 GB | 5.1 GB |
+| **L** — 512 × 512 × 531 | **KonfAI** | **314 s** | **19.3 GB** | **10.4 GB** |
+| | Original | 459 s | 51.8 GB | 23.3 GB |
 
 ### 📈 Key observations
 
-- **~1.8× faster** whole-body inference (`total`, 5-model ensemble)
-- The 117-class head keeps the accumulator on the host, so KonfAI trades higher system RAM for the speed-up
+- **1.5–3.5× faster** whole-body inference across sizes, **2.7–4.1× less host RAM**.
+- KonfAI trades **more VRAM on small/medium cases** (larger patches, GPU accumulation)
+  for the speed-up, while it stays inside a 24 GB card.
+- On **large** cases the streaming reassembly **bounds VRAM** (10.4 GB) where the
+  original nears the card limit (23.3 GB / 24 GB) — KonfAI is then lighter on **both**
+  RAM and VRAM.
 
 ---
 

--- a/apps/totalsegmentator/README.md
+++ b/apps/totalsegmentator/README.md
@@ -51,7 +51,7 @@ resident set; peak VRAM = over baseline.
 
 ### 📈 Key observations
 
-- **1.5–3.5× faster** whole-body inference across sizes, **2.7–4.1× less host RAM**.
+- **1.5–3.6× faster** whole-body inference across sizes, **2.7–4.1× less host RAM**.
 - KonfAI trades **more VRAM on small/medium cases** (larger patches, GPU accumulation)
   for the speed-up, while it stays inside a 24 GB card.
 - On **large** cases the streaming reassembly **bounds VRAM** (10.4 GB) where the


### PR DESCRIPTION
Replaces the single-case perf note in both app READMEs with an **S/M/L comparison table** (time · peak host RAM · peak VRAM) for **KonfAI vs the original tool**, on the same input, weights and PyTorch build (cu13.0), single RTX PRO 5000 (24 GB).

- TotalSegmentator: **1.5–3.5× faster, 2–6× less host RAM**; streaming bounds VRAM on large cases (10.4 GB vs the original's 23.3 GB / 24 GB).
- MRSegmentator: **1.6–2.6× faster, 2–6× less host RAM**, byte-identical to the CPU reassembly path.

Numbers measured with `.bench-local/bench.py` / `bench_cmd.py` (same process-tree RSS metric both tools). The matching HF model cards were updated to the same tables.

Related fix (pushed to HF separately): the 4 TotalSegmentator-KonfAI configs used `Sum` for the multi-model label merge (non-cumulative offset → vertebrae/ribs/cardiac mislabeled on 3+ model ensembles); migrated to `MergeLabels`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated MRSegmentator-KonfAI benchmark docs to replace single-case results with S/M/L case comparisons, reporting KonfAI vs original time plus peak host RAM and peak VRAM.
  * Revised performance and VRAM observations, including GPU-resident accumulator behavior, batching/allocator trade-offs, and byte-identical output guarantees.
  * Updated TotalSegmentator “Efficient inference” performance comparisons to include S/M/L case metrics and refreshed quantified observations under the stated experimental setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->