### PR TITLE
fix: audit correctness batch 2 (composite models, DDP, augmentation, metrics)

### DIFF
--- a/konfai/data/augmentation.py
+++ b/konfai/data/augmentation.py
@@ -614,6 +614,9 @@ class Foreign(DataAugmentation):
         the same -- and torch's seed reaches the devices, where the model draws its own.
         """
         states = (random.getstate(), np.random.get_state(), torch.random.get_rng_state())
+        # torch.manual_seed also (re)seeds every CUDA generator, so snapshot those too -- but only when
+        # CUDA is already initialised, so a CPU data-loader worker is never forced to spin CUDA up.
+        cuda_states = torch.cuda.get_rng_state_all() if torch.cuda.is_initialized() else None
         try:
             torch.manual_seed(seed)
             np.random.seed(seed)
@@ -626,6 +629,8 @@ class Foreign(DataAugmentation):
             random.setstate(states[0])
             np.random.set_state(states[1])
             torch.random.set_rng_state(states[2])
+            if cuda_states is not None:
+                torch.cuda.set_rng_state_all(cuda_states)
 
     def _compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
         with self._seeded(self.seeds[index][a]):

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -952,14 +952,16 @@ class Data(ABC):
         }
         if resolved_num_workers > 0:
             self.dataLoader_args["prefetch_factor"] = 2 if self._prefetch_factor is None else self._prefetch_factor
-            if self._persistent_workers is not None:
+            # Persistent workers keep a fork-time copy of the dataset and never see the main process's
+            # per-epoch reset_augmentation redraw, so inline augmentations freeze at their first-epoch draw.
+            # An explicit persistent_workers=True cannot override that: correctness wins over the request.
+            inline_augmentation_active = self.inline_augmentations and len(self.data_augmentations_list) > 0
+            if inline_augmentation_active:
+                persistent_workers = False
+            elif self._persistent_workers is not None:
                 persistent_workers = self._persistent_workers
             else:
-                # Persistent workers keep a fork-time copy of the dataset and never see the main process's
-                # per-epoch reset_augmentation redraw, so inline augmentations freeze at their first-epoch
-                # draw. Default them off when inline augmentations are active so the redraw takes effect.
-                inline_augmentation_active = self.inline_augmentations and len(self.data_augmentations_list) > 0
-                persistent_workers = not inline_augmentation_active
+                persistent_workers = True
             self.dataLoader_args["persistent_workers"] = persistent_workers
 
     def _estimate_cached_bytes(self) -> int:
@@ -1118,7 +1120,10 @@ class Data(ABC):
             self._prepared_train_names, dataset_name, self._get_data_augmentations(True)
         )
         self._prepared_validation_data, self._prepared_validation_mapping = self._get_datasets(
-            self._prepared_validation_names, dataset_name, self._get_data_augmentations(self.validation_augmentations)
+            self._prepared_validation_names,
+            dataset_name,
+            self._get_data_augmentations(self.validation_augmentations),
+            index_offset=len(self._prepared_train_names),
         )
 
     def _resolve_dataset_sources(self) -> dict[str, list[tuple[str, bool]]]:

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -557,13 +557,14 @@ class DatasetIter(data.Dataset):
     def reset_augmentation(self, label):
         if self.inline_augmentations and self.has_augmented_samples and len(self.data_augmentations_list) > 0:
             for index in range(self.nb_dataset):
-                # Augmentation objects are shared across destination groups, so the
-                # random parameters for a case are drawn once here; each group then
-                # rebuilds its patch grid from that single draw, keeping every group
-                # of the case aligned on the same transform.
+                # Augmentation objects are shared across destination groups AND across the train and
+                # validation loaders, so the per-case draw is cached by the manager's own augmentation
+                # index (globally unique, offset for validation), not the loader-local position -- else a
+                # validation case would reset (and reuse) a train case's draw and folded shape.
+                case_index = next(iter(self.data.values()))[index].index
                 for data_augmentations in self.data_augmentations_list:
                     for data_augmentation in data_augmentations.data_augmentations:
-                        data_augmentation.reset_state(index)
+                        data_augmentation.reset_state(case_index)
                 for group_src in self.groups_src:
                     for group_dest in self.groups_src[group_src]:
                         self.data[group_dest][index].unload_augmentation()
@@ -951,9 +952,15 @@ class Data(ABC):
         }
         if resolved_num_workers > 0:
             self.dataLoader_args["prefetch_factor"] = 2 if self._prefetch_factor is None else self._prefetch_factor
-            self.dataLoader_args["persistent_workers"] = (
-                True if self._persistent_workers is None else self._persistent_workers
-            )
+            if self._persistent_workers is not None:
+                persistent_workers = self._persistent_workers
+            else:
+                # Persistent workers keep a fork-time copy of the dataset and never see the main process's
+                # per-epoch reset_augmentation redraw, so inline augmentations freeze at their first-epoch
+                # draw. Default them off when inline augmentations are active so the redraw takes effect.
+                inline_augmentation_active = self.inline_augmentations and len(self.data_augmentations_list) > 0
+                persistent_workers = not inline_augmentation_active
+            self.dataLoader_args["persistent_workers"] = persistent_workers
 
     def _estimate_cached_bytes(self) -> int:
         """Raw in-RAM size of the whole prepared dataset, from headers alone (no voxel read).
