### PR TITLE
feat(impact-reg): accept a displacement field written as an OME-Zarr store

### DIFF
--- a/apps/impact_reg/impact_reg_konfai/impact_reg.py
+++ b/apps/impact_reg/impact_reg_konfai/impact_reg.py
@@ -98,6 +98,12 @@ def _copy_output(src: Path, dest_dir: Path, stem: str) -> Path:
     if dest.exists():
         shutil.rmtree(dest) if dest.is_dir() else dest.unlink()
     (shutil.copytree if src.is_dir() else shutil.copy2)(src, dest)
+    if dest.is_dir():
+        # A store put at a path already read is invisible to the reader's path-keyed memo, which
+        # would otherwise pair the copy's voxels with the replaced store's axes and geometry.
+        from konfai.utils.ome_zarr import clear_ome_zarr_cache
+
+        clear_ome_zarr_cache()
     return dest
 
 

--- a/apps/impact_reg/impact_reg_konfai/impact_reg.py
+++ b/apps/impact_reg/impact_reg_konfai/impact_reg.py
@@ -92,11 +92,21 @@ def _find_output(root: Path, stem: str) -> Path:
     return matches[0]
 
 
+def _output_path(dest_dir: Path, stem: str, suffixes: str) -> Path:
+    """The path ``<stem><suffixes>`` in ``dest_dir``, with every earlier output of that stem removed.
+
+    A re-run whose presets emit the other form would otherwise leave both ``DVF.mha`` and
+    ``DVF.ome.zarr`` behind, and discovery is by stem: ``_find_output`` takes the first match, which
+    sorts to the stale one. Only the current run's output is left standing.
+    """
+    for stale in [p for p in dest_dir.iterdir() if p.name.startswith(f"{stem}.")]:
+        shutil.rmtree(stale) if stale.is_dir() else stale.unlink()
+    return dest_dir / (stem + suffixes)
+
+
 def _copy_output(src: Path, dest_dir: Path, stem: str) -> Path:
     """Copy an output beside the results, keeping the form the preset produced (file or store)."""
-    dest = dest_dir / (stem + "".join(src.suffixes))
-    if dest.exists():
-        shutil.rmtree(dest) if dest.is_dir() else dest.unlink()
+    dest = _output_path(dest_dir, stem, "".join(src.suffixes))
     (shutil.copytree if src.is_dir() else shutil.copy2)(src, dest)
     if dest.is_dir():
         # A store put at a path already read is invisible to the reader's path-keyed memo, which
@@ -268,7 +278,7 @@ class ImpactRegKonfAIApp:
                     # Ensemble: average the presets' displacement fields (all on the fixed grid) and warp the
                     # moving image once with that averaged field — the one output no single preset produced.
                     avg_dvf = self._average_displacement(dvf_paths)
-                    dvf_out = case_out / ("DVF" + "".join(dvf_paths[0].suffixes))
+                    dvf_out = _output_path(case_out, "DVF", "".join(dvf_paths[0].suffixes))
                     _write_displacement_field(avg_dvf, dvf_out)
                     transform = sitk.DisplacementFieldTransform(sitk.Cast(avg_dvf, sitk.sitkVectorFloat64))
                     moving = sitk.ReadImage(str(moving_image))

--- a/apps/impact_reg/impact_reg_konfai/impact_reg.py
+++ b/apps/impact_reg/impact_reg_konfai/impact_reg.py
@@ -40,7 +40,7 @@ from pathlib import Path
 import numpy as np
 import SimpleITK as sitk
 from konfai.utils.dataset import read_landmarks, write_landmarks
-from konfai.utils.ITK import apply_to_data_transform
+from konfai.utils.ITK import apply_to_data_transform, read_displacement_field
 from konfai_apps import KonfAIApp
 from konfai_apps.app_repository import get_available_apps_on_hf_repo
 
@@ -79,17 +79,48 @@ def get_available_presets(force_update: bool = False) -> list[str]:
     return list(get_available_apps_on_hf_repo(IMPACT_REG_KONFAI_REPO, force_update))
 
 
-def _find_output(root: Path, name: str) -> Path:
-    """Locate a single ``<name>`` produced by a preset inference under ``root``."""
-    matches = sorted(root.rglob(name))
+def _find_output(root: Path, stem: str) -> Path:
+    """Locate the single output named ``stem`` under ``root``, whatever form the preset wrote it in.
+
+    Matched on the name rather than on a fixed filename: a displacement field may come out as an ITK
+    image or as an OME-Zarr store, and a store is a DIRECTORY whose ``Path.stem`` is "DVF.ome" -- so a
+    fixed "DVF.mha" finds nothing and the run dies with the output sitting in the directory it listed.
+    """
+    matches = sorted(root.rglob(f"{stem}.*"))
     if not matches:
-        raise FileNotFoundError(f"Preset inference did not produce '{name}' under {root}.")
+        raise FileNotFoundError(f"Preset inference did not produce '{stem}' under {root}.")
     return matches[0]
 
 
+def _copy_output(src: Path, dest_dir: Path, stem: str) -> Path:
+    """Copy an output beside the results, keeping the form the preset produced (file or store)."""
+    dest = dest_dir / (stem + "".join(src.suffixes))
+    if dest.exists():
+        shutil.rmtree(dest) if dest.is_dir() else dest.unlink()
+    (shutil.copytree if src.is_dir() else shutil.copy2)(src, dest)
+    return dest
+
+
+def _write_displacement_field(field: sitk.Image, dest: Path) -> None:
+    """Write a field in the form ``dest`` names, so a derived field matches the ones it came from."""
+    if "".join(dest.suffixes).endswith(".ome.zarr"):
+        from konfai.utils.ome_zarr import write_ome_zarr
+
+        array = sitk.GetArrayFromImage(field)
+        write_ome_zarr(
+            dest,
+            np.moveaxis(array, -1, 0),
+            spacing=field.GetSpacing(),
+            origin=field.GetOrigin(),
+            displacement_field=True,
+        )
+    else:
+        sitk.WriteImage(field, str(dest))
+
+
 def _displacement_transform(dvf_path: Path) -> sitk.Transform:
