### PR TITLE
feat(apps): export a bundle to onnx + manifest for a Python-free runtime

### DIFF
--- a/konfai-apps/konfai_apps/bundle.py
+++ b/konfai-apps/konfai_apps/bundle.py
@@ -16,12 +16,10 @@
 
 """Assemble a KonfAI app bundle (the HuggingFace layout) from trained artifacts.
 
-:func:`assemble_bundle` builds the
-standard bundle folder (``app.json`` + configs + checkpoints + optional ``Model.py`` /
-``requirements.txt``) and validates the metadata. With ``--onnx``,
-:func:`export_onnx_into_bundle` also emits the portable contract (``model.onnx`` +
-``manifest.json``) so the same bundle drives both the PyTorch runtime and the
-portable konfai-rs / ONNX-Runtime-Web runtimes.
+:func:`assemble_bundle` writes the bundle folder (``app.json`` + configs + checkpoints +
+optional ``Model.py`` / ``requirements.txt``) and validates the metadata. With ``--onnx``,
+:func:`export_onnx_into_bundle` also emits ``model.onnx`` + ``manifest.json`` for the
+Python-free runtime.
 """
 
 from __future__ import annotations
@@ -30,6 +28,7 @@ import json
 import os
 import shutil
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -50,12 +49,10 @@ _PROVIDED_MODULES = {"torch", "torchvision", "numpy", "scipy", "yaml", "konfai",
 
 
 def derive_requirements(py_files: list[str | Path]) -> list[str]:
-    """Best-effort: infer the *extra* PyPI requirements from imports in custom ``.py`` files.
+    """Best-effort: the *extra* PyPI requirements imported by custom ``.py`` files.
 
-    Returns third-party packages imported beyond the standard library and what konfai
-    already provides (so ``segmentation_models_pytorch`` is kept, ``torch``/``numpy`` are
-    not). Heuristic — a draft the author should review; the import→package mapping is
-    approximate.
+    Returns third-party packages beyond the standard library and what konfai provides
+    (``segmentation_models_pytorch`` kept, ``torch``/``numpy`` dropped). A draft to review.
     """
     import ast
     import sys
@@ -78,30 +75,71 @@ def derive_requirements(py_files: list[str | Path]) -> list[str]:
     return sorted(found)
 
 
-def _derive_onnx_params(config: dict[str, Any], root: str) -> tuple[list[int] | None, int | None, int]:
-    """Best-effort ``(patch_size, in_channels, extend_slice)`` read from a prediction config.
+def _find_inference_patch(node: Any) -> dict[str, Any] | None:
+    """The inference ``Patch`` sub-dict (sliding-window geometry), skipping the model's ``ModelPatch``."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "ModelPatch":
+                continue
+            if key == "Patch" and isinstance(value, dict) and "patch_size" in value:
+                return value
+            found = _find_inference_patch(value)
+            if found is not None:
+                return found
+    return None
 
-    ``patch_size`` is the inference ``Patch`` spatial size (dropping a singleton slice
-    dimension for 2.5D); ``in_channels`` comes from the model's ``nb_channel`` /
-    ``in_channels`` / first of ``channels``; ``extend_slice`` from the inference ``Patch``.
-    Returns ``None`` for values that cannot be derived (the caller may use explicit flags).
-    """
 
-    def find_inference_patch(node: Any) -> dict[str, Any] | None:
+def _derive_overlap(patch: dict[str, Any], patch_size: list[int]) -> list[int] | None:
+    """The inference ``Patch.overlap`` as a per-kept-axis list: a scalar broadcasts; a full-rank list
+    drops the same 2.5D singleton axes ``patch_size`` dropped."""
+    raw = patch.get("overlap")
+    if isinstance(raw, bool) or raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        return [int(raw)] * len(patch_size)
+    if isinstance(raw, list):
+        vals = [int(v) for v in raw]
+        if len(vals) == len(patch_size):
+            return vals
+        dims = [int(d) for d in patch.get("patch_size", [])]
+        if len(vals) == len(dims):  # full-rank overlap incl. the singleton slice axis: keep dim>1 axes
+            kept = [v for v, d in zip(vals, dims, strict=True) if d > 1]
+            return kept or vals
+    return None
+
+
+def _derive_blend(config: dict[str, Any], root: str) -> str | None:
+    """The output's ``patch_combine`` window (Gaussian/Cosinus/Mean) -> the manifest ``blend``."""
+
+    def walk(node: Any) -> str | None:
         if isinstance(node, dict):
             for key, value in node.items():
-                if key == "ModelPatch":
-                    continue
-                if key == "Patch" and isinstance(value, dict) and "patch_size" in value:
+                if key == "patch_combine" and isinstance(value, str) and value not in ("None", "none", ""):
                     return value
-                found = find_inference_patch(value)
+                found = walk(value)
+                if found is not None:
+                    return found
+        elif isinstance(node, list):
+            for item in node:
+                found = walk(item)
                 if found is not None:
                     return found
         return None
 
+    return walk(config.get(root))
+
+
+def _derive_onnx_params(config: dict[str, Any], root: str) -> tuple[list[int] | None, int | None, int, float | None]:
+    """Best-effort ``(patch_size, in_channels, extend_slice, pad_value)`` from a prediction config.
+
+    ``patch_size`` drops a singleton slice dim (2.5D); ``in_channels`` reads the model's
+    ``nb_channel`` / ``in_channels`` / first ``channels``. ``None`` for anything not derivable.
+    """
+
     patch_size: list[int] | None = None
     extend_slice = 0
-    patch = find_inference_patch(config)
+    pad_value: float | None = None
+    patch = _find_inference_patch(config)
     if patch is not None:
         raw = patch.get("patch_size")
         if isinstance(raw, list):
@@ -112,6 +150,9 @@ def _derive_onnx_params(config: dict[str, Any], root: str) -> tuple[list[int] | 
             extend_slice = raw_extend
         elif isinstance(raw_extend, str) and raw_extend.lstrip("-").isdigit():
             extend_slice = int(raw_extend)
+        raw_pad = patch.get("pad_value")
+        if isinstance(raw_pad, (int, float)) and not isinstance(raw_pad, bool):
+            pad_value = float(raw_pad)
 
     in_channels: int | None = None
     model_cfg = config.get(root, {}).get("Model", {}) if isinstance(config.get(root), dict) else {}
@@ -128,7 +169,230 @@ def _derive_onnx_params(config: dict[str, Any], root: str) -> tuple[list[int] | 
         if isinstance(channels, list) and channels and isinstance(channels[0], int):
             in_channels = channels[0]
             break
-    return patch_size, in_channels, extend_slice
+    return patch_size, in_channels, extend_slice, pad_value
+
+
+# KonfAI transform name -> runtime op. A transform outside this curated map is refused by the export.
+def _op_cast(p: dict[str, Any]) -> dict[str, Any]:
+    return {"op": "cast", "dtype": str(p.get("dtype", "float32"))}
+
+
+def _op_resample(p: dict[str, Any]) -> dict[str, Any]:
+    return {"op": "resample", "spacing": [float(s) for s in p["spacing"]], "inverse": bool(p.get("inverse", False))}
+
+
+def _clean(value: Any) -> Any:
+    return None if value in (None, "None") else value
+
+
+def _op_standardize(p: dict[str, Any]) -> dict[str, Any]:
+    step: dict[str, Any] = {"op": "standardize"}
+    if _clean(p.get("mean")) is not None:
+        step["mean"] = float(p["mean"]) if not isinstance(p["mean"], list) else p["mean"]
+    if _clean(p.get("std")) is not None:
+        step["std"] = float(p["std"]) if not isinstance(p["std"], list) else p["std"]
+    return step
+
+
+def _op_normalize(p: dict[str, Any]) -> dict[str, Any]:
+    return {"op": "normalize", "min_value": float(p.get("min_value", -1)), "max_value": float(p.get("max_value", 1))}
+
+
+def _op_unnormalize(p: dict[str, Any]) -> dict[str, Any]:
+    return {"op": "unnormalize", "min_value": float(p["min_value"]), "max_value": float(p["max_value"])}
+
+
+def _op_clip(p: dict[str, Any]) -> dict[str, Any]:
+    # Bounds are a fixed number or a data-dependent spec ("min"/"max"/"percentile:<q>") the runtime resolves.
+    def bound(v: Any) -> Any:
+        return v if isinstance(v, str) else float(v)
+
+    return {"op": "clip", "min_value": bound(p.get("min_value", -1024)), "max_value": bound(p.get("max_value", 1024))}
+
+
+_OP_MAP = {
+    "TensorCast": _op_cast,
+    "Clip": _op_clip,
+    "ResampleToResolution": _op_resample,
+    # Canonical reorients from the volume's own direction cosines at runtime; the manifest op is just the inverse flag.
+    "Canonical": lambda p: {"op": "canonical", "inverse": bool(p.get("inverse", True))},
+    "Standardize": _op_standardize,
+    "Normalize": _op_normalize,
+    "UnNormalize": _op_unnormalize,
+    "Softmax": lambda p: {"op": "softmax", "dim": int(p.get("dim", 0))},
+    "Argmax": lambda p: {"op": "argmax", "dim": int(p.get("dim", 0))},
+}
+
+
+def _find_transforms(node: Any, key: str) -> dict[str, Any] | None:
+    """First ``key`` sub-dict of a mapping value (the input ``transforms`` / output ``final_transforms``)."""
+    if isinstance(node, dict):
+        found = node.get(key)
+        if isinstance(found, dict):
+            return found
+        for value in node.values():
+            nested = _find_transforms(value, key)
+            if nested is not None:
+                return nested
+    elif isinstance(node, list):
+        for item in node:
+            nested = _find_transforms(item, key)
+            if nested is not None:
+                return nested
+    return None
+
+
+def _try_fold(name: str, params: Any) -> Callable[[Any], Any] | None:
+    """A tensor->tensor callable for the exporter's ``fold_pre`` if ``name`` is a POINTWISE,
+    torch-instantiable transform (bakeable into the ONNX graph), else ``None``."""
+    from konfai.data.transform import LocalityKind, Transform
+    from konfai.utils.dataset import Attribute
+    from konfai.utils.utils import get_module
+
+    base = name.split("/", 1)[0]  # drop the ``/N`` uniqueness suffix a repeated transform carries
+    try:
+        module, cls_name = get_module(base, "konfai.data.transform")
+        cls = getattr(module, cls_name)
+    except Exception:
+        return None
+    if not (isinstance(cls, type) and issubclass(cls, Transform)):
+        return None
+    kwargs = {k: _clean(v) for k, v in params.items()} if isinstance(params, dict) else {}
+    try:
+        inst = cls(**kwargs)
+        if inst.patch_locality(Attribute()).kind is not LocalityKind.POINTWISE:
+            return None
+    except Exception:
+        return None
+    return lambda tensor: inst("fold", tensor, Attribute())
+
+
+def _pipeline(
+    transforms: dict[str, Any] | None, *, fold: bool = False
+) -> tuple[list[dict[str, Any]], list[Callable[[Any], Any]]]:
+    """Map an ordered KonfAI transform chain to runtime ops. With ``fold=True``, a POINTWISE + torch
+    transform not in the registry is baked into the ONNX graph. Folds must form a SUFFIX: a runtime
+    op after a fold is refused."""
+    steps: list[dict[str, Any]] = []
+    folds: list[Callable[[Any], Any]] = []
+    for name, params in (transforms or {}).items():
+        base = name.split("/", 1)[0]
+        if _clean(params) is None and base not in _OP_MAP:
+            continue
+        if base in _OP_MAP:
+            if folds:
+                raise AppMetadataError(
+                    f"transform '{name}' is a runtime op but follows a folded transform; move folded "
+                    "(pointwise custom) transforms to the end of the inference pipeline."
+                )
+            steps.append(_OP_MAP[base](params if isinstance(params, dict) else {}))
+            continue
+        folded = _try_fold(name, params) if fold else None
+        if folded is None:
+            raise AppMetadataError(
+                f"transform '{name}' has no portable runtime op and is not a foldable pointwise transform; "
+                "the ONNX bundle is not deployable in a Python-free runtime. Remove it from the inference "
+                "config or extend the runtime op registry."
+            )
+        folds.append(folded)
+    return steps, folds
+
+
+def _transform_manifest(config: dict[str, Any], root: str) -> tuple[dict[str, Any], list[Callable[[Any], Any]]]:
+    """The pre/post op pipeline the portable runtime applies around the tiled forward, plus the
+    ``fold_pre`` callables (POINTWISE preprocessing transforms baked into the ONNX graph)."""
+    section = config.get(root, {})
+    pre, folds = _pipeline(_find_transforms(section.get("Dataset"), "transforms"), fold=True)
+    # Post is `before_reduction_transforms` (disjoint ensemble: argmax per fold before merge) or
+    # `final_transforms` (same-class ensemble: runs once after the mean); read both.
+    before, _ = _pipeline(_find_transforms(section.get("outputs_dataset"), "before_reduction_transforms"))
+    final, _ = _pipeline(_find_transforms(section.get("outputs_dataset"), "final_transforms"))
+    return {"preprocessing": pre, "postprocessing": before + final}, folds
+
+
+def _hoist_ensemble_tail(
+    manifests: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Hoist the post-reduction tail out of a same-class (``mean``) ensemble's per-fold manifests.
+
+    A mean ensemble reduces RAW LOGITS, then applies softmax/argmax and the inverse resample once. So
+    each fold is stripped of its ``postprocessing`` and its resample made forward-only; the removed
+    steps become program ops after the ``mean`` (softmax/argmax, then a resample back onto ``input`` --
+    nearest for a label map, linear otherwise).
+
+    Returns ``(stripped_manifests, tail_ops)``.
+    """
+    rep = manifests[0]
+    tail: list[dict[str, Any]] = []
+    for step in rep.get("postprocessing", []):
+        op = step["op"]
+        if op == "cast":
+            continue  # a dtype cast is a no-op in the float program; the final NIfTI write handles dtype
+        if op not in ("softmax", "argmax"):
+            raise AppMetadataError(
+                f"assemble_program: cannot hoist post op '{op}' across the reduction (only softmax/argmax "
+                "are channel-axis buffer ops; a per-voxel intensity op belongs in each fold's manifest)."
+            )
+        if int(step.get("dim", 0)) != 0:
+            raise AppMetadataError(
+                f"assemble_program: ensemble post op '{op}' has dim={step['dim']}; the program reduction "
+                "runs on the channel axis (dim 0), so it cannot be hoisted across the reduction."
+            )
+        tail.append({"op": op})
+    has_argmax = any(s["op"] == "argmax" for s in rep.get("postprocessing", []))
+    if any(s.get("op") == "resample" and s.get("inverse") for s in rep.get("preprocessing", [])):
+        tail.append({"op": "resample_nearest" if has_argmax else "resample_linear", "extra": ["input"]})
+
+    stripped: list[dict[str, Any]] = []
+    for mf in manifests:
+        fold = dict(mf)
+        fold["postprocessing"] = []
+        fold["preprocessing"] = [
+            {**step, "inverse": False} if step.get("op") == "resample" else step for step in mf.get("preprocessing", [])
+        ]
+        stripped.append(fold)
+    return stripped, tail
+
+
+def assemble_program(models: list[dict[str, Any]], *, reduce: str, classes: list[int] | None = None) -> dict[str, Any]:
+    """Assemble the multi-model program JSON (Model steps + a reduction Op over named buffers).
+
+    Each ``models[i]`` is ``{"id": str, "manifest": <single-model manifest>}``; every model runs on
+    ``input`` into its own buffer, then a reduction combines them. ``mean`` (same-class ensemble)
+    hoists each fold's post nonlinearity + inverse resample past the reduction (see
+    :func:`_hoist_ensemble_tail`); ``merge_labels`` (disjoint ensemble) keeps each fold's post. A single
+    model is one step, no reduction.
+    """
+    if not models:
+        raise AppMetadataError("assemble_program: at least one model is required")
+    if reduce not in ("mean", "merge_labels"):
+        raise AppMetadataError(f"assemble_program: unknown reduction '{reduce}' (expected 'mean' or 'merge_labels')")
+
+    manifests = [m["manifest"] for m in models]
+    tail: list[dict[str, Any]] = []
+    if reduce == "mean" and len(models) > 1:
+        manifests, tail = _hoist_ensemble_tail(manifests)
+
+    buffers = [f"m{i}" for i in range(len(models))]
+    steps: list[dict[str, Any]] = [
+        {"model": m["id"], "in": "input", "out": buf, "manifest": mf}
+        for m, buf, mf in zip(models, buffers, manifests, strict=True)
+    ]
+    if len(models) == 1:
+        return {"steps": [{**steps[0], "out": "output"}], "output": "output"}
+
+    reduced = "r" if tail else "output"
+    op: dict[str, Any] = {"op": reduce, "in": buffers, "out": reduced}
+    if reduce == "merge_labels":
+        op["classes"] = classes if classes is not None else [int(m["classes"]) for m in models]
+    chain: list[dict[str, Any]] = [*steps, op]
+
+    cursor = reduced
+    for i, t in enumerate(tail):
+        out = "output" if i == len(tail) - 1 else f"t{i}"
+        chain.append({"op": t["op"], "in": [cursor, *t.get("extra", [])], "out": out})
+        cursor = out
+    return {"steps": chain, "output": "output"}
 
 
 def assemble_bundle(
@@ -188,16 +452,14 @@ def export_onnx_into_bundle(
 ) -> Path:
     """Add ``model.onnx`` + ``manifest.json`` to an assembled bundle.
 
-    Loads the model declared in the bundle's prediction config (its ``Model.classpath``)
-    with the given checkpoint — mirroring how ``konfai.predictor`` loads it — and exports
-    it via :func:`konfai.export.export_to_onnx`. ``patch_size`` / ``in_channels`` are read
-    from the config (the app already declares them) when not given explicitly. The bundle's
-    custom ``Model.py`` is made importable for the duration of the call. The config file is
-    restored afterwards so the defaults-materialising config reader does not mutate the bundle.
+    Loads the model from the bundle's prediction config (``Model.classpath``) with the given
+    checkpoint and exports it via :func:`konfai.export.export_to_onnx`; ``patch_size`` /
+    ``in_channels`` fall back to the config. The config file is restored afterwards because
+    reading it mutates it.
     """
     import torch
     import yaml
-    from konfai.export import export_to_onnx, list_output_modules
+    from konfai.export import export_to_onnx, select_inference_head
     from konfai.network.network import ModelLoader
     from konfai.utils.runtime import safe_torch_load
 
@@ -212,13 +474,17 @@ def export_onnx_into_bundle(
     except (KeyError, TypeError) as exc:
         raise AppMetadataError(f"could not read {root}.Model.classpath from {config_path}") from exc
 
-    derived_patch, derived_channels, extend_slice = _derive_onnx_params(config, root)
+    derived_patch, derived_channels, extend_slice, pad_value = _derive_onnx_params(config, root)
     patch_size = patch_size or derived_patch
     in_channels = in_channels if in_channels is not None else derived_channels
     if not patch_size or not in_channels:
         raise AppMetadataError(
             "could not derive patch_size/in_channels from the config; pass --patch-size and --in-channels",
         )
+
+    inference_patch = _find_inference_patch(config)
+    patch_overlap = _derive_overlap(inference_patch, patch_size) if inference_patch else None
+    blend = _derive_blend(config, root)
 
     config_snapshot = config_path.read_text()
     env_keys = ("KONFAI_config_file", "KONFAI_CONFIG_MODE", "KONFAI_ROOT", "KONFAI_STATE")
@@ -231,8 +497,7 @@ def export_onnx_into_bundle(
         os.environ["KONFAI_STATE"] = "PREDICTION"
 
         model = ModelLoader(classpath).get_model(train=False)
-        # Disable the model's internal patch-based forward: we export the per-patch
-        # network and let the portable runtime do the sliding-window tiling.
+        # Export the per-patch network; the runtime does the sliding-window tiling.
         model.patch = None
         model.eval()
         if checkpoint is not None:
@@ -243,8 +508,22 @@ def export_onnx_into_bundle(
             model.load(state, init=False)
 
         example = torch.randn(1, in_channels, *patch_size)
-        head = output_module or list_output_modules(model, example)[-1][0]
-        return export_to_onnx(model, bundle, example, head, extend_slice=extend_slice)
+        # Default to the terminal float head; the graph's last output is often an integer Argmax.
+        head = output_module or select_inference_head(model, example)
+        extra_manifest, fold_pre = _transform_manifest(config, root)
+        if blend is not None:
+            extra_manifest["blend"] = blend
+        return export_to_onnx(
+            model,
+            bundle,
+            example,
+            head,
+            patch_overlap=patch_overlap,
+            extend_slice=extend_slice,
+            pad_value=pad_value,
+            extra_manifest=extra_manifest,
+            fold_pre=fold_pre,
+        )
     finally:
         sys.path.remove(str(bundle))
         config_path.write_text(config_snapshot)

--- a/konfai-apps/tests/unit/_fold_fixture.py
+++ b/konfai-apps/tests/unit/_fold_fixture.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A user's custom POINTWISE torch transform, for the auto-fold test (imported by classpath)."""
+
+from konfai.data.transform import LocalityKind, PatchLocality, Transform
+
+
+class DoubleThenBias(Transform):
+    """Pointwise `2*x + bias` -- the kind of custom intensity transform that folds into the ONNX."""
+
+    def __init__(self, bias: float = 1.0) -> None:
+        super().__init__()
+        self.bias = bias
+
+    def patch_locality(self, cache_attribute):
+        return PatchLocality(LocalityKind.POINTWISE)
+
+    def __call__(self, name, tensor, cache_attribute):
+        return tensor * 2.0 + self.bias

--- a/konfai-apps/tests/unit/test_bundle.py
+++ b/konfai-apps/tests/unit/test_bundle.py
@@ -48,8 +48,13 @@ def test_assemble_bundle_layout(tmp_path):
     model_py.write_text("# custom\n")
 
     bundle = assemble_bundle(
-        "MR", tmp_path / "out", app_json, [str(config)], [str(checkpoint)],
-        model_py=str(model_py), requirements=str(requirements),
+        "MR",
+        tmp_path / "out",
+        app_json,
+        [str(config)],
+        [str(checkpoint)],
+        model_py=str(model_py),
+        requirements=str(requirements),
     )
 
     assert bundle == tmp_path / "out" / "MR"
@@ -95,11 +100,105 @@ def test_derive_onnx_params_from_config():
     config = {
         "Predictor": {
             "Model": {"classpath": "Model:UNetpp", "UNetpp": {"nb_channel": 5}},
-            "Dataset": {"Patch": {"patch_size": [1, 256, 256], "extend_slice": 2}},
+            "Dataset": {"Patch": {"patch_size": [1, 256, 256], "extend_slice": 2, "pad_value": -2}},
             "Model_unused_patch": {"ModelPatch": {"patch_size": [128, 128, 128]}},
         }
     }
-    patch_size, in_channels, extend_slice = _derive_onnx_params(config, "Predictor")
+    patch_size, in_channels, extend_slice, pad_value = _derive_onnx_params(config, "Predictor")
     assert patch_size == [256, 256]  # singleton slice dim dropped (2.5D)
     assert in_channels == 5
     assert extend_slice == 2
+    assert pad_value == -2.0  # the config's border-pad value reaches the manifest
+
+
+def test_derive_overlap_broadcasts_scalar_and_drops_singleton():
+    from konfai_apps.bundle import _derive_overlap
+
+    assert _derive_overlap({"overlap": 32}, [96, 128, 160]) == [32, 32, 32]  # scalar broadcast
+    assert _derive_overlap({"overlap": [8, 8]}, [64, 64]) == [8, 8]  # per-axis list kept
+    # a full-rank overlap carrying the 2.5D singleton slice axis: kept axes match patch_size
+    assert _derive_overlap({"overlap": [0, 16, 16], "patch_size": [1, 256, 256]}, [256, 256]) == [16, 16]
+    assert _derive_overlap({}, [96, 128, 160]) is None  # no overlap declared
+
+
+def test_derive_blend_reads_patch_combine():
+    from konfai_apps.bundle import _derive_blend
+
+    cfg = {"Predictor": {"outputs_dataset": {"H": {"OutputDataset": {"patch_combine": "Gaussian"}}}}}
+    assert _derive_blend(cfg, "Predictor") == "Gaussian"
+    assert _derive_blend({"Predictor": {"outputs_dataset": {"O": {"patch_combine": "None"}}}}, "Predictor") is None
+    assert _derive_blend({"Predictor": {}}, "Predictor") is None
+
+
+def test_transform_manifest_maps_the_pipeline_to_runtime_ops():
+    from konfai_apps.bundle import _transform_manifest
+
+    config = {
+        "Predictor": {
+            "Dataset": {
+                "groups_src": {
+                    "Volume_0": {
+                        "groups_dest": {
+                            "Volume": {
+                                "transforms": {
+                                    "TensorCast": {"dtype": "float32"},
+                                    "ResampleToResolution": {"spacing": [3, 3, 3], "inverse": True},
+                                    "Standardize": {"mean": "None", "std": "None"},
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "outputs_dataset": {
+                "SegHead": {"OutputDataset": {"final_transforms": {"Softmax": {"dim": 0}, "Argmax": {"dim": 0}}}}
+            },
+        }
+    }
+    manifest, folds = _transform_manifest(config, "Predictor")
+    assert folds == []  # every transform here is a runtime op; nothing folded into the graph
+    assert manifest["preprocessing"] == [
+        {"op": "cast", "dtype": "float32"},
+        {"op": "resample", "spacing": [3.0, 3.0, 3.0], "inverse": True},
+        {"op": "standardize"},  # mean/std unset -> computed at runtime
+    ]
+    assert manifest["postprocessing"] == [{"op": "softmax", "dim": 0}, {"op": "argmax", "dim": 0}]
+
+
+def test_transform_manifest_reads_canonical_and_before_reduction_post():
+    from konfai_apps.bundle import _transform_manifest
+
+    # A disjoint (merge_labels) ensemble: Canonical -> a runtime op; the per-fold argmax lives in
+    # before_reduction_transforms (each fold argmaxes to a label map before the merge), not final_transforms.
+    config = {
+        "Predictor": {
+            "Dataset": {
+                "g": {
+                    "transforms": {
+                        "Canonical": {"inverse": True},
+                        "ResampleToResolution": {"spacing": [1.5, 1.5, 1.5], "inverse": True},
+                    }
+                }
+            },
+            "outputs_dataset": {
+                "H": {
+                    "OutputDataset": {
+                        "before_reduction_transforms": {"Softmax": {"dim": 0}, "Argmax": {"dim": 0}},
+                        "final_transforms": "None",
+                    }
+                }
+            },
+        }
+    }
+    manifest, _folds = _transform_manifest(config, "Predictor")
+    assert {"op": "canonical", "inverse": True} in manifest["preprocessing"]
+    assert manifest["postprocessing"] == [{"op": "softmax", "dim": 0}, {"op": "argmax", "dim": 0}]
+
+
+def test_transform_manifest_refuses_an_unportable_transform():
+    import pytest
+    from konfai_apps.bundle import AppMetadataError, _transform_manifest
+
+    config = {"Predictor": {"Dataset": {"g": {"transforms": {"SomeCustomTransform": {"x": 1}}}}, "outputs_dataset": {}}}
+    with pytest.raises(AppMetadataError, match="no portable runtime op"):
+        _transform_manifest(config, "Predictor")

--- a/konfai-apps/tests/unit/test_onnx_fold.py
+++ b/konfai-apps/tests/unit/test_onnx_fold.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Auto-fold: a POINTWISE torch transform is baked into the ONNX graph via ``fold_pre`` instead of
+being refused; non-pointwise / non-torch transforms are still refused. Tests the bundle-side
+detection + ordering."""
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).parent))  # make _fold_fixture importable by classpath
+
+from konfai.utils.errors import AppMetadataError
+from konfai_apps.bundle import _transform_manifest, _try_fold
+
+
+def _cfg(transforms):
+    return {"Predictor": {"Dataset": {"transforms": transforms}, "outputs_dataset": {}}}
+
+
+def test_try_fold_accepts_pointwise_refuses_global_and_geometric():
+    fold = _try_fold("Clip", {"min_value": -10.0, "max_value": 40.0})
+    assert fold is not None
+    out = fold(torch.linspace(-50.0, 50.0, 21))
+    assert out.min().item() == -10.0 and out.max().item() == 40.0
+    assert _try_fold("Standardize", {}) is None  # GLOBAL_STAT: needs whole-volume stats
+    assert _try_fold("ResampleToResolution", {"spacing": [1, 1, 3]}) is None  # not pointwise
+
+
+def test_custom_pointwise_transform_folds_instead_of_refusing():
+    manifest, folds = _transform_manifest(_cfg({"_fold_fixture:DoubleThenBias": {"bias": 3.0}}), "Predictor")
+    assert manifest["preprocessing"] == []  # folded into the graph, not a runtime op
+    assert len(folds) == 1
+    assert torch.allclose(folds[0](torch.ones(4)), torch.full((4,), 5.0))  # 2*1 + 3
+
+
+def test_runtime_op_after_fold_is_refused():
+    cfg = _cfg({"_fold_fixture:DoubleThenBias": {}, "Clip": {"min_value": -1, "max_value": 1}})
+    with pytest.raises(AppMetadataError, match="follows a folded transform"):
+        _transform_manifest(cfg, "Predictor")
+
+
+def test_non_foldable_transform_is_refused():
+    with pytest.raises(AppMetadataError, match="not a foldable pointwise"):
+        _transform_manifest(_cfg({"KonfAIInference": {"repo_id": "x", "model_name": "y"}}), "Predictor")

--- a/konfai-apps/tests/unit/test_program.py
+++ b/konfai-apps/tests/unit/test_program.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for `assemble_program` (Model steps + a reduction Op over named buffers)."""
+
+import json
+
+import pytest
+from konfai_apps.bundle import AppMetadataError, assemble_program
+
+M = {"input": {"channels": 1}, "output": {"channels": 3}, "patch": {"size": [8, 8], "overlap": [0, 0]}}
+
+# A same-class ensemble fold: per-volume resample to 1.5mm (with inverse), Gaussian-blended tiled
+# forward emitting raw logits, softmax/argmax post.
+MR = {
+    "input": {"channels": 1},
+    "output": {"channels": 41},
+    "patch": {"size": [96, 128, 160], "overlap": [32, 32, 32], "pad_value": 0},
+    "preprocessing": [
+        {"op": "cast", "dtype": "float32"},
+        {"op": "standardize"},
+        {"op": "resample", "spacing": [1.5, 1.5, 1.5], "inverse": True},
+    ],
+    "postprocessing": [{"op": "softmax", "dim": 0}, {"op": "argmax", "dim": 0}, {"op": "cast", "dtype": "uint8"}],
+    "blend": "Gaussian",
+}
+
+
+def test_single_model_is_a_one_step_program():
+    program = assemble_program([{"id": "a", "manifest": M}], reduce="mean")
+    assert program == {"steps": [{"model": "a", "in": "input", "out": "output", "manifest": M}], "output": "output"}
+
+
+def test_ensemble_merge_labels():
+    program = assemble_program(
+        [{"id": "m291", "manifest": M, "classes": 3}, {"id": "m292", "manifest": M, "classes": 2}],
+        reduce="merge_labels",
+    )
+    assert program["output"] == "output"
+    assert [s["model"] for s in program["steps"][:2]] == ["m291", "m292"]
+    assert program["steps"][0]["in"] == "input" and program["steps"][0]["out"] == "m0"
+    assert program["steps"][-1] == {"op": "merge_labels", "in": ["m0", "m1"], "out": "output", "classes": [3, 2]}
+    assert json.loads(json.dumps(program)) == program  # round-trips as JSON
+
+
+def test_explicit_classes_override_the_per_model_ones():
+    program = assemble_program(
+        [{"id": "a", "manifest": M}, {"id": "b", "manifest": M}], reduce="merge_labels", classes=[5, 7]
+    )
+    assert program["steps"][-1]["classes"] == [5, 7]
+
+
+def test_mean_reduction_carries_no_classes():
+    program = assemble_program([{"id": "a", "manifest": M}, {"id": "b", "manifest": M}], reduce="mean")
+    assert program["steps"][-1] == {"op": "mean", "in": ["m0", "m1"], "out": "output"}
+
+
+def test_unknown_reduction_is_refused():
+    with pytest.raises(AppMetadataError, match="unknown reduction"):
+        assemble_program([{"id": "a", "manifest": M}, {"id": "b", "manifest": M}], reduce="nope")
+
+
+def test_no_models_is_refused():
+    with pytest.raises(AppMetadataError, match="at least one model"):
+        assemble_program([], reduce="mean")
+
+
+def test_same_class_ensemble_hoists_post_and_inverse_resample():
+    # 5 folds mean-reduced: folds emit raw logits, so softmax/argmax + inverse resample hoist to run
+    # once after the reduction.
+    models = [{"id": f"fold_{i}", "manifest": MR} for i in range(5)]
+    program = assemble_program(models, reduce="mean")
+
+    fold_steps = program["steps"][:5]
+    for i, step in enumerate(fold_steps):
+        assert step["model"] == f"fold_{i}" and step["in"] == "input" and step["out"] == f"m{i}"
+        # Each fold emits logits: no post, and its resample is forward-only (the inverse is hoisted).
+        assert step["manifest"]["postprocessing"] == []
+        resamples = [s for s in step["manifest"]["preprocessing"] if s.get("op") == "resample"]
+        assert resamples and all(s["inverse"] is False for s in resamples)
+
+    tail = program["steps"][5:]
+    # The dtype cast(uint8) in the fold post is a no-op in the float program -> skipped, not a tail op.
+    assert [t["op"] for t in tail] == ["mean", "softmax", "argmax", "resample_nearest"]
+    assert tail[0]["in"] == [f"m{i}" for i in range(5)] and tail[0]["out"] == "r"
+    assert tail[1] == {"op": "softmax", "in": ["r"], "out": "t0"}
+    assert tail[2] == {"op": "argmax", "in": ["t0"], "out": "t1"}
+    # The inverse resample lands the label map back on the input grid (nearest, since we argmaxed).
+    assert tail[3] == {"op": "resample_nearest", "in": ["t1", "input"], "out": "output"}
+    assert program["output"] == "output"
+    assert json.loads(json.dumps(program)) == program  # round-trips as JSON
+
+
+def test_hoisting_does_not_mutate_the_input_manifest():
+    before = json.dumps(MR, sort_keys=True)
+    assemble_program([{"id": f"f{i}", "manifest": MR} for i in range(3)], reduce="mean")
+    assert json.dumps(MR, sort_keys=True) == before, "assemble_program must not mutate the caller's manifest"
+
+
+def test_mean_ensemble_without_post_or_resample_has_no_tail():
+    # A plain same-class ensemble (logits already final, no resample) reduces straight to output.
+    program = assemble_program([{"id": "a", "manifest": M}, {"id": "b", "manifest": M}], reduce="mean")
+    assert [s.get("op") for s in program["steps"] if "op" in s] == ["mean"]
+    assert program["steps"][-1] == {"op": "mean", "in": ["m0", "m1"], "out": "output"}
+
+
+def test_non_channel_axis_post_op_cannot_be_hoisted():
+    bad = {**MR, "postprocessing": [{"op": "softmax", "dim": 1}]}
+    with pytest.raises(AppMetadataError, match="channel axis"):
+        assemble_program([{"id": "a", "manifest": bad}, {"id": "b", "manifest": bad}], reduce="mean")
+
+
+def test_non_softmax_argmax_post_op_cannot_be_hoisted():
+    # A per-voxel intensity op in the post can't cross the channel reduction -- it belongs in each fold.
+    bad = {**MR, "postprocessing": [{"op": "unnormalize", "min_value": -1, "max_value": 1}]}
+    with pytest.raises(AppMetadataError, match="cannot hoist post op"):
+        assemble_program([{"id": "a", "manifest": bad}, {"id": "b", "manifest": bad}], reduce="mean")
+
+
+def test_merge_labels_keeps_per_fold_post():
+    # A disjoint ensemble does NOT hoist: each fold argmaxes to its own label map, then merge_labels tiles.
+    models = [{"id": "a", "manifest": MR, "classes": 3}, {"id": "b", "manifest": MR, "classes": 2}]
+    program = assemble_program(models, reduce="merge_labels")
+    for step in program["steps"][:2]:
+        assert step["manifest"]["postprocessing"] == MR["postprocessing"]  # untouched
+    assert program["steps"][-1] == {"op": "merge_labels", "in": ["m0", "m1"], "out": "output", "classes": [3, 2]}

--- a/konfai/export.py
+++ b/konfai/export.py
@@ -16,23 +16,21 @@
 
 """Export a frozen KonfAI ``Network`` to a self-contained ONNX graph + manifest.
 
-This is the producer side of the ``konfai-rs`` portable-inference contract: a
-trained KonfAI model becomes ``model.onnx`` (graph + weights, single file) plus
-``manifest.json`` (patch geometry, input/output spec) that a no-Python runtime
-consumes. The non-obvious steps the ``torch -> ONNX -> burn-onnx`` chain requires
-are encoded here:
+A trained model becomes ``model.onnx`` (graph + weights, single file) plus ``manifest.json``
+(patch geometry, input/output spec) for a Python-free runtime. Three constraints shape the code:
 
-* KonfAI ``Network`` overrides ``state_dict()`` with a custom signature that breaks
-  the TorchScript exporter, so the **dynamo** exporter is used.
-* ``Network.forward`` returns per-output-group results (empty without ``init()``),
-  so the graph is reached via ``named_forward`` and a named head is selected.
-* The dynamo exporter writes weights as external data; they are inlined so the
-  ``.onnx`` is a single self-contained file (required by ``burn-onnx``).
+* KonfAI ``Network`` overrides ``state_dict()`` with a custom signature that breaks the
+  TorchScript exporter, so the **dynamo** exporter is used.
+* ``Network.forward`` returns per-output-group results (empty without ``init()``), so the
+  graph is reached via ``named_forward`` and a named head is selected.
+* The dynamo exporter writes weights as external data; they are inlined so the ``.onnx`` is
+  a single self-contained file.
 """
 
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from importlib import import_module
 from pathlib import Path
 from types import ModuleType
@@ -42,7 +40,7 @@ import torch
 
 from konfai.utils.errors import PredictorError
 
-MANIFEST_VERSION = 1
+MANIFEST_VERSION = 2
 
 
 def _require(module: str) -> ModuleType:
@@ -58,17 +56,25 @@ def _require(module: str) -> ModuleType:
 class _NamedHead(torch.nn.Module):
     """Wrap a routed KonfAI graph to return a single named output tensor.
 
-    ``Network.forward`` yields per-output-group results (deep-supervision aware);
-    for export we want one specific head. ``named_forward`` exposes every module
-    output as ``(dotted_name, tensor)``; this returns the tensor of ``output_module``.
+    ``named_forward`` exposes every module output as ``(dotted_name, tensor)``; this returns the
+    tensor of ``output_module``. ``fold_pre`` are per-patch tensor->tensor callables applied to the
+    input *inside* the graph, so they trace into the ONNX; only pointwise ops are foldable.
     """
 
-    def __init__(self, net: torch.nn.Module, output_module: str) -> None:
+    def __init__(
+        self,
+        net: torch.nn.Module,
+        output_module: str,
+        fold_pre: list[Callable[[torch.Tensor], torch.Tensor]] | None = None,
+    ) -> None:
         super().__init__()
         self.net = net
         self.output_module = output_module
+        self.fold_pre = list(fold_pre or [])
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for pre in self.fold_pre:
+            x = pre(x)
         out = x
         for name, tensor in self.net.named_forward(x):
             if name == self.output_module:
@@ -77,11 +83,8 @@ class _NamedHead(torch.nn.Module):
 
 
 def list_output_modules(model: torch.nn.Module, example_input: torch.Tensor) -> list[tuple[str, tuple[int, ...]]]:
-    """Return ``(dotted_name, shape)`` for every output of the routed graph.
-
-    Use this to discover the inference head to export (e.g. ``UNetBlock_0.Head.Softmax``
-    or ``Head.Tanh``), skipping deep-supervision heads and integer ``Argmax`` outputs.
-    """
+    """Return ``(dotted_name, shape)`` for every output of the routed graph, to discover the
+    inference head to export."""
     if not hasattr(model, "named_forward"):
         raise PredictorError("export expects a KonfAI Network exposing `named_forward`.")
     model.eval()
@@ -92,11 +95,31 @@ def list_output_modules(model: torch.nn.Module, example_input: torch.Tensor) -> 
     return outputs
 
 
+def select_inference_head(model: torch.nn.Module, example_input: torch.Tensor) -> str:
+    """Pick the head to export: the last **floating-point** output in execution order.
+
+    Terminal outputs often end in an integer ``Argmax`` label map; a float runtime wants the final
+    probability/regression head, so integer outputs are skipped. Pass ``output_module`` to target a
+    specific head.
+    """
+    if not hasattr(model, "named_forward"):
+        raise PredictorError("export expects a KonfAI Network exposing `named_forward`.")
+    model.eval()
+    head: str | None = None
+    with torch.no_grad():
+        for name, tensor in model.named_forward(example_input):
+            if torch.is_floating_point(tensor):
+                head = name
+    if head is None:
+        raise PredictorError("no floating-point output to export; pass an explicit output_module.")
+    return head
+
+
 def export_to_onnx(
     model: torch.nn.Module,
     output_dir: str | Path,
     example_input: torch.Tensor,
-    output_module: str,
+    output_module: str | None = None,
     *,
     opset: int = 18,
     input_name: str = "input",
@@ -105,6 +128,8 @@ def export_to_onnx(
     output_group: str = "output",
     patch_overlap: list[int] | None = None,
     extend_slice: int = 0,
+    pad_value: float | None = None,
+    fold_pre: list[Callable[[torch.Tensor], torch.Tensor]] | None = None,
     extra_manifest: dict[str, Any] | None = None,
 ) -> Path:
     """Export ``model`` to ``output_dir/model.onnx`` (+ ``manifest.json``).
@@ -117,9 +142,10 @@ def export_to_onnx(
         Directory to write ``model.onnx`` and ``manifest.json`` into.
     example_input:
         A fixed-shape example patch ``[N, C, (Z), Y, X]``; the ONNX is exported at
-        this exact shape (burn-onnx dislikes dynamic shapes).
+        this exact shape (no dynamic axes).
     output_module:
         Dotted name of the inference head to export (see :func:`list_output_modules`).
+        When omitted, :func:`select_inference_head` picks the terminal floating-point head.
     opset:
         ONNX opset (>= 18 recommended; the dynamo exporter implements 18).
 
@@ -135,6 +161,8 @@ def export_to_onnx(
     onnx_path = out_dir / "model.onnx"
 
     model.eval()
+    if output_module is None:
+        output_module = select_inference_head(model, example_input)
     available = list_output_modules(model, example_input)
     matches = [shape for name, shape in available if name == output_module]
     if not matches:
@@ -144,7 +172,7 @@ def export_to_onnx(
         )
     output_shape = matches[-1]
 
-    wrapper = _NamedHead(model, output_module).eval()
+    wrapper = _NamedHead(model, output_module, fold_pre=fold_pre).eval()
     with torch.no_grad():
         torch.onnx.export(
             wrapper,
@@ -156,9 +184,8 @@ def export_to_onnx(
             dynamo=True,
         )
 
-    # The dynamo exporter writes weights as external data; inline them so the
-    # .onnx is a single self-contained file (required by burn-onnx's ModelGen and
-    # simpler to serve to ONNX-Runtime-Web). Remove the now-orphan sidecar.
+    # The dynamo exporter writes weights as external data; inline them so the .onnx is a
+    # single self-contained file. Remove the now-orphan sidecar.
     onnx.save(onnx.load(str(onnx_path)), str(onnx_path), save_as_external_data=False)
     sidecar = onnx_path.with_name(onnx_path.name + ".data")
     if sidecar.exists():
@@ -179,8 +206,10 @@ def export_to_onnx(
             "overlap": patch_overlap if patch_overlap is not None else [0] * dim,
             "dim": dim,
             "extend_slice": extend_slice,
+            # The border-pad value for the last (ragged) patch of an axis; 0 unless the config pins one.
+            "pad_value": float(pad_value) if pad_value is not None else 0.0,
         },
-        "geometry": "preserve_from_input",
+        "geometry": {"mode": "preserve_from_input"},
     }
     if extra_manifest:
         manifest.update(extra_manifest)

--- a/tests/unit/test_onnx_export.py
+++ b/tests/unit/test_onnx_export.py
@@ -14,24 +14,73 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""ONNX export parity test (onnxruntime vs torch) on the example UNet."""
+"""ONNX export parity (onnxruntime vs torch) across the whole KonfAI YAML catalog."""
 
 import json
+from pathlib import Path
 
 import numpy as np
 import pytest
 import torch
+import yaml
+
+CATALOG = Path(__file__).resolve().parents[2] / "konfai" / "models" / "yaml"
+CATALOG_MODELS = sorted(CATALOG.glob("*.yml"))
 
 
-def test_export_to_onnx_parity(tmp_path, monkeypatch):
+def _example_input(params: dict) -> torch.Tensor:
+    """A small fixed-shape patch matching the model's declared dim / channels."""
+    dim = int(params.get("dim", 2))
+    channels = params.get("channels")
+    in_channels = params.get("in_channels") or (channels[0] if isinstance(channels, list) and channels else 1)
+    patch_size = params.get("patch_size")
+    size = patch_size * 2 if patch_size else (64 if dim == 2 else 48)
+    return torch.randn(1, int(in_channels), *([size] * dim))
+
+
+@pytest.fixture(autouse=True)
+def _config_env(tmp_path, monkeypatch):
     monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
     monkeypatch.setenv("KONFAI_config_file", str(tmp_path / "config.yml"))
 
+
+@pytest.mark.slow
+@pytest.mark.parametrize("yml", CATALOG_MODELS, ids=lambda p: p.stem)
+def test_catalog_model_exports_with_parity(yml, tmp_path):
     pytest.importorskip("onnx")
     pytest.importorskip("onnxscript")
     ort = pytest.importorskip("onnxruntime")
 
-    from konfai.export import _NamedHead, export_to_onnx, list_output_modules
+    from konfai.export import _NamedHead, export_to_onnx, select_inference_head
+    from konfai.utils.model_builder import build_model_from_yaml
+
+    params = yaml.safe_load(yml.read_text()).get("parameters", {}) or {}
+    model = build_model_from_yaml(yaml_path=str(yml)).eval()
+    example = _example_input(params)
+
+    head = select_inference_head(model, example)
+    assert "argmax" not in head.lower(), f"{yml.stem}: exported an integer label head {head!r}"
+
+    onnx_path = export_to_onnx(model, tmp_path, example)  # output_module auto-selected
+    assert onnx_path.exists()
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    assert manifest["output_module"] == head
+    assert manifest["patch"]["dim"] == int(params.get("dim", 2))
+
+    with torch.no_grad():
+        reference = _NamedHead(model, head)(example).numpy()
+    session = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    produced = session.run(None, {"input": example.numpy().astype(np.float32)})[0]
+
+    assert produced.shape == reference.shape
+    assert float(np.mean(np.abs(produced - reference))) < 1e-4
+
+
+def test_explicit_head_overrides_auto_selection(tmp_path):
+    pytest.importorskip("onnx")
+    pytest.importorskip("onnxscript")
+
+    from konfai.export import export_to_onnx, list_output_modules
     from konfai.models.python.segmentation.UNet import UNet
 
     model = UNet(dim=2, channels=[1, 8, 16], nb_class=2).eval()
@@ -41,30 +90,39 @@ def test_export_to_onnx_parity(tmp_path, monkeypatch):
     head = "UNetBlock_0.Head.Softmax"
     assert head in heads, f"expected full-res head among {heads[-5:]}"
 
-    onnx_path = export_to_onnx(model, tmp_path, example, head, opset=18)
-    assert onnx_path.exists()
-
+    export_to_onnx(model, tmp_path, example, head, opset=18)
     manifest = json.loads((tmp_path / "manifest.json").read_text())
-    assert manifest["konfai_rs_manifest"] == 1
-    assert manifest["patch"]["size"] == [64, 64]
-    assert manifest["patch"]["dim"] == 2
-    assert manifest["input"]["channels"] == 1
-    assert manifest["output"]["channels"] == 2
     assert manifest["output_module"] == head
 
-    with torch.no_grad():
-        reference = _NamedHead(model, head)(example).numpy()
 
+def test_fold_pre_bakes_a_custom_pointwise_op_into_the_graph(tmp_path):
+    # A custom pointwise transform the runtime has no primitive for is folded into the ONNX graph.
+    pytest.importorskip("onnx")
+    pytest.importorskip("onnxscript")
+    ort = pytest.importorskip("onnxruntime")
+
+    from konfai.export import _NamedHead, export_to_onnx, select_inference_head
+    from konfai.models.python.segmentation.UNet import UNet
+
+    model = UNet(dim=2, channels=[1, 8, 16], nb_class=2).eval()
+    example = torch.randn(1, 1, 64, 64)
+
+    def custom(t):  # an arbitrary pointwise op, outside the curated op registry
+        return torch.clamp(t, -0.5, 0.5) * 2.0 + 1.0
+
+    head = select_inference_head(model, example)
+    onnx_path = export_to_onnx(model, tmp_path, example, head, fold_pre=[custom])
+
+    with torch.no_grad():
+        reference = _NamedHead(model, head, fold_pre=[custom])(example).numpy()  # custom -> model head
     session = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
     produced = session.run(None, {"input": example.numpy().astype(np.float32)})[0]
 
     assert produced.shape == reference.shape
-    assert float(np.mean(np.abs(produced - reference))) < 1e-4
+    assert float(np.mean(np.abs(produced - reference))) < 1e-4  # the custom op is baked in the graph
 
 
-def test_export_unknown_head_raises(tmp_path, monkeypatch):
-    monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
-    monkeypatch.setenv("KONFAI_config_file", str(tmp_path / "config.yml"))
+def test_export_unknown_head_raises(tmp_path):
     pytest.importorskip("onnx")
     pytest.importorskip("onnxscript")
 


### PR DESCRIPTION
Turns a KonfAI bundle (config + `.pt`) into a portable `model.onnx` + `manifest.json`, so a model can run with no Python.

- **`konfai/export.py`**: `fold_pre` bakes pointwise preprocessing transforms into the onnx graph.
- **`konfai-apps/bundle.py`**: `export_onnx_into_bundle` writes `model.onnx` + `manifest.json` (transform pipeline → runtime op registry, patch geometry, blend window, canonical reorientation, folded pointwise transforms); `assemble_program` emits the multi-model program (`mean` / `merge_labels` ensembles).

7 files, +742/-89. Tests: 26 compiler (bundle / program / onnx_fold) + 17 core export (`test_onnx_export`). `ruff` / `mypy` / `bandit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Exported bundles now include a single ONNX model and manifest for Python-free runtime execution.
  - Bundle exports automatically configure tiled inference, including patch overlap, blending, padding, and geometry.
  - Supported preprocessing and postprocessing transforms are recorded in the runtime manifest.
  - Pointwise transforms may be folded directly into the ONNX model.
  - Inference output heads are selected automatically when not specified.

- **Improvements**
  - Updated the bundle manifest format with richer geometry and padding metadata.
  - Added support for optimized ensemble postprocessing during export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->