### PR TITLE
feat(py): add Trim, a selection combine that keeps the most central patch

### DIFF
--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -590,7 +590,10 @@ class Accumulator:
             view = [1] * data.ndim
             view[self._n + dim] = -1
             share = self._share(dim, s.start, data).view(view)
-            torch.mul(data, share, out=self._weighted) if dim == 0 else self._weighted.mul_(share)
+            if dim == 0:
+                torch.mul(data, share, out=self._weighted)
+            else:
+                self._weighted.mul_(share)
         return self._weighted
 
     def is_empty(self) -> bool:

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -272,6 +272,15 @@ class PathCombine(ABC):
             data = data.unsqueeze(-1) * window
         self.data = data
 
+    @property
+    def selects(self) -> bool:
+        """Whether the window picks ONE patch per voxel (values 0 or 1) rather than weighting several.
+
+        A selection makes the kept regions a partition of the volume, so assembly writes each one
+        instead of accumulating a weighted sum -- see Accumulator._blend.
+        """
+        return False
+
     def window(self, dim: int, position: int, count: int) -> torch.Tensor:
         """The 1-D window along ``dim`` for the patch at grid ``position`` of ``count`` on that axis.
 
@@ -356,6 +365,10 @@ class Trim(PathCombine):
     map, an argmax) survives reassembly, where any weighting would invent values between its classes.
     """
 
+    @property
+    def selects(self) -> bool:
+        return True
+
     def _window_1d(self, size: int, overlap: int) -> torch.Tensor:
         window = torch.zeros(size)
         # Split an odd overlap so consecutive kept bands abut: k*stride + hi == (k+1)*stride + lo.
@@ -432,6 +445,7 @@ class Accumulator:
         # Blend-weight geometry: fixed for the accumulator's life, so it survives _reset.
         self._geometry: tuple[list[list[torch.Tensor]], list[torch.Tensor]] | None = None
         self._shares: dict[tuple[int, int, int, torch.dtype, torch.device], torch.Tensor] = {}
+        self._boxes: dict[tuple[int, ...], tuple[slice, ...]] = {}
 
     def add_layer(self, index: int, layer: torch.Tensor) -> list[tuple[slice, torch.Tensor]]:
         """Blend one patch in; returns the slabs this completes (none for the whole-volume base)."""
@@ -470,10 +484,35 @@ class Accumulator:
         dest[0] = slice(dest[0].start - row_offset, dest[0].stop - row_offset)
         slices_dest = tuple([slice(cast(torch.Tensor, self._result).shape[i]) for i in range(n)] + dest)
         result = cast(torch.Tensor, self._result)
-        if self.patch_combine is not None:
-            result[slices_dest] += self._weighted_patch(data, patch_slice)
-        else:
+        lead = slices_dest[:n]
+        if self.patch_combine is None:
             result[slices_dest] = data
