### PR TITLE
feat(apps): compile a multi-model bundle to a program.json for a Python-free runtime

### DIFF
--- a/konfai-apps/konfai_apps/bundle.py
+++ b/konfai-apps/konfai_apps/bundle.py
@@ -387,12 +387,14 @@ def assemble_program(models: list[dict[str, Any]], *, reduce: str, classes: list
     """
     if not models:
         raise AppMetadataError("assemble_program: at least one model is required")
-    if reduce not in ("mean", "merge_labels"):
-        raise AppMetadataError(f"assemble_program: unknown reduction '{reduce}' (expected 'mean' or 'merge_labels')")
+    if reduce not in ("mean", "median", "merge_labels"):
+        raise AppMetadataError(
+            f"assemble_program: unknown reduction '{reduce}' (expected 'mean', 'median' or 'merge_labels')",
+        )
 
     manifests = [m["manifest"] for m in models]
     tail: list[dict[str, Any]] = []
-    if reduce == "mean" and len(models) > 1:
+    if reduce in ("mean", "median") and len(models) > 1:
         manifests, tail = _hoist_ensemble_tail(manifests)
 
     buffers = [f"m{i}" for i in range(len(models))]
@@ -467,11 +469,11 @@ def _derive_reduction(config: dict[str, Any], root: str) -> str | None:
     ``MergeLabels`` (models with disjoint label spaces) -> ``merge_labels``; ``InferenceStack``
     (same-class probability ensemble) -> ``mean``. ``None`` when the config declares no reduction."""
     after = _find_transforms(config.get(root, {}).get("outputs_dataset"), "after_reduction_transforms") or {}
-    names = {name.split("/", 1)[0] for name in after}
-    if "MergeLabels" in names:
+    if "MergeLabels" in {name.split("/", 1)[0] for name in after}:
         return "merge_labels"
-    if "InferenceStack" in names:
-        return "mean"
+    stack = next((p for name, p in after.items() if name.split("/", 1)[0] == "InferenceStack"), None)
+    if stack is not None:
+        return "median" if isinstance(stack, dict) and stack.get("mode") == "median" else "mean"
     return None
 
 
@@ -541,6 +543,7 @@ def _assemble_masked_tta_program(
     tta_passes: list[list[int]],
     aux: dict[str, dict[str, Any]],
     mask_specs: list[dict[str, Any]],
+    reduce: str = "mean",
 ) -> dict[str, Any]:
     """The synthesis-with-mask program: nested mask model(s) -> primary folds x TTA flip passes ->
     mean -> mask -> hoisted inverse resample -> final integer cast.
@@ -591,7 +594,7 @@ def _assemble_masked_tta_program(
             cur = nxt
         mask_buffers[name] = cur
 
-    steps.append({"op": "mean", "in": copies, "out": "synth"})
+    steps.append({"op": reduce, "in": copies, "out": "synth"})
     cur = "synth"
     for i, spec in enumerate(mask_specs):
         nxt = f"masked{i}"
@@ -750,7 +753,9 @@ def export_portable_into_bundle(
                 name: {**_export_nested_model(bundle, name, g["inference"]), "ops": g["ops"]}
                 for name, g in aux_groups.items()
             }
-            program = _assemble_masked_tta_program(models, _tta_passes(config, root), aux, _mask_specs(config, root))
+            program = _assemble_masked_tta_program(
+                models, _tta_passes(config, root), aux, _mask_specs(config, root), reduce=reduction or "mean"
+            )
             program_path = bundle / "program.json"
             program_path.write_text(json.dumps(program, indent=2))
             return program_path

--- a/konfai-apps/konfai_apps/bundle.py
+++ b/konfai-apps/konfai_apps/bundle.py
@@ -440,22 +440,36 @@ def assemble_bundle(
     return bundle
 
 
-def export_onnx_into_bundle(
+def _derive_reduction(config: dict[str, Any], root: str) -> str | None:
+    """The ensemble reduction a multi-model program applies, read from the output transforms:
+    ``MergeLabels`` (models with disjoint label spaces) -> ``merge_labels``; ``InferenceStack``
+    (same-class probability ensemble) -> ``mean``. ``None`` when the config declares no reduction."""
+    after = _find_transforms(config.get(root, {}).get("outputs_dataset"), "after_reduction_transforms") or {}
+    names = {name.split("/", 1)[0] for name in after}
+    if "MergeLabels" in names:
+        return "merge_labels"
+    if "InferenceStack" in names:
+        return "mean"
+    return None
+
+
+def export_portable_into_bundle(
     bundle: str | Path,
     *,
+    checkpoints: list[str] | None = None,
     patch_size: list[int] | None = None,
     in_channels: int | None = None,
     prediction_config: str = "Prediction.yml",
-    checkpoint: str | None = None,
     output_module: str | None = None,
     root: str = "Predictor",
 ) -> Path:
-    """Add ``model.onnx`` + ``manifest.json`` to an assembled bundle.
+    """Write the bundle's portable-runtime artifacts from its prediction config.
 
-    Loads the model from the bundle's prediction config (``Model.classpath``) with the given
-    checkpoint and exports it via :func:`konfai.export.export_to_onnx`; ``patch_size`` /
-    ``in_channels`` fall back to the config. The config file is restored afterwards because
-    reading it mutates it.
+    One checkpoint -> ``model.onnx`` + ``manifest.json``. Several checkpoints combined by the ensemble
+    reduction the config declares (``MergeLabels`` / ``InferenceStack``) -> one ``<fold>.onnx`` per
+    checkpoint plus ``program.json``, the multi-model dataflow the konfai-rs runtime executes. The patch
+    geometry, transforms, blend, and reduction are all read from the config -- nothing is per-app. The
+    config file is restored afterwards because reading it mutates it.
     """
     import torch
     import yaml
@@ -477,14 +491,20 @@ def export_onnx_into_bundle(
     derived_patch, derived_channels, extend_slice, pad_value = _derive_onnx_params(config, root)
     patch_size = patch_size or derived_patch
     in_channels = in_channels if in_channels is not None else derived_channels
-    if not patch_size or not in_channels:
-        raise AppMetadataError(
-            "could not derive patch_size/in_channels from the config; pass --patch-size and --in-channels",
-        )
+    if not patch_size:
+        raise AppMetadataError("could not derive patch_size from the config; pass --patch-size")
 
     inference_patch = _find_inference_patch(config)
     patch_overlap = _derive_overlap(inference_patch, patch_size) if inference_patch else None
     blend = _derive_blend(config, root)
+    reduction = _derive_reduction(config, root)
+    checkpoints = checkpoints or [None]
+    ensemble = len(checkpoints) > 1
+    if ensemble and reduction is None:
+        raise AppMetadataError(
+            "several checkpoints were given but the config declares no ensemble reduction "
+            "(MergeLabels / InferenceStack in outputs_dataset); cannot assemble a multi-model program.",
+        )
 
     config_snapshot = config_path.read_text()
     env_keys = ("KONFAI_config_file", "KONFAI_CONFIG_MODE", "KONFAI_ROOT", "KONFAI_STATE")
@@ -496,34 +516,59 @@ def export_onnx_into_bundle(
         os.environ["KONFAI_ROOT"] = root
         os.environ["KONFAI_STATE"] = "PREDICTION"
 
-        model = ModelLoader(classpath).get_model(train=False)
-        # Export the per-patch network; the runtime does the sliding-window tiling.
-        model.patch = None
-        model.eval()
-        if checkpoint is not None:
-            ckpt_path = Path(checkpoint)
-            if not ckpt_path.is_absolute():
-                ckpt_path = bundle / ckpt_path.name
-            state = safe_torch_load(ckpt_path, "cpu")
-            model.load(state, init=False)
-
-        example = torch.randn(1, in_channels, *patch_size)
-        # Default to the terminal float head; the graph's last output is often an integer Argmax.
-        head = output_module or select_inference_head(model, example)
         extra_manifest, fold_pre = _transform_manifest(config, root)
         if blend is not None:
             extra_manifest["blend"] = blend
-        return export_to_onnx(
-            model,
-            bundle,
-            example,
-            head,
-            patch_overlap=patch_overlap,
-            extend_slice=extend_slice,
-            pad_value=pad_value,
-            extra_manifest=extra_manifest,
-            fold_pre=fold_pre,
+
+        models: list[dict[str, Any]] = []
+        onnx_path = bundle / "model.onnx"
+        for checkpoint in checkpoints:
+            model = ModelLoader(classpath).get_model(train=False)
+            # Export the per-patch network; the runtime does the sliding-window tiling.
+            model.patch = None
+            model.eval()
+            if checkpoint is not None:
+                ckpt_path = Path(checkpoint)
+                if not ckpt_path.is_absolute():
+                    ckpt_path = bundle / ckpt_path.name
+                model.load(safe_torch_load(ckpt_path, "cpu"), init=False)
+
+            # The input channel count is intrinsic to the architecture; read it off the loaded model
+            # when the config does not declare it.
+            if not in_channels:
+                in_channels = getattr(model, "in_channels", None)
+            if not in_channels:
+                raise AppMetadataError("could not derive in_channels from the config or model; pass --in-channels")
+            example = torch.randn(1, in_channels, *patch_size)
+            # Default to the terminal float head; the graph's last output is often an integer Argmax.
+            head = output_module or select_inference_head(model, example)
+            fold_id = Path(checkpoint).stem if ensemble else "model"
+            onnx_path, manifest = export_to_onnx(
+                model,
+                bundle,
+                example,
+                head,
+                patch_overlap=patch_overlap,
+                extend_slice=extend_slice,
+                pad_value=pad_value,
+                extra_manifest=dict(extra_manifest),
+                fold_pre=fold_pre,
+                model_filename="model.onnx" if not ensemble else f"{fold_id}.onnx",
+                write_manifest=not ensemble,
+            )
+            models.append({"id": fold_id, "manifest": manifest})
+
+        if not ensemble:
+            return onnx_path
+
+        program = assemble_program(
+            models,
+            reduce=reduction,
+            classes=[int(m["manifest"]["output"]["channels"]) for m in models],
         )
+        program_path = bundle / "program.json"
+        program_path.write_text(json.dumps(program, indent=2))
+        return program_path
     finally:
         sys.path.remove(str(bundle))
         config_path.write_text(config_snapshot)
@@ -532,6 +577,29 @@ def export_onnx_into_bundle(
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = value
+
+
+def export_onnx_into_bundle(
+    bundle: str | Path,
+    *,
+    patch_size: list[int] | None = None,
+    in_channels: int | None = None,
+    prediction_config: str = "Prediction.yml",
+    checkpoint: str | None = None,
+    output_module: str | None = None,
+    root: str = "Predictor",
+) -> Path:
+    """Single-checkpoint portable export (``model.onnx`` + ``manifest.json``); a thin wrapper over
+    :func:`export_portable_into_bundle`, which also handles the ensemble (``program.json``) form."""
+    return export_portable_into_bundle(
+        bundle,
+        checkpoints=[checkpoint] if checkpoint is not None else None,
+        patch_size=patch_size,
+        in_channels=in_channels,
+        prediction_config=prediction_config,
+        output_module=output_module,
+        root=root,
+    )
 
 
 def run_bundle_cli(args: dict[str, Any]) -> None:
@@ -555,11 +623,11 @@ def run_bundle_cli(args: dict[str, Any]) -> None:
             print(f"Drafted requirements.txt (review!): {', '.join(drafted)}")
 
     if args.get("onnx"):
-        onnx_path = export_onnx_into_bundle(
+        artifact = export_portable_into_bundle(
             bundle,
+            checkpoints=[Path(c).name for c in args["checkpoint"]] if args.get("checkpoint") else None,
             patch_size=args.get("patch_size"),
             in_channels=args.get("in_channels"),
-            checkpoint=Path(args["checkpoint"][0]).name if args.get("checkpoint") else None,
             output_module=args.get("output_module"),
         )
-        print(f"Portable model exported: {onnx_path} (+ manifest.json)")
+        print(f"Portable model exported: {artifact}")

--- a/konfai-apps/konfai_apps/bundle.py
+++ b/konfai-apps/konfai_apps/bundle.py
@@ -481,9 +481,10 @@ def _tta_passes(config: dict[str, Any], root: str) -> list[list[int]]:
     """Flip test-time-augmentation passes: identity plus each augmentation's ``nb`` random draws, matching
     the config's pass count and per-axis Flip probabilities. Randomness is embraced -- the exact draw is
     not KonfAI's (whose torch RNG is not reproducible here), so the result is CLOSE, not byte-identical --
-    but it is reproducible from the config's ``manual_seed``. A non-Flip TTA augmentation is refused rather
-    than silently dropped (the runtime has no portable op for it yet). ``f_prob`` index ``i`` maps to
-    channel-first tensor dim ``i + 1`` and hence to spatial axis ``i``; ``[[]]`` when there is no TTA."""
+    but it is reproducible from the config's ``manual_seed``. A non-Flip TTA augmentation is skipped (the
+    runtime has no portable op for it yet), leaving the TTA lighter but never wrong. ``f_prob`` index ``i``
+    maps to channel-first tensor dim ``i + 1`` and hence to spatial axis ``i``; ``[[]]`` when there is no
+    TTA."""
     predictor = config.get(root, {})
     augmentations = predictor.get("Dataset", {}).get("augmentations")
     if not isinstance(augmentations, dict) or not augmentations:
@@ -498,7 +499,9 @@ def _tta_passes(config: dict[str, Any], root: str) -> list[list[int]]:
             (p.get("f_prob") for n, p in (chain or {}).items() if n.split("/", 1)[0] == "Flip" and isinstance(p, dict)),
             None,
         )
-        for _ in range(int(aug.get("nb", 0)) if f_prob else 0):
+        if not f_prob:
+            continue
+        for _ in range(int(aug.get("nb", 0))):
             passes.append([i for i, p in enumerate(f_prob) if rng.random() < float(p)])
     return passes
 
@@ -625,6 +628,15 @@ def _export_nested_model(main_bundle: Path, group_name: str, inference: dict[str
 
     from konfai_apps.app import KonfAIApp
 
+    # Several checkpoints would make the nested export emit `program.json` + per-fold onnx instead of the
+    # `model.onnx` + `manifest.json` this step copies, so refuse it here rather than fail on a missing file.
+    nested_checkpoints = inference.get("checkpoints_name") or []
+    if len(nested_checkpoints) > 1:
+        raise AppMetadataError(
+            f"nested model '{group_name}' declares {len(nested_checkpoints)} checkpoints; the portable "
+            "runtime supports a single-checkpoint nested model (a mask/condition producer) only.",
+        )
+
     app = KonfAIApp(f"{inference['repo_id']}:{inference['model_name']}", True, False)
     with tempfile.TemporaryDirectory() as tmp:
         # Materialise the bundle under its real filenames (the HF cache stores blobs under content hashes,
@@ -685,13 +697,17 @@ def export_portable_into_bundle(
     patch_overlap = _derive_overlap(inference_patch, patch_size) if inference_patch else None
     blend = _derive_blend(config, root)
     reduction = _derive_reduction(config, root)
-    checkpoints = checkpoints or [None]
-    ensemble = len(checkpoints) > 1
+    # `None` stands for "the config's own checkpoint", so the loop below is uniform over both cases.
+    selected: list[str | None] = list(checkpoints) if checkpoints else [None]
+    ensemble = len(selected) > 1
     if ensemble and reduction is None:
         raise AppMetadataError(
             "several checkpoints were given but the config declares no ensemble reduction "
             "(MergeLabels / InferenceStack in outputs_dataset); cannot assemble a multi-model program.",
         )
+    # Guarded above, so the fallback never applies on the ensemble path; it only names the reduction of
+    # the single-model masked/TTA program, which has nothing to combine.
+    ensemble_reduction = reduction or "mean"
 
     config_snapshot = config_path.read_text()
     env_keys = ("KONFAI_config_file", "KONFAI_CONFIG_MODE", "KONFAI_ROOT", "KONFAI_STATE")
@@ -709,7 +725,7 @@ def export_portable_into_bundle(
 
         models: list[dict[str, Any]] = []
         onnx_path = bundle / "model.onnx"
-        for checkpoint in checkpoints:
+        for checkpoint in selected:
             model = ModelLoader(classpath).get_model(train=False)
             # Export the per-patch network; the runtime does the sliding-window tiling.
             model.patch = None
@@ -729,7 +745,8 @@ def export_portable_into_bundle(
             example = torch.randn(1, in_channels, *patch_size)
             # Default to the terminal float head; the graph's last output is often an integer Argmax.
             head = output_module or select_inference_head(model, example)
-            fold_id = Path(checkpoint).stem if ensemble else "model"
+            # `ensemble` implies a real checkpoint name; the None check only narrows the type.
+            fold_id = Path(checkpoint).stem if ensemble and checkpoint is not None else "model"
             onnx_path, manifest = export_to_onnx(
                 model,
                 bundle,
@@ -754,7 +771,7 @@ def export_portable_into_bundle(
                 for name, g in aux_groups.items()
             }
             program = _assemble_masked_tta_program(
-                models, _tta_passes(config, root), aux, _mask_specs(config, root), reduce=reduction or "mean"
+                models, _tta_passes(config, root), aux, _mask_specs(config, root), reduce=ensemble_reduction
             )
             program_path = bundle / "program.json"
             program_path.write_text(json.dumps(program, indent=2))
@@ -765,7 +782,7 @@ def export_portable_into_bundle(
 
         program = assemble_program(
             models,
-            reduce=reduction,
+            reduce=ensemble_reduction,
             classes=[int(m["manifest"]["output"]["channels"]) for m in models],
         )
         program_path = bundle / "program.json"

--- a/konfai-apps/konfai_apps/bundle.py
+++ b/konfai-apps/konfai_apps/bundle.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import os
+import random
 import shutil
 import sys
 from collections.abc import Callable
@@ -224,6 +225,25 @@ _OP_MAP = {
 }
 
 
+# Transforms compiled into PROGRAM steps (cross-buffer, or a buffer produced by a nested model), never
+# per-buffer manifest pipeline ops: the multi-model program handles them, so `_pipeline` skips them.
+_PROGRAM_TRANSFORMS = {"Mask", "KonfAIInference", "Dilate", "Save", "InferenceStack"}
+
+
+def _input_group_transforms(config: dict[str, Any], root: str) -> dict[str, Any] | None:
+    """The transform chain of the ``is_input: true`` dest group -- the model's actual input pipeline.
+    A config may carry auxiliary groups (a mask, a conditioning image) whose transforms are NOT the
+    model preprocessing; falls back to the first ``transforms`` block for single-group configs."""
+    dataset = config.get(root, {}).get("Dataset", {})
+    for src in (dataset.get("groups_src") or {}).values():
+        if not isinstance(src, dict):
+            continue
+        for group in (src.get("groups_dest") or {}).values():
+            if isinstance(group, dict) and group.get("is_input") and isinstance(group.get("transforms"), dict):
+                return group["transforms"]
+    return _find_transforms(dataset, "transforms")
+
+
 def _find_transforms(node: Any, key: str) -> dict[str, Any] | None:
     """First ``key`` sub-dict of a mapping value (the input ``transforms`` / output ``final_transforms``)."""
     if isinstance(node, dict):
@@ -277,6 +297,8 @@ def _pipeline(
     folds: list[Callable[[Any], Any]] = []
     for name, params in (transforms or {}).items():
         base = name.split("/", 1)[0]
+        if base in _PROGRAM_TRANSFORMS:
+            continue  # compiled into a program step, not a per-buffer pipeline op
         if _clean(params) is None and base not in _OP_MAP:
             continue
         if base in _OP_MAP:
@@ -302,7 +324,7 @@ def _transform_manifest(config: dict[str, Any], root: str) -> tuple[dict[str, An
     """The pre/post op pipeline the portable runtime applies around the tiled forward, plus the
     ``fold_pre`` callables (POINTWISE preprocessing transforms baked into the ONNX graph)."""
     section = config.get(root, {})
-    pre, folds = _pipeline(_find_transforms(section.get("Dataset"), "transforms"), fold=True)
+    pre, folds = _pipeline(_input_group_transforms(config, root), fold=True)
     # Post is `before_reduction_transforms` (disjoint ensemble: argmax per fold before merge) or
     # `final_transforms` (same-class ensemble: runs once after the mean); read both.
     before, _ = _pipeline(_find_transforms(section.get("outputs_dataset"), "before_reduction_transforms"))
@@ -453,6 +475,168 @@ def _derive_reduction(config: dict[str, Any], root: str) -> str | None:
     return None
 
 
+def _tta_passes(config: dict[str, Any], root: str) -> list[list[int]]:
+    """Flip test-time-augmentation passes: identity plus each augmentation's ``nb`` random draws, matching
+    the config's pass count and per-axis Flip probabilities. Randomness is embraced -- the exact draw is
+    not KonfAI's (whose torch RNG is not reproducible here), so the result is CLOSE, not byte-identical --
+    but it is reproducible from the config's ``manual_seed``. A non-Flip TTA augmentation is refused rather
+    than silently dropped (the runtime has no portable op for it yet). ``f_prob`` index ``i`` maps to
+    channel-first tensor dim ``i + 1`` and hence to spatial axis ``i``; ``[[]]`` when there is no TTA."""
+    predictor = config.get(root, {})
+    augmentations = predictor.get("Dataset", {}).get("augmentations")
+    if not isinstance(augmentations, dict) or not augmentations:
+        return [[]]
+    rng = random.Random(int(predictor.get("manual_seed") or 0))  # nosec B311 - TTA sampling, not security
+    passes: list[list[int]] = [[]]  # the identity pass is always present
+    for aug in augmentations.values():
+        chain = aug.get("data_augmentations") if isinstance(aug, dict) else None
+        # Only Flip has a portable runtime op; other augmentations are skipped (the TTA is a bit lighter,
+        # never wrong) rather than blocking the export -- extend the runtime registry to add them.
+        f_prob = next(
+            (p.get("f_prob") for n, p in (chain or {}).items() if n.split("/", 1)[0] == "Flip" and isinstance(p, dict)),
+            None,
+        )
+        for _ in range(int(aug.get("nb", 0)) if f_prob else 0):
+            passes.append([i for i, p in enumerate(f_prob) if rng.random() < float(p)])
+    return passes
+
+
+def _aux_mask_groups(config: dict[str, Any], root: str) -> dict[str, dict[str, Any]]:
+    """Auxiliary dest groups (``is_input`` false) a ``Mask`` references: each is produced by a nested
+    model (``KonfAIInference``) then pipeline ops (resample onto the primary grid, dilate). Returns
+    ``{group_name: {"inference": <KonfAIInference params>, "ops": [("resample"|"dilate", param)]}}``."""
+    dataset = config.get(root, {}).get("Dataset", {})
+    groups: dict[str, dict[str, Any]] = {}
+    for src in (dataset.get("groups_src") or {}).values():
+        for name, group in (src.get("groups_dest") or {}).items() if isinstance(src, dict) else []:
+            if not isinstance(group, dict) or group.get("is_input") or not isinstance(group.get("transforms"), dict):
+                continue
+            inference, ops = None, []
+            for tname, params in group["transforms"].items():
+                base = tname.split("/", 1)[0]
+                if base == "KonfAIInference":
+                    inference = params
+                elif base == "ResampleToResolution":
+                    ops.append(("resample", params))
+                elif base == "Dilate":
+                    ops.append(("dilate", int((params or {}).get("dilate", 0))))
+            if inference is not None:
+                groups[name] = {"inference": inference, "ops": ops}
+    return groups
+
+
+def _mask_specs(config: dict[str, Any], root: str) -> list[dict[str, Any]]:
+    """``Mask`` ops in ``before_reduction`` (masking the primary output by an auxiliary group's buffer):
+    ``[{"group": <aux group name>, "value_outside": float}]``."""
+    before = _find_transforms(config.get(root, {}).get("outputs_dataset"), "before_reduction_transforms") or {}
+    return [
+        {"group": params.get("path"), "value_outside": float((params or {}).get("value_outside", 0))}
+        for name, params in before.items()
+        if name.split("/", 1)[0] == "Mask" and isinstance(params, dict)
+    ]
+
+
+def _assemble_masked_tta_program(
+    fold_models: list[dict[str, Any]],
+    tta_passes: list[list[int]],
+    aux: dict[str, dict[str, Any]],
+    mask_specs: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """The synthesis-with-mask program: nested mask model(s) -> primary folds x TTA flip passes ->
+    mean -> mask -> hoisted inverse resample -> final integer cast.
+
+    ``fold_models``/``aux`` values carry an ``id`` and a single-model ``manifest``. Each fold keeps its
+    per-fold post (unnormalize + truncating cast) and its inverse resample is hoisted to a single tail op
+    after the reduction. Each TTA pass flips the input, runs every fold, and unflips the output; the mask
+    model's buffer is resampled onto the primary grid and dilated, then applied to the mean.
+    """
+    rep = fold_models[0]["manifest"]
+    final_dtype = next((s.get("dtype") for s in reversed(rep.get("postprocessing", [])) if s["op"] == "cast"), None)
+    has_inverse = any(s.get("op") == "resample" and s.get("inverse") for s in rep.get("preprocessing", []))
+
+    def hoisted(manifest: dict[str, Any]) -> dict[str, Any]:
+        fold = json.loads(json.dumps(manifest))
+        for step in fold.get("preprocessing", []):
+            if step.get("op") == "resample":
+                step["inverse"] = False
+        return fold
+
+    steps: list[dict[str, Any]] = [
+        {"model": g["id"], "in": "input", "out": f"{name}__raw", "manifest": g["manifest"]} for name, g in aux.items()
+    ]
+    copies: list[str] = []
+    grid_ref: str | None = None
+    for p, axes in enumerate(tta_passes):
+        flipped = "input" if not axes else f"in{p}"
+        if axes:
+            steps.append({"op": "flip", "in": ["input"], "out": flipped, "axes": axes})
+        for model in fold_models:
+            raw = f"{model['id']}__p{p}"
+            steps.append({"model": model["id"], "in": flipped, "out": raw, "manifest": hoisted(model["manifest"])})
+            out = raw
+            if axes:
+                out = f"{model['id']}__u{p}"
+                steps.append({"op": "flip", "in": [raw], "out": out, "axes": axes})  # undo the flip
+            copies.append(out)
+            grid_ref = grid_ref or out  # any fold output sits on the primary (post-resample) grid
+    mask_buffers: dict[str, str] = {}
+    for name, g in aux.items():
+        cur = f"{name}__raw"
+        for kind, param in g["ops"]:
+            nxt = f"{name}__{kind[:1]}"
+            if kind == "resample":
+                steps.append({"op": "resample_nearest", "in": [cur, grid_ref], "out": nxt})
+            else:  # dilate
+                steps.append({"op": "dilate", "in": [cur], "out": nxt, "radius": param})
+            cur = nxt
+        mask_buffers[name] = cur
+
+    steps.append({"op": "mean", "in": copies, "out": "synth"})
+    cur = "synth"
+    for i, spec in enumerate(mask_specs):
+        nxt = f"masked{i}"
+        steps.append(
+            {
+                "op": "mask",
+                "in": [cur, mask_buffers[spec["group"]]],
+                "out": nxt,
+                **{"value_outside": spec["value_outside"]},
+            }
+        )
+        cur = nxt
+    if has_inverse:
+        steps.append({"op": "resample_linear", "in": [cur, "input"], "out": "resampled"})
+        cur = "resampled"
+    if final_dtype:
+        steps.append({"op": "cast", "in": [cur], "out": "output", "dtype": final_dtype})
+    else:
+        steps[-1]["out"] = "output"
+    return {"steps": steps, "output": "output"}
+
+
+def _export_nested_model(main_bundle: Path, group_name: str, inference: dict[str, Any]) -> dict[str, Any]:
+    """Resolve the app a ``KonfAIInference`` references (``repo_id:model_name``), export its single-model
+    onnx + manifest, copy the onnx into the main bundle as ``<group>.onnx``, and return ``{id, manifest}``
+    for the program. The nested model's own transforms (resample / argmax / inverse) live in its manifest."""
+    import tempfile
+
+    from konfai_apps.app import KonfAIApp
+
+    app = KonfAIApp(f"{inference['repo_id']}:{inference['model_name']}", True, False)
+    with tempfile.TemporaryDirectory() as tmp:
+        # Materialise the bundle under its real filenames (the HF cache stores blobs under content hashes,
+        # but the config's bundle-relative classpaths need the real names).
+        nested_dir = Path(tmp)
+        for name, path in app.app_repository.download_app():
+            dest = nested_dir / name
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(path, dest)
+        export_portable_into_bundle(nested_dir, checkpoints=inference.get("checkpoints_name"))
+        shutil.copy(nested_dir / "model.onnx", main_bundle / f"{group_name}.onnx")
+        manifest = json.loads((nested_dir / "manifest.json").read_text())
+    return {"id": group_name, "manifest": manifest}
+
+
 def export_portable_into_bundle(
     bundle: str | Path,
     *,
@@ -557,6 +741,19 @@ def export_portable_into_bundle(
                 write_manifest=not ensemble,
             )
             models.append({"id": fold_id, "manifest": manifest})
+
+        # A config with an auxiliary mask group (a nested KonfAIInference model + a Mask on the output) is a
+        # masked / TTA synthesis, not a plain ensemble: nested model(s) + folds x TTA passes -> mean -> mask.
+        aux_groups = _aux_mask_groups(config, root)
+        if aux_groups:
+            aux = {
+                name: {**_export_nested_model(bundle, name, g["inference"]), "ops": g["ops"]}
+                for name, g in aux_groups.items()
+            }
+            program = _assemble_masked_tta_program(models, _tta_passes(config, root), aux, _mask_specs(config, root))
+            program_path = bundle / "program.json"
+            program_path.write_text(json.dumps(program, indent=2))
+            return program_path
 
         if not ensemble:
             return onnx_path

--- a/konfai-apps/tests/unit/test_bundle.py
+++ b/konfai-apps/tests/unit/test_bundle.py
@@ -208,6 +208,52 @@ def test_derive_reduction_reads_the_ensemble_reduction():
     assert _derive_reduction({"Predictor": {}}, "Predictor") is None
 
 
+def test_masked_tta_compiler_reads_the_config():
+    from konfai_apps.bundle import _assemble_masked_tta_program, _aux_mask_groups, _mask_specs, _tta_passes
+
+    config = {
+        "Predictor": {
+            "manual_seed": 32,
+            "Dataset": {
+                "groups_src": {
+                    "Volume_0": {
+                        "groups_dest": {
+                            "MASK": {
+                                "is_input": False,
+                                "transforms": {
+                                    "KonfAIInference": {"repo_id": "R/S", "model_name": "body"},
+                                    "ResampleToResolution": {"spacing": [1, 1, 3]},
+                                    "Dilate": {"dilate": 5},
+                                    "Save": {"dataset": "x"},
+                                },
+                            },
+                            "Volume": {"is_input": True, "transforms": {"Normalize": {}}},
+                        }
+                    }
+                },
+                "augmentations": {"DA0": {"nb": 2, "data_augmentations": {"Flip": {"f_prob": [0, 0.5, 0.5]}}}},
+            },
+            "outputs_dataset": {"H": {"OutputDataset": {"before_reduction_transforms": {"Mask": {"path": "MASK", "value_outside": -1024}}}}},
+        }
+    }
+    passes = _tta_passes(config, "Predictor")
+    assert passes[0] == [] and len(passes) == 3  # identity + nb draws; other augmentations would be skipped
+    aux = _aux_mask_groups(config, "Predictor")
+    assert set(aux) == {"MASK"} and [op for op, _ in aux["MASK"]["ops"]] == ["resample", "dilate"]
+    assert _mask_specs(config, "Predictor") == [{"group": "MASK", "value_outside": -1024.0}]
+
+    fold = {"preprocessing": [{"op": "resample", "inverse": True}], "postprocessing": [{"op": "cast", "dtype": "int16"}]}
+    program = _assemble_masked_tta_program(
+        [{"id": f"CV_{i}", "manifest": fold} for i in range(5)],
+        passes,
+        {"MASK": {"id": "MASK", "manifest": {}, "ops": aux["MASK"]["ops"]}},
+        _mask_specs(config, "Predictor"),
+    )
+    ops = [s["op"] for s in program["steps"] if "op" in s]
+    assert "mask" in ops and "resample_linear" in ops  # the mask and the hoisted inverse resample
+    assert program["steps"][-1] == {"op": "cast", "in": ["resampled"], "out": "output", "dtype": "int16"}
+
+
 def test_transform_manifest_refuses_an_unportable_transform():
     import pytest
     from konfai_apps.bundle import AppMetadataError, _transform_manifest

--- a/konfai-apps/tests/unit/test_bundle.py
+++ b/konfai-apps/tests/unit/test_bundle.py
@@ -195,6 +195,19 @@ def test_transform_manifest_reads_canonical_and_before_reduction_post():
     assert manifest["postprocessing"] == [{"op": "softmax", "dim": 0}, {"op": "argmax", "dim": 0}]
 
 
+def test_derive_reduction_reads_the_ensemble_reduction():
+    from konfai_apps.bundle import _derive_reduction
+
+    def cfg(after):
+        return {"Predictor": {"outputs_dataset": {"H": {"OutputDataset": {"after_reduction_transforms": after}}}}}
+
+    # The multi-model reduction is read from the output transforms, never hard-coded per app.
+    assert _derive_reduction(cfg({"MergeLabels": {}}), "Predictor") == "merge_labels"
+    assert _derive_reduction(cfg({"InferenceStack": {"mode": "mean"}}), "Predictor") == "mean"
+    assert _derive_reduction(cfg("None"), "Predictor") is None
+    assert _derive_reduction({"Predictor": {}}, "Predictor") is None
+
+
 def test_transform_manifest_refuses_an_unportable_transform():
     import pytest
     from konfai_apps.bundle import AppMetadataError, _transform_manifest

--- a/konfai-apps/tests/unit/test_bundle.py
+++ b/konfai-apps/tests/unit/test_bundle.py
@@ -204,6 +204,7 @@ def test_derive_reduction_reads_the_ensemble_reduction():
     # The multi-model reduction is read from the output transforms, never hard-coded per app.
     assert _derive_reduction(cfg({"MergeLabels": {}}), "Predictor") == "merge_labels"
     assert _derive_reduction(cfg({"InferenceStack": {"mode": "mean"}}), "Predictor") == "mean"
+    assert _derive_reduction(cfg({"InferenceStack": {"mode": "median"}}), "Predictor") == "median"
     assert _derive_reduction(cfg("None"), "Predictor") is None
     assert _derive_reduction({"Predictor": {}}, "Predictor") is None
 

--- a/konfai-apps/tests/unit/test_onnx_fold.py
+++ b/konfai-apps/tests/unit/test_onnx_fold.py
@@ -42,5 +42,7 @@ def test_runtime_op_after_fold_is_refused():
 
 
 def test_non_foldable_transform_is_refused():
+    # A real transform that is neither a runtime op nor pointwise (Gradient is a HALO transform); a
+    # program-level transform such as KonfAIInference is instead compiled into a nested model step.
     with pytest.raises(AppMetadataError, match="not a foldable pointwise"):
-        _transform_manifest(_cfg({"KonfAIInference": {"repo_id": "x", "model_name": "y"}}), "Predictor")
+        _transform_manifest(_cfg({"Gradient": {"per_dim": False}}), "Predictor")

--- a/konfai-apps/tests/unit/test_program.py
+++ b/konfai-apps/tests/unit/test_program.py
@@ -122,3 +122,14 @@ def test_merge_labels_keeps_per_fold_post():
     for step in program["steps"][:2]:
         assert step["manifest"]["postprocessing"] == MR["postprocessing"]  # untouched
     assert program["steps"][-1] == {"op": "merge_labels", "in": ["m0", "m1"], "out": "output", "classes": [3, 2]}
+
+
+def test_multi_checkpoint_nested_model_is_refused(tmp_path):
+    # A nested mask/condition producer is copied as `<group>.onnx` + its `manifest.json`. Several
+    # checkpoints would make the nested export emit `program.json` + per-fold onnx instead, so the
+    # step refuses up front rather than failing later on a missing `model.onnx`.
+    from konfai_apps.bundle import _export_nested_model
+
+    inference = {"repo_id": "org/app", "model_name": "body", "checkpoints_name": ["a.pt", "b.pt"]}
+    with pytest.raises(AppMetadataError, match="single-checkpoint nested model"):
+        _export_nested_model(tmp_path, "MASK", inference)

--- a/konfai/export.py
+++ b/konfai/export.py
@@ -131,7 +131,9 @@ def export_to_onnx(
     pad_value: float | None = None,
     fold_pre: list[Callable[[torch.Tensor], torch.Tensor]] | None = None,
     extra_manifest: dict[str, Any] | None = None,
-) -> Path:
+    model_filename: str = "model.onnx",
+    write_manifest: bool = True,
+) -> tuple[Path, dict[str, Any]]:
     """Export ``model`` to ``output_dir/model.onnx`` (+ ``manifest.json``).
 
     Parameters
@@ -148,17 +150,23 @@ def export_to_onnx(
         When omitted, :func:`select_inference_head` picks the terminal floating-point head.
     opset:
         ONNX opset (>= 18 recommended; the dynamo exporter implements 18).
+    model_filename:
+        ONNX file name to write (a multi-model ensemble exports one file per fold).
+    write_manifest:
+        Write ``manifest.json`` beside the ONNX. Off for a multi-model bundle, whose
+        per-fold manifests are embedded in a single ``program.json`` instead.
 
     Returns
     -------
-    Path to the written ``model.onnx``.
+    ``(onnx_path, manifest)`` -- the written ONNX path and the manifest dict (also written
+    to ``manifest.json`` when ``write_manifest``).
     """
     onnx = _require("onnx")
     _require("onnxscript")  # required by the torch dynamo ONNX exporter
 
     out_dir = Path(output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    onnx_path = out_dir / "model.onnx"
+    onnx_path = out_dir / model_filename
 
     model.eval()
     if output_module is None:
@@ -213,5 +221,6 @@ def export_to_onnx(
     }
     if extra_manifest:
         manifest.update(extra_manifest)
-    (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
-    return onnx_path
+    if write_manifest:
+        (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    return onnx_path, manifest

--- a/tests/unit/test_onnx_export.py
+++ b/tests/unit/test_onnx_export.py
@@ -61,7 +61,7 @@ def test_catalog_model_exports_with_parity(yml, tmp_path):
     head = select_inference_head(model, example)
     assert "argmax" not in head.lower(), f"{yml.stem}: exported an integer label head {head!r}"
 
-    onnx_path = export_to_onnx(model, tmp_path, example)  # output_module auto-selected
+    onnx_path, _ = export_to_onnx(model, tmp_path, example)  # output_module auto-selected
     assert onnx_path.exists()
     manifest = json.loads((tmp_path / "manifest.json").read_text())
     assert manifest["output_module"] == head
@@ -111,7 +111,7 @@ def test_fold_pre_bakes_a_custom_pointwise_op_into_the_graph(tmp_path):
         return torch.clamp(t, -0.5, 0.5) * 2.0 + 1.0
 
     head = select_inference_head(model, example)
-    onnx_path = export_to_onnx(model, tmp_path, example, head, fold_pre=[custom])
+    onnx_path, _ = export_to_onnx(model, tmp_path, example, head, fold_pre=[custom])
 
     with torch.no_grad():
         reference = _NamedHead(model, head, fold_pre=[custom])(example).numpy()  # custom -> model head


### PR DESCRIPTION
## What

Follow-up to #64 (single-model onnx + manifest). Adds **multi-model** export so a whole
bundle — an ensemble's folds or a nested pipeline — compiles to one `program.json` a
Python-free runtime can execute.

- `assemble_program(models, *, reduce, classes)` emits an ordered dataflow program
  (`{steps, output}`) over named buffers: one `Model` step per checkpoint, then a
  reduction step.
- Reductions: `mean`, **`median`** (new), and `merge_labels` (disjoint-label ensembles
  like TotalSegmentator's 5 tasks — cumulative per-model offset, last-model-wins).
- A masked / TTA synthesis bundle compiles to a program (mask + flip TTA steps around the
  model), matching what the KonfAI predictor does at runtime.
- The reduction is **derived from the bundle's output transforms** (`InferenceStack`
  mode → `mean`/`median`), so the emitted program mirrors the app's own config.

## Why

`manifest.json` (from #64) covers one model; real apps are ensembles or nested pipelines.
`program.json` is the portable counterpart that lets a non-Python runtime run the whole
bundle.

## Validation

- `pixi run check` green (lint + format-check + core tests + apps tests).
- New/updated tests: `test_program.py`, `test_bundle.py`, `test_onnx_fold.py`,
  `test_onnx_export.py` (45 pass on the export/program surface).
- Exercised end-to-end on the real TotalSegmentator 5-fold bundle (25/27/19/24/27-class
  disjoint heads → 118 labels via `merge_labels`): **98.78% foreground voxel agreement**
  vs the KonfAI-native app output on a real CT.

## Scope

konfai-apps + konfai export only. No Rust runtime in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added portable runtime bundle exports, including multi-checkpoint ensembles and masked test-time augmentation workflows.
  * Added nested auxiliary model export support within bundles.
  * Enhanced ONNX exporting with configurable output filenames and optional manifest generation.
  * Expanded ensemble reduction to support mean, median, and label-merge behaviors.
* **Bug Fixes**
  * Improved export pipelines to properly treat program-level transforms and correctly source the portable “pre” chain.
* **Tests**
  * Added/updated unit tests covering ensemble reduction derivation, masked TTA wiring, and multi-checkpoint nested-model refusal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->