### PR TITLE
fix: audit correctness tail (h5 output, dataset hygiene, CI wheel)

### DIFF
--- a/.github/workflows/konfai_ci.yml
+++ b/.github/workflows/konfai_ci.yml
@@ -98,6 +98,22 @@ jobs:
       - name: Build sdist and wheel
         run: python -m build --sdist --wheel
 
+      - name: Verify the wheel ships the model catalog and no sibling package
+        # The test job installs editable, which hides PEP 420 (konfai/models/python has no __init__.py)
+        # and package-data (the catalog *.yml) breakage. Inspect the built artifact directly.
+        run: |
+          python - <<'PY'
+          import glob, zipfile
+          names = zipfile.ZipFile(glob.glob("dist/*.whl")[0]).namelist()
+          py = sum(1 for n in names if "/models/python/" in n and n.endswith(".py"))
+          yml = sum(1 for n in names if "/models/yaml/" in n and n.endswith(".yml"))
+          leaked = [n for n in names if n.split("/")[0].endswith("-apps")]
+          assert py >= 16, f"models/python underpopulated in the wheel: {py} files"
+          assert yml == 14, f"catalog .yml count wrong in the wheel: {yml}"
+          assert not leaked, f"hyphenated sibling leaked into the wheel: {leaked[:3]}"
+          print(f"wheel OK: {py} models/python files, {yml} catalog .yml, no sibling leak")
+          PY
+
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/konfai_ci.yml
+++ b/.github/workflows/konfai_ci.yml
@@ -107,7 +107,7 @@ jobs:
           names = zipfile.ZipFile(glob.glob("dist/*.whl")[0]).namelist()
           py = sum(1 for n in names if "/models/python/" in n and n.endswith(".py"))
           yml = sum(1 for n in names if "/models/yaml/" in n and n.endswith(".yml"))
-          leaked = [n for n in names if n.split("/")[0].endswith("-apps")]
+          leaked = [n for n in names if n.split("/", 1)[0].endswith("-apps") or n.split("/", 1)[0] == "konfai_apps"]
           assert py >= 16, f"models/python underpopulated in the wheel: {py} files"
           assert yml == 14, f"catalog .yml count wrong in the wheel: {yml}"
           assert not leaked, f"hyphenated sibling leaked into the wheel: {leaked[:3]}"

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -1950,7 +1950,9 @@ class Predictor(DistributedObject):
         self.predict_path = predictions_directory() / self.name
         for output_dataset in self.outputs_dataset.values():
             self.datasets_filename.append(output_dataset.filename)
-            output_dataset.filename = str(self.predict_path / output_dataset.filename) + "/"
+            # Rebase under the run directory, re-deriving is_directory: a bare string + "/" turned an h5
+            # output into a directory-flagged path and wrote the hidden dotfile Predictions/<run>/Dataset/.h5.
+            output_dataset.rebase(self.predict_path)
         self.data_log = data_log
         modules = []
         for i, _ in self.model.named_modules():

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -133,8 +133,17 @@ class Attribute(dict[str, Any]):
         for k, v in attributes.items():
             super().__setitem__(copy.deepcopy(k), copy.deepcopy(v))
 
+    @staticmethod
+    def _is_stack_member(stored_key: str, key: str) -> bool:
+        # Values are stacked as ``{key}_{n}``; match that exact pattern (or the bare key) so a sibling that
+        # merely shares a prefix -- ``SpacingOriginal`` vs ``Spacing`` -- is not miscounted as another entry.
+        if stored_key == key:
+            return True
+        prefix = f"{key}_"
+        return stored_key.startswith(prefix) and stored_key[len(prefix) :].isdigit()
+
     def _count_key(self, key: str) -> int:
-        return len([k for k in super().keys() if k.startswith(key)])
+        return sum(1 for k in super().keys() if Attribute._is_stack_member(k, key))
 
     def __getitem__(self, key: str) -> Any:
         i = self._count_key(key)
@@ -180,7 +189,7 @@ class Attribute(dict[str, Any]):
     def __contains__(self, key: object) -> bool:
         if not isinstance(key, str):
             return False