-    """Read a displacement-field image (3-component, fixed grid) as a SimpleITK transform."""
-    return sitk.DisplacementFieldTransform(sitk.ReadImage(str(dvf_path), sitk.sitkVectorFloat64))
+    """Read a displacement field (3-component, fixed grid) as a SimpleITK transform."""
+    return sitk.DisplacementFieldTransform(read_displacement_field(dvf_path))
 
 
 def _neutral_mask(out_path: Path) -> Path:
@@ -161,7 +192,7 @@ class ImpactRegKonfAIApp:
         subprocess.run(command, check=True)  # nosec B603
         # The model emits both the moved image and the displacement field on the fixed grid; reusing them
         # (rather than re-resampling here) keeps the single-preset path free of any extra image read/write.
-        return _find_output(out, "Moved.mha"), _find_output(out, "DVF.mha")
+        return _find_output(out, "Moved"), _find_output(out, "DVF")
 
     def register(
         self,
@@ -213,9 +244,7 @@ class ImpactRegKonfAIApp:
                         config_overrides,
                     )
                     if keep_dvf:
-                        member = case_out / _ENSEMBLE_DIR / f"{preset}.mha"
-                        shutil.copy2(dvf, member)
-                        dvf = member
+                        dvf = _copy_output(dvf, case_out / _ENSEMBLE_DIR, preset)
                     moved_paths.append(moved)
                     dvf_paths.append(dvf)
 
@@ -223,13 +252,14 @@ class ImpactRegKonfAIApp:
                     # One preset: the model already produced the moved image AND the displacement field on
                     # the fixed grid — reuse them verbatim. No input re-read, no re-resample, and the input
                     # format is whatever the model handled (OME-Zarr included).
-                    shutil.copy2(moved_paths[0], case_out / "Moved.mha")
-                    shutil.copy2(dvf_paths[0], case_out / "DVF.mha")
+                    _copy_output(moved_paths[0], case_out, "Moved")
+                    dvf_out = _copy_output(dvf_paths[0], case_out, "DVF")
                 else:
                     # Ensemble: average the presets' displacement fields (all on the fixed grid) and warp the
                     # moving image once with that averaged field — the one output no single preset produced.
                     avg_dvf = self._average_displacement(dvf_paths)