+        elif self.patch_combine.selects:
+            # The kept regions partition the volume: nothing to weight, nothing to sum. Writing the box
+            # this patch owns IS the operation -- and it is what carries a discrete output through,
+            # where a weighting would invent values between its classes.
+            box = self._kept_box(patch_slice)
+            kept = [slice(d.start + b.start, d.start + b.stop) for d, b in zip(dest, box, strict=True)]
+            result[(*lead, *kept)] = data[(*lead, *box)]
+        else:
+            result[slices_dest] += self._weighted_patch(data, patch_slice)
+
+    def _kept_box(self, patch_slice: tuple[slice, ...]) -> tuple[slice, ...]:
+        """The sub-box a selection keeps of this patch: the run of ones in its window, per axis.
+
+        Pure geometry, so it is read once from the host-side windows and cached per grid position.
+        Deriving it from the share instead would read a device tensor -- a host sync on every patch,
+        which costs more than the weighting it replaces.
+        """
+        key = tuple(s.start for s in patch_slice)
+        if key not in self._boxes:
+            windows, _ = self._weight_geometry()
+            box = []
+            for dim, s in enumerate(patch_slice):
+                kept = windows[dim][self._starts(dim).index(s.start)].nonzero().flatten()
+                box.append(slice(int(kept[0]), int(kept[-1]) + 1))
+            self._boxes[key] = tuple(box)
+        return self._boxes[key]
 
     def _weight_geometry(self) -> tuple[list[list[torch.Tensor]], list[torch.Tensor]]:
         """Per axis: the blend window, and its sum over the patch grid.

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -241,12 +241,14 @@ class PathCombine(ABC):
         self.data: torch.Tensor
         self.windows_1d: list[torch.Tensor]
         self.overlap: int
+        self.overlaps: list[int]
         self._data_per_device: dict[tuple[torch.device, torch.dtype], torch.Tensor] = {}
 
     def set_patch_config(self, patch_size: list[int], overlap: int | list[int]) -> None:
         self._data_per_device.clear()
         overlaps = [overlap] * len(patch_size) if isinstance(overlap, int) else list(overlap)
         self.overlap = max(overlaps)
+        self.overlaps = overlaps
         # The per-patch weight is the outer product of one 1-D window per axis. It is separable by
         # construction, so a per-axis partition of unity stays a partition of unity in N-D and overlapping
         # patches blend without darkening — no distance map or explicit renormalisation loop is needed, and
@@ -269,6 +271,15 @@ class PathCombine(ABC):
         for window in self.windows_1d[1:]:
             data = data.unsqueeze(-1) * window
         self.data = data
+
+    def window(self, dim: int, position: int, count: int) -> torch.Tensor:
+        """The 1-D window along ``dim`` for the patch at grid ``position`` of ``count`` on that axis.
+
+        A weighting is the same wherever the patch sits; a selection opens its border patches so the
+        kept bands still reach the volume edge (see :class:`Trim`).
+        """
+        del position, count
+        return self.windows_1d[dim]
 
     def weight(self, tensor: torch.Tensor) -> torch.Tensor:
         """The raw per-voxel window on ``tensor``'s device and dtype (cached per pair).
@@ -332,6 +343,38 @@ class Cosinus(PathCombine):
         return window
 
 