-        return any(k.startswith(key) for k in super().keys())
+        return any(Attribute._is_stack_member(k, key) for k in super().keys())
 
     def is_info(self, key: str, value: str) -> bool:
         return key in self and self[key] == value

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -1418,7 +1418,7 @@ class Dataset:
             from konfai.utils.dicom import get_dicom_info, read_dicom_series_slice
 
             path = self._path(name)
-            info = get_dicom_info(path)
+            info = dict(get_dicom_info(path))  # copy: get_dicom_info is memoised, and we update it below
             data, origin, spacing, direction = read_dicom_series_slice(
                 path, slices, series_uid=info["series_uid"], info=info
             )

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -1523,10 +1523,7 @@ class Dataset:
         base_format, self.level = split_format_level(file_format)
         normalized_format = base_format.lower().removeprefix(".").replace("_", "-")
         file_format = {"ome-zarr": "omezarr", "zarr": "omezarr"}.get(normalized_format, normalized_format)
-        if file_format != "h5" and not str(filename).endswith("/"):
-            filename = f"{filename}/"
-        self.is_directory = str(filename).endswith("/")
-        self.filename = str(filename)
+        self.filename, self.is_directory = Dataset._normalize_path(filename, file_format)
         self.file_format = file_format
         # The store backend is auto-detected from what is actually on disk (like SitkFile already probes
         # every supported extension) — an OME-Zarr / Zarr / DICOM store is a directory whose type is
@@ -1537,6 +1534,20 @@ class Dataset:
             self.file_format = detected
         self._names_cache: dict[str, list[str]] = {}
         self._infos_cache: dict[tuple[str, str], tuple[list[int], Attribute]] = {}
+
+    @staticmethod
+    def _normalize_path(filename: str | Path, file_format: str) -> tuple[str, bool]:
+        # A single-store h5 is one file, every other backend a directory of cases: only the latter gets the
+        # trailing slash that marks ``is_directory``. Keep the two in lock-step so a path never ends up a
+        # directory-flagged h5 (which would write the hidden dotfile ``<dir>/.h5``).
+        path = str(filename)
+        if file_format != "h5" and not path.endswith("/"):
+            path += "/"
+        return path, path.endswith("/")
+
+    def rebase(self, prefix: Path) -> None:
+        """Prepend ``prefix`` to this dataset's path, re-deriving ``is_directory`` from the format."""
+        self.filename, self.is_directory = Dataset._normalize_path(prefix / self.filename, self.file_format)
 
     @staticmethod
     def _detect_directory_store_format(root: str) -> str | None:

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -1556,8 +1556,10 @@ class Dataset:
     def _normalize_path(filename: str | Path, file_format: str) -> tuple[str, bool]:
         # A single-store h5 is one file, every other backend a directory of cases: only the latter gets the
         # trailing slash that marks ``is_directory``. Keep the two in lock-step so a path never ends up a
-        # directory-flagged h5 (which would write the hidden dotfile ``<dir>/.h5``).
-        path = str(filename)
+        # directory-flagged h5 (which would write the hidden dotfile ``<dir>/.h5``). ``as_posix`` keeps the
+        # separator forward on every OS, so the stored filename (and the trailing-slash marker) is the same
+        # on Windows, where ``prefix / name`` would otherwise render backslashes.
+        path = Path(filename).as_posix()
         if file_format != "h5" and not path.endswith("/"):
             path += "/"
         return path, path.endswith("/")

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -550,16 +550,24 @@ class _OmeZarrDataStream(DataStream):
         if not success:
             shutil.rmtree(self._store_path, ignore_errors=True)
             return
-        if self._final_path.exists():
-            shutil.rmtree(self._final_path)
+        # Move an existing store aside instead of deleting it up front, so a replaced entry stays
+        # recoverable (at <name>.replaced-<pid>) until the new store is renamed into place -- a directory
+        # swap is not atomic, and the old rmtree-then-rename lost both on a crash in the window.
+        replaced = self._final_path.exists()
+        backup = self._final_path.with_name(f"{self._final_path.name}.replaced-{os.getpid()}")
+        if replaced:
+            shutil.rmtree(backup, ignore_errors=True)
+            os.rename(self._final_path, backup)
         try:
             os.rename(self._store_path, self._final_path)
         except OSError:
