### PR TITLE
fix: audit correctness batch (config binder, nested resume, geometry, metrics)

### DIFF
--- a/.github/workflows/konfai_apps_ci.yml
+++ b/.github/workflows/konfai_apps_ci.yml
@@ -66,6 +66,9 @@ jobs:
         run: |
           pip install -e ./konfai-apps
 
+      - name: Pin gloo to the loopback interface on macOS
+        if: runner.os == 'macOS'
+        run: echo "GLOO_SOCKET_IFNAME=lo0" >> "$GITHUB_ENV"
       - name: Run apps tests
         run: |
           python -m pytest -q konfai-apps/tests

--- a/.github/workflows/konfai_ci.yml
+++ b/.github/workflows/konfai_ci.yml
@@ -41,6 +41,9 @@ jobs:
           python -m pip install -U pip
           pip install -e ".[dev]"
 
+      - name: Pin gloo to the loopback interface on macOS
+        if: runner.os == 'macOS'
+        run: echo "GLOO_SOCKET_IFNAME=lo0" >> "$GITHUB_ENV"
       - name: Run pytest
         run: |
           pytest -q tests

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -1075,14 +1075,9 @@ class ResampleTransform(TransformInverse):
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         if len(tensor.shape) != 4:
             raise NameError("Input size should be 5 dim")
+        _require_simpleitk()
         image = data_to_image(tensor, cache_attribute)
 
-        vectors = [torch.arange(0, s) for s in tensor.shape[1:]]
-        grids = torch.meshgrid(vectors, indexing="ij")
-        grid = torch.stack(grids)
-        grid = torch.unsqueeze(grid, 0)
-
-        _require_simpleitk()
         transforms = []
         for transform_group, invert in self.transforms.items():
             transform = None
@@ -1111,29 +1106,15 @@ class ResampleTransform(TransformInverse):
             transforms.append(transform)
         result_transform = sitk.CompositeTransform(transforms)
 