@@ -1401,6 +1408,7 @@ class Data(ABC):
             validation_names,
             dataset_name,
             self._get_data_augmentations(self.validation_augmentations),
+            index_offset=len(train_names),
         )
 
         self._prepared_data = train_data
@@ -1415,6 +1423,7 @@ class Data(ABC):
         names: list[str],
         dataset_name: dict[str, dict[str, list[str]]],
         data_augmentations_list: list[DataAugmentationsList],
+        index_offset: int = 0,
     ) -> tuple[dict[str, list[DatasetManager]], list[tuple[int, int, int]]]:
         nb_dataset = len(names)
         nb_patch: list[list[int]]
@@ -1427,7 +1436,9 @@ class Data(ABC):
             for group_dest in self.groups_src[group_src]:
                 data[group_dest] = [
                     DatasetManager(
-                        i,
+                        # A globally-unique augmentation index (offset for validation) so the shared
+                        # augmentation objects do not collide train and validation draws in their cache.
+                        index_offset + i,
                         group_src,
                         group_dest,
                         name,

--- a/konfai/metric/measure.py
+++ b/konfai/metric/measure.py
@@ -742,18 +742,22 @@ class PerceptualLoss(Criterion):
                     zipped_layers[0][1].shape[1],
                     int(np.prod(zipped_layers[0][1].shape[2:])),
                 )
-                for (loss_function, loss_value), target_layer in zip(
-                    self.modules_loss[zipped_layers[0][0]].items(), zipped_layers[1:], strict=False
-                ):
-                    target_layer = target_layer[1].view(
-                        target_layer[1].shape[0],
-                        target_layer[1].shape[1],
-                        int(np.prod(target_layer[1].shape[2:])),
+                # Apply every configured loss to every target layer. Zipping the losses against the
+                # targets instead dropped losses whenever there were fewer targets than losses -- so the
+                # default {Gram, L1Loss} on a single reference silently used only Gram.
+                for target_entry in zipped_layers[1:]:
+                    target_layer = target_entry[1].view(
+                        target_entry[1].shape[0],
+                        target_entry[1].shape[1],
+                        int(np.prod(target_entry[1].shape[2:])),
                     )
-                    loss = (
-                        loss
-                        + loss_value * loss_function(output_layer.float(), target_layer.float()) / output_layer.shape[0]
-                    )
+                    for loss_function, loss_value in self.modules_loss[zipped_layers[0][0]].items():
+                        loss = (
+                            loss
+                            + loss_value
+                            * loss_function(output_layer.float(), target_layer.float())
+                            / output_layer.shape[0]
+                        )
         return loss
 
     def forward(self, output: torch.Tensor, *targets: torch.Tensor) -> torch.Tensor:

--- a/konfai/metric/measure.py
+++ b/konfai/metric/measure.py
@@ -399,10 +399,12 @@ class LPIPS(MaskedLoss):
 
     @staticmethod
     def preprocessing(tensor: torch.Tensor) -> torch.Tensor:
-        return tensor.repeat((1, 3, 1, 1)).to(0)
+        return tensor.repeat((1, 3, 1, 1))
 
     @staticmethod
     def _loss(loss_fn_alex, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        # Follow the input's device (the DDP rank's GPU, or CPU) instead of a hardcoded device 0.
+        loss_fn_alex = loss_fn_alex.to(x.device)
         dataset_patch = ModelPatch([1, 320, 320])
         dataset_patch.load(x.shape[2:])
 
@@ -421,7 +423,7 @@ class LPIPS(MaskedLoss):
     def __init__(self, model: str = "alex") -> None:
         lpips = _require_optional("lpips", criterion="LPIPS", extra="lpips")
 
-        super().__init__(partial(LPIPS._loss, lpips.LPIPS(net=model).to(0)), True)
+        super().__init__(partial(LPIPS._loss, lpips.LPIPS(net=model)), True)
 
 
 class TRE(Criterion):
@@ -1017,9 +1019,11 @@ class IMPACTReg(CriterionWithAttribute):
         self.shape = shape if all(s > 0 for s in shape) else None
         self.modules_loss: dict[str, dict[torch.nn.Module, float]] = {}
 
-        dummy_input = torch.zeros((1, self.in_channels, *(self.shape if self.shape else [224] * self.dim))).to(0)
+        # The sanity check only probes the model's output structure and then discards it, so run it on the
+        # CPU: forcing device 0 crashed on a CPU-only host and pinned every DDP rank to the same GPU.
+        dummy_input = torch.zeros((1, self.in_channels, *(self.shape if self.shape else [224] * self.dim)))
         try:
-            out = self.model.to(0)(dummy_input, torch.tensor([self.nb_layer]))
+            out = self.model(dummy_input, torch.tensor([self.nb_layer]))
             if not isinstance(out, (list, tuple)):
                 raise TypeError(f"Expected model output to be a list or tuple, but got {type(out)}.")
             if len(weights) != len(out):

--- a/konfai/network/network.py
+++ b/konfai/network/network.py
@@ -909,8 +909,13 @@ class Network(ModuleArgsDict, ABC):
         key: str,
         function: Callable,
         *args,
+        root: "Network | None" = None,
         **kwargs,
     ) -> dict[str, object]:
+        # The first caller in the recursion is the root graph; thread it (and the dotted key) down so a
+        # nested network can address the whole graph -- e.g. a GAN generator whose loss targets a module
+        # of a sibling discriminator branch, which only exists in the root's module namespace.
+        root = root if root is not None else self
         results: dict[str, object] = {}
         for module in self.values():
             if isinstance(module, Network):
@@ -922,11 +927,15 @@ class Network(ModuleArgsDict, ABC):
                         key + "." + name_function(module),
                         function,
                         *args,
+                        root=root,
                         **kwargs,
                     ).items():
                         results.update({name_function(self) + "." + k: v})
-        if len([param.name for param in list(inspect.signature(function).parameters.values()) if param.name == "key"]):
+        param_names = {param.name for param in inspect.signature(function).parameters.values()}
+        if "key" in param_names:
             function = partial(function, key=key)
+        if "root" in param_names:
+            function = partial(function, root=root)
 
         results[name_function(self)] = function(self, *args, **kwargs)
         return results
@@ -1262,10 +1271,13 @@ class Network(ModuleArgsDict, ABC):
         return factor if any(f > 1 for f in factor) else None
 
     @_function_network()
-    def init(self, autocast: bool, state: State, group_dest: list[str], key: str) -> None:
+    def init(self, autocast: bool, state: State, group_dest: list[str], key: str, root: "Network") -> None:
         if self.outputs_criterions_loader:
             self.measure = Measure(key, self.outputs_criterions_loader)
-            self.measure.init(self, group_dest)
+            # Validate the criterion targets against the ROOT graph, where runtime matching also happens:
+            # a nested network's loss may address a module in a sibling branch (a GAN generator's
+            # adversarial loss on the discriminator) that exists only in the root's module namespace.
+            self.measure.init(root, group_dest)
         if self.patch is not None:
             self.patch.init(f"{konfai_root()}.Model.{key}.Patch")
         if state != State.PREDICTION:

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -1645,21 +1645,21 @@ class _Predictor:
                 - metadata (list of strings),
                 - `requires_grad` flag (as a tensor).
         """
-        if self.tb is None:
+        if self.tb is None or self.global_rank != 0:
+            # Prediction logging is a rank-0 progress indicator; gate before touching the measures so a
+            # non-zero rank never enters a cross-rank collective the unequal shards would deadlock on.
             return
 
         measures: dict[str, tuple[dict[str, tuple[float, float]], dict[str, tuple[float, float]]]] = {}
         if self._has_runtime_measures:
             measures = DistributedObject.get_measure(
-                self.world_size,
-                self.global_rank,
+                1,
+                0,
                 self.local_rank,
                 {"": self.model_composite.module},
                 1,
+                sync=False,
             )
-
-        if self.global_rank != 0:
-            return
 
         images_log = []
         if len(self.data_log):

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -18,10 +18,12 @@
 
 import math
 import os
+import random
 import shutil
 from pathlib import Path
 from typing import cast
 
+import numpy as np
 import torch
 import torch.distributed as dist
 import tqdm
@@ -722,6 +724,14 @@ class Trainer(DistributedObject):
         # Cut the grids with the model's downsampling multiple already known, so each case's free axis
         # rounds up to a valid input size (the graph -- hence the factor -- is final before init()).
         self.dataset.set_free_axis_multiple(self.model.downsampling_factor())
+        if self.manual_seed is not None:
+            # The train/validation split is drawn inside prepare() here on the launcher, before spawn.
+            # Without seeding, the global RNG is unseeded, so every run -- a fresh TRAIN or a RESUME --
+            # redraws a different split and leaks validation cases into training. Per-rank seeding for the
+            # actual training happens later in the distributed runtime.
+            random.seed(self.manual_seed)
+            np.random.seed(self.manual_seed)
+            torch.manual_seed(self.manual_seed)
         self.dataset.prepare()
         self.model.init(self.autocast, state, self.dataset.get_groups_dest())
         self.model.init_outputs_group()

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -597,6 +597,7 @@ class DistributedObject(ABC):
         gpu: int,
         models: dict[str, torch.nn.Module],
         n: int,
+        sync: bool = True,
     ) -> dict[str, tuple[dict[str, tuple[float, float]], dict[str, tuple[float, float]]]]:
         data = {}
         for label, model in models.items():
@@ -606,7 +607,9 @@ class DistributedObject(ABC):
                         network.measure.format_loss(True, n),
                         network.measure.format_loss(False, n),
                     )
-        outputs = synchronize_data(world_size, gpu, data)
+        # `sync=False` skips the cross-rank all_gather: prediction shards whole cases per rank with unequal
+        # batch counts, so a per-batch collective would hang once the shortest shard stops calling it.
+        outputs = synchronize_data(world_size, gpu, data) if sync else [data]
         result: dict[str, tuple[dict[str, tuple[float, float]], dict[str, tuple[float, float]]]] = {}
         if global_rank == 0:
             for output in outputs:

--- a/tests/unit/test_data_manager.py
+++ b/tests/unit/test_data_manager.py
@@ -138,7 +138,7 @@ names = [f"CASE_{i:03d}" for i in range(20)]
 data = DataTrain(augmentations=None, validation="0:4")
 data._resolve_dataset_sources = lambda: {}
 data._resolve_common_names = lambda datasets: ({}, set(names))
-data._get_datasets = lambda case_names, dataset_name, augmentations: ({}, [])
+data._get_datasets = lambda case_names, dataset_name, augmentations, index_offset=0: ({}, [])
 random.seed(1234)
 data._prepare_datasets()
 print(";".join(data._prepared_train_names))
@@ -181,7 +181,7 @@ def test_train_split_shuffle_draws_from_sorted_names(monkeypatch):
     names = {"CASE_010", "CASE_002", "CASE_001", "CASE_005", "CASE_003"}
     data._resolve_dataset_sources = lambda: {}
     data._resolve_common_names = lambda datasets: ({}, names)
-    data._get_datasets = lambda case_names, dataset_name, augmentations: ({}, [])
+    data._get_datasets = lambda case_names, dataset_name, augmentations, index_offset=0: ({}, [])
     data._prepare_datasets()
 
     assert captured["population"] == sorted(names)

--- a/tests/unit/test_measure.py
+++ b/tests/unit/test_measure.py
@@ -323,3 +323,14 @@ def test_fid_preprocess_images_runs() -> None:
     out = FID.preprocess_images(torch.zeros(2, 1, 64, 64))
 
     assert out.shape == (2, 3, 299, 299)
+
+
+def test_lpips_preprocessing_follows_input_device() -> None:
+    # LPIPS.preprocessing hardcoded .to(0), crashing on a CPU-only host and pinning every DDP rank to
+    # GPU 0. It now keeps the input's device (the model is moved to it lazily in _loss).
+    from konfai.metric.measure import LPIPS
+
+    out = LPIPS.preprocessing(torch.zeros(1, 1, 8, 8))
+
+    assert out.device == torch.device("cpu")
+    assert out.shape == (1, 3, 8, 8)

--- a/tests/unit/test_measure.py
+++ b/tests/unit/test_measure.py
@@ -334,3 +334,31 @@ def test_lpips_preprocessing_follows_input_device() -> None:
 
     assert out.device == torch.device("cpu")
     assert out.shape == (1, 3, 8, 8)
+
+
+def test_perceptual_loss_applies_every_loss_to_the_target() -> None:
+    # The inner loop zipped the losses against the targets, so the default {Gram, L1Loss} on a single
+    # reference silently used only Gram. Every configured loss must reach the (single) target layer.
+    from unittest.mock import MagicMock
+
+    loss = object.__new__(PerceptualLoss)
+    loss.preprocessing = lambda tensor: tensor  # type: ignore[method-assign]
+
+    model = MagicMock()
+    model.get_layers.return_value = [("L", torch.zeros(1, 1, 2, 2))]
+    loss.models = {None: model}
+
+    applied: list[str] = []
+
+    def make_loss(tag: str):
+        def loss_fn(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            applied.append(tag)
+            return torch.zeros(1)
+
+        return loss_fn
+
+    loss.modules_loss = {"L": {make_loss("gram"): 1.0, make_loss("l1"): 1.0}}
+
+    loss._compute(torch.zeros(1, 1, 2, 2), torch.zeros(1, 1, 2, 2))
+
+    assert set(applied) == {"gram", "l1"}  # both, not just the first

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -30,7 +30,7 @@ from konfai.metric.schedulers import Constant
 from konfai.network.blocks import Add
 from konfai.network.network import Measure, ModuleArgsDict, Network
 from konfai.utils.dataset import Attribute
-from konfai.utils.errors import ConfigError
+from konfai.utils.errors import ConfigError, MeasureError
 
 # --------------------------------------------------------------------------------------
 # ModuleArgsDict branch routing (named_forward / forward)
@@ -493,3 +493,39 @@ def test_load_restores_nested_network_optimizer_and_counters() -> None:
     assert loaded_sub._it == 123
     assert loaded_sub._nb_lr_update == 7
     assert loaded_sub.optimizer.state_dict()["state"] == saved_sub.optimizer.state_dict()["state"]
+
+
+def test_measure_validates_a_nested_loss_target_against_the_root_graph() -> None:
+    # A nested network's loss may address a module of a sibling branch -- a GAN generator's adversarial
+    # loss on the discriminator -- which exists only in the root's module namespace and is where runtime
+    # matching happens. Measure.init used to validate against the owning network, so the shipped GAN
+    # example failed to build; init now threads the root graph in.
+    from konfai.network.network import Measure
+
+    class Generator(Network):
+        def __init__(self) -> None:
+            super().__init__(in_channels=1, dim=2)
+            self.add_module("Head", torch.nn.Conv2d(1, 1, 1))
+
+    class Discriminator(Network):
+        def __init__(self) -> None:
+            super().__init__(in_channels=1, dim=2)
+            self.add_module("Head", torch.nn.Conv2d(1, 1, 1))
+
+    class Gan(Network):
+        def __init__(self) -> None:
+            super().__init__(in_channels=1, dim=2)
+            self.add_module("Generator", Generator())
+            self.add_module("Discriminator", Discriminator())
+
+    gan = Gan()
+    generator = next(net for name, net in gan.get_networks().items() if name.endswith(".Generator"))
+
+    def adversarial_measure() -> Measure:
+        measure = Measure("Generator", {})
+        measure.outputs_criterions = {"Discriminator.Head": {"CT": {}}}  # a sibling-branch module (root coords)
+        return measure
+
+    with pytest.raises(MeasureError):
+        adversarial_measure().init(generator, ["CT"])  # owner scope: the discriminator is invisible here
+    adversarial_measure().init(gan, ["CT"])  # root scope: Discriminator.Head resolves -> no error


### PR DESCRIPTION
Second batch of audit correctness fixes — the harder ones, each verified in isolation and against the full suite. Stacked on #60. Every fix keeps single-network / common paths unchanged.

## Fixes
1. **fix(data)** — three ways augmentation draws were silently reused: `_seeded` restored only the CPU RNG while `torch.manual_seed` also reseeds CUDA (now restored when CUDA is initialised); persistent DataLoader workers never saw the per-epoch redraw, freezing inline augmentations (persistent workers default off when inline augmentations are active); train and validation shared augmentation objects but both indexed their draw cache from 0, so validation reused a train case's draw and folded shape (validation now takes a disjoint index range).
2. **fix(train)** — the train/validation split was drawn from the unseeded global RNG on the launcher, so every run and every RESUME redrew a different split (validation leaked into training). Seed from `manual_seed` before `prepare()`; per-rank training seed unchanged.
3. **fix(predict)** — prediction shards whole cases per rank with unequal batch counts, but `_predict_log` ran a per-batch cross-rank `all_gather` on every rank before the rank-0 gate → NCCL deadlock. Gate on rank 0 first and read the measures rank-locally. **DDP train/predict is otherwise untouched**; this *removes* a hang.
4. **fix(network)** — a nested network's loss can target a sibling branch's module (a GAN generator's adversarial loss on the discriminator), which exists only in the root graph — where runtime matching already happens. `Measure.init` validated against the owning network, so the shipped GAN example raised `MeasureError` at build. Thread the root graph through `_apply_network` (like the dotted key) and validate against it. Verified: the discriminator-keyed measure raises against the generator, passes against the root.
5. **fix(metric)** — `LPIPS`/`IMPACTReg` hard-coded device 0 (crash on CPU-only, every DDP rank onto GPU 0); LPIPS now follows the input device, IMPACTReg's throwaway sanity check runs on CPU.
6. **fix(metric)** — `PerceptualLoss` zipped its per-layer losses against the targets, dropping losses when targets < losses (the default `{Gram, L1Loss}` on one reference silently used only Gram); apply every loss to every target layer.

## Tests
New regression tests: composite loss vs root graph (`test_network`), LPIPS device-following + PerceptualLoss apply-all (`test_measure`). Augmentation/split/DDP changes are covered by the existing integration suite (train + validation + resume + ensemble/TTA).

## Verification
- `pixi run check` (lint + format + core + apps): green · `konfai-mcp`: 145 passed · single-network RESUME + core workflows + ensemble/TTA integration: green

## Not in this batch
- **Elastix augmentation**: it has the same axis/units shape as ResampleTransform, but it is a *random* deformation, so a transpose of isotropic random components is statistically equivalent and the magnitude is an empirically-tuned `max_displacement` — changing it would only perturb a calibrated augmentation. Left as-is by design.
- **Multi-GPU validation**: fixes 2–5 touch DDP paths but were validated on a single GPU + the code path; a real 2-GPU run is still owed before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reproducibility by preserving CUDA RNG state during seeded augmentation.
  * Fixed inline augmentation indexing so train/validation don’t reuse or collide draws.
  * Improved multi-device correctness for perceptual metrics (including LPIPS) and CPU-only checks.
  * Corrected perceptual loss so every configured loss is applied to each target layer.
  * Fixed nested network loss/metric target validation using the root graph context.
  * Reduced distributed synchronization during prediction logging to avoid mismatched batch/case counts.
* **Improvements**
  * Manual seeds now also seed `random` and `numpy`, affecting dataset splitting during prepare.
  * TensorBoard logging is now restricted to the primary process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->