### PR TITLE
spike(konfai-rs): portable Rust/Burn inference engine (WIP)

### DIFF
--- a/RUST_BURN_IMPLEMENTATION_PLAN.md
+++ b/RUST_BURN_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,153 @@
+# konfai-rs — Implementation Plan (portable inference engine)
+
+> Companion to [`RUST_BURN_ROADMAP.md`](RUST_BURN_ROADMAP.md) (the *why*). This is the *how*.
+> Status: **plan only — no code written yet. Nothing is pushed.**
+> **Base branch:** `pr/audit-followup`. **Work branch:** `konfai-rs`.
+
+## 0. Goal & scope (decided)
+
+Build **`konfai-rs`** — a **portable inference engine** (one Rust/Burn crate, a separate package sibling to `konfai-apps`/`konfai-mcp`) that runs the **feed-forward inference** of a KonfAI model from an exported `.onnx`, with **no Python at inference time**.
+
+**The engine is one codebase; the browser is one compile target, not the identity.** From the same crate:
+
+```
+                 konfai-rs  (ONNX→Burn + patch tiling + I/O)
+        ┌──────────────┬──────────────────┬────────────────────┐
+   native binary     WASM + WebGPU     embeddable lib        (future)
+   CUDA/Metal/CPU      browser           Slicer / edge        server/batch
+```
+
+- **First validated target:** **native** (CPU Flex + WGPU) — fastest to iterate and debug, and itself a useful deliverable (edge / offline clinic / Slicer / server).
+- **Showcase target:** the **browser** (WASM + WebGPU), layered on top once the native core is proven.
+- **First model:** **IMPACT-Synth** — synthetic-CT (sCT) generation from MR / CBCT (`VBoussot/ImpactSynth`, a supervised CNN generator, resolved today through `KonfAIApp`). Feed-forward → a valid candidate.
+- **Parity metric:** synthesis → **MAE / PSNR on HU values** (+ SSIM), *not* Dice.
+- **Out of scope (MVP):** training, TTA, ensembling, MC-dropout (`--tta/--ensemble/--mc`), registration/diffusion apps. Single deterministic forward only.
+
+The KonfAI Python core is **not touched**. `konfai-rs` is additive and lives on its own branch/package.
+
+## 1. The one architectural principle
+
+**Push everything ONNX can express into the exported graph; keep Rust thin.**
+
+| Stage | Where | Note (synthesis-specific) |
+|---|---|---|
+| Input normalization (MR/CBCT intensity → model range) | **ONNX graph** | data-dependent stats via ReduceMin/Max/Mean |
+| Resample / resize | **ONNX graph** (`Resize`) | if the app resamples |
+| Generator forward | **ONNX → Burn** (Flex/WGPU/CUDA/Metal) | the point |
+| Output **HU denormalization + clamp/Tanh** | **ONNX graph** | sCT must come out in HU; fold the inverse-normalize in |
+| File parse + geometry (Origin/Spacing/Direction) | **Rust** | not expressible in ONNX |
+| 3D patch sliding-window + overlap blend | **Rust** | control flow over tiles |
+| TTA / ensemble / MC | deferred | orchestration over many forwards |
+
+This keeps the engine small and concentrates risk on **(a) burn-onnx import of the generator** and **(b) I/O + tiling** — identical regardless of native vs browser target.
+
+## 2. Hard problems, named up front
+
+1. **What to export.** IMPACT-Synth is a routed `ModuleArgsDict`; export the **inference forward path / prediction output module** the `Predictor` consumes, at a **fixed patch size**, opset 17.
+2. **Synthesis op coverage in burn-onnx.** Generators often use **InstanceNorm** (reported supported), **ReflectionPad** (ONNX `Pad` mode=reflect — *verify*), **ConvTranspose / Resize upsampling**, **Tanh/clamp**. The spike must confirm these import.
+3. **burn-onnx import reliability** (not op coverage) — the real failure mode (burn-onnx #18). **Phase 0 gates everything.**
+4. **In-browser medical I/O** (later phase). The `nifti` Rust crate may not target WASM cleanly → may parse in JS and hand a typed array to WASM. DICOM deferred. (Native target has no such constraint.)
+5. **WebGPU availability** (later phase). WGPU-in-WASM only where the browser ships WebGPU; a 3D generator on Flex-CPU-WASM is likely too slow → treat WebGPU as required in-browser, message unsupported browsers. (Native target uses CUDA/Metal/CPU freely.)
+6. **Model provenance/licensing.** IMPACT-Synth weights live on HF; confirm redistribution terms before bundling an exported `.onnx` in a public demo.
+
+## 3. Phased plan (native-first, browser layered on top)
+
+Each phase: deliverable · key files · tests/benchmarks · **GO/NO-GO gate** · effort.
+
+---
+
+### Phase 0 — Spike / decision gate ⟵ START HERE
+**Make-or-break. Build nothing permanent until this passes. Native only — the cheapest test of the riskiest assumption.**
+
+- **Steps:**
+  1. Resolve an IMPACT-Synth model via `KonfAIApp("VBoussot/ImpactSynth:<model>")`; read its `Prediction.yml` for `patch_size`, groups, normalization; confirm 2.5D vs 3D.
+  2. `torch.onnx.export` the underlying generator `nn.Module` at that fixed `patch_size`, opset 17, **folding input-normalize + HU-denormalize into the graph**.
+  3. `onnxruntime` parity vs torch (MAE ≤ 1 HU, high PSNR) — validates the export *before* blaming Burn.
+  4. `burn-onnx` `ModelGen` (`build.rs`) → one native binary → run a patch on **Flex (CPU)** then **WGPU**; parity vs the onnxruntime reference.
+- **Files (throwaway `spike/`, not committed to the product):** `spike/export_impact_synth.py`, `spike/konfai-rs-spike/{Cargo.toml,build.rs,src/main.rs}`.
+- **GATE:**
+  - **GO** → generator imports + compiles + matches torch (MAE ≤ 1 HU) on CPU **and** WGPU. Proceed to Phase 1.
+  - **NO-GO** → import/compile failure (likely InstanceNorm/ReflectionPad/ConvTranspose) or numeric divergence unfixable in <1–2 days. **Park**, write up the failing op(s), revisit next Burn release.
+- **Effort:** 1–3 days.
+
+---
+
+### Phase 1 — ONNX export (Python, no-regret value)
+**Productionize the spike's export. Valuable even if Burn is dropped (general interop; ONNXRuntime-Web is a fallback deploy path).**
+
+- **Files:** `konfai/export/__init__.py`, `konfai/export/onnx.py` — `export_to_onnx(model, patch_size, output_module, opset=17, fold_pre=True, fold_post=True)`; `konfai/main.py` — `EXPORT` CLI state (mirrors PREDICTION) or a `konfai-export` entrypoint; docs.
+- **Tests:** `tests/unit/test_onnx_export.py` — onnxruntime-vs-torch parity (MAE/PSNR); assert opset ≥16, fixed dims, HU range preserved. Update `tests/unit/test_config.py` if config binding added.
+- **Deps:** declare `onnx`/`onnxruntime` as an `export` extra in `pyproject.toml` **in the same commit** (AGENTS.md §13.4).
+- **GATE:** parity test green in CI. Proceed to Phase 2.
+- **Effort:** 3–5 days.
+
+---
+
+### Phase 2 — `konfai-rs` native core + CLI (the primary deliverable)
+**A usable, Python-free inference binary. Separate package, off the wheel.**
+
+- **Files:**
+  - `konfai-rs/Cargo.toml` — deps `burn`, `burn-onnx` (build), feature flags `wgpu`/`cpu`(Flex)/`cuda`/`metal`; `crate-type` includes `cdylib` (for the later WASM target).
+  - `konfai-rs/build.rs` — `ModelGen` over `konfai-rs/models/impact_synth.onnx`.
+  - `konfai-rs/src/{lib.rs,model.rs,infer.rs,patch.rs,tensor_io.rs}` — `infer_patch`, sliding-window + overlap-blend (port of `patching.py`, deterministic order per AGENTS.md §10), `.safetensors`/`.npy` tensor I/O.
+  - `konfai-rs/src/bin/cli.rs` — `konfai-rs infer --model … --input … --backend {cpu,wgpu,cuda}`.
+  - `konfai-rs/tests/parity.rs` — Burn output vs committed onnxruntime reference (MAE/PSNR tolerance).
+  - `konfai-rs/README.md`, CI `.github/workflows/konfai-rs.yml` (own workflow; **not** in the wheel build).
+- **Benchmarks:** `konfai-rs/benches/` (criterion) — per-patch latency torch(CUDA) vs Burn(WGPU/CUDA); **binary size + cold-start**.
+- **GATE:** native parity green on CPU + WGPU; benchmarks recorded. This is already shippable as an edge/Slicer/server binary. Proceed to Phase 3.
+- **Effort:** ~1 week.
+
+---
+
+### Phase 3 — Browser target: WASM + WebGPU (the showcase)
+**The same crate, compiled to WASM, running on WebGPU in a browser tab.**
+
+- **Files:**
+  - `konfai-rs/src/wasm.rs` — `wasm-bindgen` exports (`init`, `infer_patch(Float32Array, dims) -> Float32Array`); WGPU backend init from the browser GPU device.
+  - `konfai-rs/web/{index.html,main.js,vite.config.*}` — load the WASM, feed a patch, render output; clear "WebGPU unavailable" message.
+  - `konfai-rs/web/tests/` — Playwright smoke (model loads + runs one patch in headless WebGPU).
+- **GATE:** model runs one patch in a real WebGPU browser; output matches the native reference; WASM size + first-inference latency recorded. Proceed to Phase 4.
+- **Effort:** 1–2 weeks.
+
+---
+
+### Phase 4 — Full pipeline (native first, then browser)
+**End-to-end: a volume in → sCT out, with no server.**
+
+- **Files:**
+  - `konfai-rs/src/io/{mod.rs,nifti.rs}` (+ `mha.rs`) — parse to typed array + geometry; native uses the Rust crate, browser decides Rust/WASM vs JS by what compiles.
+  - `konfai-rs/src/pipeline.rs` — `parse → (graph pre) → 3D tile → per-patch forward → overlap blend → (graph post) → sCT volume`.
+  - `konfai-rs/web/` — upload UI, slice viewer (canvas), sCT download (NIfTI) / overlay.
+- **GATE:** full-volume sCT (native, then browser) matches the Python `Predictor` output within tolerance (MAE/PSNR) on a fixture case.
+- **Effort:** 2–3 weeks (tiling + geometry + viewer).
+
+---
+
+### Phase 5 — Package polish & reuse (stretch)
+- Package the deliverable (native binaries per platform; static web build / npm), demo page, docs.
+- Embeddable lib reuse: Slicer plugin / edge / batch server from the same crate.
+- Optionally re-add **TTA / ensemble / MC-dropout** as multi-forward orchestration in Rust.
+- **Effort:** 1–2 weeks.
+
+## 4. Cross-cutting conventions
+
+- **Separate package, off the wheel, own branch.** `konfai-rs` mirrors `konfai-mcp`/`konfai-apps`: own `Cargo.toml`/build, own tests + CI, never imported by core, depends only on the public API + the exported `.onnx`. Lives on the **`konfai-rs` branch (based on `pr/audit-followup`)**, **local-only for now (no push)** — same posture as the `konfai-mcp` branch.
+- **Parity-first.** Every phase validates against a torch/onnxruntime reference within a fixed tolerance; parity dumps are committed fixtures.
+- **No new core runtime deps** (AGENTS.md §13.4). The Python side adds only an ONNX exporter; `onnx`/`onnxruntime` become an `export` extra declared in the same commit.
+- **Commits:** Conventional Commits, no AI branding/trailers (AGENTS.md §12). **No push without an explicit ask.**
+
+## 5. First concrete actions (next steps)
+
+1. **Toolchain** — installing now: Rust (`rustup`/`cargo`) + `wasm32` target; `onnx`/`onnxruntime` in the Pixi dev env. (Pixi dev already has torch 2.12 + konfai.)
+2. **Run Phase 0 spike** against an IMPACT-Synth model (download via `KonfAIApp`) → GO/NO-GO report appended to the roadmap.
+3. If GO → open Phase 1 (`feat/onnx-export`) as the first real, no-regret commit on this branch.
+
+> We do **not** scaffold `konfai-rs` until Phase 0 is GO. The spike is the cheapest test of the riskiest assumption (does the IMPACT-Synth generator import into burn-onnx and run?).
+
+## 6. Open decisions to confirm
+
+1. **IMPACT-Synth patch geometry:** 2.5D or 3D? (Read from the model's `Prediction.yml` in Phase 0 — drives tiling.)
+2. **Browser input format (Phase 4):** NIfTI upload (likely); DICOM in-browser deferred? 2D slice vs full 3D volume?
+3. **Output UX:** download sCT as NIfTI, render slices in-canvas, or both?
+4. **Weights/license:** are IMPACT-Synth weights redistributable as an exported `.onnx` for a public demo?
+5. **First shippable surface to prioritize after the spike:** native edge binary, Slicer plugin, or browser demo? (All come from the same crate; this is about ordering Phases 3–5.)

--- a/RUST_BURN_IMPLEMENTATION_PLAN.md
+++ b/RUST_BURN_IMPLEMENTATION_PLAN.md
@@ -136,6 +136,55 @@ Each phase: deliverable · key files · tests/benchmarks · **GO/NO-GO gate** ·
 - **No new core runtime deps** (AGENTS.md §13.4). The Python side adds only an ONNX exporter; `onnx`/`onnxruntime` become an `export` extra declared in the same commit.
 - **Commits:** Conventional Commits, no AI branding/trailers (AGENTS.md §12). **No push without an explicit ask.**
 
+## 4b. konfai-apps integration — the seam, runtime selector, and manifest contract
+
+Mapped from the konfai-apps source. konfai-rs is a **runtime**, not a surface; it plugs into konfai-apps at exactly **one seam** and leaves everything else untouched.
+
+**The run flow & the seam.** `KonfAIApp.infer()` (`konfai-apps/konfai_apps/app.py`) runs under `@run_distributed_app` (isolated temp workspace) and:
+1. `_write_inputs_to_dataset()` → symlinks inputs into `./Dataset/P{idx}/Volume_{i}`,
+2. `app_repository.install_inference()` → downloads `.pt` + `.yml` + `.py`, pip-installs `requirements.txt`,
+3. **`konfai.predictor.predict(models_path, …, Prediction.yml)`** ← **THE SEAM** (`app.py:900`),
+4. torch forward (`predictor.py:565` → `network.py:710`), writes `./Predictions/`,
+5. `copytree(./Predictions → output)`.
+
+**Runtime selector.** Branch at `app.py:900` on an `app.json` `runtime` field:
+```
+runtime: pytorch  → konfai.predictor.predict(.pt, Prediction.yml)            # today
+runtime: portable → konfai_rs(model.onnx, manifest.json, ./Dataset → ./Predictions)
+```
+A `--runtime {pytorch,portable}` flag is added in `cli.py:add_common_konfai_apps`; the dispatch branch sits just before the `predict()` call.
+
+**What stays in konfai-apps (Python) vs moves to konfai-rs (Rust):**
+
+| Stays in konfai-apps | Moves to konfai-rs |
+|---|---|
+| App resolution Local/HF/Remote; download/cache | Load `model.onnx` |
+| `./Dataset/P*/Volume_*` layout + input symlinking | Read `./Dataset`, geometry-aware |
+| `./Predictions` collection → output | Patch sliding-window + overlap blend; write `./Predictions` (same layout) |
+| Surfaces: CLI, FastAPI server, remote client, SSE | Forward + reduction (Mean/Median for TTA/ensemble) |
+| VRAM-aware config mutation; `app.json` schema | Pre/post folded into the ONNX graph |
+
+**The contract = `model.onnx` + `manifest.json`.** Proposed minimal manifest (produced by the Phase-1 exporter, consumed by konfai-rs):
+```json
+{
+  "konfai_rs_manifest": 1,
+  "model": "model.onnx",
+  "input":  { "name": "input",  "group": "Volume_0", "channels": 5, "dtype": "f32" },
+  "output": { "name": "output", "group": "sCT",      "channels": 1, "dtype": "f32" },
+  "patch":  { "size": [256, 256], "overlap": [0, 0], "dim": 2, "extend_slice": 2 },
+  "preprocess_in_graph": true,
+  "postprocess_in_graph": true,
+  "reduction": "mean",
+  "geometry": "preserve_from_input"
+}
+```
+
+**Distribution.** `app_repository.install_inference` gains a `portable` branch: download `model.onnx` + `manifest.json` instead of `.pt`. The bundle on HF/Local/Remote carries both, so an app can ship *both* runtimes and the selector picks.
+
+**Trust win.** The `portable` path performs **no `pip install`, no `torch.load(weights_only=False)` pickle, no arbitrary `.py` import** — the model is just an ONNX graph + a fixed Rust runtime (`AUDIT.md` §4b).
+
+**Browser.** The FastAPI server (`app_server.py`) can `StaticFiles`-mount the konfai-rs WASM bundle + `model.onnx`; execution is 100% client-side — konfai-apps distributes, konfai-rs executes.
+
 ## 5. First concrete actions (next steps)
 
 1. **Toolchain** — installing now: Rust (`rustup`/`cargo`) + `wasm32` target; `onnx`/`onnxruntime` in the Pixi dev env. (Pixi dev already has torch 2.12 + konfai.)

--- a/RUST_BURN_ROADMAP.md
+++ b/RUST_BURN_ROADMAP.md
@@ -1,0 +1,212 @@
+# KonfAI × Rust / Burn — Strategy & Roadmap
+
+> Status: **RFC / decision document.** No code in the core is changed by this proposal.
+> Companion to [`AUDIT.md`](AUDIT.md) and [`AGENTS.md`](AGENTS.md). Read those first for the architecture.
+
+This document answers a single strategic question raised internally (Matt → Burn, `https://burn.dev`):
+
+**Should KonfAI move toward Rust / Burn — a full version, a Rust layer, or a Burn integration for some parts — or stay Python/PyTorch?**
+
+The analysis below is grounded in the *actual* KonfAI code (file:line references) and in dated facts about Burn (mid-2026), not in intuition. It is deliberately critical.
+
+---
+
+## TL;DR
+
+**Keep the core (training + research) in Python/PyTorch. Burn is not a PyTorch replacement today. But Burn's portability (WebGPU/WASM, single self-contained binary, one codebase across CPU/CUDA/Metal/browser) maps onto a real KonfAI gap: *deployment of inference* — and specifically the `konfai-apps` packaged-model layer (§4.1), where today running one model requires a full Python + torch + imaging stack and the execution of arbitrary downloaded code. The correct entry point is neither a Burn backend inside the network core, nor a Rust preprocessing layer, but a separate `konfai-rs` crate dedicated to portable inference of the feed-forward subset of already-trained models — gated behind one decisive spike: does a KonfAI 3D U-Net survive `torch → ONNX → burn-onnx` import?**
+
+---
+
+## 1. What the code actually says (not intuition)
+
+Three findings reframe the entire question.
+
+### 1.1 Preprocessing is already torch, not slow Python
+
+| Module | `torch.` | `np.` | `sitk.` |
+|---|---|---|---|
+| `konfai/data/transform.py` | 147 | 10 | 12 |
+| `konfai/data/augmentation.py` | 142 | 8 | — |
+| `konfai/data/patching.py` | 29 | 4 | — |
+
+`Resample` already runs `F.interpolate` (trilinear) **on GPU** when the tensor is on device (`konfai/data/transform.py:386-399`). The math is already delegated to torch's C++/CUDA kernels.
+
+➡️ **The "Rust for fast preprocessing" thesis is dead on arrival.** The only Python overhead left is per-patch *orchestration* (the `DataLoader.__getitem__` loop), which is solved with `num_workers` / streaming — not by rewriting tensor math in Rust. The real bottleneck of a medical run is the **GPU forward/backward**, not the CPU.
+
+### 1.2 I/O is already delegated to mature C/C++ libraries
+
+`SimpleITK`, `h5py`, `zarr`, `pydicom` do the heavy lifting. The only genuinely pure-Python hot spots:
+
+- DICOM series sort/read — non-vectorised Python loops, redundant series re-discovery on sliced reads (`konfai/utils/dicom.py:163-179`, `:310-369`, `:397-427`).
+- `Attribute` stringify/reparse per access (`konfai/utils/dataset.py:68-95`).
+
+These are micro-optimisations, not a transformation. A Rust DICOM crate would duplicate GDCM/pydicom with **worse** coverage.
+
+### 1.3 The model/training core is 100% torch-coupled — not "swappable"
+
+- `ModuleArgsDict(torch.nn.Module, ABC)` at `konfai/network/network.py:478` — the routed graph **is** an `nn.Module`. Routing metadata is a layer *on top of* torch; it does **not** abstract the backend.
+- `named_forward` is built on `torch.utils.checkpoint`, `isinstance(module, torch.nn.Module)` dispatch, manual `.to()` device moves (`network.py:663-722`).
+- KonfAI's distinctive features — `outputs_criterions` attached to **named** module outputs, `alias`-based pretrained-weight remapping, deep supervision — depend on torch `state_dict`/`named_parameters` introspection (`network.py:860-944`).
+- `GradScaler`, `autocast`, DDP, `torch.optim`: all torch (`network.py:1104`, `:1310-1328`; `trainer.py:307-312`).
+
+➡️ **Putting a Burn backend "under" the `Network` is not an abstraction, it's a rewrite** that would have to reinvent named routing + alias remapping + checkpointing.
+
+### 1.4 The MCP/agent layer is backend-agnostic
+
+`konfai-mcp/konfai_mcp/server.py` only ever sees YAML strings, subprocess jobs, and JSON metrics. The reflection engine (`apply_config`, `inspect.signature`) runs *inside the runtime*, after the job subprocess starts — not in the agent layer.
+
+➡️ **Burn neither helps nor hurts the agentic loop.** It would just need a CLI + a config surface. The MCP loop is neutral with respect to the compute backend.
+
+### 1.5 There is no ONNX/TorchScript export of KonfAI's own models today
+
+The only `torch.jit.load` usage loads *third-party* perceptual/IMPACT loss models (`konfai/metric/measure.py`). Any "deploy via Burn" path must **build the export first**.
+
+---
+
+## 2. Burn reality check (dated, mid-2026)
+
+| Dimension | Reality | Verdict |
+|---|---|---|
+| **Overall maturity** | v0.21.0 (2026-05-07), **still pre-1.0** after ~3 years. API not stabilised; churn between minors. Backing is real though: Tracel AI ($3M seed), ~15.5k GitHub stars, 3 substantive releases (0.19→0.21) in ~7 months targeting training/distributed gaps. | ⚠️ Young but well-funded, steep trajectory |
+| **Backends** | CUDA, ROCm, Metal, Vulkan, **WebGPU**, LibTorch, Cpu(CubeCL), **Flex** (replaces ndarray; WASM/no_std). Autodiff + Fusion + Remote = *composable* backend decorators. **CubeCL** = "write the kernel once, run everywhere". | ✅ **Excellent — the real asset** |
+| **Training** | Mature autodiff, `LearnerBuilder` (checkpointing, early-stopping, grad-accum, multi-device). Optimizers SGD/Adam/AdamW/RmsProp/Adan; schedulers cosine/Noam/step/linear. | ⚠️ OK, but **distributed = least-settled area** (0.19+), no LAMB/OneCycle/ReduceLROnPlateau, thin third-party ecosystem |
+| **ONNX import** | New `burn-onnx` crate (~May 2026; old `burn-import` ONNX path now *legacy*). **Build-time codegen**, not a runtime loader. **Opset 16+ required.** Op coverage is now **~75-80% (~230/300)** — GridSample, Einsum, InstanceNorm, LRN, **3D Conv/ConvTranspose**, Resize are all marked supported as of mid-2026. **So missing ops are no longer the main blocker.** The real risk is the gap between *op-on-paper* and *model-actually-imports*: mainstream CNNs (ResNet-50, MobileNet) still fail to import (burn-onnx issue #18). Dynamic shapes & control-flow (If/Loop) remain structural problems for a static-codegen importer. | ⚠️ **Risk #1 for 3D medical deployment — but it's import-pipeline reliability, not op coverage** |
+| **PyTorch weight import** | `PyTorchFileRecorder`/safetensors = **weights only**; you must have **hand-written the model in Rust** already. | ⚠️ Manual labour |
+| **WebGPU / WASM** | **Real and first-class.** Official in-browser demos (`mnist-inference-web`, `image-classification-web`). WGPU-in-WASM where the browser ships WebGPU; otherwise Flex CPU. "Same code across backends" portability genuinely holds. | ✅ **The killer feature** |
+| **Complex models** | Transformer primitives (MHA, encoder/decoder, RoPE, GQA) — but *low-level building blocks*, not an HF catalog. **SAM**: a single-dev hobby port (`karelnagel/sam-rs`), unmaintained; **no SAM2/SAM3**. **No first-class LoRA/PEFT** (hand-rolled). Thin official zoo (ResNet, RoBERTa, YOLOX). **Zero medical models, no nnU-Net, no MONAI.** Also: Burn's `grid_sample` is **2D-only** (`grid_sample_2d`, 0.20.0) → KonfAI's **3D VoxelMorph/registration cannot run on Burn** at all. | ⛔ **Exactly where medical research lives, Burn is empty** |
+
+### The three optimistic claims, refuted
+
+1. *"Burn can replace PyTorch for KonfAI training"* → **REFUTED.** Pre-1.0, unstable distributed, no medical/PEFT ecosystem, no pretrained weights. Researchers' time is the scarce resource; Burn would burn it.
+2. *"A train-in-PyTorch / deploy-in-Burn pipeline is reliable today"* → **REFUTED for "reliable enough to ship today".** The path exists and op coverage is now ~75-80% (3D conv, GridSample, Resize supported), so the blocker has **shifted from missing ops to import-pipeline reliability** — mainstream CNNs (ResNet-50, MobileNet) still fail to import (burn-onnx #18). Note too: "data on GPU end-to-end" is only literally true for the model *interior* — inputs still marshal through WASM linear memory. **This is exactly what the spike must test.**
+3. *"Rust would speed up preprocessing/IO beyond numpy+SITK+zarr"* → **MIXED, leaning refuted.** Already C/C++/torch — marginal gains, high friction. One genuine measured exception: **OME-Zarr decompression** via the Rust `zarrs`/`zarrs-py` crate (~3× on zarr reads), but contingent on actually using OME-Zarr (KonfAI's default + all examples use `.mha` → no win). And free-threaded Python (3.13/3.14) + a multithreaded DataLoader is a lower-effort path to the same GIL relief.
+
+---
+
+## 3. Options evaluated
+
+| Option | Effort | Real benefit | Risk / tech debt | Impact on current users | Verdict |
+|---|---|---|---|---|---|
+| **A — Do nothing** | 0 | Keeps velocity | None | None | ✅ **For the core** |
+| **B — Rust for some bricks** (preproc/IO/patch/metrics) | Medium-high | **Low** (already torch/C++) | FFI, two languages, complex build | Install friction | ⛔ Poor ROI (one narrow niche: DICOM decode, and even that competes with C libs) |
+| **C — Optional Burn backend inside `Network`** | **Very high** | Low | **Huge**: reinvent named routing + alias + checkpointing; two paths to keep in sync | Breakage risk | ⛔ A rewrite in disguise |
+| **D — Separate `konfai-rs` sub-project (inference)** | Medium (bounded) | **High** (portability, deployment) | Contained (isolated crate, like `konfai-mcp`) | **None** (does not touch the core) | ✅ **The right target** |
+| **E — Ambitious rewrite** | Massive | Negative short/medium term | Disperses the project; Burn pre-1.0 | Regressions | ⛔ Premature |
+
+**Recommendation: A for the core + D as an isolated strategic bet.** B, C, E are traps.
+
+---
+
+## 4. Target architecture
+
+```
+┌─────────────────────── PYTHON / PyTorch (unchanged) ───────────────────────┐
+│  Research · training · fine-tuning · challenges · MCP/agents · YAML configs │
+│  Dataset/transform/patching/augmentation (already torch, GPU-capable)       │
+│                                                                             │
+│   new, pure Python, useful on its own:  konfai export → ONNX (opset 16+)     │
+└────────────────────────────────┬────────────────────────────────────────────┘
+                                  │  trained model → .onnx (clean boundary)
+                                  ▼
+┌──────────────── konfai-rs (separate Rust crate, excluded from wheel) ───────┐
+│  burn-onnx (build-time codegen) → Burn Network → chosen backend:            │
+│     Flex (CPU/WASM) · WGPU (browser/GPU) · CUDA/Metal (desktop/edge)        │
+│  + ports the portable KonfAI logic: sliding-window patching + overlap blend │
+│  Targets: CLI binary · browser WASM module · Slicer plugin · edge server    │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+### What stays Python / what could move / what should use Burn
+
+- **Stays Python (do not touch):** declarative configs + reflection, datasets, transforms, training-side patching, models, losses, training metrics, training, fine-tuning, train CLI, MCP/agents, OME-Zarr/DICOM/NIfTI readers, challenge workflows.
+- **Could move to Rust/Burn:** *only* inference of frozen models + patch reassembly + post-processing, **plus** a new ONNX export (Python-side, but serves Burn).
+- **Does NOT use Burn:** training, KonfAI autograd, perceptual/IMPACT losses (TorchScript), anything touching SAM/LoRA.
+- **Not worth rewriting:** Rust preprocessing, a Burn backend inside `Network`, the config reflection engine.
+
+### 4.1 The pulling use case: `konfai-apps` portability
+
+The strongest concrete target is **`konfai-apps`** — the packaged-model / deployment layer, not the research core. This is where Burn's portability becomes a product advantage rather than a science project.
+
+Today a packaged app is `app.json` + `Prediction.yml` + custom `.py` + `.pt` weights, resolved from HuggingFace / local / remote, and run by **copying the app's `.py` into the working dir, importing it, and `pip install`-ing its `requirements.txt`** — i.e. a downloaded app **runs arbitrary code and arbitrary dependency installs** (see `AUDIT.md` §4b trust model), and needs a full Python + PyTorch + SimpleITK/h5py/zarr/pydicom environment to run *one inference*.
+
+A `konfai-rs` inference runtime would let a class of apps ship as a **self-contained artifact** instead:
+
+| `konfai-apps` today (Python) | `konfai-apps` + `konfai-rs` (portable) |
+|---|---|
+| Python + torch + imaging deps must be installed | Single static binary, or a WASM module |
+| Downloads & imports arbitrary `.py`, `pip install`s `requirements.txt` | **No arbitrary code execution** — model is the ONNX graph + fixed Rust runtime |
+| Server-side / workstation only | Browser, Slicer plugin, edge device, offline kiosk |
+| GPU optional but heavy stack | WGPU on whatever GPU is present; CPU fallback via Flex |
+
+This reframes the whole effort: the deliverable is **a portable inference target for the *feed-forward subset* of packaged apps** (segmentation/synthesis U-Nets — exactly the migratable subset in `AGENTS.md` §7). Apps whose `.py` carries genuine custom Python logic (diffusion sampling, registration grid math, custom training loops) stay on the Python runtime.
+
+**Delivery shape (decided):** rather than modifying `konfai-apps`, this ships as **its own separate package** — **`konfai-rs`**, a sibling to `konfai-apps`/`konfai-mcp` with its own build, tests/CI, and branch, depending only on the public API + an exported `.onnx`. It is a **portable inference *engine*, not a web project**: one Rust/Burn crate that compiles to a **native binary** (CUDA/Metal/CPU — edge/clinic/Slicer/server) *and* to **WASM + WebGPU** for the browser, from the same code. First validated target is **native** (fastest to iterate); the **browser is the showcase target**, layered on top. First model: the **IMPACT-Synth** sCT generator (`VBoussot/ImpactSynth`). See [`RUST_BURN_IMPLEMENTATION_PLAN.md`](RUST_BURN_IMPLEMENTATION_PLAN.md).
+
+> Caveat that keeps this honest: only apps whose model survives the ONNX → `burn-onnx` spike qualify, and apps with custom-`.py` inference logic do **not** become portable just by swapping the tensor backend. So this is a *subset* portability story, not "all apps become a binary".
+
+---
+
+## 5. PR roadmap
+
+### PR #1 (smart, minimal) — the decision + the decisive spike
+- **Branch:** `docs/rust-burn-strategy`
+- **Creates:** this `RUST_BURN_ROADMAP.md` (sibling to `AUDIT.md` for agent discoverability) + a spike protocol note.
+- **The spike (~1-2 days):** export the example U-Net (`examples/Segmentation`) to ONNX → `burn-onnx` codegen → run 1 patch → compare against the torch reference (tol 1e-3) → benchmark latency + binary size. **This is the go/no-go for the entire thesis.** Note the mid-2026 failure mode is *import-pipeline bugs* (does the generated Rust compile and run?), **not** missing ops — see burn-onnx issue #18 where mainstream CNNs still fail to import despite their ops being "supported".
+
+### PR #2 (pure Python, value independent of Burn) — ONNX export
+- **Branch:** `feat/onnx-export`
+- **Modifies:** `konfai/predictor.py` or a new `EXPORT` CLI state in `konfai/main.py`.
+- **Adds:** `konfai/export/onnx.py` (export a frozen `Network`, opset ≥16, handle named outputs).
+- **Tests:** `tests/unit/test_onnx_export.py` — onnxruntime-vs-torch parity on the example U-Net.
+- This PR has value **even if Burn is dropped** (ONNX = general interop). The best "no-regret" first step.
+
+### PR #3 (large but bounded, *only if the spike is GO*) — `konfai-rs`
+- **Branch:** `feat/konfai-rs-inference-poc`
+- **Creates an isolated crate (excluded from the wheel, like `konfai-mcp`):**
+  - `konfai-rs/Cargo.toml`, `konfai-rs/build.rs` (burn-onnx `ModelGen`), `konfai-rs/src/{main.rs,patch.rs,io.rs}` (CLI + sliding-window + overlap reassembly ported), `konfai-rs/README.md`
+  - `konfai-rs/benches/inference.rs` (criterion: torch CPU/CUDA vs Burn Flex/WGPU)
+  - `konfai-rs/tests/parity.rs` (Burn output vs ONNX reference, fixed tolerance)
+  - **Stretch:** `konfai-rs/web/` — WASM/WebGPU in-browser demo of the model.
+
+### Benchmarks to run
+- Single-patch latency: torch (CPU/CUDA) vs Burn (Flex/WGPU).
+- **Binary size + cold-start** (the deployment metric that matters).
+- Op coverage: how much of the 3D U-Net imports without manual patching.
+- Browser: does the model run *at all* via WGPU+WASM.
+
+### GO / NO-GO criteria
+- **GO if:** a KonfAI 3D U-Net survives `torch → ONNX → burn-onnx` **and** compiles **and** output ≈ torch (1e-3) **and** WGPU runs **and** the binary is meaningfully simpler to deploy than Python+torch+imaging.
+- **NO-GO / PARK if:** burn-onnx stumbles on conv3d / trilinear resample / dynamic shapes without manual patching; or numerical divergence; or maintaining two inference paths costs more than the deployment pain it removes. **Re-test at Burn 1.0.**
+
+---
+
+## 6. Principal risks
+
+1. **burn-onnx can't digest 3D segmentation** (conv3d/trilinear/dynamic) → the spike reveals this fast and cheap. *The right risk to take early.*
+2. **Project dispersion** — two languages, two implementations to keep in sync. Mitigated by *isolating* in an out-of-wheel crate, never in the core.
+3. **Pre-1.0 churn** — Burn API moves between versions. Mitigated by staying on inference (small surface).
+4. **Effort without a user** — building `konfai-rs` nobody uses. Mitigated by requiring a *pulling* use case (Slicer? browser? a specific Fideus partner?) before PR #3.
+5. **ONNX as a fragile boundary** — KonfAI named outputs ↔ ONNX. PR #2 handles this cleanly.
+
+---
+
+## 7. Questions to align with Matt / Fideus
+
+1. **Pulling use case — likely `konfai-apps` portability (§4.1).** Confirm: is the goal to ship packaged apps as a self-contained binary/WASM (no Python, no arbitrary-code trust issue), and for which delivery surface first — Slicer plugin? browser demo? edge/offline clinic? Which specific app(s) should be the first portable target?
+2. **Inference only — agreed?** Or does he actually picture Burn *training* (then the gaps must be shown: PEFT, distributed, medical zoo)?
+3. **"Data on GPU end-to-end":** preprocessing included, or only network→viz? (KonfAI preprocessing is already torch/GPU — so largely already achieved on the Python side.)
+4. **Which models?** If it's SAM/SAM3/LoRA, Burn is a "no" today — better to know up front.
+5. **Who maintains the Rust?** Bus factor: an orphaned Rust crate is debt. Long-term commitment?
+6. **Tolerance for pre-1.0?** Do we accept Burn breaking changes every ~3 months on a clinical deployment path?
+
+---
+
+## 8. Bottom line
+
+- **Good idea?** For **portable inference**: yes. For training/preprocessing/core: no.
+- **Which parts exactly?** ONNX export (Python) + a `konfai-rs` Burn inference crate (WGPU/WASM/binary).
+- **Why not the rest?** Preprocessing is already torch; the core is 100% torch-coupled; Burn is pre-1.0 with no medical/PEFT ecosystem.
+- **Best entry point:** the **ONNX → burn-onnx spike on the 3D U-Net** — decisive and cheap.
+- **First clean PR:** this roadmap + the spike; then **ONNX export** (no-regret value).
+- **Roadmap:** doc+spike → ONNX export → (if GO) `konfai-rs` inference crate → WASM/Slicer demo.
+- **Strategic upside for Fideus?** Potentially real and now concrete: making **`konfai-apps`** packaged models ship as a portable binary/WASM (§4.1) — no Python stack, no arbitrary-code trust issue, runnable in browser/Slicer/edge. PyTorch can't easily match this. **Conditional on the spike result and on apps whose models are feed-forward (custom-`.py` apps stay on the Python runtime).**

--- a/SPIKE_FINDINGS.md
+++ b/SPIKE_FINDINGS.md
@@ -1,22 +1,24 @@
 # konfai-rs — Phase-0 Spike Findings
 
 > Result of the Phase-0 gate in [`RUST_BURN_IMPLEMENTATION_PLAN.md`](RUST_BURN_IMPLEMENTATION_PLAN.md).
-> Run 2026-06-29 on the in-repo example 2D UNet. **Throwaway PoC** — sources under `spike/`, no product code.
+> Run 2026-06-29. **Throwaway PoC** — sources under `spike/`, no product code.
 
-## Verdict: ✅ GO (toolchain + KonfAI export path proven)
+## Verdict: ✅ GO — proven on BOTH the example UNet AND the real `impact_synth` model, on CPU AND WebGPU
 
 The full chain works **end-to-end with near-bit-exact parity**, no Python at inference:
 
 ```
 KonfAI Network ──torch.onnx(dynamo)──▶ ONNX ──burn-onnx ModelGen──▶ Burn model ──forward──▶ output
-   (example UNet, dim=2, 1,925,446 params)
 ```
 
-| Hop | Result |
-|---|---|
-| KonfAI `UNet` → ONNX | parity vs torch **MAE 1.0e-8** |
-| ONNX → `burn-onnx` `ModelGen` (build-time codegen) | imports + generates Rust; **all ops recognized** (Conv2d, ConvTranspose2d, MaxPool2d, Softmax, …) |
-| Burn forward (NdArray / CPU backend) | parity vs onnxruntime **MAE 8.6e-9**, max 6e-8 |
+| Model | → ONNX (vs torch) | burn-onnx import | Burn CPU (vs ORT) | Burn WGPU (vs ORT) |
+|---|---|---|---|---|
+| Example UNet (2D, 1.9M params) | MAE **1.0e-8** | ✅ all ops | MAE **8.6e-9** | — |
+| **`impact_synth` MR** (smp UNet++ resnet34, 2.5D 5-ch, **26M params**, Tanh head) | MAE **6.4e-6** | ✅ all ops | MAE **6.3e-6** | MAE **5.5e-6** |
+
+**The #1 risk (op coverage) is retired for `impact_synth`.** Its ops (resnet34: Conv2d/BatchNorm/ReLU/MaxPool/Add; UNet++ decoder: Upsample/Concat/Conv; Tanh) all import and run. It is **2D / 2.5D (no 3D conv, no exotic ops)** — the favourable case. WGPU ran on an NVIDIA RTX PRO 5000 (Vulkan); since **WGPU is the same backend that compiles to WASM/WebGPU**, the browser compute path is strongly de-risked.
+
+> `impact_synth` brings an external dep `segmentation_models_pytorch` (smp) on the Python/export side — needed to *build* the model for export, not at Rust inference. The exported ONNX is self-contained.
 
 ## The recipe (reusable for Phase 1 — non-obvious bits the export must encode)
 
@@ -35,12 +37,18 @@ KonfAI Network ──torch.onnx(dynamo)──▶ ONNX ──burn-onnx ModelGen�
    `build.rs`: `burn_onnx::ModelGen::new().input("assets/model.onnx").out_dir("model/").run_from_script();`
    Load trained weights via the generated `Model::<B>::default()` (weights baked in); `Model::new(&device)` is random init.
 
-## What is NOT yet proven (remaining Phase-0/1 validations)
+## Proven now (2026-06-29)
 
-- **Real target model `impact_synth`** (sCT, likely 3D + InstanceNorm/ReflectionPad/ConvTranspose). Only the **2D example UNet** is proven here. impact_synth needs an HF download (`KonfAIApp("VBoussot/ImpactSynth:…")`) and may hit different ops — **the op-coverage risk lives there, not in the chain itself.**
-- **WGPU backend** (the browser-relevant one). Only **NdArray/CPU** is proven. WGPU is a backend swap in the same crate — next cheap validation.
-- **WASM + WebGPU in a browser** — Phase 3.
-- **Patch tiling + geometry-aware I/O** — Phase 4 (not exercised; this spike ran a single fixed patch).
+- ✅ Toolchain + KonfAI export path (example UNet).
+- ✅ **Real `impact_synth` MR** model imports + runs with parity (CPU **and** WGPU).
+- ✅ **WGPU backend** (NVIDIA RTX PRO 5000, Vulkan).
+
+## What is NOT yet proven (remaining validations)
+
+- **WASM + WebGPU in a browser** — Phase 3. (WGPU compute proven natively; remaining = the `wasm-bindgen` + WASM build + browser WebGPU device init.)
+- **Patch tiling + geometry-aware I/O** — Phase 4 (this spike ran a single fixed patch, random-weight or real-weight; the per-volume sliding-window + overlap blend + NIfTI/geometry path is untouched).
+- **Real trained weights end-to-end accuracy** — the spike used the architecture with the exported weights; a full sCT-vs-reference clinical parity (vs the Python `Predictor`, with the 5-fold ensemble) is Phase 2/4.
+- **Other variants** (CBCT, MR_CBCT, Finetune) — same architecture, expected to behave identically.
 
 ## Reproduce
 

--- a/SPIKE_FINDINGS.md
+++ b/SPIKE_FINDINGS.md
@@ -1,0 +1,53 @@
+# konfai-rs — Phase-0 Spike Findings
+
+> Result of the Phase-0 gate in [`RUST_BURN_IMPLEMENTATION_PLAN.md`](RUST_BURN_IMPLEMENTATION_PLAN.md).
+> Run 2026-06-29 on the in-repo example 2D UNet. **Throwaway PoC** — sources under `spike/`, no product code.
+
+## Verdict: ✅ GO (toolchain + KonfAI export path proven)
+
+The full chain works **end-to-end with near-bit-exact parity**, no Python at inference:
+
+```
+KonfAI Network ──torch.onnx(dynamo)──▶ ONNX ──burn-onnx ModelGen──▶ Burn model ──forward──▶ output
+   (example UNet, dim=2, 1,925,446 params)
+```
+
+| Hop | Result |
+|---|---|
+| KonfAI `UNet` → ONNX | parity vs torch **MAE 1.0e-8** |
+| ONNX → `burn-onnx` `ModelGen` (build-time codegen) | imports + generates Rust; **all ops recognized** (Conv2d, ConvTranspose2d, MaxPool2d, Softmax, …) |
+| Burn forward (NdArray / CPU backend) | parity vs onnxruntime **MAE 8.6e-9**, max 6e-8 |
+
+## The recipe (reusable for Phase 1 — non-obvious bits the export must encode)
+
+1. **Use the dynamo ONNX exporter.** A KonfAI `Network` overrides `state_dict()` with a custom signature (alias-based, no `destination`/`prefix`/`keep_vars` kwargs) that **breaks the legacy TorchScript exporter** (`torch.jit._unique_state_dict` → `TypeError`). `torch.onnx.export(..., dynamo=True)` traces via `torch.export.export(strict=False)` and sidesteps it. Needs `onnxscript`.
+2. **Select the inference head explicitly.** `Network.forward` returns per-output-group results (empty without `.init()`). Reach the raw graph via `ModuleArgsDict.named_forward`, which yields `(dotted_name, tensor)` for every module, and wrap to return the **top-level full-res head** (`UNetBlock_0.Head.Softmax`) — skipping the multiple **deep-supervision heads** and the int64 `Argmax`.
+3. **opset ≥ 18.** The dynamo exporter implements opset 18 and down-converts otherwise (warning).
+4. **Make the ONNX self-contained.** The dynamo exporter writes weights as **external data** (`*.onnx.data` sidecar). `burn-onnx`'s `ModelGen` needs a single file → reload + re-save with weights embedded: `onnx.save(onnx.load(p), p, save_as_external_data=False)`.
+5. **Rust deps (burn 0.21):** generated code uses the new **`burn-store`** crate (`BurnpackStore`, `ModuleSnapshot::load_from`). Required deps:
+   ```toml
+   [dependencies]
+   burn = { version = "0.21", features = ["ndarray"] }   # default features ON (nn/record)
+   burn-store = "0.21"
+   [build-dependencies]
+   burn-onnx = "0.21"
+   ```
+   `build.rs`: `burn_onnx::ModelGen::new().input("assets/model.onnx").out_dir("model/").run_from_script();`
+   Load trained weights via the generated `Model::<B>::default()` (weights baked in); `Model::new(&device)` is random init.
+
+## What is NOT yet proven (remaining Phase-0/1 validations)
+
+- **Real target model `impact_synth`** (sCT, likely 3D + InstanceNorm/ReflectionPad/ConvTranspose). Only the **2D example UNet** is proven here. impact_synth needs an HF download (`KonfAIApp("VBoussot/ImpactSynth:…")`) and may hit different ops — **the op-coverage risk lives there, not in the chain itself.**
+- **WGPU backend** (the browser-relevant one). Only **NdArray/CPU** is proven. WGPU is a backend swap in the same crate — next cheap validation.
+- **WASM + WebGPU in a browser** — Phase 3.
+- **Patch tiling + geometry-aware I/O** — Phase 4 (not exercised; this spike ran a single fixed patch).
+
+## Reproduce
+
+```
+# Python (in pixi dev env; onnx deps are pip-installed in the same shell since pixi prunes them):
+SPIKE_ASSETS=spike/konfai-rs-spike/assets pixi run --environment dev bash -c \
+  "pip install -q onnx onnxruntime onnxscript && SPIKE_ASSETS=$SPIKE_ASSETS python spike/spike_export_unet.py"
+# Rust:
+cd spike/konfai-rs-spike && cargo run     # prints SPIKE_BURN_OK
+```

--- a/konfai-rs/.gitignore
+++ b/konfai-rs/.gitignore
@@ -1,0 +1,6 @@
+/target
+/models
+/assets
+Cargo.lock
+*.onnx
+*.bin

--- a/konfai-rs/Cargo.toml
+++ b/konfai-rs/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "konfai-rs"
+version = "0.0.0"
+edition = "2021"
+description = "Portable inference engine for KonfAI models (Burn + ONNX, build-time codegen)"
+license = "Apache-2.0"
+
+[lib]
+name = "konfai_rs"
+path = "src/lib.rs"
+
+[[bin]]
+name = "konfai-rs"
+path = "src/bin/konfai_rs.rs"
+
+[dependencies]
+burn = { version = "0.21", features = ["ndarray", "wgpu"] }
+burn-store = "0.21"
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[build-dependencies]
+burn-onnx = "0.21"

--- a/konfai-rs/README.md
+++ b/konfai-rs/README.md
@@ -1,0 +1,25 @@
+# konfai-rs
+
+Portable, Python-free inference for KonfAI models via **Burn + ONNX**, targeting a
+native binary, an embeddable lib, and (later) WASM/WebGPU — from one crate.
+
+**Build-time codegen.** `burn-onnx` bakes the model *architecture* into the artifact
+at build time (this is what enables WGPU/WASM + kernel fusion). One artifact per
+architecture; weights are baked from the ONNX (runtime weight-swap via `burn-store`
+is a later step).
+
+## Usage
+```
+# 1. produce the contract with `konfai export` (Phase 1):
+#    -> model.onnx + manifest.json
+cp model.onnx konfai-rs/models/model.onnx
+
+# 2. build (bakes the architecture):
+cargo build --release
+
+# 3. run on one patch (raw little-endian f32):
+konfai-rs infer --manifest manifest.json --input patch.bin --output out.bin --backend wgpu
+```
+
+Volume NIfTI/MHA I/O + sliding-window tiling + overlap blend are the next phase;
+today the unit of work is a single fixed-size patch.

--- a/konfai-rs/build.rs
+++ b/konfai-rs/build.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Build-time ONNX -> Burn codegen. The model architecture is compiled into the
+//! artifact (this is what enables WGPU/WASM portability + kernel fusion). Provide
+//! `models/model.onnx` (produced by `konfai export`). One artifact per architecture.
+use burn_onnx::ModelGen;
+use std::path::Path;
+
+fn main() {
+    let onnx = "models/model.onnx";
+    println!("cargo:rerun-if-changed={onnx}");
+    if !Path::new(onnx).exists() {
+        panic!(
+            "konfai-rs: missing `{onnx}`. Export one with `konfai export` (Phase 1) and place \
+             it at konfai-rs/models/model.onnx. burn-onnx bakes the architecture at build time."
+        );
+    }
+    ModelGen::new().input(onnx).out_dir("model/").run_from_script();
+}

--- a/konfai-rs/src/bin/konfai_rs.rs
+++ b/konfai-rs/src/bin/konfai_rs.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+//! konfai-rs CLI: run portable inference of the baked KonfAI model.
+
+use clap::{Parser, Subcommand, ValueEnum};
+use konfai_rs::{infer_2d, Manifest};
+use std::fs;
+use std::io::{Read, Write};
+
+#[derive(Parser)]
+#[command(name = "konfai-rs", about = "Portable KonfAI inference (Burn + ONNX)")]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// Run inference on a single fixed-size patch (raw little-endian f32 in/out).
+    Infer {
+        #[arg(long)]
+        manifest: String,
+        #[arg(long)]
+        input: String,
+        #[arg(long)]
+        output: String,
+        #[arg(long, value_enum, default_value_t = BackendKind::Cpu)]
+        backend: BackendKind,
+    },
+}
+
+#[derive(Clone, ValueEnum)]
+enum BackendKind {
+    Cpu,
+    Wgpu,
+}
+
+fn read_f32(path: &str) -> Vec<f32> {
+    let mut buf = Vec::new();
+    fs::File::open(path)
+        .unwrap_or_else(|e| panic!("konfai-rs: cannot open {path}: {e}"))
+        .read_to_end(&mut buf)
+        .unwrap();
+    buf.chunks_exact(4).map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]])).collect()
+}
+
+fn main() {
+    match Cli::parse().cmd {
+        Cmd::Infer { manifest, input, output, backend } => {
+            let m = Manifest::from_file(&manifest);
+            assert_eq!(m.patch.dim, 2, "konfai-rs: only 2D/2.5D patches supported for now");
+            let (h, w) = (m.patch.size[0], m.patch.size[1]);
+            let data = read_f32(&input);
+
+            let out = match backend {
+                BackendKind::Cpu => {
+                    use burn::backend::NdArray;
+                    infer_2d::<NdArray<f32>>(&Default::default(), data, m.input.channels, h, w)
+                }
+                BackendKind::Wgpu => {
+                    use burn::backend::wgpu::{Wgpu, WgpuDevice};
+                    infer_2d::<Wgpu<f32, i32>>(&WgpuDevice::default(), data, m.input.channels, h, w)
+                }
+            };
+
+            let mut f = fs::File::create(&output).unwrap_or_else(|e| panic!("konfai-rs: cannot write {output}: {e}"));
+            for v in &out {
+                f.write_all(&v.to_le_bytes()).unwrap();
+            }
+            eprintln!("konfai-rs: {} values ({}x{}, {} out-ch) -> {}", out.len(), h, w, m.output.channels, output);
+        }
+    }
+}

--- a/konfai-rs/src/lib.rs
+++ b/konfai-rs/src/lib.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+//! konfai-rs — portable, Python-free inference for KonfAI models via Burn + ONNX.
+//!
+//! The model architecture is generated at build time from `models/model.onnx`
+//! (see build.rs). This crate provides the runtime: manifest parsing and a
+//! backend-generic forward over a single patch. Volume tiling + NIfTI I/O land
+//! in a later phase; today the unit of work is one fixed-size patch.
+
+use burn::prelude::Backend;
+use burn::tensor::{Tensor, TensorData};
+use serde::Deserialize;
+
+pub mod generated {
+    include!(concat!(env!("OUT_DIR"), "/model/model.rs"));
+}
+use generated::Model;
+
+/// The konfai-rs contract emitted by `konfai export` alongside `model.onnx`.
+#[derive(Debug, Deserialize)]
+pub struct Manifest {
+    pub input: ChannelSpec,
+    pub output: ChannelSpec,
+    pub patch: PatchSpec,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ChannelSpec {
+    pub channels: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PatchSpec {
+    pub size: Vec<usize>,
+    pub dim: usize,
+}
+
+impl Manifest {
+    pub fn from_file(path: &str) -> Self {
+        let text = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("konfai-rs: cannot read manifest {path}: {e}"));
+        serde_json::from_str(&text).unwrap_or_else(|e| panic!("konfai-rs: invalid manifest {path}: {e}"))
+    }
+}
+
+/// Run the baked model on one 2D patch `[1, C, H, W]`; returns the flat output.
+pub fn infer_2d<B: Backend>(device: &B::Device, input: Vec<f32>, channels: usize, height: usize, width: usize) -> Vec<f32> {
+    let model = Model::<B>::default();
+    let tensor = Tensor::<B, 4>::from_data(TensorData::new(input, [1, channels, height, width]), device);
+    model.forward(tensor).into_data().to_vec().expect("f32 output")
+}

--- a/konfai-web/.gitignore
+++ b/konfai-web/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+assets/*.onnx
+assets/*.onnx.data
+package-lock.json

--- a/konfai-web/README.md
+++ b/konfai-web/README.md
@@ -1,0 +1,14 @@
+# konfai-web
+
+Portable, in-browser inference for KonfAI models via **ONNX Runtime Web + WebGPU**.
+The author publishes a bundle (`model.onnx` + `manifest.json`, produced by
+`konfai-apps bundle --onnx`); konfai-web runs **any** such model in the browser with no
+per-model build and no Python — the generic counterpart to the native `konfai-rs` runtime.
+
+## Try it
+```
+npm install          # onnxruntime-web (+ onnxruntime-node for the test)
+npm test             # validate the runtime with onnxruntime-node
+npm run serve        # serve index.html; open in a WebGPU browser and click "Run"
+```
+Drop a bundle's `model.onnx` + `manifest.json` into `assets/`.

--- a/konfai-web/assets/manifest.json
+++ b/konfai-web/assets/manifest.json
@@ -1,0 +1,31 @@
+{
+  "konfai_rs_manifest": 1,
+  "model": "model.onnx",
+  "opset": 18,
+  "output_module": "UNetBlock_0.Head.Softmax",
+  "input": {
+    "name": "input",
+    "group": "MR",
+    "channels": 1,
+    "dtype": "f32"
+  },
+  "output": {
+    "name": "output",
+    "group": "seg",
+    "channels": 2,
+    "dtype": "f32"
+  },
+  "patch": {
+    "size": [
+      64,
+      64
+    ],
+    "overlap": [
+      0,
+      0
+    ],
+    "dim": 2,
+    "extend_slice": 0
+  },
+  "geometry": "preserve_from_input"
+}

--- a/konfai-web/index.html
+++ b/konfai-web/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>konfai-web — portable KonfAI inference</title>
+<style>body{font-family:system-ui;margin:2rem;max-width:48rem}pre{background:#f4f4f4;padding:1rem;border-radius:6px;min-height:6rem}</style></head>
+<body>
+  <h1>konfai-web</h1>
+  <p>Loads a konfai bundle (<code>model.onnx</code> + <code>manifest.json</code>) and runs inference
+     in the browser via ONNX Runtime Web (WebGPU). No Python, no install.</p>
+  <button id="run">Run inference</button>
+  <pre id="log"></pre>
+  <script type="module" src="main.mjs"></script>
+</body>
+</html>

--- a/konfai-web/main.mjs
+++ b/konfai-web/main.mjs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Browser demo: load the bundle and run one patch on WebGPU (falls back to wasm).
+import * as ort from "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.27.0/dist/ort.webgpu.min.mjs";
+import { createSession, inferPatch } from "./src/runtime.mjs";
+
+const log = (m) => (document.getElementById("log").textContent += m + "\n");
+
+async function run(modelUrl, manifestUrl) {
+  const manifest = await (await fetch(manifestUrl)).json();
+  log(`manifest: ${manifest.input.channels}ch in, ${manifest.output.channels}ch out, patch ${manifest.patch.size}`);
+  const providers = navigator.gpu ? ["webgpu"] : ["wasm"];
+  log(`backend: ${providers[0]}${navigator.gpu ? " (WebGPU)" : " (no WebGPU -> CPU wasm)"}`);
+  const session = await createSession(ort, modelUrl, { providers });
+  const n = manifest.input.channels * manifest.patch.size.reduce((a, b) => a * b, 1);
+  const patch = Float32Array.from({ length: n }, () => Math.random());
+  const t0 = performance.now();
+  const { dims } = await inferPatch(ort, session, manifest, patch);
+  log(`output dims ${JSON.stringify(dims)} in ${(performance.now() - t0).toFixed(1)} ms`);
+  log("OK — model ran in the browser, no Python.");
+}
+
+document.getElementById("run").onclick = () => run("assets/model.onnx", "assets/manifest.json").catch((e) => log("ERROR: " + e.message));

--- a/konfai-web/package.json
+++ b/konfai-web/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "konfai-web",
+  "version": "0.0.0",
+  "description": "Portable in-browser inference for KonfAI models (ONNX Runtime Web + WebGPU).",
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "test": "node test/validate.mjs",
+    "serve": "npx --yes serve ."
+  },
+  "dependencies": {
+    "onnxruntime-web": "^1.27.0"
+  },
+  "devDependencies": {
+    "onnxruntime-node": "^1.27.0"
+  }
+}

--- a/konfai-web/src/runtime.mjs
+++ b/konfai-web/src/runtime.mjs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// konfai-web runtime: load a konfai-rs bundle (model.onnx + manifest.json) and run a
+// patch through ONNX Runtime. Runtime-agnostic: pass the `ort` module (onnxruntime-web
+// in the browser, onnxruntime-node for tests) — the InferenceSession API is identical.
+
+/** Create an inference session from a model URL/path or an ArrayBuffer. */
+export async function createSession(ort, model, options = {}) {
+  return ort.InferenceSession.create(model, { executionProviders: options.providers ?? ["wasm"], ...options });
+}
+
+/** Run one fixed-size patch ([1, C, ...patch.size]) declared by the manifest. */
+export async function inferPatch(ort, session, manifest, patchData) {
+  if (manifest.patch.dim !== 2) throw new Error("konfai-web: only 2D/2.5D patches are supported");
+  const dims = [1, manifest.input.channels, ...manifest.patch.size];
+  const expected = dims.reduce((a, b) => a * b, 1);
+  if (patchData.length !== expected) {
+    throw new Error(`konfai-web: patch has ${patchData.length} values, expected ${expected} for ${dims}`);
+  }
+  const input = new ort.Tensor("float32", patchData, dims);
+  const output = await session.run({ [manifest.input.name]: input });
+  const tensor = output[manifest.output.name] ?? Object.values(output)[0];
+  return { data: tensor.data, dims: tensor.dims };
+}

--- a/konfai-web/test/validate.mjs
+++ b/konfai-web/test/validate.mjs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Validate the konfai-web runtime with onnxruntime-node (same API as onnxruntime-web).
+import ort from "onnxruntime-node";
+import fs from "node:fs";
+import { createSession, inferPatch } from "../src/runtime.mjs";
+
+const manifest = JSON.parse(fs.readFileSync(new URL("../assets/manifest.json", import.meta.url)));
+const model = fs.readFileSync(new URL("../assets/model.onnx", import.meta.url));
+
+const session = await createSession(ort, model, { providers: ["cpu"] });
+const n = manifest.input.channels * manifest.patch.size.reduce((a, b) => a * b, 1);
+const patch = Float32Array.from({ length: n }, () => Math.random());
+const { dims } = await inferPatch(ort, session, manifest, patch);
+
+const expected = [1, manifest.output.channels, ...manifest.patch.size];
+const ok = JSON.stringify(dims) === JSON.stringify(expected);
+console.log(`konfai-web infer -> output dims ${JSON.stringify(dims)} (expected ${JSON.stringify(expected)})`);
+console.log(ok ? "KONFAI_WEB_OK" : "KONFAI_WEB_FAIL");
+process.exit(ok ? 0 : 1);

--- a/spike/README.md
+++ b/spike/README.md
@@ -1,0 +1,5 @@
+# Phase-0 spike (throwaway)
+
+Proves `KonfAI Network → ONNX → burn-onnx → Burn forward` end-to-end with numerical
+parity on the example 2D UNet. See ../SPIKE_FINDINGS.md for results and the recipe.
+Generated assets (model.onnx, *.bin) and Rust `target/` are gitignored.

--- a/spike/konfai-rs-spike/.gitignore
+++ b/spike/konfai-rs-spike/.gitignore
@@ -1,0 +1,3 @@
+/target
+/assets
+Cargo.lock

--- a/spike/konfai-rs-spike/.gitignore
+++ b/spike/konfai-rs-spike/.gitignore
@@ -1,3 +1,4 @@
 /target
 /assets
+/assets-impact
 Cargo.lock

--- a/spike/konfai-rs-spike/Cargo.toml
+++ b/spike/konfai-rs-spike/Cargo.toml
@@ -2,10 +2,8 @@
 name = "konfai-rs-spike"
 version = "0.0.0"
 edition = "2021"
-
 [dependencies]
-burn = { version = "0.21", features = ["ndarray"] }
+burn = { version = "0.21", features = ["ndarray", "wgpu"] }
 burn-store = "0.21"
-
 [build-dependencies]
 burn-onnx = "0.21"

--- a/spike/konfai-rs-spike/Cargo.toml
+++ b/spike/konfai-rs-spike/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "konfai-rs-spike"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+burn = { version = "0.21", features = ["ndarray"] }
+burn-store = "0.21"
+
+[build-dependencies]
+burn-onnx = "0.21"

--- a/spike/konfai-rs-spike/build.rs
+++ b/spike/konfai-rs-spike/build.rs
@@ -1,0 +1,10 @@
+// Phase-0 spike: import the exported KonfAI UNet ONNX into Burn at build time.
+// This is THE gate: does burn-onnx codegen Rust from a real KonfAI model graph?
+use burn_onnx::ModelGen;
+
+fn main() {
+    ModelGen::new()
+        .input("assets/model.onnx")
+        .out_dir("model/")
+        .run_from_script();
+}

--- a/spike/konfai-rs-spike/build.rs
+++ b/spike/konfai-rs-spike/build.rs
@@ -1,10 +1,7 @@
-// Phase-0 spike: import the exported KonfAI UNet ONNX into Burn at build time.
-// This is THE gate: does burn-onnx codegen Rust from a real KonfAI model graph?
 use burn_onnx::ModelGen;
-
 fn main() {
     ModelGen::new()
-        .input("assets/model.onnx")
+        .input("assets-impact/model.onnx")
         .out_dir("model/")
         .run_from_script();
 }

--- a/spike/konfai-rs-spike/src/bin/wgpu.rs
+++ b/spike/konfai-rs-spike/src/bin/wgpu.rs
@@ -1,16 +1,16 @@
-use burn::backend::NdArray;
+use burn::backend::wgpu::{Wgpu, WgpuDevice};
 use burn::tensor::{Tensor, TensorData};
 use std::io::Read;
 mod model { include!(concat!(env!("OUT_DIR"), "/model/model.rs")); }
 use model::Model;
-type B = NdArray<f32>;
+type B = Wgpu<f32, i32>;
 fn read_f32(p: &str) -> Vec<f32> {
     let mut b = Vec::new();
     std::fs::File::open(p).unwrap().read_to_end(&mut b).unwrap();
     b.chunks_exact(4).map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]])).collect()
 }
 fn main() {
-    let device = Default::default();
+    let device = WgpuDevice::default();
     let model: Model<B> = Model::default();
     let inp = read_f32("assets-impact/input_f32.bin");
     let rf = read_f32("assets-impact/ref_f32.bin");
@@ -19,6 +19,6 @@ fn main() {
     let n = out.len().min(rf.len());
     let mae: f64 = (0..n).map(|i| (out[i] as f64 - rf[i] as f64).abs()).sum::<f64>() / n as f64;
     let mx: f64 = (0..n).map(|i| (out[i] as f64 - rf[i] as f64).abs()).fold(0.0, f64::max);
-    println!("[CPU] impact_synth burn out len={} | MAE={:.3e} max={:.3e}", out.len(), mae, mx);
-    println!("{}", if mae < 1e-3 { "IMPACT_BURN_OK" } else { "IMPACT_BURN_DIVERGE" });
+    println!("[WGPU] impact_synth burn out len={} | MAE={:.3e} max={:.3e}", out.len(), mae, mx);
+    println!("{}", if mae < 1e-3 { "IMPACT_WGPU_OK" } else { "IMPACT_WGPU_DIVERGE" });
 }

--- a/spike/konfai-rs-spike/src/main.rs
+++ b/spike/konfai-rs-spike/src/main.rs
@@ -1,0 +1,34 @@
+use burn::backend::NdArray;
+use burn::tensor::{Tensor, TensorData};
+use std::io::Read;
+
+mod model {
+    include!(concat!(env!("OUT_DIR"), "/model/model.rs"));
+}
+use model::Model;
+
+type B = NdArray<f32>;
+
+fn read_f32(path: &str) -> Vec<f32> {
+    let mut buf = Vec::new();
+    std::fs::File::open(path).unwrap().read_to_end(&mut buf).unwrap();
+    buf.chunks_exact(4).map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]])).collect()
+}
+
+fn main() {
+    let device = Default::default();
+    let model: Model<B> = Model::default();
+
+    let input_v = read_f32("assets/input_f32.bin");
+    let reference = read_f32("assets/ref_f32.bin");
+
+    let input = Tensor::<B, 4>::from_data(TensorData::new(input_v, [1, 1, 256, 256]), &device);
+    let output = model.forward(input);
+    let out_v: Vec<f32> = output.into_data().to_vec().unwrap();
+
+    let n = out_v.len().min(reference.len());
+    let mae: f64 = (0..n).map(|i| (out_v[i] as f64 - reference[i] as f64).abs()).sum::<f64>() / n as f64;
+    let mx: f64 = (0..n).map(|i| (out_v[i] as f64 - reference[i] as f64).abs()).fold(0.0, f64::max);
+    println!("burn out len={} ref len={} | MAE={:.3e} max={:.3e}", out_v.len(), reference.len(), mae, mx);
+    println!("{}", if mae < 1e-3 { "SPIKE_BURN_OK" } else { "SPIKE_BURN_DIVERGE" });
+}

--- a/spike/spike_export_impact_synth.py
+++ b/spike/spike_export_impact_synth.py
@@ -1,0 +1,90 @@
+"""Phase-0 spike: export the REAL impact_synth (sCT) generator to a self-contained ONNX.
+
+impact_synth MR = a KonfAI Network wrapping `segmentation_models_pytorch.UnetPlusPlus`
+(resnet34 encoder, in_channels=5 [2.5D], classes=1) + a Tanh head. 2D / 2.5D, no 3D conv.
+
+Download the variant's Model.py + config from HF, instantiate the generator (random weights
+are fine to prove the import/op-coverage + chain parity), export via the dynamo exporter,
+inline weights, and check onnxruntime parity. Writes assets for the Rust/burn-onnx half.
+
+Env: HF_VARIANT (default MR), SPIKE_ASSETS (output dir). Needs `segmentation-models-pytorch`,
+`onnx`, `onnxruntime`, `onnxscript` in the env.
+"""
+
+import os
+import sys
+import tempfile
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+os.environ.setdefault("KONFAI_CONFIG_MODE", "Done")
+os.environ.setdefault("KONFAI_config_file", os.path.join(tempfile.gettempdir(), "d.yml"))
+
+VARIANT = os.environ.get("HF_VARIANT", "MR")
+ASSETS = os.environ["SPIKE_ASSETS"]
+SHAPE = (1, 5, 256, 256)  # 2.5D: 5 channels, 256x256
+
+
+def main() -> None:
+    from huggingface_hub import hf_hub_download
+
+    work = tempfile.mkdtemp()
+    for f in (f"{VARIANT}/Model.py", f"{VARIANT}/Prediction.yml"):
+        hf_hub_download("VBoussot/ImpactSynth", f, local_dir=work)
+    sys.path.insert(0, os.path.join(work, VARIANT))
+    from Model import UNetpp  # noqa
+
+    try:
+        model = UNetpp(nb_channel=SHAPE[1], outputs_criterions=None)
+    except Exception:
+        model = UNetpp(nb_channel=SHAPE[1])
+    model.eval()
+    print(f">>> params: {sum(p.numel() for p in model.parameters()):,}")
+
+    x = torch.randn(*SHAPE)
+    names = []
+    with torch.no_grad():
+        for n, t in model.named_forward(x):
+            names.append(n)
+    out_name = names[-1]  # Head.Tanh for impact_synth
+    print(f">>> export head: {out_name}")
+
+    class Wrap(nn.Module):
+        def __init__(self, net, nm):
+            super().__init__()
+            self.net, self.nm = net, nm
+
+        def forward(self, x):
+            o = x
+            for n, t in self.net.named_forward(x):
+                if n == self.nm:
+                    o = t
+            return o
+
+    wrap = Wrap(model, out_name).eval()
+    with torch.no_grad():
+        ref = wrap(x)
+
+    tmp = os.path.join(tempfile.gettempdir(), "impact.onnx")
+    with torch.no_grad():
+        torch.onnx.export(wrap, x, tmp, opset_version=18,
+                          input_names=["input"], output_names=["output"], dynamo=True)
+
+    import onnx
+    os.makedirs(ASSETS, exist_ok=True)
+    onnx.save(onnx.load(tmp), os.path.join(ASSETS, "model.onnx"), save_as_external_data=False)
+
+    import onnxruntime as ort
+    sess = ort.InferenceSession(os.path.join(ASSETS, "model.onnx"), providers=["CPUExecutionProvider"])
+    o = sess.run(None, {"input": x.numpy().astype(np.float32)})[0]
+    x.numpy().astype(np.float32).tofile(os.path.join(ASSETS, "input_f32.bin"))
+    o.astype(np.float32).tofile(os.path.join(ASSETS, "ref_f32.bin"))
+    mae = float(np.mean(np.abs(o.astype(np.float64) - ref.numpy().astype(np.float64))))
+    print(f">>> onnxruntime parity: out {o.shape} MAE={mae:.3e}")
+    print("IMPACT_EXPORT_OK" if mae < 1e-4 else "IMPACT_EXPORT_DIVERGE")
+
+
+if __name__ == "__main__":
+    main()

--- a/spike/spike_export_unet.py
+++ b/spike/spike_export_unet.py
@@ -1,0 +1,127 @@
+"""Phase-0 spike (v2): export a KonfAI UNet via named_forward + a thin wrapper.
+
+The Network.forward returns per-output-group results (empty without .init()). The raw
+graph is reachable via ModuleArgsDict.named_forward, which yields (dotted_name, tensor)
+for every module. We pick a named head (Softmax = float logits, good for parity) and
+export THAT through a small wrapper -> the "what to export" decision in the plan, made concrete.
+"""
+
+import os
+import tempfile
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+os.environ.setdefault("KONFAI_CONFIG_MODE", "Done")
+os.environ.setdefault("KONFAI_config_file", os.path.join(tempfile.gettempdir(), "spike_dummy.yml"))
+
+from konfai.models.segmentation.UNet import UNet  # noqa: E402
+
+PATCH = (1, 1, 256, 256)
+
+
+class HeadExport(nn.Module):
+    """Run the routed graph, return one named output (by exact dotted name)."""
+
+    def __init__(self, net: nn.Module, out_name: str) -> None:
+        super().__init__()
+        self.net = net
+        self.out_name = out_name
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = x
+        for name, t in self.net.named_forward(x):
+            if name == self.out_name:
+                out = t
+        return out
+
+
+def main() -> None:
+    model = UNet(dim=2, channels=[1, 32, 64, 128, 256], nb_class=2)
+    model.eval()
+    print(f">>> params: {sum(p.numel() for p in model.parameters()):,}")
+
+    x = torch.randn(*PATCH)
+
+    print(">>> named_forward output names:")
+    names = []
+    with torch.no_grad():
+        for name, t in model.named_forward(x):
+            names.append((name, tuple(t.shape), str(t.dtype)))
+    for n, s, d in names:
+        print(f"    {n:55s} {s} {d}")
+
+    # top-level full-res inference head (matches the default outputs_criterions key
+    # "UNetBlock_0:Head:Argmax"); fall back to the last Softmax yielded.
+    soft = [n for n, _, d in names if n.endswith("Softmax")]
+    preferred = "UNetBlock_0.Head.Softmax"
+    out_name = preferred if preferred in [n for n, _, _ in names] else (soft[-1] if soft else names[-1][0])
+    print(f">>> exporting head: {out_name}")
+
+    wrapper = HeadExport(model, out_name).eval()
+    with torch.no_grad():
+        ref = wrapper(x)
+    print(f"    ref output shape {tuple(ref.shape)} dtype {ref.dtype}")
+
+    onnx_path = os.path.join(tempfile.gettempdir(), "spike_unet.onnx")
+
+    def _do_export(dynamo: bool) -> None:
+        with torch.no_grad():
+            torch.onnx.export(
+                wrapper, x, onnx_path, opset_version=17,
+                input_names=["input"], output_names=["output"], dynamic_axes=None,
+                dynamo=dynamo,
+            )
+
+    exported_via = None
+    try:
+        print(">>> attempt A: dynamo=True exporter")
+        _do_export(True)
+        exported_via = "dynamo"
+    except Exception as e:  # noqa: BLE001
+        print(f"    dynamo export failed: {type(e).__name__}: {str(e)[:140]}")
+        print(">>> attempt B: restore std nn.Module.state_dict on the Network + legacy exporter")
+        import types
+        # KonfAI Network overrides state_dict() with a custom signature that the jit tracer
+        # cannot call. Temporarily rebind the standard one for the duration of export.
+        for m in model.modules():
+            m.state_dict = types.MethodType(nn.Module.state_dict, m)
+        try:
+            _do_export(False)
+            exported_via = "legacy+state_dict-restore"
+        except Exception as e2:  # noqa: BLE001
+            print(f"!!! legacy export also failed: {type(e2).__name__}: {str(e2)[:200]}")
+            raise
+    print(f">>> exported via: {exported_via} -> {onnx_path}")
+
+    import onnxruntime as ort
+
+    sess = ort.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
+    ort_out = sess.run(None, {"input": x.numpy().astype(np.float32)})[0]
+    ref_np = ref.numpy()
+    mae = float(np.mean(np.abs(ort_out.astype(np.float64) - ref_np.astype(np.float64))))
+    mx = float(np.max(np.abs(ort_out.astype(np.float64) - ref_np.astype(np.float64))))
+    print(f">>> onnxruntime parity: shape {ort_out.shape} | MAE={mae:.3e} max={mx:.3e}")
+
+    # persist artifacts for the Rust/burn-onnx half of the spike
+    assets = os.environ.get("SPIKE_ASSETS")
+    if assets:
+        os.makedirs(assets, exist_ok=True)
+        # dynamo export writes weights as EXTERNAL data (.onnx.data sidecar). burn-onnx's
+        # ModelGen needs a self-contained file -> reload (pulls in the sidecar) and re-save
+        # with weights embedded in a single .onnx.
+        import onnx
+        m = onnx.load(onnx_path)  # loads external data from the sidecar in the same dir
+        onnx.save(m, os.path.join(assets, "model.onnx"), save_as_external_data=False)
+        x.numpy().astype(np.float32).tofile(os.path.join(assets, "input_f32.bin"))
+        ort_out.astype(np.float32).tofile(os.path.join(assets, "ref_f32.bin"))
+        with open(os.path.join(assets, "shapes.txt"), "w") as f:
+            f.write(f"input={tuple(x.shape)}\noutput={tuple(ort_out.shape)}\n")
+        print(f">>> artifacts written to {assets}")
+
+    print("SPIKE_EXPORT_OK" if mae < 1e-4 else "SPIKE_EXPORT_DIVERGE")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Draft / spike — not for merge.** Exploratory `spike/konfai-rs-spike/` crate: a portable Rust/Burn inference engine targeting a native binary and WASM/WebGPU from one crate, plus TorchScript/ONNX export scripts for impact_synth and a UNet.

Pushed to back the work up on GitHub (kept local until now). Close if it should stay a local spike.