+class Trim(PathCombine):
+    """Selection instead of weighting: each voxel comes from the patch that holds it most centrally.
+
+    An interior patch keeps its central ``patch - overlap`` band, so the kept bands tile the axis
+    exactly and the weights already sum to one; the first and last patch of an axis open to the volume
+    edge. Every kept voxel therefore carries at least half the overlap of context on each side, where
+    the unweighted default keeps whichever patch wrote last -- possibly one holding that voxel on its
+    own border with no context behind it, which is what a seam is.
+
+    The values are 0 or 1, so the patch is selected rather than averaged: a discrete output (a label
+    map, an argmax) survives reassembly, where any weighting would invent values between its classes.
+    """
+
+    def _window_1d(self, size: int, overlap: int) -> torch.Tensor:
+        window = torch.zeros(size)
+        # Split an odd overlap so consecutive kept bands abut: k*stride + hi == (k+1)*stride + lo.
+        window[overlap // 2 : size - (overlap - overlap // 2)] = 1.0
+        return window
+
+    def window(self, dim: int, position: int, count: int) -> torch.Tensor:
+        overlap = self.overlaps[dim]
+        window = self.windows_1d[dim]
+        if overlap <= 0 or (position > 0 and position < count - 1):
+            return window
+        window = window.clone()
+        if position == 0:
+            window[: overlap // 2] = 1.0
+        if position == count - 1:
+            window[window.shape[0] - (overlap - overlap // 2) :] = 1.0
+        return window
+
+
 class Gaussian(PathCombine):
     """nnU-Net-style Gaussian importance weighting.
 
@@ -387,7 +430,7 @@ class Accumulator:
         self._result: torch.Tensor | None = None
         self._weighted: torch.Tensor | None = None
         # Blend-weight geometry: fixed for the accumulator's life, so it survives _reset.
-        self._geometry: tuple[list[torch.Tensor], list[torch.Tensor]] | None = None
+        self._geometry: tuple[list[list[torch.Tensor]], list[torch.Tensor]] | None = None
         self._shares: dict[tuple[int, int, int, torch.dtype, torch.device], torch.Tensor] = {}
 
     def add_layer(self, index: int, layer: torch.Tensor) -> list[tuple[slice, torch.Tensor]]:
@@ -432,7 +475,7 @@ class Accumulator:
         else:
             result[slices_dest] = data
 
-    def _weight_geometry(self) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+    def _weight_geometry(self) -> tuple[list[list[torch.Tensor]], list[torch.Tensor]]:
         """Per axis: the blend window, and its sum over the patch grid.
 
         The outer product of those sums is the total weight covering each voxel. It factorises because
@@ -442,21 +485,31 @@ class Accumulator:
 
         The patch extent comes from the slices, not from the window: a free axis carries a single
         broadcast entry (the ModelPatch blend-window contract) that must cover the whole extent.
+
+        The window is asked for per grid position, because a selection opens its border patches to the
+        volume edge (see Trim); a weighting returns the same window everywhere.
         """
         if self._geometry is None:
+            combine = cast(PathCombine, self.patch_combine)
             windows, totals = [], []
             for dim, extent in enumerate(self.shape):
-                window = cast(PathCombine, self.patch_combine).windows_1d[dim]
+                starts = self._starts(dim)
                 length = self.patch_slices[0][dim].stop - self.patch_slices[0][dim].start
-                window = window.expand(length) if window.numel() == 1 else window
-                total = torch.zeros(extent)
-                for start in sorted({patch[dim].start for patch in self.patch_slices}):
+                per_position, total = [], torch.zeros(extent)
+                for position, start in enumerate(starts):
+                    window = combine.window(dim, position, len(starts))
+                    window = window.expand(length) if window.numel() == 1 else window
                     stop = min(start + length, extent)
                     total[start:stop] += window[: stop - start]
-                windows.append(window)
+                    per_position.append(window)
+                windows.append(per_position)
                 totals.append(total)
             self._geometry = (windows, totals)
         return self._geometry
+
+    def _starts(self, dim: int) -> list[int]:
+        """The patch grid's positions along one axis, in order."""
+        return sorted({patch[dim].start for patch in self.patch_slices})
 
     def _share(self, dim: int, start: int, data: torch.Tensor) -> torch.Tensor:
         """This patch's fraction of the blend weight along one axis, ``w / sum_k w``, cached per axis."""
@@ -464,7 +517,8 @@ class Accumulator:
         key = (dim, start, extent, data.dtype, data.device)
         if key not in self._shares:
             windows, totals = self._weight_geometry()
-            share = windows[dim][:extent] / totals[dim][start : start + extent]
+            window = windows[dim][self._starts(dim).index(start)]
+            share = window[:extent] / totals[dim][start : start + extent]
             self._shares[key] = share.to(device=data.device, dtype=data.dtype)
         return self._shares[key]
 

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -370,6 +370,11 @@ class Trim(PathCombine):
         return True
 
     def _window_1d(self, size: int, overlap: int) -> torch.Tensor:
+        if overlap >= size:
+            # Nothing central left to keep: trimming both sides would leave an empty band, and a patch
+            # that keeps nothing has no box to write. Keep the patch whole instead — the axis stops
+            # being a partition and falls back to last-write-wins on it, which is what it was before.
+            return torch.ones(size)
         window = torch.zeros(size)
         # Split an odd overlap so consecutive kept bands abut: k*stride + hi == (k+1)*stride + lo.
         window[overlap // 2 : size - (overlap - overlap // 2)] = 1.0

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -349,11 +349,15 @@ class OutputDataset(Dataset, NeedDevice, ABC):
                     )
                     transform_type.append(transform)
 
-        if self._patch_combine is not None:
-            module, name = get_module(self._patch_combine, "konfai.data.patching")
-            self.patch_combine = apply_config(f"{konfai_root()}.outputs_dataset.{name_layer}.OutputDataset")(
-                getattr(module, name)
-            )()
+        # A patch grid overlaps whether or not a combine is declared, and an undeclared one used to
+        # leave the overlap to whichever patch wrote last -- an arbitrary winner, possibly holding that
+        # voxel on its own border with no context behind it, which is what a seam is. Trim keeps each
+        # patch's central band instead: the bands tile the volume exactly, so the default is a seamless
+        # selection that still never averages (a label map survives it).
+        module, name = get_module(self._patch_combine or "Trim", "konfai.data.patching")
+        self.patch_combine = apply_config(f"{konfai_root()}.outputs_dataset.{name_layer}.OutputDataset")(
+            getattr(module, name)
+        )()
 
         module, name = get_module(self.reduction_classpath, "konfai.predictor")
         # get_module returns the module OBJECT: compare its dotted name, not the module against the string

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -387,7 +387,10 @@ class OutputDataset(Dataset, NeedDevice, ABC):
         overlap: int | float | str | list[int | float | str] | None,
         nb_data_augmentation: int,
     ) -> None:
-        if patch_size is not None and overlap is not None:
+        # EMPTY, not just missing: the caller drops the axes of extent 1, so a case with nothing tiled
+        # arrives as []. That is a single patch covering the volume — no combine applies, and a blend
+        # window built on no axis leaves max() nothing to take.
+        if patch_size and overlap is not None:
             if self.patch_combine is not None:
                 self.patch_combine.set_patch_config(patch_size, blend_overlap(overlap, patch_size))
         else:

--- a/tests/unit/test_patching.py
+++ b/tests/unit/test_patching.py
@@ -127,7 +127,7 @@ def test_accumulator_gpu_blend_matches_cpu(combine_cls):
 # --------------------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("combine_cls", [None, Gaussian])
+@pytest.mark.parametrize("combine_cls", [None, Gaussian, Trim])
 @pytest.mark.parametrize("free_axis", [0, 1, 2])
 def test_free_axis_reassembles_like_its_concrete_extent(free_axis, combine_cls):
     """A free (``0``) axis spans the full extent and must reassemble identically to the concrete-extent
@@ -577,3 +577,46 @@ def test_trim_reassembles_exactly_and_keeps_values_discrete():
     out = accumulator.assemble()
     assert torch.equal(out, labels)
     assert torch.equal(out, out.round())
+
+
+@pytest.mark.parametrize(
+    "shape, patch, overlap",
+    [
+        ([8], [4], 2),  # 1-D, exact tiling
+        ([10, 12, 14], [6, 6, 6], 2),  # 3-D, no axis divisible by the stride
+        ([12, 14, 16], [6, 8, 8], [0, 2, 4]),  # a different overlap per axis, including none
+        ([5, 14, 14], [8, 8, 8], 4),  # patch larger than the volume on axis 0
+        ([16, 16], [8, 8], 0),  # no overlap at all
+        ([10, 10], [10, 10], 2),  # a single patch covering everything
+        ([9, 11], [4, 4], 3),  # odd overlap: the two halves must still abut
+    ],
+)
+def test_trim_kept_boxes_partition_the_volume(shape, patch, overlap):
+    """Every voxel is written exactly once — no gap, no overlap.
+
+    This is the property the selection path rests on: if the kept boxes tiled imperfectly, assembly
+    would leave holes (never written) or race (written twice), and neither shows up as an error.
+    """
+    slices, _ = get_patch_slices_from_shape(patch, shape, overlap)
+    combine = Trim()
+    combine.set_patch_config(patch, overlap)
+    accumulator = Accumulator(slices, patch, patch_combine=combine, batch=False)
+
+    hits = torch.zeros(shape, dtype=torch.int32)
+    for patch_slice in accumulator.patch_slices:
+        dest = [slice(s.start, min(s.stop, shape[d])) for d, s in enumerate(patch_slice)]
+        box = accumulator._kept_box(patch_slice)
+        hits[tuple(slice(d.start + b.start, d.start + b.stop) for d, b in zip(dest, box, strict=True))] += 1
+
+    assert int(hits.min()) == 1, f"{int((hits == 0).sum())} voxel(s) written by no patch"
+    assert int(hits.max()) == 1, f"{int((hits > 1).sum())} voxel(s) written by more than one patch"
+
+
+def test_trim_keeps_the_patch_whole_when_there_is_nothing_to_trim():
+    """An overlap at least as wide as the patch leaves no central band; keep the patch instead.
+
+    Trimming both sides would give an empty window, and a patch that keeps nothing has no box to
+    write — the box derivation would fail on an empty ``nonzero()``.
+    """
+    for size, overlap in ((4, 4), (3, 4), (1, 2), (2, 3)):
+        assert torch.equal(Trim()._window_1d(size, overlap), torch.ones(size)), (size, overlap)

--- a/tests/unit/test_patching.py
+++ b/tests/unit/test_patching.py
@@ -20,7 +20,7 @@ import itertools
 
 import pytest
 import torch
-from konfai.data.patching import Accumulator, Cosinus, Gaussian, Mean, StreamingAccumulator, blend_overlap
+from konfai.data.patching import Accumulator, Cosinus, Gaussian, Mean, StreamingAccumulator, Trim, blend_overlap
 from konfai.utils.errors import PatchError
 from konfai.utils.utils import get_patch_slices_from_shape, resolve_overlap
 
@@ -482,3 +482,98 @@ def test_blend_recovers_the_source_in_low_precision(combine_cls):
     for index, patch_slice in enumerate(slices):
         accumulator.add_layer(index, full[(slice(None), *patch_slice)].to(torch.float16))
     torch.testing.assert_close(accumulator.assemble().float(), full, rtol=0, atol=5e-3)
+
+
+# --------------------------------------------------------------------------------------
+# Reassembly contract: per-axis overlap, arrival order, unweighted semantics
+# --------------------------------------------------------------------------------------
+@pytest.mark.parametrize("combine_cls", [Cosinus, Gaussian])
+def test_anisotropic_overlap_reassembles_exactly(combine_cls):
+    """A different overlap per axis still reconstructs the source.
+
+    The window tapers over each axis's own overlap, so an axis that does not tile (overlap 0) must
+    contribute a flat factor rather than the taper of its neighbours.
+    """
+    # 12=2x6, 14=6+8, 16=4+4+8: every patch is full patch_size (the model emits full-size patches)
+    shape, patch, overlap = [12, 14, 16], [6, 8, 8], [0, 2, 4]
+    full = torch.rand(2, *shape)
+    slices, _ = get_patch_slices_from_shape(patch, shape, overlap)
+    combine = combine_cls()
+    combine.set_patch_config(patch, overlap)
+    accumulator = Accumulator(slices, patch, patch_combine=combine, batch=False)
+    for index, patch_slice in enumerate(slices):
+        accumulator.add_layer(index, full[(slice(None), *patch_slice)])
+    torch.testing.assert_close(accumulator.assemble(), full, rtol=0, atol=1e-5)
+
+
+@pytest.mark.parametrize("combine_cls", [Mean, Cosinus, Gaussian])
+def test_blend_does_not_depend_on_patch_arrival_order(combine_cls):
+    """A weighted blend is a sum, so the assembled volume does not depend on the order patches arrive.
+
+    Only the whole-volume accumulator: StreamingAccumulator requires non-decreasing starts by
+    construction and rejects anything else.
+    """
+    shape, patch, overlap = [10, 10, 14], [6, 6, 6], 2  # exact tiling at step 4
+    full = torch.rand(2, *shape)
+    slices, _ = get_patch_slices_from_shape(patch, shape, overlap)
+
+    def assemble(order: list[int]) -> torch.Tensor:
+        combine = combine_cls()
+        combine.set_patch_config(patch, overlap)
+        accumulator = Accumulator(slices, patch, patch_combine=combine, batch=False)
+        for index in order:
+            accumulator.add_layer(index, full[(slice(None), *slices[index])])
+        return accumulator.assemble()
+
+    forward = list(range(len(slices)))
+    torch.testing.assert_close(assemble(forward), assemble(forward[::-1]), rtol=0, atol=1e-6)
+
+
+def test_unweighted_overlap_is_last_write_wins():
+    """Without a combine, an overlapped voxel keeps the LAST patch that covered it.
+
+    Pinned because it is a choice, not a consequence: the winning patch may hold that voxel on its
+    own border, with no context behind it, which is what shows up as a seam.
+    """
+    shape, patch, overlap = [8], [4], 2
+    slices, _ = get_patch_slices_from_shape(patch, shape, overlap)
+    accumulator = Accumulator(slices, patch, patch_combine=None, batch=False)
+    for index, _ in enumerate(slices):
+        accumulator.add_layer(index, torch.full((1, 4), float(index)))
+    out = accumulator.assemble()[0]
+    # starts 0, 2, 4 -> the last patch covering each voxel wins, so the volume reads 0,0,1,1,2,2,2,2
+    assert out.tolist() == [0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0]
+
+
+def test_trim_selects_the_most_central_patch():
+    """Trim keeps the patch that holds a voxel most centrally, not the last one that wrote it.
+
+    Volume 8, patch 4, overlap 2 -> starts 0, 2, 4. The kept bands are [0,3), [3,5), [5,8): they tile
+    the axis, the first and last open to the edge, and every interior voxel sits at least one row
+    inside the patch it came from. Compare test_unweighted_overlap_is_last_write_wins.
+    """
+    slices, _ = get_patch_slices_from_shape([4], [8], 2)
+    combine = Trim()
+    combine.set_patch_config([4], 2)
+    accumulator = Accumulator(slices, [4], patch_combine=combine, batch=False)
+    for index, _ in enumerate(slices):
+        accumulator.add_layer(index, torch.full((1, 4), float(index)))
+    assert accumulator.assemble()[0].tolist() == [0.0, 0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 2.0]
+
+
+def test_trim_reassembles_exactly_and_keeps_values_discrete():
+    """The kept bands tile every axis, so the weights sum to one: the volume comes back untouched.
+
+    Values are never averaged, which is what lets a label map survive reassembly.
+    """
+    shape, patch, overlap = [10, 10, 14], [6, 6, 6], 2
+    labels = torch.randint(0, 5, (2, *shape)).float()
+    slices, _ = get_patch_slices_from_shape(patch, shape, overlap)
+    combine = Trim()
+    combine.set_patch_config(patch, overlap)
+    accumulator = Accumulator(slices, patch, patch_combine=combine, batch=False)
+    for index, patch_slice in enumerate(slices):
+        accumulator.add_layer(index, labels[(slice(None), *patch_slice)])
+    out = accumulator.assemble()
+    assert torch.equal(out, labels)
+    assert torch.equal(out, out.round())

--- a/tests/unit/test_patching.py
+++ b/tests/unit/test_patching.py
@@ -561,12 +561,20 @@ def test_trim_selects_the_most_central_patch():
     assert accumulator.assemble()[0].tolist() == [0.0, 0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 2.0]
 
 
-def test_trim_reassembles_exactly_and_keeps_values_discrete():
+@pytest.mark.parametrize(
+    "shape, patch, overlap",
+    [
+        ([10, 10, 14], [6, 6, 6], 2),  # every patch reaches full patch_size
+        ([9, 11], [6, 6], 4),  # the last patch of each axis is truncated AND needs its tail opened
+    ],
+)
+def test_trim_reassembles_exactly_and_keeps_values_discrete(shape, patch, overlap):
     """The kept bands tile every axis, so the weights sum to one: the volume comes back untouched.
 
-    Values are never averaged, which is what lets a label map survive reassembly.
+    Values are never averaged, which is what lets a label map survive reassembly. A truncated last
+    patch is what Trim is most fragile to: a weighting always has a strictly positive total, so a
+    coverage gap only darkens a voxel, where a 0/1 selection leaves it unwritten.
     """
-    shape, patch, overlap = [10, 10, 14], [6, 6, 6], 2
     labels = torch.randint(0, 5, (2, *shape)).float()
     slices, _ = get_patch_slices_from_shape(patch, shape, overlap)
     combine = Trim()
@@ -589,6 +597,7 @@ def test_trim_reassembles_exactly_and_keeps_values_discrete():
         ([16, 16], [8, 8], 0),  # no overlap at all
         ([10, 10], [10, 10], 2),  # a single patch covering everything
         ([9, 11], [4, 4], 3),  # odd overlap: the two halves must still abut
+        ([9, 11], [6, 6], 4),  # truncated last patch whose tail opening is what closes the volume
     ],
 )
 def test_trim_kept_boxes_partition_the_volume(shape, patch, overlap):


### PR DESCRIPTION
Stacked on #69 — review that one first.

## The problem

Without a combine, an overlapped voxel keeps whichever patch wrote **last**. That is a choice, not a
consequence, and an arbitrary one: the winning patch may hold that voxel on its own border, with no
context behind it. That is what a seam is.

## Trim

Each patch keeps its central `patch - overlap` band. Those bands tile every axis exactly, so the
weights already sum to one and there is nothing to normalise; the first and last patch of an axis open
to the volume edge, so the tiling has no gap there either. Every kept voxel then carries at least half
the overlap of context on each side.

Volume 8, patch 4, overlap 2 (starts 0, 2, 4), each patch carrying its own index:

```
last-write-wins   0 0 1 1 2 2 2 2
Trim              0 0 0 1 1 2 2 2      kept bands [0,3) [3,5) [5,8)
```

The values are 0 or 1, so the patch is **selected**, not averaged — a label map or an argmax survives
reassembly, where any weighting invents values between its classes. Verified on `int64`, `uint8` and
`float32`.

## It is now the default

`patch_combine` left undeclared resolves to `Trim` instead of last-write-wins. **This changes the
output of any configuration that declared no combine**; an explicit `Mean`/`Cosinus`/`Gaussian` is
untouched. Separate commit, so it can be dropped on its own.

Assembly takes the shorter path for it: a selection declares itself through `PathCombine.selects`, and
`_blend` writes the box a patch owns instead of scaling by a 0/1 mask and accumulating. On a
128×384×384 volume, patch [64,192,192], 3 channels, CUDA:

| | |
|---|---|
| last-write-wins (plain assign) | 2.4 ms |
| Trim | 3.3 ms |
| Cosinus (a reduction) | 9.8 ms |

The kept box is read once from the host-side windows and cached per grid position. Deriving it from
the device share instead syncs the host on every patch — that first version measured **25.4 ms**, more
than the weighting it replaced.

## What it needed

The window is now asked for **per grid position**: a selection opens its border patches, a weighting
returns the same window everywhere. Per-axis overlaps are kept alongside their max for the same
reason. Both additive; every existing combine takes the default.

## Tested

The partition is the property everything rests on — a gap leaves voxels **unwritten** and nothing
reports it. Seven geometries (1-D, no axis divisible by the stride, a different overlap per axis
including none, a patch larger than the volume, no overlap, a single patch, an odd overlap, a
truncated last patch) assert every voxel is written exactly once. An off-by-one in the kept band fails
five of them; disabling the last patch's tail opening fails six.

The truncated geometry is chosen deliberately: with shape 9, patch 4, overlap 2 the volume clamp
already cuts where the tail would have been opened, so that case passes even with the opening removed.
Shape 9/11, patch 6, overlap 4 exercises it.

Also fixes a crash found on the way: an overlap at least as wide as the patch left no central band, so
the window came out all zeros and the box derivation raised `IndexError` on an empty `nonzero()`. The
patch is kept whole there instead.

Plus three properties of the reassembly the suite did not pin: an anisotropic overlap reassembles
exactly, a weighted blend does not depend on the order patches arrive in, and the last-write-wins
semantics itself.

## Not done

No quality measurement of the new default on a real model — what is established is that the tiling is
exact and that discrete values survive, not that the result is better.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new patch combination strategy (`Trim`) that keeps a central interior region when reconstructing discrete/label-like outputs.
  * Prediction output now defaults to `Trim` automatically when no patch-combine strategy is specified.

* **Bug Fixes**
  * Improved patch reassembly to support selection-based blending (writes only the “kept” region) and correct per-axis anisotropic overlap weighting.
  * Ensures deterministic reconstruction independent of patch arrival order.
  * Treats an explicitly empty `patch_size` as “no patch tiling” (skips patch combining).

* **Tests**
  * Expanded unit tests to cover exact reconstruction, selection/tiling behavior, and empty-trim edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->