-        transform_to_displacement_field_filter = sitk.TransformToDisplacementFieldFilter()
-        transform_to_displacement_field_filter.SetReferenceImage(image)
-        transform_to_displacement_field_filter.SetNumberOfThreads(16)
-        new_locs = grid + torch.tensor(
-            sitk.GetArrayFromImage(transform_to_displacement_field_filter.Execute(result_transform))
-        ).unsqueeze(0).permute(0, 4, 1, 2, 3)
-        shape = new_locs.shape[2:]
-        for i in range(len(shape)):
-            new_locs[:, i, ...] = 2 * (new_locs[:, i, ...] / (shape[i] - 1) - 0.5)
-        new_locs = new_locs.permute(0, 2, 3, 4, 1)
-        new_locs = new_locs[..., [2, 1, 0]]
-        result = (
-            F.grid_sample(
-                tensor.to(self.device).unsqueeze(0).float(),
-                new_locs.to(self.device).float(),
-                align_corners=True,
-                padding_mode="border",
-                mode="nearest" if tensor.dtype == torch.uint8 else "bilinear",
-            )
-            .squeeze(0)
-            .cpu()
-        )
-        return result.type(torch.uint8) if tensor.dtype == torch.uint8 else result
+        # Resample through SimpleITK so the stored transform is applied in physical space: spacing,
+        # direction and the (x, y, z) mm units of the displacement are all honoured. The previous
+        # hand-rolled grid_sample added the physical (dx, dy, dz) displacement straight onto a (z, y, x)
+        # voxel-index grid, transposing the x/z axes and treating millimetres as voxels.
+        interpolator = sitk.sitkNearestNeighbor if tensor.dtype == torch.uint8 else sitk.sitkLinear
+        resampled = sitk.Resample(image, image, result_transform, interpolator, 0.0)
+        data, _ = image_to_data(resampled)
+        result = torch.from_numpy(np.ascontiguousarray(data))
+        return result.to(torch.uint8) if tensor.dtype == torch.uint8 else result.float()
 
     def inverse(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         raise NotImplementedError(

--- a/konfai/metric/measure.py
+++ b/konfai/metric/measure.py
@@ -806,16 +806,12 @@ class KLDivergence(CriterionWithInit):
 class Accuracy(Criterion):
     maximize = True  # reported value is the accuracy fraction (higher-is-better)
 
-    def __init__(self) -> None:
-        super().__init__()
-        self.n: int = 0
-        self.corrects = torch.zeros(1)
-
     def forward(self, output: torch.Tensor, *targets: torch.Tensor) -> torch.Tensor:
-        target_0 = targets[0]
-        self.n += output.shape[0]
-        self.corrects += (torch.argmax(torch.softmax(output, dim=1), dim=1) == target_0).sum().float().cpu()
-        return self.corrects / self.n
+        # Return this batch's accuracy; the logging window means it over the batches and resets between
+        # train and validation. Accumulating n/corrects on the instance instead reported one lifetime
+        # fraction that blended every epoch and both splits.
+        predicted = torch.argmax(torch.softmax(output, dim=1), dim=1)
+        return (predicted == targets[0]).float().mean()
 
 
 class TripletLoss(Criterion):
@@ -895,11 +891,11 @@ class FID(Criterion):
 
     @staticmethod
     def preprocess_images(image: torch.Tensor) -> torch.Tensor:
-        return F.normalize(
-            F.resize(image, (299, 299)).repeat((1, 3, 1, 1)),
-            mean=[0.485, 0.456, 0.406],
-            std=[0.229, 0.224, 0.225],
-        ).cuda()
+        # resize/normalise-with-mean-std live in torchvision.transforms.functional, not torch.nn.functional
+        # (which has no ``resize`` and whose ``normalize`` takes no mean/std) -- the old calls raised at once.
+        tvf = _require_optional("torchvision.transforms.functional", criterion="FID", extra="fid")
+        resized = tvf.resize(image, [299, 299]).repeat((1, 3, 1, 1))
+        return tvf.normalize(resized, mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
 
     @staticmethod
     def get_features(images: torch.Tensor, model: torch.nn.Module) -> np.ndarray:

--- a/konfai/network/network.py
+++ b/konfai/network/network.py
@@ -1091,7 +1091,12 @@ class Network(ModuleArgsDict, ABC):
         init: bool = True,
         ema: bool = False,
         override_lr: float | None = None,
+        key: str | None = None,
     ):
+        # `checkpoint_save` writes the optimizer/iteration/LR-schedule state under the network's DOTTED path
+        # (its get_networks() key, e.g. "Gan.Generator"). `_apply_network` injects that same dotted path as
+        # `key` here, so a nested network resumes its own state instead of silently missing the bare-name key.
+        state_key = key if key is not None else self.get_name()
         if init:
             self.apply(
                 partial(
@@ -1127,14 +1132,14 @@ class Network(ModuleArgsDict, ABC):
                 else:
                     model_state_dict[alias] = model_state_dict_tmp[alias]
             self.load_state_dict(model_state_dict)
-        if f"{self.get_name()}_optimizer_state_dict" in state_dict and self.optimizer:
-            self.optimizer.load_state_dict(state_dict[f"{self.get_name()}_optimizer_state_dict"])
-        if f"{self.get_name()}_it" in state_dict:
-            _it = state_dict.get(f"{self.get_name()}_it")
+        if f"{state_key}_optimizer_state_dict" in state_dict and self.optimizer:
+            self.optimizer.load_state_dict(state_dict[f"{state_key}_optimizer_state_dict"])
+        if f"{state_key}_it" in state_dict:
+            _it = state_dict.get(f"{state_key}_it")
             if isinstance(_it, int):
                 self._it = _it
-        if f"{self.get_name()}_nb_lr_update" in state_dict:
-            _nb_lr_update = state_dict.get(f"{self.get_name()}_nb_lr_update")
+        if f"{state_key}_nb_lr_update" in state_dict:
+            _nb_lr_update = state_dict.get(f"{state_key}_nb_lr_update")
             if isinstance(_nb_lr_update, int):
                 self._nb_lr_update = _nb_lr_update
 

--- a/konfai/utils/config.py
+++ b/konfai/utils/config.py
@@ -405,6 +405,21 @@ def _convert_union_sequence_value(
     valid_types: tuple[type | object, ...],
     param_name: str,
 ) -> object:
+    # Keep a value whose runtime type already satisfies a union member. Coercing in declaration order is
+    # lossy: int(0.25) == 0 silently beats a float member, str([1, 2]) swallows a list member, and a
+    # list[...] member is never a `type`, so a list value could otherwise never bind through it.
+    if value not in (None, "None"):
+        for candidate_type in valid_types:
+            origin = get_origin(candidate_type)
+            if origin is not None:
+                if isinstance(value, origin):
+                    return value
+            elif isinstance(candidate_type, type) and candidate_type not in (type(None), types.NoneType):
+                # bool subclasses int: only a bool member accepts a bool, never int/float.
+                matched = candidate_type is bool if isinstance(value, bool) else isinstance(value, candidate_type)
+                if matched:
+                    return value
+
     converted = None
     last_error: Exception | None = None
     for candidate_type in valid_types:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -314,6 +314,33 @@ def test_apply_config_converts_sequence_of_union_scalars(write_config) -> None:
     assert all(isinstance(value, int) for value in root.values)
 
 
+def test_apply_config_union_keeps_the_value_type_over_lossy_coercion(write_config) -> None:
+    # A value whose YAML type already matches a union member must bind unchanged: coercing in
+    # declaration order used to turn ``overlap: 0.25`` into ``int(0.25) == 0`` (silent no overlap),
+    # let ``str`` swallow a list, and never reach a ``list[...]`` member at all.
+    write_config("Root:\n  frac: 0.25\n  voxels: 8\n  percent: '20%'\n  per_axis:\n    - 10\n    - 20\n    - 0\n")
+
+    class Root:
+        def __init__(
+            self,
+            frac: int | float | str | list[int] | None = None,
+            voxels: int | float | str | list[int] | None = None,
+            percent: int | float | str | list[int] | None = None,
+            per_axis: int | float | str | list[int] | None = None,
+        ) -> None:
+            self.frac = frac
+            self.voxels = voxels
+            self.percent = percent
+            self.per_axis = per_axis
+
+    root = apply_config("Root")(Root)()
+
+    assert root.frac == 0.25 and isinstance(root.frac, float)  # not int(0.25) == 0
+    assert root.voxels == 8 and isinstance(root.voxels, int)
+    assert root.percent == "20%"
+    assert list(root.per_axis) == [10, 20, 0] and isinstance(root.per_axis, list)  # not the string "[10, 20, 0]"
+
+
 def test_apply_config_binds_scalar_float_or_str_union(write_config) -> None:
     # Mirrors the Clip transform (``min_value``/``max_value: float | str``) which accepts numeric
     # bounds as well as string sentinels such as ``min`` / ``percentile:99.5``.

--- a/tests/unit/test_itk_transforms.py
+++ b/tests/unit/test_itk_transforms.py
@@ -53,3 +53,36 @@ def test_apply_to_data_transform_returns_ndarray() -> None:
     result = apply_to_data_transform(points, {translation: False})
     assert isinstance(result, np.ndarray)
     np.testing.assert_allclose(result, points + np.array([10.0, 20.0, 30.0]))
+
+
+def test_resample_transform_applies_displacement_in_physical_space() -> None:
+    # ResampleTransform used to add the physical (dx, dy, dz) displacement straight onto a (z, y, x)
+    # voxel-index grid, transposing x/z and treating millimetres as voxels. A +6 mm translation along X
+    # on a 2 mm-X grid must move content 3 voxels along X (not 6 voxels along Z).
+    import torch
+    from konfai.data.transform import ResampleTransform
+    from konfai.utils.dataset import Attribute
+
+    volume = torch.zeros(1, 8, 8, 8, dtype=torch.uint8)
+    volume[0, 4, 4, 6] = 1  # (z=4, y=4, x=6)
+    attribute = Attribute()
+    attribute["Origin"] = np.array([0.0, 0.0, 0.0])
+    attribute["Spacing"] = np.array([2.0, 1.0, 1.0])  # (x=2 mm, y=1, z=1)
+    attribute["Direction"] = np.eye(3).flatten()
+
+    translation = sitk.TranslationTransform(3, (6.0, 0.0, 0.0))
+
+    class _TransformStore:
+        def is_dataset_exist(self, group: str, name: str) -> bool:
+            return True
+
+        def read_transform(self, group: str, name: str) -> "sitk.Transform":
+            return translation
+
+    transform = ResampleTransform({"reg": False})
+    transform.datasets = [_TransformStore()]
+
+    out = transform("case", volume, attribute)
+    bright = torch.nonzero(out[0] > 0).tolist()
+
+    assert bright == [[4, 4, 3]]  # moved 6 mm / 2 mm = 3 voxels along X, staying on z=4, y=4

--- a/tests/unit/test_measure.py
+++ b/tests/unit/test_measure.py
@@ -296,3 +296,30 @@ class TestImpactRegPCA:
         centred_ch0 = (fixed[0, 0] - fixed[0, 0].mean()).flatten()
         corr = torch.corrcoef(torch.stack([proj, centred_ch0]))[0, 1].abs()
         assert corr > 0.99
+
+
+def test_accuracy_reports_per_batch_not_a_lifetime_running_fraction() -> None:
+    # Accuracy used to accumulate n/corrects on the instance forever, so it reported one fraction that
+    # blended every epoch and both splits. It must now report the current batch (the logging window means
+    # and resets it), so an all-correct batch is 1.0 and a following all-wrong batch is 0.0 -- not 0.5.
+    from konfai.metric.measure import Accuracy
+
+    accuracy = Accuracy()
+    logits = torch.tensor([[9.0, 0.0, 0.0], [0.0, 9.0, 0.0]])  # argmax -> [0, 1]
+
+    all_correct = accuracy(logits, torch.tensor([0, 1]))
+    all_wrong = accuracy(logits, torch.tensor([1, 0]))
+
+    assert all_correct.item() == pytest.approx(1.0)
+    assert all_wrong.item() == pytest.approx(0.0)  # not blended with the previous batch
+
+
+def test_fid_preprocess_images_runs() -> None:
+    # FID.preprocess_images called torch.nn.functional.resize / .normalize(mean, std), neither of which
+    # exists there -- the metric could not execute. It now uses torchvision.transforms.functional.
+    pytest.importorskip("torchvision")
+    from konfai.metric.measure import FID
+
+    out = FID.preprocess_images(torch.zeros(2, 1, 64, 64))
+
+    assert out.shape == (2, 3, 299, 299)

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -445,3 +445,51 @@ def test_model_patch_deep_supervision_heads_each_reassemble_their_own_patches() 
 
     assert torch.equal(outputs["Aux"], x)
     assert torch.equal(outputs["Head"], x * 2.0)
+
+
+def test_load_restores_nested_network_optimizer_and_counters() -> None:
+    # checkpoint_save writes a nested network's optimizer/iteration/LR-schedule state under its DOTTED
+    # get_networks() key ("Root.Sub_optimizer_state_dict"), while load used to look it up under the bare
+    # class name ("Sub_..."), so every composite model (GAN family) silently resumed with a fresh Adam and
+    # _it == 0. load now consumes the dotted key injected by _apply_network.
+    from konfai.network.network import OptimizerLoader
+
+    class Sub(Network):
+        def __init__(self) -> None:
+            super().__init__(in_channels=1, optimizer=OptimizerLoader(), dim=2)
+            self.add_module("Conv", torch.nn.Conv2d(1, 1, 1))
+
+    class Root(Network):
+        def __init__(self) -> None:
+            super().__init__(in_channels=1, optimizer=None, dim=2)
+            self.add_module("Sub", Sub())
+
+    def with_optimizers(root: Network) -> Network:
+        for sub in root.get_networks().values():
+            if isinstance(sub, Sub):
+                sub.optimizer = torch.optim.AdamW(sub.parameters())
+        return root
+
+    source = with_optimizers(Root())
+    saved_sub = next(net for name, net in source.get_networks().items() if name.endswith(".Sub"))
+    sum(param.sum() for param in saved_sub.parameters()).backward()
+    saved_sub.optimizer.step()
+    saved_sub._it = 123
+    saved_sub._nb_lr_update = 7
+
+    # Mirror checkpoint_save: dotted get_networks() keys.
+    state_dict: dict = {"Model": source.state_dict()}
+    for name, net in source.get_networks().items():
+        if net.optimizer is not None:
+            state_dict[f"{name}_optimizer_state_dict"] = net.optimizer.state_dict()
+            state_dict[f"{name}_it"] = net._it
+            state_dict[f"{name}_nb_lr_update"] = net._nb_lr_update
+    assert "Root.Sub_optimizer_state_dict" in state_dict  # the dotted key checkpoint_save actually writes
+
+    target = with_optimizers(Root())
+    target.load(state_dict, init=False)
+
+    loaded_sub = next(net for name, net in target.get_networks().items() if name.endswith(".Sub"))
+    assert loaded_sub._it == 123
+    assert loaded_sub._nb_lr_update == 7
+    assert loaded_sub.optimizer.state_dict()["state"] == saved_sub.optimizer.state_dict()["state"]


### PR DESCRIPTION
Applies the **clean, tested, low-risk** correctness findings from the audit. Each fix is minimal, guarded by a regression test, and verified not to change the common paths. Riskier or unverifiable findings are intentionally left for dedicated PRs (listed below).

## Fixes
1. **fix(config)** — the union binder tried members in declaration order with lossy `candidate_type(value)`, so `overlap: 0.25` bound `int(0.25) == 0` (silent no overlap → seam artifacts), a `str` member swallowed a list, and a `list[...]` member never bound. Now the value is kept when its runtime type already satisfies a member (isinstance-first), falling back to coercion only otherwise. *(P0)*
2. **fix(network)** — `checkpoint_save` writes a nested network's optimizer/`_it`/`_nb_lr_update` under its **dotted** `get_networks()` key, but `Network.load` looked them up under the bare class name, so every composite model (GAN family) silently resumed with a fresh Adam and `_it == 0`. `load` now consumes the dotted key `_apply_network` already injects. Single-network models are unaffected (key == class name); the weights path is untouched. *(P1)*
3. **fix(transform)** — `ResampleTransform` added the stored transform's physical `(dx,dy,dz)` displacement straight onto a `(z,y,x)` voxel-index grid (x/z transposed, mm treated as voxels). It now resamples via `sitk.Resample`, honouring spacing/direction/units by construction. Not used by any shipped config. *(P1)*
4. **fix(metric)** — `FID.preprocess_images` called `torch.nn.functional.resize`/`.normalize(mean,std)` (neither exists), so FID could never run → uses `torchvision.transforms.functional`. `Accuracy` accumulated `n`/`corrects` for the whole process (one fraction blending every epoch and both splits) → returns the current batch, letting the logging window mean and reset it. Both were unused in tests/configs. *(P2)*

## Tests
New regression tests: union type-preservation (`test_config`), nested-composite resume of optimizer/counters (`test_network`), known-translation geometry (`test_itk_transforms`), and metric smoke tests for FID + Accuracy (`test_measure`).

## Verification
- `pixi run check` (lint + format + core + apps): green · `konfai-mcp`: 145 passed
- single-network RESUME integration test still green (the common path is unchanged)

## Intentionally deferred (own verified PRs — still tracked in the audit)
- GAN example won't build (criterion coordinates validated per-owner but matched in root coords) — touches all criterion routing
- Elastix augmentation axis/units (same class as #3, but unverified and changes augmentation output)
- multi-GPU prediction deadlock (per-batch `all_gather` on unequal shards) — needs a 2-GPU repro
- augmentation determinism (persistent workers / validation index / CUDA RNG) and train/val split seeding — change RNG behaviour
- `PerceptualLoss` dropping losses when targets < losses; `LPIPS`/`IMPACTReg` hard-coded `cuda:0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Checkpoint loading now supports restoring nested component optimizer/counter state (via an optional key).
  - Image resampling now operates in physical space and performs label-aware interpolation.
  - Configuration union binding preserves the original YAML value type when it already matches a union member.

- **Bug Fixes**
  - Accuracy now reports per-batch accuracy (not a lifetime running fraction).
  - FID image preprocessing now runs reliably with optional torchvision support and avoids unconditional device assumptions.

- **Tests**
  - Added coverage for physical-space displacement resampling, nested checkpoint restoration, accuracy behavior, union type preservation, and FID preprocessing.

- **Chores**
  - macOS CI now sets the Gloo network interface to loopback for stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->