### PR TITLE
feat(omezarr): store a displacement field as an NGFF RFC-5 vector field

### DIFF
--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -305,6 +305,27 @@ def data_to_image(data: np.ndarray, attributes: Attribute) -> sitk.Image:
     return image
 
 
+# Set on an entry read back from a store that types its component axis as an RFC-5 displacement
+# field, so ``Dataset.read_transform`` can rebuild the transform. The underscore matters: a key
+# without one is stack-renamed by ``Attribute.__setitem__`` (``Transform`` becomes ``Transform_0``).
+DISPLACEMENT_FIELD_ATTRIBUTE = "konfai_displacement_field"
+
+
+def displacement_field_to_data(transform: sitk.Transform, name: str) -> tuple[np.ndarray, Attribute]:
+    """A displacement-field transform as a channel-first array plus its geometry.
+
+    The counterpart of ``_encode_transform_leaves`` for the one transform kind that cannot go through
+    it: a displacement field's parameters ARE the field, so serialising it as a parameter vector
+    would drop the geometry that makes it meaningful. It travels as an image instead, and the store
+    records what it is (see ``write_ome_zarr(displacement_field=True)``).
+    """
+    if not isinstance(transform, sitk.DisplacementFieldTransform):
+        raise DatasetManagerError(
+            f"Expected a DisplacementFieldTransform for entry '{name}', got '{type(transform).__name__}'."
+        )
+    return image_to_data(transform.GetDisplacementField())
+
+
 def image_to_data(image: sitk.Image) -> tuple[np.ndarray, Attribute]:
     """Convert a SimpleITK image into a channel-first NumPy array and attributes."""
     attributes = Attribute()
@@ -1283,8 +1304,16 @@ class Dataset:
             return attributes
 
         def file_to_data(self, group: str, name: str) -> tuple[np.ndarray, Attribute]:
+            from konfai.utils.ome_zarr import is_displacement_field
+
             info_shape, _ = self.get_infos(group, name)
-            return self.file_to_data_slice(group, name, tuple(slice(None) for _ in info_shape))
+            data, attributes = self.file_to_data_slice(group, name, tuple(slice(None) for _ in info_shape))
+            # Marked here and not in file_to_data_slice: that one is the streamed path, called once per
+            # patch, and re-reading the store's metadata per patch is exactly the overhead _load_image
+            # is memoised to avoid. A transform is only ever rebuilt from a whole entry.
+            if is_displacement_field(self._path(name)):
+                attributes[DISPLACEMENT_FIELD_ATTRIBUTE] = "true"
+            return data, attributes
 
         def file_to_data_slice(self, group: str, name: str, slices: tuple[slice, ...]) -> tuple[np.ndarray, Attribute]:
             from konfai.utils.ome_zarr import read_ome_zarr_data_slice
@@ -1329,9 +1358,17 @@ class Dataset:
             from konfai.utils.ome_zarr import write_ome_zarr
 
             attributes = attributes or Attribute()
+            displacement_field = False
             if sitk is not None and isinstance(data, sitk.Image):
                 data, image_attributes = image_to_data(data)
                 attributes.update(image_attributes)