-                    sitk.WriteImage(avg_dvf, str(case_out / "DVF.mha"))
+                    dvf_out = case_out / ("DVF" + "".join(dvf_paths[0].suffixes))
+                    _write_displacement_field(avg_dvf, dvf_out)
                     transform = sitk.DisplacementFieldTransform(sitk.Cast(avg_dvf, sitk.sitkVectorFloat64))
                     moving = sitk.ReadImage(str(moving_image))
                     sitk.WriteImage(
@@ -239,14 +269,14 @@ class ImpactRegKonfAIApp:
 
                 # Transform.h5 (consumed by `evaluate` and SlicerImpactReg): the fixed-grid displacement
                 # field as a SimpleITK transform.
-                sitk.WriteTransform(_displacement_transform(case_out / "DVF.mha"), str(case_out / "Transform.h5"))
+                sitk.WriteTransform(_displacement_transform(dvf_out), str(case_out / "Transform.h5"))
             finally:
                 shutil.rmtree(work, ignore_errors=True)
 
     def _average_displacement(self, dvf_paths: list[Path]) -> sitk.Image:
         """Average several presets' displacement fields (all on the same fixed grid) into one field."""
-        reference = sitk.ReadImage(str(dvf_paths[0]))
-        stack = np.stack([sitk.GetArrayFromImage(sitk.ReadImage(str(p))) for p in dvf_paths], axis=0)
+        reference = read_displacement_field(dvf_paths[0])
+        stack = np.stack([sitk.GetArrayFromImage(read_displacement_field(p)) for p in dvf_paths], axis=0)
         avg = sitk.GetImageFromArray(stack.mean(axis=0), isVector=True)
         avg.CopyInformation(reference)
         return avg

--- a/apps/impact_reg/impact_reg_konfai/impact_reg.py
+++ b/apps/impact_reg/impact_reg_konfai/impact_reg.py
@@ -284,7 +284,7 @@ class ImpactRegKonfAIApp:
                     moving = sitk.ReadImage(str(moving_image))
                     sitk.WriteImage(
                         sitk.Resample(moving, avg_dvf, transform, sitk.sitkLinear, 0.0, moving.GetPixelID()),
-                        str(case_out / "Moved.mha"),
+                        str(_output_path(case_out, "Moved", ".mha")),
                     )
 
                 # Transform.h5 (consumed by `evaluate` and SlicerImpactReg): the fixed-grid displacement

--- a/apps/impact_reg/impact_reg_konfai/impact_reg.py
+++ b/apps/impact_reg/impact_reg_konfai/impact_reg.py
@@ -104,14 +104,18 @@ def _copy_output(src: Path, dest_dir: Path, stem: str) -> Path:
 def _write_displacement_field(field: sitk.Image, dest: Path) -> None:
     """Write a field in the form ``dest`` names, so a derived field matches the ones it came from."""
     if "".join(dest.suffixes).endswith(".ome.zarr"):
+        from konfai.utils.dataset import image_to_data
         from konfai.utils.ome_zarr import write_ome_zarr
 
-        array = sitk.GetArrayFromImage(field)
+        # image_to_data yields the channel-first array and the Origin/Spacing/Direction the store must
+        # carry -- the same encoding the Dataset backend writes, so the field round-trips through either.
+        data, attributes = image_to_data(field)
         write_ome_zarr(
             dest,
-            np.moveaxis(array, -1, 0),
+            data,
             spacing=field.GetSpacing(),
             origin=field.GetOrigin(),
+            attributes=dict(attributes),
             displacement_field=True,
         )
     else:
@@ -274,10 +278,16 @@ class ImpactRegKonfAIApp:
                 shutil.rmtree(work, ignore_errors=True)
 
     def _average_displacement(self, dvf_paths: list[Path]) -> sitk.Image:
-        """Average several presets' displacement fields (all on the same fixed grid) into one field."""
+        """Average several presets' displacement fields (all on the same fixed grid) into one field.
+
+        A running sum keeps memory flat in the number of members: a few field-sized buffers are live
+        at any instant, whatever the size of the ensemble.
+        """
         reference = read_displacement_field(dvf_paths[0])
-        stack = np.stack([sitk.GetArrayFromImage(read_displacement_field(p)) for p in dvf_paths], axis=0)
-        avg = sitk.GetImageFromArray(stack.mean(axis=0), isVector=True)
+        total = sitk.GetArrayFromImage(reference)
+        for path in dvf_paths[1:]:
+            total += sitk.GetArrayFromImage(read_displacement_field(path))
+        avg = sitk.GetImageFromArray(total / len(dvf_paths), isVector=True)
         avg.CopyInformation(reference)
         return avg
 
@@ -395,10 +405,11 @@ class ImpactRegKonfAIApp:
             raise ValueError("Uncertainty needs at least two ensemble displacement fields.")
         work = Path(tempfile.mkdtemp(prefix="impact_reg_unc_"))
         try:
-            reference = sitk.ReadImage(str(dvfs[0]))
+            reference = read_displacement_field(dvfs[0])
             rank = reference.GetDimension()
             stack = sitk.GetImageFromArray(
-                np.stack([sitk.GetArrayFromImage(sitk.ReadImage(str(p))) for p in dvfs], axis=-1), isVector=True
+                np.stack([sitk.GetArrayFromImage(read_displacement_field(p)) for p in dvfs], axis=-1),
+                isVector=True,
             )
             # The extra leading image axis holds the vector components (dropped by ``Norm``); the real
             # fixed-grid geometry lives on the remaining axes so the uncertainty map stays aligned.

--- a/apps/impact_reg/tests/unit/test_displacement_field_io.py
+++ b/apps/impact_reg/tests/unit/test_displacement_field_io.py
@@ -36,7 +36,8 @@ from impact_reg_konfai.impact_reg import (  # noqa: E402
     _find_output,
     _write_displacement_field,
 )
-from konfai.utils.ome_zarr import _zarr_v3_available, is_displacement_field  # noqa: E402
+from konfai.utils.ITK import read_displacement_field  # noqa: E402
+from konfai.utils.ome_zarr import _zarr_v3_available, is_displacement_field, write_ome_zarr  # noqa: E402
 
 # The OME-Zarr side of these tests writes an RFC-5 field, a zarr v3 store that zarr 2.x
 # (Python 3.10) cannot write.
@@ -109,6 +110,43 @@ def test_copy_output_replaces_an_existing_store(tmp_path: Path) -> None:
 
     assert again.is_dir()
     assert is_displacement_field(again)
+
+
+def test_replacing_a_store_is_not_served_from_the_reader_cache(tmp_path: Path) -> None:
+    """The second of two registrations writing to one output directory must read its own field.
+
+    The reader memoises NGFF metadata per store path, so a store copied over one already read is a
+    hit: the new voxels arrive carrying the replaced store's geometry. Nothing raises when the two
+    have the same shape -- the field is simply sampled in the wrong place. Written without a konfai
+    sidecar (what a third-party RFC-5 producer emits), since the sidecar is read outside the memo
+    and would mask exactly the staleness under test.
+    """
+    source, destination = tmp_path / "src", tmp_path / "out"
+    (source / "first").mkdir(parents=True)
+    (source / "second").mkdir(parents=True)
+    destination.mkdir()
+    shape = (3, 4, 5, 6)
+    write_ome_zarr(
+        source / "first" / "DVF.ome.zarr",
+        np.ones(shape, dtype=np.float32),
+        spacing=SPACING,
+        origin=ORIGIN,
+        displacement_field=True,
+    )
+    write_ome_zarr(
+        source / "second" / "DVF.ome.zarr",
+        np.full(shape, 9.0, dtype=np.float32),
+        spacing=(0.5, 0.5, 0.5),
+        origin=(100.0, 200.0, 300.0),
+        displacement_field=True,
+    )
+
+    read_displacement_field(_copy_output(source / "first" / "DVF.ome.zarr", destination, "DVF"))
+    second = read_displacement_field(_copy_output(source / "second" / "DVF.ome.zarr", destination, "DVF"))
+
+    assert second.GetSpacing() == pytest.approx((0.5, 0.5, 0.5))
+    assert second.GetOrigin() == pytest.approx((100.0, 200.0, 300.0))
+    assert sitk.GetArrayFromImage(second).flat[0] == pytest.approx(9.0)
 
 
 def test_store_written_by_the_orchestrator_is_a_declared_field(tmp_path: Path) -> None:

--- a/apps/impact_reg/tests/unit/test_displacement_field_io.py
+++ b/apps/impact_reg/tests/unit/test_displacement_field_io.py
@@ -34,6 +34,7 @@ from impact_reg_konfai.impact_reg import (  # noqa: E402
     _copy_output,
     _displacement_transform,
     _find_output,
+    _output_path,
     _write_displacement_field,
 )
 from konfai.utils.errors import TransformError  # noqa: E402
@@ -159,6 +160,21 @@ def test_an_ordinary_image_store_is_refused_as_a_field(tmp_path: Path) -> None:
     assert not is_displacement_field(image)
     with pytest.raises(TransformError, match="not a displacement field"):
         read_displacement_field(image)
+
+
+def test_output_path_clears_the_stem_whatever_the_previous_form(tmp_path: Path) -> None:
+    """The contract both writers share: one output per stem. The ensemble branch writes ``Moved.mha``
+    verbatim, so a preceding single-preset run that produced ``Moved.ome.zarr`` has to be cleared here
+    rather than at the copy. Neighbouring stems are left alone."""
+    (tmp_path / "Moved.ome.zarr").mkdir()
+    (tmp_path / "Moved.mha").touch()
+    (tmp_path / "MovedMask.mha").touch()  # shares a prefix, not the stem
+    (tmp_path / "DVF.mha").touch()
+
+    dest = _output_path(tmp_path, "Moved", ".mha")
+
+    assert dest == tmp_path / "Moved.mha"
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["DVF.mha", "MovedMask.mha"]
 
 
 def test_rerunning_in_the_other_form_leaves_one_output(tmp_path: Path) -> None:

--- a/apps/impact_reg/tests/unit/test_displacement_field_io.py
+++ b/apps/impact_reg/tests/unit/test_displacement_field_io.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The orchestrator's displacement-field I/O, for a field written either as an ITK image or as an
+NGFF RFC-5 OME-Zarr store.
+
+A preset may emit its DVF in either form, and every step that follows -- locating it, copying it
+beside the results, averaging an ensemble, exporting ``Transform.h5`` -- used to assume ``DVF.mha``.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sitk = pytest.importorskip("SimpleITK")
+pytest.importorskip("zarr")
+pytest.importorskip("ngff_zarr")
+
+from impact_reg_konfai.impact_reg import (  # noqa: E402
+    _copy_output,
+    _displacement_transform,
+    _find_output,
+    _write_displacement_field,
+)
+from konfai.utils.ome_zarr import is_displacement_field  # noqa: E402
+
+SPACING = (1.5, 1.5, 2.0)
+ORIGIN = (7.0, -3.0, 10.0)
+
+
+def _field(seed: int = 0) -> "sitk.Image":
+    values = np.random.default_rng(seed).normal(size=(4, 5, 6, 3)) * 8
+    field = sitk.GetImageFromArray(values, isVector=True)
+    field.SetSpacing(SPACING)
+    field.SetOrigin(ORIGIN)
+    return sitk.Cast(field, sitk.sitkVectorFloat64)
+
+
+def _write_store(dest: Path, field: "sitk.Image") -> Path:
+    _write_displacement_field(field, dest)
+    return dest
+
+
+@pytest.mark.parametrize("suffix", [".mha", ".ome.zarr"])
+def test_find_output_locates_either_form(tmp_path: Path, suffix: str) -> None:
+    """Discovery is by name, not by filename: a store is a directory whose stem is 'DVF.ome'."""
+    produced = tmp_path / "P000"
+    produced.mkdir()
+    _write_displacement_field(_field(), produced / f"DVF{suffix}")
+
+    assert _find_output(tmp_path, "DVF").name == f"DVF{suffix}"
+
+
+def test_find_output_reports_the_name_it_looked_for(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="DVF"):
+        _find_output(tmp_path, "DVF")
+
+
+@pytest.mark.parametrize("suffix", [".mha", ".ome.zarr"])
+def test_copy_output_keeps_the_produced_form(tmp_path: Path, suffix: str) -> None:
+    """A store is copied as a store, an image as an image -- the destination keeps the suffix rather
+    than renaming everything to a form only one of them has."""
+    source = tmp_path / "src"
+    source.mkdir()
+    _write_displacement_field(_field(), source / f"DVF{suffix}")
+    destination = tmp_path / "out"
+    destination.mkdir()
+
+    copied = _copy_output(source / f"DVF{suffix}", destination, "DVF")
+
+    assert copied.name == f"DVF{suffix}"
+    assert copied.is_dir() == (suffix == ".ome.zarr")
+
+
+def test_copy_output_replaces_an_existing_store(tmp_path: Path) -> None:
+    """Re-running a case overwrites its outputs; a directory cannot be overwritten by copytree."""
+    source, destination = tmp_path / "src", tmp_path / "out"
+    source.mkdir()
+    destination.mkdir()
+    _write_displacement_field(_field(), source / "DVF.ome.zarr")
+
+    _copy_output(source / "DVF.ome.zarr", destination, "DVF")
+    again = _copy_output(source / "DVF.ome.zarr", destination, "DVF")
+
+    assert again.is_dir()
+    assert is_displacement_field(again)
+
+
+def test_store_written_by_the_orchestrator_is_a_declared_field(tmp_path: Path) -> None:
+    """An averaged ensemble field is written in the members' form, and stays a declared field."""
+    store = _write_store(tmp_path / "DVF.ome.zarr", _field())
+    assert is_displacement_field(store)
+
+
+@pytest.mark.parametrize("suffix", [".mha", ".ome.zarr"])
+def test_transform_reads_back_identically_from_either_form(tmp_path: Path, suffix: str) -> None:
+    """What Transform.h5 is built from: the same transform whichever form the field was written in.
+
+    Checked on a mapped point, not only on the array -- a field read with its component axis mishandled
+    keeps a plausible shape, and only applying it exposes that.
+    """
+    original = _field()
+    _write_displacement_field(original, tmp_path / f"DVF{suffix}")
+
+    restored = _displacement_transform(tmp_path / f"DVF{suffix}")
+
+    assert isinstance(restored, sitk.DisplacementFieldTransform)
+    reference = sitk.DisplacementFieldTransform(sitk.Image(original))
+    for point in ((9.0, -1.0, 12.0), (7.5, -2.5, 11.0)):
+        assert restored.TransformPoint(point) == pytest.approx(reference.TransformPoint(point))

--- a/apps/impact_reg/tests/unit/test_displacement_field_io.py
+++ b/apps/impact_reg/tests/unit/test_displacement_field_io.py
@@ -36,6 +36,7 @@ from impact_reg_konfai.impact_reg import (  # noqa: E402
     _find_output,
     _write_displacement_field,
 )
+from konfai.utils.errors import TransformError  # noqa: E402
 from konfai.utils.ITK import read_displacement_field  # noqa: E402
 from konfai.utils.ome_zarr import _zarr_v3_available, is_displacement_field, write_ome_zarr  # noqa: E402
 
@@ -147,6 +148,33 @@ def test_replacing_a_store_is_not_served_from_the_reader_cache(tmp_path: Path) -
     assert second.GetSpacing() == pytest.approx((0.5, 0.5, 0.5))
     assert second.GetOrigin() == pytest.approx((100.0, 200.0, 300.0))
     assert sitk.GetArrayFromImage(second).flat[0] == pytest.approx(9.0)
+
+
+def test_an_ordinary_image_store_is_refused_as_a_field(tmp_path: Path) -> None:
+    """The declaration the store carries is the point: a three-component volume is a normal image,
+    and reading one as a field yields a transform that registers to nowhere without ever failing."""
+    image = tmp_path / "Image.ome.zarr"
+    write_ome_zarr(image, np.ones((3, 4, 5, 6), dtype=np.float32), spacing=SPACING, origin=ORIGIN)
+
+    assert not is_displacement_field(image)
+    with pytest.raises(TransformError, match="not a displacement field"):
+        read_displacement_field(image)
+
+
+def test_rerunning_in_the_other_form_leaves_one_output(tmp_path: Path) -> None:
+    """Discovery is by stem, so a run that emits the other form must not leave the previous one
+    beside it -- ``_find_output`` returns the first match, and ``DVF.mha`` sorts before its store."""
+    source, destination = tmp_path / "src", tmp_path / "out"
+    source.mkdir()
+    destination.mkdir()
+    _write_displacement_field(_field(), source / "DVF.mha")
+    _write_displacement_field(_field(), source / "DVF.ome.zarr")
+
+    _copy_output(source / "DVF.mha", destination, "DVF")
+    _copy_output(source / "DVF.ome.zarr", destination, "DVF")
+
+    assert [p.name for p in destination.iterdir()] == ["DVF.ome.zarr"]
+    assert _find_output(destination, "DVF").name == "DVF.ome.zarr"
 
 
 def test_store_written_by_the_orchestrator_is_a_declared_field(tmp_path: Path) -> None:

--- a/apps/impact_reg/tests/unit/test_displacement_field_io.py
+++ b/apps/impact_reg/tests/unit/test_displacement_field_io.py
@@ -36,10 +36,20 @@ from impact_reg_konfai.impact_reg import (  # noqa: E402
     _find_output,
     _write_displacement_field,
 )
-from konfai.utils.ome_zarr import is_displacement_field  # noqa: E402
+from konfai.utils.ome_zarr import _zarr_v3_available, is_displacement_field  # noqa: E402
+
+# The OME-Zarr side of these tests writes an RFC-5 field, a zarr v3 store that zarr 2.x
+# (Python 3.10) cannot write.
+pytestmark = pytest.mark.skipif(
+    not _zarr_v3_available(),
+    reason="NGFF RFC-5 displacement fields need a zarr v3 store (zarr>=3, Python>=3.11)",
+)
 
 SPACING = (1.5, 1.5, 2.0)
 ORIGIN = (7.0, -3.0, 10.0)
+# A 90 deg in-plane rotation: non-identity, so a Direction dropped on the store round-trip changes
+# where the field is sampled and the mapped-point assertion below catches it.
+DIRECTION = (0.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0)
 
 
 def _field(seed: int = 0) -> "sitk.Image":
@@ -47,6 +57,7 @@ def _field(seed: int = 0) -> "sitk.Image":
     field = sitk.GetImageFromArray(values, isVector=True)
     field.SetSpacing(SPACING)
     field.SetOrigin(ORIGIN)
+    field.SetDirection(DIRECTION)
     return sitk.Cast(field, sitk.sitkVectorFloat64)
 
 

--- a/konfai/utils/ITK.py
+++ b/konfai/utils/ITK.py
@@ -18,6 +18,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 import torch
 
@@ -34,6 +36,40 @@ def _require_simpleitk() -> None:
     """Raise a clear project error when an ITK-only path is used without SimpleITK."""
     if sitk is None:
         raise TransformError("SimpleITK is required for this operation. Install it with `pip install konfai[itk]`.")
+
+
+def read_displacement_field(path: str | Path) -> sitk.Image:
+    """A displacement field, from an ITK image file OR an NGFF RFC-5 OME-Zarr store.
+
+    A field written as a store cannot go through ``sitk.ReadImage``, and reading it as an ordinary
+    image is worse than failing: the component axis looks like any other, so indexing it yields one
+    third of the field and a registration that is wrong without being obviously wrong. This is the one
+    place that knows how to open either form, so no caller has to decide.
+
+    The result is ``sitkVectorFloat64`` -- what ``DisplacementFieldTransform`` requires.
+    """
+    _require_simpleitk()
+    path = Path(path)
+    if not path.is_dir():
+        return sitk.ReadImage(str(path), sitk.sitkVectorFloat64)
+
+    from konfai.utils.ome_zarr import get_ome_zarr_info, read_ome_zarr_data_slice
+
+    info = get_ome_zarr_info(path)
+    axes = info["axes"]
+    spatial = [axis for axis in ("z", "y", "x") if axis in axes]
+    shape = [int(dict(zip(axes, info["shape"], strict=True)).get("c", 1))]
+    shape += [int(dict(zip(axes, info["shape"], strict=True))[axis]) for axis in spatial]
+    data, metadata = read_ome_zarr_data_slice(path, tuple(slice(None) for _ in shape))
+
+    scale = dict(zip(metadata["axes"], metadata["scale"], strict=True))
+    translation = dict(zip(metadata["axes"], metadata["translation"], strict=True))
+    # KonfAI arrays are channel-first; a SimpleITK vector image wants the components last, and its
+    # geometry in (x, y, z) -- the reverse of the NGFF axis order.
+    field = sitk.GetImageFromArray(np.moveaxis(np.asarray(data), 0, -1), isVector=True)
+    field.SetSpacing([float(scale[axis]) for axis in reversed(spatial)])
+    field.SetOrigin([float(translation[axis]) for axis in reversed(spatial)])
+    return sitk.Cast(field, sitk.sitkVectorFloat64)
 
 
 def _invert_via_displacement_field(transform: sitk.Transform, image: sitk.Image) -> sitk.DisplacementFieldTransform:

--- a/konfai/utils/ITK.py
+++ b/konfai/utils/ITK.py
@@ -53,22 +53,15 @@ def read_displacement_field(path: str | Path) -> sitk.Image:
     if not path.is_dir():
         return sitk.ReadImage(str(path), sitk.sitkVectorFloat64)
 
+    from konfai.utils.dataset import data_to_image, ome_zarr_attributes
     from konfai.utils.ome_zarr import get_ome_zarr_info, read_ome_zarr_data_slice
 
-    info = get_ome_zarr_info(path)
-    axes = info["axes"]
-    spatial = [axis for axis in ("z", "y", "x") if axis in axes]
-    shape = [int(dict(zip(axes, info["shape"], strict=True)).get("c", 1))]
-    shape += [int(dict(zip(axes, info["shape"], strict=True))[axis]) for axis in spatial]
-    data, metadata = read_ome_zarr_data_slice(path, tuple(slice(None) for _ in shape))
-
-    scale = dict(zip(metadata["axes"], metadata["scale"], strict=True))
-    translation = dict(zip(metadata["axes"], metadata["translation"], strict=True))
-    # KonfAI arrays are channel-first; a SimpleITK vector image wants the components last, and its
-    # geometry in (x, y, z) -- the reverse of the NGFF axis order.
-    field = sitk.GetImageFromArray(np.moveaxis(np.asarray(data), 0, -1), isVector=True)
-    field.SetSpacing([float(scale[axis]) for axis in reversed(spatial)])
-    field.SetOrigin([float(translation[axis]) for axis in reversed(spatial)])
+    axes = get_ome_zarr_info(path)["axes"]
+    n_axes = 1 + sum(axis in axes for axis in ("z", "y", "x"))  # channel-first C[Z]YX
+    data, metadata = read_ome_zarr_data_slice(path, tuple(slice(None) for _ in range(n_axes)))
+    # Origin, Spacing and Direction together: NGFF scale/translation alone cannot express the
+    # direction matrix, so the geometry comes from the konfai sidecar through data_to_image.
+    field = data_to_image(data, ome_zarr_attributes(metadata))
     return sitk.Cast(field, sitk.sitkVectorFloat64)
 
 

--- a/konfai/utils/ITK.py
+++ b/konfai/utils/ITK.py
@@ -54,8 +54,16 @@ def read_displacement_field(path: str | Path) -> sitk.Image:
         return sitk.ReadImage(str(path), sitk.sitkVectorFloat64)
 
     from konfai.utils.dataset import data_to_image, ome_zarr_attributes
-    from konfai.utils.ome_zarr import get_ome_zarr_info, read_ome_zarr_data_slice
+    from konfai.utils.ome_zarr import get_ome_zarr_info, is_displacement_field, read_ome_zarr_data_slice
 
+    if not is_displacement_field(path):
+        raise TransformError(
+            f"'{path}' is an OME-Zarr image, not a displacement field: its component axis is not "
+            "typed as an NGFF RFC-5 displacement.",
+            "A three-component volume is a perfectly ordinary image, so the store's own declaration "
+            "is the only thing that tells them apart -- write the field with "
+            "write_ome_zarr(displacement_field=True).",
+        )
     axes = get_ome_zarr_info(path)["axes"]
     n_axes = 1 + sum(axis in axes for axis in ("z", "y", "x"))  # channel-first C[Z]YX
     data, metadata = read_ome_zarr_data_slice(path, tuple(slice(None) for _ in range(n_axes)))

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -343,6 +343,29 @@ def image_to_data(image: sitk.Image) -> tuple[np.ndarray, Attribute]:
     return data, attributes
 
 
+def ome_zarr_attributes(metadata: dict[str, Any]) -> Attribute:
+    """A KonfAI ``Attribute`` (Origin / Spacing / Direction) from an OME-Zarr entry's metadata.
+
+    The store's konfai sidecar wins when present -- it carries the full Direction matrix, which NGFF
+    scale/translation cannot express -- otherwise geometry falls back to the NGFF transforms, Direction
+    defaulting to identity. Shared by the Dataset OME-Zarr reader and ``ITK.read_displacement_field``
+    so both recover geometry the one same way.
+    """
+    attributes = Attribute(metadata.get("attributes", {}))
+    axes = metadata["axes"]
+    scale = dict(zip(axes, metadata.get("scale", []), strict=False))
+    translation = dict(zip(axes, metadata.get("translation", []), strict=False))
+    spatial_axes = [axis for axis in ("x", "y", "z") if axis in axes]
+    if "Spacing" not in attributes:
+        attributes["Spacing"] = np.asarray([scale.get(axis, 1.0) for axis in spatial_axes])
+    if "Origin" not in attributes:
+        attributes["Origin"] = np.asarray([translation.get(axis, 0.0) for axis in spatial_axes])
+    if "Direction" not in attributes:
+        attributes["Direction"] = np.eye(len(spatial_axes), dtype=np.float64).flatten()
+    attributes["OMEAxes"] = np.asarray(axes)
+    return attributes
+
+
 def _flatten_transforms(transform: sitk.Transform) -> list[sitk.Transform]:
     """The leaf transforms of a (possibly nested) composite, in application order.
 
@@ -1289,19 +1312,7 @@ class Dataset:
 
         @staticmethod
         def _attributes(metadata: dict[str, Any]) -> Attribute:
-            attributes = Attribute(metadata.get("attributes", {}))
-            axes = metadata["axes"]
-            scale = dict(zip(axes, metadata.get("scale", []), strict=False))
-            translation = dict(zip(axes, metadata.get("translation", []), strict=False))
-            spatial_axes = [axis for axis in ("x", "y", "z") if axis in axes]
-            if "Spacing" not in attributes:
-                attributes["Spacing"] = np.asarray([scale.get(axis, 1.0) for axis in spatial_axes])
-            if "Origin" not in attributes:
-                attributes["Origin"] = np.asarray([translation.get(axis, 0.0) for axis in spatial_axes])
-            if "Direction" not in attributes:
-                attributes["Direction"] = np.eye(len(spatial_axes), dtype=np.float64).flatten()
-            attributes["OMEAxes"] = np.asarray(axes)
-            return attributes
+            return ome_zarr_attributes(metadata)
 
         def file_to_data(self, group: str, name: str) -> tuple[np.ndarray, Attribute]:
             from konfai.utils.ome_zarr import is_displacement_field

--- a/konfai/utils/ome_zarr.py
+++ b/konfai/utils/ome_zarr.py
@@ -118,8 +118,8 @@ def _load_image(store_path: str, level: int) -> Any:
 
     A streamed run reads one patch per call, and re-parsing the NGFF metadata and rebuilding the
     lazy array graph per patch is pure per-read overhead: the image object is lazy (no voxel data),
-    so a handful of them is cheap to keep. Every write path calls ``_load_image.cache_clear()`` —
-    a store just written must be re-read, never served from the memo.
+    so a handful of them is cheap to keep. The key is the path alone, so anything that puts a
+    different store at a path already read must call ``clear_ome_zarr_cache()`` — see there.
 
     ``@N`` selects among the levels a store offers, so a single-level store has nothing to select: its
     one level is read whatever ``N`` says (as every other backend does -- ``SitkFile`` ignores
@@ -138,6 +138,17 @@ def _load_image(store_path: str, level: int) -> Any:
             f"Cannot open OME-Zarr store '{store_path}' (level {level}).",
             "Ensure the directory is a valid OME-NGFF store.",
         ) from exc
+
+
+def clear_ome_zarr_cache() -> None:
+    """Forget the memoised NGFF images, so a store replaced on disk is parsed afresh.
+
+    The write paths here call it for their own output. Anything that materialises a store by other
+    means -- copying one over another, say -- has to call it too: the memo is keyed on the path, and
+    a hit serves the previous store's axes and geometry against the new store's voxels. That reads as
+    a shape mismatch when the two differ, and as nothing at all when they do not.
+    """
+    _load_image.cache_clear()
 
 
 def is_displacement_field(store_path: str | Path) -> bool:
@@ -270,7 +281,7 @@ def write_ome_zarr(
     exist only from 0.6, so a caller passing both could only ever pass them consistently -- an
     invariant worth removing rather than documenting.
     """
-    _load_image.cache_clear()
+    clear_ome_zarr_cache()
     _require_ngff_zarr()
     array_data = np.asarray(data)
     spatial_axes, scale_values, translation_values = _spatial_geometry(
@@ -340,7 +351,7 @@ def create_ome_zarr_store(
     read back as zeros. Metadata (the 0.4 multiscales entry plus the KonfAI attribute sidecar) is
     complete from the start, so the store is readable at any point during the write.
     """
-    _load_image.cache_clear()
+    clear_ome_zarr_cache()
     _require_zarr()
     spatial_axes, scale_values, translation_values = _spatial_geometry(
         len(shape), f"shape {list(shape)}", spacing, origin

--- a/pixi.lock
+++ b/pixi.lock
@@ -316,8 +316,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/57/b2/453099f5f3b698d7d0eab38916aac44c7f76229f451709e2eb9db6615dcd/cuda_toolkit-13.0.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5a/b9/b71828ecfa6097d2690489f5ff8adb4f6e74a021fc043e667f4e4884994b/ngff_zarr-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/67/314f6151bad77a93d751978a344033e1fc890822f05f0416079338e34231/nh3-0.3.6-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/5c/1f/1957d07725e6abdaef43b05c30a797fa2a2e7093ced9dbd750d796921a5d/ngff_zarr-0.40.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl
@@ -525,8 +525,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/55/8c/aed55408879043d72bb9135f4d0d19a02b886dd569631e113e3d2706cb8d/mypy-2.1.0-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5a/b9/b71828ecfa6097d2690489f5ff8adb4f6e74a021fc043e667f4e4884994b/ngff_zarr-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/0b/a81b5daf5adea482ecb68d9615f6a348486ab4d8e980a915d4420e57ee4d/wasmtime-45.0.0-py3-none-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/5c/1f/1957d07725e6abdaef43b05c30a797fa2a2e7093ced9dbd750d796921a5d/ngff_zarr-0.40.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl
@@ -723,8 +723,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5a/b9/b71828ecfa6097d2690489f5ff8adb4f6e74a021fc043e667f4e4884994b/ngff_zarr-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5c/10/3d18e3bbdf8fc50bbb4ac3cc45970aa5a9753c5cb51bf9ed9a3cd8b79fa3/ruff-0.15.2-py3-none-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/5c/1f/1957d07725e6abdaef43b05c30a797fa2a2e7093ced9dbd750d796921a5d/ngff_zarr-0.40.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl
@@ -1987,7 +1987,7 @@ packages:
   - h5py ; extra == 'imaging'
   - pydicom ; extra == 'imaging'
   - zarr ; extra == 'imaging'
-  - ngff-zarr ; extra == 'imaging'
+  - ngff-zarr>=0.38 ; extra == 'imaging'
   - vtk ; extra == 'vtk'
   - lpips ; extra == 'lpips'
   - segmentation-models-pytorch ; extra == 'smp'
@@ -1997,7 +1997,7 @@ packages:
   - submitit ; extra == 'cluster'
   - pydicom ; extra == 'dicom'
   - zarr ; extra == 'omezarr'
-  - ngff-zarr ; extra == 'omezarr'
+  - ngff-zarr>=0.38 ; extra == 'omezarr'
   - onnx ; extra == 'export'
   - onnxruntime ; extra == 'export'
   - onnxscript ; extra == 'export'
@@ -2017,7 +2017,7 @@ packages:
   - h5py ; extra == 'dev'
   - pydicom ; extra == 'dev'
   - zarr ; extra == 'dev'
-  - ngff-zarr ; extra == 'dev'
+  - ngff-zarr>=0.38 ; extra == 'dev'
   - scikit-image ; extra == 'dev'
   - onnx ; extra == 'dev'
   - onnxruntime ; extra == 'dev'
@@ -3279,12 +3279,32 @@ packages:
   - webencodings
   - tinycss2>=1.1.0 ; extra == 'css'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/5a/b9/b71828ecfa6097d2690489f5ff8adb4f6e74a021fc043e667f4e4884994b/ngff_zarr-0.37.0-py3-none-any.whl
-  name: ngff-zarr
-  version: 0.37.0
-  sha256: e09775ff04c78d89932e2ecc22ee49fb259efcb2065e52a52fee690f947f4c86
+- pypi: https://files.pythonhosted.org/packages/5b/0b/a81b5daf5adea482ecb68d9615f6a348486ab4d8e980a915d4420e57ee4d/wasmtime-45.0.0-py3-none-macosx_11_0_arm64.whl
+  name: wasmtime
+  version: 45.0.0
+  sha256: 31d10f25c330cebcfb364e9a357123deeec96c41725ff2bba91b705587f38a93
   requires_dist:
-  - dask[array]!=2025.12.0,!=2026.1.0,!=2026.1.1
+  - coverage ; extra == 'testing'
+  - pycparser ; extra == 'testing'
+  - pytest-mypy ; extra == 'testing'
+  - pytest ; extra == 'testing'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/5b/67/314f6151bad77a93d751978a344033e1fc890822f05f0416079338e34231/nh3-0.3.6-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: nh3
+  version: 0.3.6
+  sha256: 905f877dc66dd7aea4a76e54bcb26acb5ff8216f720c0017ccf63e0e6035698e
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/5c/10/3d18e3bbdf8fc50bbb4ac3cc45970aa5a9753c5cb51bf9ed9a3cd8b79fa3/ruff-0.15.2-py3-none-win_amd64.whl
+  name: ruff
+  version: 0.15.2
+  sha256: d20014e3dfa400f3ff84830dfb5755ece2de45ab62ecea4af6b7262d0fb4f7c5
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/5c/1f/1957d07725e6abdaef43b05c30a797fa2a2e7093ced9dbd750d796921a5d/ngff_zarr-0.40.0-py3-none-any.whl
+  name: ngff-zarr
+  version: 0.40.0
+  sha256: d8b07b4bc27a198190cfa98b292b5f1a5b7fb88ff3a72e401308347abb852866
+  requires_dist:
+  - dask[array]>=2026.1.2
   - importlib-resources
   - itkwasm-downsample>=1.8.0
   - itkwasm>=1.0b183
@@ -3362,26 +3382,6 @@ packages:
   - pytest>=6 ; extra == 'test'
   - jsonschema ; extra == 'validate'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/5b/0b/a81b5daf5adea482ecb68d9615f6a348486ab4d8e980a915d4420e57ee4d/wasmtime-45.0.0-py3-none-macosx_11_0_arm64.whl
-  name: wasmtime
-  version: 45.0.0
-  sha256: 31d10f25c330cebcfb364e9a357123deeec96c41725ff2bba91b705587f38a93
-  requires_dist:
-  - coverage ; extra == 'testing'
-  - pycparser ; extra == 'testing'
-  - pytest-mypy ; extra == 'testing'
-  - pytest ; extra == 'testing'
-  requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/5b/67/314f6151bad77a93d751978a344033e1fc890822f05f0416079338e34231/nh3-0.3.6-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  name: nh3
-  version: 0.3.6
-  sha256: 905f877dc66dd7aea4a76e54bcb26acb5ff8216f720c0017ccf63e0e6035698e
-  requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/5c/10/3d18e3bbdf8fc50bbb4ac3cc45970aa5a9753c5cb51bf9ed9a3cd8b79fa3/ruff-0.15.2-py3-none-win_amd64.whl
-  name: ruff
-  version: 0.15.2
-  sha256: d20014e3dfa400f3ff84830dfb5755ece2de45ab62ecea4af6b7262d0fb4f7c5
-  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl
   name: charset-normalizer
   version: 3.4.7

--- a/tests/unit/test_imaging_formats.py
+++ b/tests/unit/test_imaging_formats.py
@@ -238,6 +238,22 @@ class TestOmeZarrRequireZarr:
             with pytest.raises(DatasetManagerError, match="zarr is required"):
                 ome_zarr._require_zarr()
 
+    def test_displacement_field_raises_without_zarr_v3(self, tmp_path: Path) -> None:
+        """An RFC-5 field is an NGFF >= 0.5 store, which only zarr v3 can write. The check must fire
+        before ngff-zarr is handed the version, so what surfaces on zarr 2.x names the requirement
+        instead of the ValueError ngff-zarr raises from inside its writer."""
+        pytest.importorskip("zarr")
+        from konfai.utils import ome_zarr
+
+        field = np.zeros((3, 2, 3, 4), dtype=np.float32)
+        with patch.object(ome_zarr, "_zarr_v3_available", lambda: False):
+            with pytest.raises(DatasetManagerError, match="zarr v3"):
+                ome_zarr.write_ome_zarr(tmp_path / "DVF.ome.zarr", field, displacement_field=True)
+
+        # The guard is specific to RFC-5: an ordinary image is a 0.4 store and stays writable.
+        ome_zarr.write_ome_zarr(tmp_path / "Image.ome.zarr", field)
+        assert (tmp_path / "Image.ome.zarr").is_dir()
+
 
 class TestDatasetImagingBackends:
     def test_ome_zarr_dataset_round_trip_and_patch_read(self, tmp_path: Path) -> None:

--- a/tests/unit/test_omezarr_displacement_field.py
+++ b/tests/unit/test_omezarr_displacement_field.py
@@ -44,7 +44,7 @@ pytestmark = pytest.mark.skipif(
 
 SPACING = (1.5, 1.5, 2.0)
 ORIGIN = (7.0, -3.0, 10.0)
-# A 90 deg in-plane rotation: non-identity and anisotropic, so a dropped or transposed Direction shows.
+# A 90 deg in-plane rotation: an identity matrix would let a dropped Direction pass unnoticed.
 DIRECTION = (0.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0)
 
 


### PR DESCRIPTION
> Stacked on #67 — review that one first; this branch targets it, not `main`.

## Why

#67 lets KonfAI *write* a DVF as an [NGFF RFC-5](https://github.com/ome/ngff/pull/253) vector field. The orchestrator could not then *consume* one: every step after inference assumed an ITK image literally called `DVF.mha` — discovery, the copy beside the results, the ensemble average, and the `Transform.h5` export.

A preset emitting a store failed on:

```
FileNotFoundError: Preset inference did not produce 'DVF.mha' under /tmp/...
```

with the store sitting in the directory it had just listed, because `Path("DVF.ome.zarr").stem` is `"DVF.ome"`.

## What

- **Discovery by name**, not by filename, so either form is found.
- **`_copy_output`** keeps the form the preset produced (file → `copy2`, store → `copytree`), and replaces an existing output of either kind so a re-run overwrites cleanly.
- **`_write_displacement_field`** writes a derived (averaged) field in the form its members arrived in, so an ensemble does not silently change format.
- **Reading** goes through `konfai.utils.ITK.read_displacement_field`, which opens an ITK image *or* a store.

That reader lives in `konfai`, not here, deliberately: reading a field as if it were an ordinary image is a failure that **does not announce itself** — the component axis looks like any other, so indexing it returns a third of the field, and a registration that is wrong without looking wrong. One place should know how to open either form.

## Tests

`apps/impact_reg/tests/unit/test_displacement_field_io.py` — parametrised over `.mha` and `.ome.zarr`: discovery finds either, the copy preserves the form and overwrites a store, an averaged field stays a *declared* field, and the transform reads back identically from both.

The last one is asserted on a **mapped point**, not on the array: a field read with its component axis mishandled keeps a plausible shape, and only applying it exposes that.

34 orchestrator unit tests pass; `ruff`, `ruff format`, `mypy`, `bandit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added generic handling of displacement-field outputs across SimpleITK image files and OME-Zarr stores.
- **Bug Fixes**
  - Improved discovery/copying of displacement-field outputs while preserving their original representation form.
  - Fixed ensemble DVF averaging and transform generation for consistent results across formats.
  - Ensured overwriting an OME-Zarr store refreshes cached reads; standardized OME-Zarr geometry/attribute handling.
- **Tests**
  - Added unit coverage for round-tripping, output discovery, overwrite behavior, and correct errors when OME-Zarr displacement-field support isn’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->