-            # A concurrent writer of the same entry renamed its complete, identical store into place
-            # between the rmtree and this rename; keep it and drop ours.
+            # A concurrent writer of the same entry renamed its complete, identical store into place;
+            # keep it and drop ours.
             if not self._final_path.exists():
                 raise
             shutil.rmtree(self._store_path, ignore_errors=True)
+        if replaced:
+            shutil.rmtree(backup, ignore_errors=True)
 
 
 class Dataset:

--- a/konfai/utils/dicom.py
+++ b/konfai/utils/dicom.py
@@ -50,6 +50,7 @@ import os
 import re
 from collections.abc import Sequence
 from datetime import datetime
+from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -369,12 +370,17 @@ def read_volume(
     return volume[np.newaxis]  # (1, Z, Y, X)
 
 
+@lru_cache(maxsize=64)
 def get_dicom_info(
     directory: str | Path,
     *,
     series_uid: str | None = None,
 ) -> dict[str, Any]:
-    """Read DICOM series shape and geometry without decoding pixel data."""
+    """Read DICOM series shape and geometry without decoding pixel data.
+
+    Memoised per directory: input DICOM is read-only for a run, so the series walk and header reads are
+    done once instead of on every patch read. Callers that mutate the result must copy it first.
+    """
     selected_uid, files = _select_series_files(directory, series_uid)
     datasets = sort_series(files, stop_before_pixels=True)
     origin, spacing, direction = extract_geometry(datasets)

--- a/konfai/utils/pretrained.py
+++ b/konfai/utils/pretrained.py
@@ -139,19 +139,21 @@ def transfer_weights_by_execution_order(
             "Weight transfer requires a weight-exact architecture; check that hyperparameters "
             "(channels/depth/dim) match the reference and that both forwards ran on the same input.",
         )
-    # A parameter tied across two target leaves would be written twice by the per-leaf loads below, so the
-    # earlier leaf would silently end up with the later leaf's source weights. Refuse rather than mis-load.
-    seen_parameters: dict[int, str] = {}
+    # A tensor tied across two target leaves would be written twice by the per-leaf loads below, so the
+    # earlier leaf would silently end up with the later leaf's source weights. state_dict(keep_vars=True)
+    # yields the live parameters AND persistent buffers -- exactly what load_state_dict writes -- so a tied
+    # buffer is caught as well. Refuse rather than mis-load.
+    seen_tensors: dict[int, str] = {}
     for leaf in target_leaves:
-        for parameter_name, parameter in leaf.named_parameters():
-            if id(parameter) in seen_parameters:
+        for tensor_name, tensor in leaf.state_dict(keep_vars=True).items():
+            if id(tensor) in seen_tensors:
                 raise ConfigError(
-                    "Cannot transfer weights: the target ties a parameter across two weighted leaves "
-                    f"('{seen_parameters[id(parameter)]}' and '{parameter_name}').",
+                    "Cannot transfer weights: the target ties a tensor across two weighted leaves "
+                    f"('{seen_tensors[id(tensor)]}' and '{tensor_name}').",
                     "Execution-order pairing loads each leaf's source into the shared tensor in turn, so the "
                     "earlier leaf would silently keep the later one's weights. Transfer such a model by name.",
                 )
-            seen_parameters[id(parameter)] = parameter_name
+            seen_tensors[id(tensor)] = tensor_name
     for index, (target_leaf, source_leaf) in enumerate(zip(target_leaves, source_leaves, strict=True)):
         target_state = target_leaf.state_dict()
         source_state = source_leaf.state_dict()

--- a/konfai/utils/pretrained.py
+++ b/konfai/utils/pretrained.py
@@ -139,6 +139,19 @@ def transfer_weights_by_execution_order(
             "Weight transfer requires a weight-exact architecture; check that hyperparameters "
             "(channels/depth/dim) match the reference and that both forwards ran on the same input.",
         )
+    # A parameter tied across two target leaves would be written twice by the per-leaf loads below, so the
+    # earlier leaf would silently end up with the later leaf's source weights. Refuse rather than mis-load.
+    seen_parameters: dict[int, str] = {}
+    for leaf in target_leaves:
+        for parameter_name, parameter in leaf.named_parameters():
+            if id(parameter) in seen_parameters:
+                raise ConfigError(
+                    "Cannot transfer weights: the target ties a parameter across two weighted leaves "
+                    f"('{seen_parameters[id(parameter)]}' and '{parameter_name}').",
+                    "Execution-order pairing loads each leaf's source into the shared tensor in turn, so the "
+                    "earlier leaf would silently keep the later one's weights. Transfer such a model by name.",
+                )
+            seen_parameters[id(parameter)] = parameter_name
     for index, (target_leaf, source_leaf) in enumerate(zip(target_leaves, source_leaves, strict=True)):
         target_state = target_leaf.state_dict()
         source_state = source_leaf.state_dict()

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -410,3 +410,17 @@ def test_dataset_rebase_keeps_h5_a_file_and_directory_formats_a_directory() -> N
     mha.rebase(Path("Predictions/run"))
     assert mha.filename == "Predictions/run/Dataset/"
     assert mha.is_directory is True
+
+
+def test_attribute_lookup_is_not_fooled_by_a_prefixing_sibling_key() -> None:
+    # Values stack as {key}_{n}; the count used startswith(key), so SpacingOriginal was miscounted as a
+    # second Spacing entry and a["Spacing"] then raised while "Spacing" in a still answered True.
+    from konfai.utils.dataset import Attribute
+
+    attribute = Attribute()
+    attribute["Spacing"] = "1.0 1.0 2.0"
+    attribute["SpacingOriginal"] = "0.5 0.5 1.0"
+
+    assert "Spacing" in attribute
+    assert attribute["Spacing"] == "1.0 1.0 2.0"
+    assert attribute["SpacingOriginal"] == "0.5 0.5 1.0"

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -115,7 +115,7 @@ def test_h5_writes_are_serialised_per_file(tmp_path: Path, image_attributes) -> 
     attrs = image_attributes([0.0, 0.0], [1.0, 1.0])
     dataset.write("CT", "CASE_000", np.zeros((1, 2, 2), dtype=np.float32), attrs)
 
-    lock = _get_h5_file_lock(str(tmp_path / "Volumes") + ".h5")
+    lock = _get_h5_file_lock(dataset.filename + ".h5")  # the store's own key, whatever the OS separator
     started = threading.Event()
     finished = threading.Event()
 

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -392,3 +392,21 @@ def test_directory_store_detects_extensionless_dicom(tmp_path: Path) -> None:
     (series / "IM000001").write_bytes(b"\x00" * 128 + b"DICM" + b"\x00" * 32)
 
     assert Dataset._detect_directory_store_format(f"{tmp_path}/ds/") == "dicom"
+
+
+def test_dataset_rebase_keeps_h5_a_file_and_directory_formats_a_directory() -> None:
+    # Predictor.rebase used to string-append "/" unconditionally, so an h5 output became a
+    # directory-flagged path and the single-store writer wrote the hidden dotfile <dir>/.h5.
+    from pathlib import Path
+
+    from konfai.utils.dataset import Dataset
+
+    h5 = Dataset("Dataset", "h5")
+    h5.rebase(Path("Predictions/run"))
+    assert h5.filename == "Predictions/run/Dataset"  # a file, not "…/Dataset/" -> ".h5"
+    assert h5.is_directory is False
+
+    mha = Dataset("Dataset", "mha")
+    mha.rebase(Path("Predictions/run"))
+    assert mha.filename == "Predictions/run/Dataset/"
+    assert mha.is_directory is True

--- a/tests/unit/test_perf_hot_paths.py
+++ b/tests/unit/test_perf_hot_paths.py
@@ -170,15 +170,26 @@ def test_dicom_slice_info_threading_is_byte_identical_and_removes_rescans(tmp_pa
 
     dataset_file = Dataset.DicomFile(str(tmp_path), read=True)
 
-    # one patch read: 1 discovery + 2 sorts (pre-fix: 3 discoveries + 4 sorts)
+    # one COLD patch read: 1 discovery + 2 sorts (pre-fix: 3 discoveries + 4 sorts). get_dicom_info
+    # is memoised, so the cache must be cleared for the spy to see the cold cost at all.
     calls["discover"] = calls["sort"] = 0
+    dicom.get_dicom_info.cache_clear()
     data, _attr = dataset_file.file_to_data_slice("", "case", sl)
     assert np.array_equal(np.asarray(data), np.asarray(ref[0]))
     assert calls["discover"] == 1
     assert calls["sort"] == 2
 
-    # statistics over Z: 1 discovery (pre-fix: O(Z)); numerics preserved (Welford, ddof=1)
+    # a WARM read of the same case re-discovers nothing; only the per-read slab sort (pixel
+    # loading of the selected files) remains
     calls["discover"] = calls["sort"] = 0
+    data, _attr = dataset_file.file_to_data_slice("", "case", sl)
+    assert np.array_equal(np.asarray(data), np.asarray(ref[0]))
+    assert calls["discover"] == 0
+    assert calls["sort"] == 1
+
+    # statistics over Z: 1 cold discovery (pre-fix: O(Z)); numerics preserved (Welford, ddof=1)
+    calls["discover"] = calls["sort"] = 0
+    dicom.get_dicom_info.cache_clear()
     stats = dataset_file.file_to_data_statistics("", "case")
     assert calls["discover"] == 1
     assert np.isclose(stats["mean"], float(vol.mean()), atol=1e-4)

--- a/tests/unit/test_pretrained_bridge.py
+++ b/tests/unit/test_pretrained_bridge.py
@@ -159,3 +159,30 @@ def test_bridge_ignores_source_branches_the_forward_skips() -> None:
     )
     assert transferred == 1
     assert torch.equal(target.used.weight, source.used.weight)
+
+
+def test_bridge_refuses_a_weight_tied_target() -> None:
+    # Two target leaves sharing one Parameter (weight tying) would each be loaded in turn, so the earlier
+    # leaf would silently keep the later leaf's source weights. The bridge must refuse, not mis-load.
+    class TwoLinear(torch.nn.Module):
+        def __init__(self, tie: bool) -> None:
+            super().__init__()
+            self.a = torch.nn.Linear(4, 4)
+            self.b = torch.nn.Linear(4, 4)
+            if tie:
+                self.b.weight = self.a.weight
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.b(self.a(x))
+
+    target = TwoLinear(tie=True)
+    source = TwoLinear(tie=False)
+    inputs = torch.randn(1, 4)
+
+    with pytest.raises(ConfigError, match=r"ties a parameter"):
+        transfer_weights_by_execution_order(
+            target=target,
+            source=source,
+            target_forward=lambda: target(inputs),
+            source_forward=lambda: source(inputs),
+        )

--- a/tests/unit/test_pretrained_bridge.py
+++ b/tests/unit/test_pretrained_bridge.py
@@ -179,7 +179,34 @@ def test_bridge_refuses_a_weight_tied_target() -> None:
     source = TwoLinear(tie=False)
     inputs = torch.randn(1, 4)
 
-    with pytest.raises(ConfigError, match=r"ties a parameter"):
+    with pytest.raises(ConfigError, match=r"ties a tensor"):
+        transfer_weights_by_execution_order(
+            target=target,
+            source=source,
+            target_forward=lambda: target(inputs),
+            source_forward=lambda: source(inputs),
+        )
+
+
+def test_bridge_refuses_a_buffer_tied_target() -> None:
+    # load_state_dict writes persistent buffers too, so a buffer shared across two weighted leaves would be
+    # overwritten by the later leaf's source just like a tied parameter. The bridge must refuse that as well.
+    class TwoLinearSharedBuffer(torch.nn.Module):
+        def __init__(self, tie: bool) -> None:
+            super().__init__()
+            self.a = torch.nn.Linear(4, 4)
+            self.b = torch.nn.Linear(4, 4)
+            self.a.register_buffer("scale", torch.ones(4))
+            self.b.register_buffer("scale", self.a.scale if tie else torch.ones(4))
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.b(self.a(x) * self.a.scale) * self.b.scale
+
+    target = TwoLinearSharedBuffer(tie=True)
+    source = TwoLinearSharedBuffer(tie=False)
+    inputs = torch.randn(1, 4)
+
+    with pytest.raises(ConfigError, match=r"ties a tensor"):
         transfer_weights_by_execution_order(
             target=target,
             source=source,


### PR DESCRIPTION
The remaining tractable audit findings, each tested. Stacked on #61. Every fix is minimal and keeps the common paths unchanged.

## Fixes
1. **fix(predict)** — the predictor rebased an output path by string-appending `/` without re-deriving `is_directory`, so a single-store **h5 output** became a directory-flagged path and the writer produced the hidden dotfile `Predictions/<run>/Dataset/.h5` no dataset spec could read back. Added `Dataset.rebase`, sharing the trailing-slash / `is_directory` rule with `__init__`. *(P1)*
2. **fix(dataset)** — `Attribute` stacks values as `{key}_{n}` but counted/matched with `startswith(key)`, so a prefixing sibling (`SpacingOriginal` vs `Spacing`) was miscounted and `a["Spacing"]` then raised while `"Spacing" in a` still answered True. Match the `{key}_{digit}` pattern (or the bare key). *(P2)*
3. **perf(dicom)** — `DicomFile.file_to_data_slice` re-walked the directory and re-read every slice header on every patch. Memoise `get_dicom_info` per directory (input DICOM is read-only for a run); the one caller that updates the geometry copies it first. *(P2 perf)*
4. **fix(dataset)** — the OME-Zarr stream deleted the previous store before renaming the new one in, losing both on a crash in the window. Move the old store aside to `<name>.replaced-<pid>` first, then swap, then drop it. *(P2)*
5. **fix(pretrained)** — the execution-order bridge loaded each target leaf in turn, so a weight-**tied** target silently kept the later leaf's source weights (a partial load reported as success). Detect a shared parameter across leaves and refuse. *(P2)*
6. **ci** — the build job built the wheel but never checked it; it now asserts the wheel ships `models/python/**` and the 14 catalog `.yml` and excludes the hyphenated sibling — the PEP 420 / package-data trap an editable install hides.

## Tests
New regression tests: `Dataset.rebase` (h5 vs directory), `Attribute` prefixing sibling, OME-Zarr replace path (existing streaming suite), weight-tied refusal (`test_pretrained_bridge`).

## Verification
`pixi run check` (lint + format + core + apps): green · `konfai-mcp`: 145 passed.

## Left by design (documented deliberate choice or statistically harmless) — see `AUDIT.md` "Fix status"
- **Elastix** axis/units — a random augmentation (transpose of isotropic random components is equivalent).
- **`_flat_downsampling`** ×8 over-count — the opaque-leaf fallback; over-padding is safe, under-counting crashes.
- **`_accumulate_device`** lifetime-peak — the comment states it errs toward CPU, never toward OOM.
- **h5 `locking=False`** — deliberate (the pooled reader needs it).
- **`number_of_mc_dropout`** — documented as reserved.

## Still open (small, deferred)
- Nested criterion `_it` frozen (credible, **unverified** — subtle scheduling semantics).
- `SitkFile.get_infos` full-decode on extension mismatch (niche perf, entangled with the read path).
- Overwrite path `rmtree`s the open rank-0 log dir (plausible, unverified; a log, not data).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prediction dataset output path rebasing and path normalization across formats.
  * Fixed stacked key lookup to match exact `{key}` vs `{key}_{n}` semantics.
  * Improved streamed dataset store replacement for recoverability and concurrent writers; reduced cross-call interference in DICOM reads.
  * Prevented silent mis-loading when pretrained weight/buffer targets are tied/shared.
  * Reduced repeated DICOM metadata scans via caching.
* **Tests**
  * Added/strengthened regression coverage for dataset rebasing, attribute key matching, HDF5 lock keying, pretrained bridge tied targets, and DICOM cold/warm caching behavior.
* **Chores**
  * Enhanced CI wheel artifact verification to validate expected contents and prevent unintended package leakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->