+            elif sitk is not None and isinstance(data, sitk.Transform):
+                # The parametric transforms the other backends serialise (Euler, affine, B-spline) have
+                # no OME-NGFF form; a displacement field does, and it is array-backed, so this backend
+                # stores exactly the one kind it can store faithfully.
+                data, field_attributes = displacement_field_to_data(data, name)
+                attributes.update(field_attributes)
+                displacement_field = True
             if not isinstance(data, np.ndarray):
                 raise DatasetManagerError("OME-Zarr datasets can only store image arrays.")
             write_ome_zarr(
@@ -1340,6 +1377,7 @@ class Dataset:
                 spacing=attributes.get_np_array("Spacing") if "Spacing" in attributes else None,
                 origin=attributes.get_np_array("Origin") if "Origin" in attributes else None,
                 attributes=dict(attributes),
+                displacement_field=displacement_field,
             )
 
         def open_data_stream(
@@ -1770,6 +1808,11 @@ class Dataset:
         if not self._exists_on_disk():
             raise NameError(f"Dataset {self.filename} not found")
         transform_parameters, attribute = self.read_data(group, name)
+        if DISPLACEMENT_FIELD_ATTRIBUTE in attribute:
+            # A displacement field carries no parameter vector to decode: the entry IS the transform,
+            # and the store said so (NGFF RFC-5). float64 is what DisplacementFieldTransform requires.
+            field = sitk.Cast(data_to_image(transform_parameters, attribute), sitk.sitkVectorFloat64)
+            return sitk.DisplacementFieldTransform(field)
         transforms_type = [v for k, v in attribute.items() if k.endswith(":Transform_0")]
         transforms = []
         for i, transform_type in enumerate(transforms_type):

--- a/konfai/utils/ome_zarr.py
+++ b/konfai/utils/ome_zarr.py
@@ -70,6 +70,22 @@ _RFC5_VERSION = "0.6"
 _DEFAULT_VERSION = "0.4"
 
 
+def _zarr_v3_available() -> bool:
+    """Whether the installed zarr can write a v3 store, which NGFF >= 0.5 (RFC-5) requires.
+
+    RFC-5 axis types live only in NGFF 0.6, a zarr v3 layout, and zarr-python 3 needs Python >= 3.11 --
+    so on Python 3.10 (zarr 2.x) a displacement field cannot be written. This is the capability the
+    RFC-5 write actually depends on: ``coordinateSystems`` (checked in ``_type_component_axis``) tracks
+    the ngff-zarr version, not the zarr one, so it alone lets a 2.x store through to an opaque failure.
+    """
+    if not _ZARR_AVAILABLE:
+        return False
+    try:
+        return int(zarr.__version__.split(".")[0]) >= 3
+    except (AttributeError, ValueError):
+        return False
+
+
 def _require_zarr() -> None:
     if not _ZARR_AVAILABLE:
         raise DatasetManagerError(
@@ -270,6 +286,12 @@ def write_ome_zarr(
     )
     version = _DEFAULT_VERSION
     if displacement_field:
+        if not _zarr_v3_available():
+            raise DatasetManagerError(
+                "Writing an NGFF RFC-5 displacement field needs a zarr v3 store, i.e. "
+                "zarr-python >= 3 (Python >= 3.11); this environment has zarr 2.",
+                "Install it with: pip install 'zarr>=3' on Python >= 3.11.",
+            )
         _type_component_axis(multiscales, _DISPLACEMENT_AXIS_TYPE)
         version = _RFC5_VERSION
     ngff_zarr.to_ngff_zarr(str(store_path), multiscales, overwrite=True, version=version)

--- a/konfai/utils/ome_zarr.py
+++ b/konfai/utils/ome_zarr.py
@@ -62,6 +62,13 @@ except ImportError:
 _KONFAI_ATTR_KEY = "konfai"
 _SPATIAL = ("z", "y", "x")
 
+# NGFF RFC-5 types the component axis of a vector field, so a displacement field says what it is on
+# disk. Those types only exist from NGFF 0.6 (zarr v3); 0.4 (zarr v2 layout) stays the default
+# everywhere else, being the version portable across the whole CI matrix.
+_DISPLACEMENT_AXIS_TYPE = "displacement"
+_RFC5_VERSION = "0.6"
+_DEFAULT_VERSION = "0.4"
+
 
 def _require_zarr() -> None:
     if not _ZARR_AVAILABLE:
@@ -115,6 +122,31 @@ def _load_image(store_path: str, level: int) -> Any:
             f"Cannot open OME-Zarr store '{store_path}' (level {level}).",
             "Ensure the directory is a valid OME-NGFF store.",
         ) from exc
+
+
+def is_displacement_field(store_path: str | Path) -> bool:
+    """Whether the store declares its component axis as an NGFF RFC-5 displacement field.
+
+    This is what lets a DVF be read back as a transform rather than as a 3-channel image, and it is
+    read from the store itself: the producer does not have to be trusted, and no sidecar convention
+    (a filename, an attribute) has to be agreed on separately.
+
+    A store that predates RFC-5, or an ngff-zarr too old to model it, simply answers False -- an
+    unreadable or absent store is not a displacement field either, so this never raises.
+    """
+    if not _NGFF_ZARR_AVAILABLE:
+        return False
+    try:
+        metadata = ngff_zarr.from_ngff_zarr(str(store_path)).metadata
+    except Exception:
+        # "Not a displacement field" is the only answer this owes: it is asked purely to decide HOW to
+        # read an entry, and an absent or unreadable store is not one either.
+        return False
+    return any(
+        axis.name == "c" and axis.type == _DISPLACEMENT_AXIS_TYPE
+        for system in getattr(metadata, "coordinateSystems", None) or []
+        for axis in system.axes
+    )
 
 
 def _canonical_shape(dims: Sequence[str], shape: Sequence[int]) -> list[int]:
@@ -207,8 +239,21 @@ def write_ome_zarr(
     origin: Sequence[float] | None = None,
     attributes: dict[str, Any] | None = None,
     chunks: Sequence[int] | None = None,
+    displacement_field: bool = False,
 ) -> None:
-    """Write one channel-first KonfAI array as a single-level OME-NGFF store."""
+    """Write one channel-first KonfAI array as a single-level OME-NGFF store.
+
+    ``displacement_field`` writes it as a vector FIELD rather than an image: the component axis is
+    typed ``displacement`` (NGFF RFC-5), which is what makes a registration DVF self-describing
+    instead of an anonymous 3-channel image. A reader then no longer has to be told out of band that
+    the channels are a displacement -- the mistake that path invites is silent, not loud: index the
+    component axis like any other and you get one third of the field back, and a plausible-looking
+    registration with it.
+
+    The NGFF version follows from that flag and is deliberately NOT a parameter. RFC-5 axis types
+    exist only from 0.6, so a caller passing both could only ever pass them consistently -- an
+    invariant worth removing rather than documenting.
+    """
     _load_image.cache_clear()
     _require_ngff_zarr()
     array_data = np.asarray(data)
@@ -223,13 +268,38 @@ def write_ome_zarr(
     multiscales = ngff_zarr.to_multiscales(
         image, scale_factors=[], chunks=tuple(chunks) if chunks is not None else None
     )
-    # version 0.4 (zarr v2 layout) stays compatible with zarr-python 2.x; v0.5 needs zarr>=3
-    # (unavailable on Python 3.10), so pin 0.4 for portability across the CI matrix.
-    ngff_zarr.to_ngff_zarr(str(store_path), multiscales, overwrite=True, version="0.4")
+    version = _DEFAULT_VERSION
+    if displacement_field:
+        _type_component_axis(multiscales, _DISPLACEMENT_AXIS_TYPE)
+        version = _RFC5_VERSION
+    ngff_zarr.to_ngff_zarr(str(store_path), multiscales, overwrite=True, version=version)
 
     if attributes:
         group = zarr.open_group(str(store_path), mode="r+")
         group.attrs[_KONFAI_ATTR_KEY] = {"attributes": dict(attributes)}
+
+
+def _type_component_axis(multiscales: Any, axis_type: str) -> None:
+    """Type the ``c`` axis of every coordinate system, in place.
+
+    The axis type is set on the RFC-5 coordinate systems rather than on the ``NgffImage``, because
+    ``to_multiscales`` derives the axes itself and hardcodes ``type="channel"`` for a ``c`` dim --
+    tagging the image is a dead assignment on a non-frozen dataclass, and the store comes out an
+    ordinary 3-channel image with no error raised anywhere.
+
+    Coordinate systems are also the capability check: an ngff-zarr too old to model RFC-5 has no
+    ``coordinateSystems`` on its metadata, and would otherwise write a silently untyped store.
+    """
+    systems = getattr(multiscales.metadata, "coordinateSystems", None)
+    if not systems:
+        raise DatasetManagerError(
+            f"Writing a '{axis_type}' field needs NGFF RFC-5 coordinate systems, which this ngff-zarr cannot model.",
+            "Upgrade it with: pip install 'ngff-zarr>=0.38'",
+        )
+    for system in systems:
+        for axis in system.axes:
+            if axis.name == "c":
+                axis.type = axis_type
 
 
 def create_ome_zarr_store(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ itk = ["SimpleITK"]
 hdf5 = ["h5py"]
 monitoring = ["nvidia-ml-py"]
 tensorboard = ["tensorboard"]
-imaging = ["SimpleITK", "h5py", "pydicom", "zarr", "ngff-zarr"]
+imaging = ["SimpleITK", "h5py", "pydicom", "zarr", "ngff-zarr>=0.38"]
 vtk = ["vtk"]
 lpips = ["lpips"]
 smp = ["segmentation-models-pytorch"]
@@ -64,7 +64,7 @@ ssim = ["scikit-image"]
 fid = ["scipy", "torchvision"]
 cluster = ["submitit"]
 dicom = ["pydicom"]
-omezarr = ["zarr", "ngff-zarr"]
+omezarr = ["zarr", "ngff-zarr>=0.38"]
 export = ["onnx", "onnxruntime", "onnxscript"]
 all = [
   "konfai[itk]",
@@ -85,7 +85,7 @@ dev = [
   "h5py",
   "pydicom",
   "zarr",
-  "ngff-zarr",
+  "ngff-zarr>=0.38",
   "scikit-image",
   "onnx",
   "onnxruntime",
@@ -161,7 +161,7 @@ tensorboard = "*"
 nvidia-ml-py = "*"
 pydicom = "*"
 zarr = "*"
-ngff-zarr = "*"
+ngff-zarr = ">=0.38"
 scikit-image = "*"
 
 [tool.pixi.feature.dev.tasks]

--- a/tests/unit/test_omezarr_displacement_field.py
+++ b/tests/unit/test_omezarr_displacement_field.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for displacement fields stored as NGFF RFC-5 OME-Zarr.
+
+The point of the feature is that the store says what it holds: a DVF written through the OME-Zarr
+backend comes back as a ``DisplacementFieldTransform``, not as an anonymous 3-channel image that the
+reader has to be told about out of band.
+"""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from konfai.utils.errors import DatasetManagerError
+
+sitk = pytest.importorskip("SimpleITK")
+pytest.importorskip("zarr")
+pytest.importorskip("ngff_zarr")
+
+from konfai.utils.dataset import Dataset  # noqa: E402
+from konfai.utils.ome_zarr import is_displacement_field, write_ome_zarr  # noqa: E402
+
+SPACING = (1.5, 1.5, 2.0)
+ORIGIN = (7.0, -3.0, 10.0)
+
+
+def _displacement_field_transform() -> "sitk.DisplacementFieldTransform":
+    """A field with a non-trivial, anisotropic geometry, so a lost or transposed axis shows up."""
+    values = np.arange(4 * 5 * 6 * 3, dtype=np.float64).reshape(4, 5, 6, 3)
+    field = sitk.GetImageFromArray(values, isVector=True)
+    field.SetSpacing(SPACING)
+    field.SetOrigin(ORIGIN)
+    return sitk.DisplacementFieldTransform(sitk.Cast(field, sitk.sitkVectorFloat64))
+
+
+def _store(tmp_path: Path) -> Dataset:
+    return Dataset(f"{tmp_path}/dataset/", "omezarr")
+
+
+def test_written_store_declares_the_displacement_axis(tmp_path: Path) -> None:
+    """The component axis is typed ``displacement`` on disk -- the whole point of RFC-5 here."""
+    _store(tmp_path).write("case", "DVF", _displacement_field_transform())
+
+    stores = list(tmp_path.rglob("*.ome.zarr"))
+    assert len(stores) == 1
+    assert is_displacement_field(stores[0])
+    metadata = json.dumps(json.loads((stores[0] / "zarr.json").read_text()))
+    assert '"type": "displacement"' in metadata
+
+
+def test_transform_round_trips_through_the_store(tmp_path: Path) -> None:
+    """A DVF written as a transform is read back as one, geometry and displacements intact."""
+    dataset = _store(tmp_path)
+    original = _displacement_field_transform()
+    dataset.write("case", "DVF", original)
+
+    restored = dataset.read_transform("case", "DVF")
+    assert isinstance(restored, sitk.DisplacementFieldTransform)
+
+    before, after = original.GetDisplacementField(), restored.GetDisplacementField()
+    assert after.GetSize() == before.GetSize()
+    assert after.GetSpacing() == pytest.approx(SPACING)
+    assert after.GetOrigin() == pytest.approx(ORIGIN)
+    assert after.GetNumberOfComponentsPerPixel() == 3
+    assert np.array_equal(sitk.GetArrayFromImage(after), sitk.GetArrayFromImage(before))
+
+
+def test_restored_transform_maps_points_identically(tmp_path: Path) -> None:
+    """The reconstruction is checked by BEHAVIOUR, not only by the array it was built from.
+
+    A field read back with its component axis transposed, or with one component silently selected,
+    still has a plausible shape; only applying it to a point catches that.
+    """
+    dataset = _store(tmp_path)
+    original = _displacement_field_transform()
+    dataset.write("case", "DVF", original)
+    restored = dataset.read_transform("case", "DVF")
+
+    for point in ((9.0, -1.0, 12.0), (7.5, -2.5, 11.0), (10.0, 0.0, 14.0)):
+        assert restored.TransformPoint(point) == pytest.approx(original.TransformPoint(point))
+
+
+def test_plain_image_is_not_a_displacement_field(tmp_path: Path) -> None:
+    """An ordinary multi-channel image must not be mistaken for a field: a 3-channel volume is a
+    perfectly normal image, so the store's declaration is what distinguishes them."""
+    store = tmp_path / "image.ome.zarr"
+    write_ome_zarr(store, np.zeros((3, 4, 5, 6), dtype=np.float32), spacing=SPACING, origin=ORIGIN)
+
+    assert not is_displacement_field(store)
+
+    dataset = _store(tmp_path)
+    dataset.write("case", "Volume", sitk.GetImageFromArray(np.zeros((4, 5, 6), dtype=np.float32)))
+    _, attributes = dataset.read_data("case", "Volume")
+    assert "konfai_displacement_field" not in attributes
+
+
+def test_is_displacement_field_is_false_for_a_missing_store(tmp_path: Path) -> None:
+    """Absent or unreadable is answered, not raised: the question is only ever asked to decide how to
+    read something, and 'not a displacement field' is a valid answer for both."""
+    assert not is_displacement_field(tmp_path / "does-not-exist.ome.zarr")
+
+
+def test_non_displacement_transform_is_rejected(tmp_path: Path) -> None:
+    """The parametric transforms the other backends serialise have no OME-NGFF form, and failing
+    loudly beats writing their parameter vector as if it were a field."""
+    with pytest.raises(DatasetManagerError, match="DisplacementFieldTransform"):
+        _store(tmp_path).write("case", "Affine", sitk.AffineTransform(3))

--- a/tests/unit/test_omezarr_displacement_field.py
+++ b/tests/unit/test_omezarr_displacement_field.py
@@ -33,10 +33,19 @@ pytest.importorskip("zarr")
 pytest.importorskip("ngff_zarr")
 
 from konfai.utils.dataset import Dataset  # noqa: E402
-from konfai.utils.ome_zarr import is_displacement_field, write_ome_zarr  # noqa: E402
+from konfai.utils.ome_zarr import _zarr_v3_available, is_displacement_field, write_ome_zarr  # noqa: E402
+
+# RFC-5 fields are a zarr v3 store (NGFF >= 0.5), which zarr 2.x (Python 3.10) cannot write: the
+# feature does not exist there.
+pytestmark = pytest.mark.skipif(
+    not _zarr_v3_available(),
+    reason="NGFF RFC-5 displacement fields need a zarr v3 store (zarr>=3, Python>=3.11)",
+)
 
 SPACING = (1.5, 1.5, 2.0)
 ORIGIN = (7.0, -3.0, 10.0)
+# A 90 deg in-plane rotation: non-identity and anisotropic, so a dropped or transposed Direction shows.
+DIRECTION = (0.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0)
 
 
 def _displacement_field_transform() -> "sitk.DisplacementFieldTransform":
@@ -45,6 +54,7 @@ def _displacement_field_transform() -> "sitk.DisplacementFieldTransform":
     field = sitk.GetImageFromArray(values, isVector=True)
     field.SetSpacing(SPACING)
     field.SetOrigin(ORIGIN)
+    field.SetDirection(DIRECTION)
     return sitk.DisplacementFieldTransform(sitk.Cast(field, sitk.sitkVectorFloat64))
 
 
@@ -76,6 +86,7 @@ def test_transform_round_trips_through_the_store(tmp_path: Path) -> None:
     assert after.GetSize() == before.GetSize()
     assert after.GetSpacing() == pytest.approx(SPACING)
     assert after.GetOrigin() == pytest.approx(ORIGIN)
+    assert after.GetDirection() == pytest.approx(DIRECTION)
     assert after.GetNumberOfComponentsPerPixel() == 3
     assert np.array_equal(sitk.GetArrayFromImage(after), sitk.GetArrayFromImage(before))
 


### PR DESCRIPTION
## Why

The OME-Zarr backend could only store **images**. A registration DVF therefore went out as an anonymous 3-channel volume: nothing on disk said the channels were a displacement, nor which way it pointed.

The failure that invites is silent rather than loud — index the component axis like any other and you get **a third of the field** back, and a plausible-looking registration with it. Downstream code had to be *told* out of band what the store held, so in practice DVFs kept travelling as `.mha`.

## What

Displacement fields are stored as [**NGFF RFC-5**](https://github.com/ome/ngff/pull/253) vector fields: the component axis is typed `displacement`, so the store is self-describing.

This follows the shape the other backends already use rather than adding a mechanism beside them — `Dataset.write` accepts a `Transform`, dispatch is by `isinstance`, and read/write are symmetric:

| | H5 / SimpleITK | OME-Zarr *(this PR)* |
|---|---|---|
| write | `sitk.WriteTransform(...)` → `.itk.txt` | RFC-5 typed store |
| read | `_decode_transform` + parameter vector | `DisplacementFieldTransform` from the field |

`read_transform` gains the displacement case: the counterpart of `_decode_transform` for the one transform kind whose *parameters are the field*, and which therefore cannot travel as a parameter vector without losing the geometry that gives it meaning.

```python
dataset.write("case", "DVF", displacement_field_transform)
dataset.read_transform("case", "DVF")   # -> sitk.DisplacementFieldTransform
```

Nothing to declare: the **type of the data** decides, and the store — not the producer — is what is trusted on read.

## Two traps worth recording

**The axis type goes on the coordinate systems, not on the `NgffImage`.** `to_multiscales` derives the axes itself and hardcodes `type="channel"` for a `c` dim, so tagging the image is a dead assignment on a non-frozen dataclass: the store comes out an ordinary 3-channel image and **nothing raises**. Verified end-to-end before settling on the coordinate-system path.

**The NGFF version is not a parameter.** RFC-5 axis types exist only from 0.6, so a caller passing both could only ever pass them consistently — an invariant worth removing rather than documenting. `0.4` stays the default for every other write. The absence of `coordinateSystems` doubles as the capability check, which is why `ngff-zarr` moves to `>= 0.38`.

## Tests

`tests/unit/test_omezarr_displacement_field.py` — the axis type reaches disk, the transform round-trips with its geometry, a plain 3-channel image is *not* mistaken for a field, a missing store answers rather than raises, and a parametric transform is rejected loudly.

The round-trip is asserted on **behaviour**, not only on the array: a field read back transposed, or with one component selected, still has a plausible shape — only applying it to a point catches that.

`ruff`, `ruff format`, `mypy`, `bandit` clean; existing dataset / imaging / streaming suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for storing and restoring SimpleITK displacement-field transforms in OME-Zarr (NGFF RFC-5).
  * Added detection for displacement-typed component axes in OME-Zarr stores.
  * Introduced a `displacement_field` option for the OME-Zarr writer to emit displacement-field representations.
* **Bug Fixes**
  * Prevents regular multichannel images from being misidentified as displacement fields.
* **Tests**
  * Added unit tests for NGFF RFC-5 displacement-field metadata, round-trip fidelity, transform application, missing-store handling, and invalid transform rejection.
* **Chores**
  * Updated `ngff-zarr` minimum version requirements for relevant optional dependency groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->