### PR TITLE
fix(omezarr): self-describing streamed stores, typed fields, no spill

### DIFF
--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -216,6 +216,7 @@ class OutputDataset(Dataset, NeedDevice, ABC):
         final_transforms: dict[str, TransformLoader],
         patch_combine: str | None,
         reduction: str,
+        attributes: list[str] | None = None,
     ) -> None:
         filename, _, file_format = split_path_spec(filename)
         super().__init__(filename, file_format)
@@ -229,6 +230,10 @@ class OutputDataset(Dataset, NeedDevice, ABC):
         self._after_reduction_transforms = after_reduction_transforms
         self._final_transforms = final_transforms
         self._patch_combine = patch_combine
+        # "key=value" strings rather than a mapping: the config layer accepts list[str] and not
+        # dict[str, str], so a mapping here would be unreachable from the YAML that is supposed to
+        # drive it. Same spelling as the --set overrides.
+        self._attributes = dict(entry.split("=", 1) for entry in attributes or [])
         self.reduction_classpath = reduction
         self.reduction: Reduction
 
@@ -564,6 +569,7 @@ class OutSameAsGroupDataset(OutputDataset):
         final_transforms: dict[str, TransformLoader] = {"default|Normalize": TransformLoader()},
         patch_combine: str | None = None,
         reduction: str = "Mean",
+        attributes: list[str] | None = None,
     ) -> None:
         super().__init__(
             dataset_filename,
@@ -573,6 +579,7 @@ class OutSameAsGroupDataset(OutputDataset):
             final_transforms,
             patch_combine,
             reduction,
+            attributes,
         )
         self.group_src, self.group_dest = same_as_group.split(":")
         # Slab streaming has no config knob: it is applied automatically, per case, whenever it is
@@ -610,6 +617,15 @@ class OutSameAsGroupDataset(OutputDataset):
             source_attribute = (
                 Attribute(attribute) if attribute is not None else Attribute(input_dataset.cache_attributes[0])
             )
+            # What the output declares about itself, applied over what it inherited from its input.
+            # Inheritance carries the geometry, which is right, but it also carries whatever the source
+            # entry said it WAS -- and that describes the source, not this. Declared last, so the
+            # config always wins; declare a key empty to drop an inherited one.
+            for key, value in self._attributes.items():
+                if value == "":
+                    source_attribute.pop(key, None)
+                else:
+                    source_attribute[key] = value
             if index_dataset not in self.output_layer_accumulator:
                 self.output_layer_accumulator[index_dataset] = {}
                 self.attributes[index_dataset] = {}

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -627,6 +627,8 @@ class _OmeZarrDataStream(DataStream):
         self._array[slices] = data
 
     def _close(self, success: bool) -> None:
+        from konfai.utils.ome_zarr import clear_ome_zarr_cache
+
         if not success:
             shutil.rmtree(self._store_path, ignore_errors=True)
             return
@@ -648,6 +650,11 @@ class _OmeZarrDataStream(DataStream):
             shutil.rmtree(self._store_path, ignore_errors=True)
         if replaced:
             shutil.rmtree(backup, ignore_errors=True)
+        # The reader memoises loaded stores by path, and this rename changes what that path holds.
+        # A store replaced by one written through a different code path can differ down to the key
+        # its level-0 array lives under, so a stale entry does not merely serve old pixels -- it
+        # points at a component that is no longer there.
+        clear_ome_zarr_cache()
 
 
 class Dataset:

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -1376,7 +1376,11 @@ class Dataset:
             from konfai.utils.ome_zarr import write_ome_zarr
 
             attributes = attributes or Attribute()
-            displacement_field = False
+            # Two ways to say "this is a field": hand over a DisplacementFieldTransform, or mark the
+            # attributes. The second exists because a producer that never builds a transform -- the
+            # predictor emits arrays -- would otherwise have to wrap its output in one purely to be
+            # described correctly, and a field too large to hold in memory cannot be wrapped at all.
+            displacement_field = DISPLACEMENT_FIELD_ATTRIBUTE in attributes
             if sitk is not None and isinstance(data, sitk.Image):
                 data, image_attributes = image_to_data(data)
                 attributes.update(image_attributes)
@@ -1418,6 +1422,7 @@ class Dataset:
                 spacing=attributes.get_np_array("Spacing") if "Spacing" in attributes else None,
                 origin=attributes.get_np_array("Origin") if "Origin" in attributes else None,
                 attributes=dict(attributes),
+                displacement_field=DISPLACEMENT_FIELD_ATTRIBUTE in attributes,
             )
             return _OmeZarrDataStream(array, store_path, final_path)
 

--- a/konfai/utils/ome_zarr.py
+++ b/konfai/utils/ome_zarr.py
@@ -107,6 +107,22 @@ def _require_ngff_zarr() -> None:
         )
 
 
+def _require_zarr_v3_for_rfc5() -> None:
+    """Both write paths type a component axis, so both need the same capability check.
+
+    Raised rather than silently downgraded to an untyped 0.4 store: a caller asking for a displacement
+    field is asking for the one property that makes it readable as a transform, and a store that
+    quietly is not one gets found out much later, by a reader that took its three channels for an
+    image.
+    """
+    if not _zarr_v3_available():
+        raise DatasetManagerError(
+            "Writing an NGFF RFC-5 displacement field needs a zarr v3 store, i.e. "
+            "zarr-python >= 3 (Python >= 3.11); this environment has zarr 2.",
+            "Install it with: pip install 'zarr>=3' on Python >= 3.11.",
+        )
+
+
 def _read_konfai_attributes(store_path: str | Path) -> dict[str, Any]:
     """Read KonfAI's proprietary ``Attribute`` sidecar from the store, if present."""
     try:
@@ -301,12 +317,7 @@ def write_ome_zarr(
     )
     version = _DEFAULT_VERSION
     if displacement_field:
-        if not _zarr_v3_available():
-            raise DatasetManagerError(
-                "Writing an NGFF RFC-5 displacement field needs a zarr v3 store, i.e. "
-                "zarr-python >= 3 (Python >= 3.11); this environment has zarr 2.",
-                "Install it with: pip install 'zarr>=3' on Python >= 3.11.",
-            )
+        _require_zarr_v3_for_rfc5()
         _type_component_axis(multiscales, _DISPLACEMENT_AXIS_TYPE)
         version = _RFC5_VERSION
     ngff_zarr.to_ngff_zarr(str(store_path), multiscales, overwrite=True, version=version)
@@ -348,6 +359,7 @@ def create_ome_zarr_store(
     origin: Sequence[float] | None = None,
     attributes: dict[str, Any] | None = None,
     chunks: Sequence[int] | None = None,
+    displacement_field: bool = False,
 ) -> Any:
     """Create an empty single-level OME-NGFF store for region-by-region writes.
 
@@ -356,9 +368,10 @@ def create_ome_zarr_store(
     during the write.
 
     ngff-zarr writes that metadata, exactly as it does for the whole-array path, so both paths describe
-    a store the same way. The hand-built ``multiscales`` entry this replaces was frozen at version 0.4
-    with the component axis typed ``channel``: the streaming path could never describe a displacement
-    field, however well ``write_ome_zarr`` could.
+    a store the same way -- ``displacement_field`` included, which is the point of routing it through
+    ngff-zarr at all. A field too large to assemble in memory is written region by region, so this is
+    the ONLY path a real one takes, and until it could type its component axis a DVF came out
+    self-describing exactly when it was small enough not to need to be.
 
     It describes the store from a one-voxel stand-in rather than from an array of the target shape.
     With a single resolution level the metadata does not depend on the extent at all -- axes and
@@ -389,8 +402,13 @@ def create_ome_zarr_store(
     stand_in = dask.array.zeros((shape[0], *(1,) * len(spatial_axes)), dtype=np.dtype(dtype))
     image = ngff_zarr.to_ngff_image(stand_in, dims=dims, scale=scale, translation=translation)
     multiscales = ngff_zarr.to_multiscales(image, scale_factors=[])
+    version = _DEFAULT_VERSION
+    if displacement_field:
+        _require_zarr_v3_for_rfc5()
+        _type_component_axis(multiscales, _DISPLACEMENT_AXIS_TYPE)
+        version = _RFC5_VERSION
     # version is explicit because to_ngff_zarr defaults to 0.5, which zarr-python 2 cannot write.
-    ngff_zarr.to_ngff_zarr(str(store_path), multiscales, overwrite=True, version=_DEFAULT_VERSION)
+    ngff_zarr.to_ngff_zarr(str(store_path), multiscales, overwrite=True, version=version)
 
     # The level-0 key comes from the metadata rather than a literal: ngff-zarr builds it from the
     # image name, so "scale0/image" is its convention to change, not ours to hardcode.

--- a/konfai/utils/ome_zarr.py
+++ b/konfai/utils/ome_zarr.py
@@ -52,10 +52,14 @@ except ImportError:
     _ZARR_AVAILABLE = False
 
 try:
+    # dask sits under the same guard because it is ngff-zarr's own hard dependency: the two are
+    # present or absent together, and dask.array is used only to describe a store to ngff-zarr.
+    import dask.array
     import ngff_zarr  # type: ignore[import-untyped]
 
     _NGFF_ZARR_AVAILABLE = True
 except ImportError:
+    dask = None  # type: ignore[assignment]
     ngff_zarr = None  # type: ignore[assignment]
     _NGFF_ZARR_AVAILABLE = False
 
@@ -348,47 +352,67 @@ def create_ome_zarr_store(
     """Create an empty single-level OME-NGFF store for region-by-region writes.
 
     Returns the level-0 zarr array: chunks materialise as regions are assigned, and unwritten regions
-    read back as zeros. Metadata (the 0.4 multiscales entry plus the KonfAI attribute sidecar) is
-    complete from the start, so the store is readable at any point during the write.
+    read back as zeros. Metadata is complete from the start, so the store is readable at any point
+    during the write.
+
+    ngff-zarr writes that metadata, exactly as it does for the whole-array path, so both paths describe
+    a store the same way. The hand-built ``multiscales`` entry this replaces was frozen at version 0.4
+    with the component axis typed ``channel``: the streaming path could never describe a displacement
+    field, however well ``write_ome_zarr`` could.
+
+    It describes the store from a one-voxel stand-in rather than from an array of the target shape.
+    With a single resolution level the metadata does not depend on the extent at all -- axes and
+    coordinate transformations come from ``dims``, ``scale`` and ``translation`` -- and the two come
+    out byte-identical, verified for 0.4 and 0.6. Handing ngff-zarr the real shape instead costs a
+    pass over every chunk of an array that is entirely zeros (~44 ms per chunk, ~33 s for a 13.6 GiB
+    field) to write no bytes at all. The real array is then created underneath that metadata, which is
+    also what makes its chunking exactly the caller's: the region grid is the one thing ngff-zarr
+    cannot infer, and a store whose chunks straddle it turns every region write into a
+    read-modify-write.
     """
     clear_ome_zarr_cache()
-    _require_zarr()
+    _require_ngff_zarr()
     spatial_axes, scale_values, translation_values = _spatial_geometry(
         len(shape), f"shape {list(shape)}", spacing, origin
     )
-    scale = [1.0, *scale_values]
-    translation = [0.0, *translation_values]
+    dims = ["c", *spatial_axes]
+    scale = {"c": 1.0, **dict(zip(spatial_axes, scale_values, strict=True))}
+    translation = {"c": 0.0, **dict(zip(spatial_axes, translation_values, strict=True))}
 
     if chunks is None:
         spatial_chunks = [min(extent, 128) for extent in shape[1:]]
         # Keep one chunk around 32 MiB: full 128-wide spatial tiles, channels split to fit the budget.
         tile_bytes = int(np.prod(spatial_chunks, dtype=np.int64)) * np.dtype(dtype).itemsize
         chunks = [min(shape[0], max(1, (32 << 20) // max(1, tile_bytes))), *spatial_chunks]
+    chunks = tuple(chunks)
 
-    try:
-        group = zarr.open_group(str(store_path), mode="w", zarr_format=2)
-    except TypeError:  # zarr-python 2.x: the v2 layout is its only format
-        group = zarr.open_group(str(store_path), mode="w")
+    stand_in = dask.array.zeros((shape[0], *(1,) * len(spatial_axes)), dtype=np.dtype(dtype))
+    image = ngff_zarr.to_ngff_image(stand_in, dims=dims, scale=scale, translation=translation)
+    multiscales = ngff_zarr.to_multiscales(image, scale_factors=[])
+    # version is explicit because to_ngff_zarr defaults to 0.5, which zarr-python 2 cannot write.
+    ngff_zarr.to_ngff_zarr(str(store_path), multiscales, overwrite=True, version=_DEFAULT_VERSION)
+
+    # The level-0 key comes from the metadata rather than a literal: ngff-zarr builds it from the
+    # image name, so "scale0/image" is its convention to change, not ours to hardcode.
+    group = zarr.open_group(str(store_path), mode="r+")
     create_array = getattr(group, "create_array", None) or group.create_dataset
-    array = create_array("0", shape=tuple(shape), chunks=tuple(chunks), dtype=np.dtype(dtype), fill_value=0)
-    group.attrs["multiscales"] = [
-        {
-            "version": "0.4",
-            "name": "image",
-            "axes": [{"name": "c", "type": "channel"}, *[{"name": axis, "type": "space"} for axis in spatial_axes]],
-            "datasets": [
-                {
-                    "path": "0",
-                    "coordinateTransformations": [
-                        {"type": "scale", "scale": scale},
-                        {"type": "translation", "translation": translation},
-                    ],
-                }
-            ],
-        }
-    ]
+    array = create_array(
+        multiscales.metadata.datasets[0].path,
+        shape=tuple(shape),
+        chunks=chunks,
+        dtype=np.dtype(dtype),
+        fill_value=0,
+        overwrite=True,
+    )
+    # Sidecar last: to_ngff_zarr(overwrite=True) reopens the root with mode="w" and drops every
+    # attribute it finds, so writing this first loses Direction -- and losing Direction is silent,
+    # the reader falls back to identity and returns a plausibly-oriented volume.
     if attributes:
         group.attrs[_KONFAI_ATTR_KEY] = {"attributes": dict(attributes)}
+    # ngff-zarr leaves a consolidated index behind, and readers trust it over the arrays themselves --
+    # so until it is rebuilt the store still advertises the one-voxel stand-in, whatever is on disk.
+    # Last, so that the sidecar written just above is part of what gets indexed.
+    zarr.consolidate_metadata(str(store_path))
     return array
 
 

--- a/konfai/utils/ome_zarr.py
+++ b/konfai/utils/ome_zarr.py
@@ -312,8 +312,13 @@ def write_ome_zarr(
     translation = {"c": 0.0, **dict(zip(spatial_axes, translation_values, strict=True))}
 
     image = ngff_zarr.to_ngff_image(array_data, dims=dims, scale=scale, translation=translation)
+    # cache=False because the array is already resident: this function is handed one in memory, and
+    # spilling it to a disk cache "to limit memory consumption" cannot lower a peak that has already
+    # happened -- it only adds a full write and a full read. The estimate that would otherwise trigger
+    # it is inflated besides, by itemsize once per dimension, so a 13.6 GiB field reports 868 GiB and
+    # takes that path every time.
     multiscales = ngff_zarr.to_multiscales(
-        image, scale_factors=[], chunks=tuple(chunks) if chunks is not None else None
+        image, scale_factors=[], chunks=tuple(chunks) if chunks is not None else None, cache=False
     )
     version = _DEFAULT_VERSION
     if displacement_field:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ itk = ["SimpleITK"]
 hdf5 = ["h5py"]
 monitoring = ["nvidia-ml-py"]
 tensorboard = ["tensorboard"]
-imaging = ["SimpleITK", "h5py", "pydicom", "zarr", "ngff-zarr>=0.38"]
+imaging = ["SimpleITK", "h5py", "pydicom", "zarr", "ngff-zarr>=0.38", "dask"]
 vtk = ["vtk"]
 lpips = ["lpips"]
 smp = ["segmentation-models-pytorch"]
@@ -64,7 +64,7 @@ ssim = ["scikit-image"]
 fid = ["scipy", "torchvision"]
 cluster = ["submitit"]
 dicom = ["pydicom"]
-omezarr = ["zarr", "ngff-zarr>=0.38"]
+omezarr = ["zarr", "ngff-zarr>=0.38", "dask"]
 export = ["onnx", "onnxruntime", "onnxscript"]
 all = [
   "konfai[itk]",
@@ -86,6 +86,7 @@ dev = [
   "pydicom",
   "zarr",
   "ngff-zarr>=0.38",
+  "dask",
   "scikit-image",
   "onnx",
   "onnxruntime",
@@ -162,6 +163,7 @@ nvidia-ml-py = "*"
 pydicom = "*"
 zarr = "*"
 ngff-zarr = ">=0.38"
+dask = "*"
 scikit-image = "*"
 
 [tool.pixi.feature.dev.tasks]

--- a/tests/unit/test_omezarr_displacement_field.py
+++ b/tests/unit/test_omezarr_displacement_field.py
@@ -32,8 +32,13 @@ sitk = pytest.importorskip("SimpleITK")
 pytest.importorskip("zarr")
 pytest.importorskip("ngff_zarr")
 
-from konfai.utils.dataset import Dataset  # noqa: E402
-from konfai.utils.ome_zarr import _zarr_v3_available, is_displacement_field, write_ome_zarr  # noqa: E402
+from konfai.utils.dataset import DISPLACEMENT_FIELD_ATTRIBUTE, Attribute, Dataset  # noqa: E402
+from konfai.utils.ome_zarr import (  # noqa: E402
+    _zarr_v3_available,
+    clear_ome_zarr_cache,
+    is_displacement_field,
+    write_ome_zarr,
+)
 
 # RFC-5 fields are a zarr v3 store (NGFF >= 0.5), which zarr 2.x (Python 3.10) cannot write: the
 # feature does not exist there.
@@ -131,3 +136,34 @@ def test_non_displacement_transform_is_rejected(tmp_path: Path) -> None:
     loudly beats writing their parameter vector as if it were a field."""
     with pytest.raises(DatasetManagerError, match="DisplacementFieldTransform"):
         _store(tmp_path).write("case", "Affine", sitk.AffineTransform(3))
+
+
+def test_a_field_streamed_region_by_region_is_still_a_field(tmp_path: Path) -> None:
+    """The marker on the attributes declares it, so no transform has to be built to say so.
+
+    A producer that emits blocks -- the predictor, and anything writing a field too large to hold --
+    has no transform to hand over, and wrapping one purely to be described correctly would mean
+    assembling in memory the very volume streaming exists to avoid. So the declaration travels with
+    the attributes instead, and the streamed store ends up saying exactly what the whole-volume one
+    says.
+    """
+    values = np.arange(3 * 4 * 5 * 6, dtype=np.float32).reshape(3, 4, 5, 6) / 100.0
+    attributes = Attribute()
+    attributes["Spacing"] = np.asarray(SPACING)
+    attributes["Origin"] = np.asarray(ORIGIN)
+    attributes["Direction"] = np.asarray(DIRECTION)
+    attributes[DISPLACEMENT_FIELD_ATTRIBUTE] = "true"
+
+    dataset = _store(tmp_path)
+    stream = dataset.open_data_stream("DVF", "case", list(values.shape), values.dtype, attributes)
+    assert stream is not None
+    with stream:
+        for z in range(0, values.shape[1], 2):
+            stream.write_slice(
+                (slice(0, 3), slice(z, z + 2), slice(0, values.shape[2]), slice(0, values.shape[3])),
+                values[:, z : z + 2],
+            )
+
+    clear_ome_zarr_cache()
+    assert is_displacement_field(tmp_path / "dataset" / "case" / "DVF.ome.zarr")
+    assert isinstance(dataset.read_transform("DVF", "case"), sitk.DisplacementFieldTransform)

--- a/tests/unit/test_omezarr_store_creation.py
+++ b/tests/unit/test_omezarr_store_creation.py
@@ -35,9 +35,11 @@ pytest.importorskip("ngff_zarr")
 
 import zarr
 from konfai.utils.ome_zarr import (
+    _zarr_v3_available,
     clear_ome_zarr_cache,
     create_ome_zarr_store,
     get_ome_zarr_info,
+    is_displacement_field,
 )
 
 SPACING = (2.0, 1.5, 0.5)
@@ -155,3 +157,33 @@ def test_creating_a_store_writes_no_pixel_bytes(tmp_path: Path) -> None:
     written = sum(item.stat().st_size for item in path.rglob("*") if item.is_file())
     metadata_only = 64 << 10
     assert written < metadata_only, f"{written} bytes written for an untouched store"
+
+
+@pytest.mark.skipif(
+    not _zarr_v3_available(),
+    reason="NGFF RFC-5 displacement fields need a zarr v3 store (zarr>=3, Python>=3.11)",
+)
+def test_a_streamed_displacement_field_says_that_it_is_one(tmp_path: Path) -> None:
+    """A field written region by region must be as self-describing as one written whole.
+
+    This is the case that matters, not the whole-volume one: a field small enough to assemble in
+    memory never had to be streamed, so before this the store said what it was exactly when nobody
+    needed to be told. A reader handed an untyped store sees three channels and no reason to treat
+    them as anything but an image -- and taking the first of them is a plausible-looking registration
+    built on a third of the displacement.
+    """
+    path = tmp_path / "field.ome.zarr"
+    array = _create(path, displacement_field=True)
+    array[:] = 1
+
+    clear_ome_zarr_cache()
+    assert is_displacement_field(path)
+    assert get_ome_zarr_info(path)["shape"] == list(SHAPE)
+
+
+def test_a_store_is_not_a_field_unless_it_was_asked_to_be(tmp_path: Path) -> None:
+    array = _create(tmp_path / "image.ome.zarr")
+    array[:] = 1
+
+    clear_ome_zarr_cache()
+    assert not is_displacement_field(tmp_path / "image.ome.zarr")

--- a/tests/unit/test_omezarr_store_creation.py
+++ b/tests/unit/test_omezarr_store_creation.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``create_ome_zarr_store``: the properties a region-by-region write depends on.
+
+``write_ome_zarr`` and ``create_ome_zarr_store`` now share ngff-zarr as their single source of
+OME-NGFF metadata, which is what these tests are really protecting -- the alternative, a hand-built
+``multiscales`` entry, drifts from the spec silently and can only ever describe what its author knew.
+What that sharing must not cost is any of the guarantees the streaming path relies on, and most of
+them were previously covered only end to end, where a regression shows up as a wrong volume rather
+than as a wrong store.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytest.importorskip("zarr")
+pytest.importorskip("ngff_zarr")
+
+import zarr
+from konfai.utils.ome_zarr import (
+    clear_ome_zarr_cache,
+    create_ome_zarr_store,
+    get_ome_zarr_info,
+)
+
+SPACING = (2.0, 1.5, 0.5)
+ORIGIN = (7.0, -3.0, 10.0)
+# A non-identity direction: an identity one lets a dropped sidecar pass unnoticed, because the reader
+# falls back to identity exactly when the attribute is missing.
+DIRECTION = (0.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0)
+SHAPE = (3, 8, 10, 12)
+
+
+def _create(path: Path, **kwargs: Any) -> Any:
+    attributes = {
+        "Spacing": " ".join(str(value) for value in SPACING),
+        "Origin": " ".join(str(value) for value in ORIGIN),
+        "Direction": " ".join(str(value) for value in DIRECTION),
+    }
+    return create_ome_zarr_store(path, SHAPE, np.int16, spacing=SPACING, origin=ORIGIN, attributes=attributes, **kwargs)
+
+
+def test_requested_chunks_are_the_store_chunks(tmp_path: Path) -> None:
+    """The caller's chunk grid must survive untouched.
+
+    A store whose chunks straddle the region grid turns every region write into a read-modify-write,
+    and the grid is the one thing a writer handed only a shape cannot infer. Only the producer knows
+    it, so only the producer can choose.
+    """
+    array = _create(tmp_path / "chunked.ome.zarr", chunks=(3, 4, 5, 6))
+    assert tuple(array.chunks) == (3, 4, 5, 6)
+
+
+def test_store_shape_and_dtype_are_exactly_what_was_asked(tmp_path: Path) -> None:
+    array = _create(tmp_path / "typed.ome.zarr")
+    assert tuple(array.shape) == SHAPE
+    assert array.dtype == np.dtype(np.int16)
+
+
+def test_unwritten_regions_read_back_as_zero(tmp_path: Path) -> None:
+    """Region writes leave the rest of the volume untouched, and untouched must mean zero.
+
+    Anything a stream does not reach has to read back as zero rather than as whatever the store
+    happens to default to, because a partial write is a normal outcome here, not a failure.
+    """
+    array = _create(tmp_path / "sparse.ome.zarr", chunks=(3, 4, 5, 6))
+    array[:, 0:4, 0:5, 0:6] = np.full((3, 4, 5, 6), 7, dtype=np.int16)
+
+    np.testing.assert_array_equal(np.asarray(array[:, 0:4, 0:5, 0:6]), 7)
+    np.testing.assert_array_equal(np.asarray(array[:, 4:8, 5:10, 6:12]), 0)
+
+
+def test_store_is_readable_before_any_region_is_written(tmp_path: Path) -> None:
+    """Metadata lands first, so a stream interrupted at any point leaves a valid store behind.
+
+    This is also what lets a reader open an entry while it is still being written, which the dataset
+    layer relies on when it replaces an existing entry.
+    """
+    path = tmp_path / "empty.ome.zarr"
+    _create(path)
+    clear_ome_zarr_cache()
+
+    info = get_ome_zarr_info(path)
+    assert info["shape"] == list(SHAPE)
+    assert info["dtype"] == "int16"
+    # spacing and origin arrive in SimpleITK's xyz order and are stored per axis, so the spatial part
+    # of the store geometry reads back reversed. Asserting the reversal rather than a symmetric value
+    # is the point: a transposed geometry is the failure this test exists to catch.
+    np.testing.assert_allclose(info["scale"][1:], SPACING[::-1])
+    np.testing.assert_allclose(info["translation"][1:], ORIGIN[::-1])
+
+
+def test_konfai_attributes_survive_the_metadata_write(tmp_path: Path) -> None:
+    """The sidecar must outlive ngff-zarr's own root write.
+
+    ``to_ngff_zarr(overwrite=True)`` reopens the root group in ``mode="w"`` and drops every attribute
+    already there, so ordering is the whole test: written first, Direction disappears, and its loss is
+    silent -- the reader substitutes identity and returns a plausibly oriented volume.
+    """
+    path = tmp_path / "attrs.ome.zarr"
+    _create(path)
+    clear_ome_zarr_cache()
+
+    stored = get_ome_zarr_info(path)["attributes"]
+    assert [float(value) for value in stored["Direction"].split()] == list(DIRECTION)
+
+
+def test_level_zero_key_is_taken_from_the_metadata_not_a_literal(tmp_path: Path) -> None:
+    """Whatever key ngff-zarr chose, the array returned is the one the metadata points at.
+
+    The key moved from ``"0"`` to ``"scale0/image"`` when ngff-zarr took over the metadata; hardcoding
+    either spelling makes KonfAI break on a convention that is not its own.
+
+    Reading through the group, rather than through ngff-zarr, is also the only thing here that sees the
+    store's consolidated index -- a summary of its own contents that readers trust over the arrays
+    themselves, and that is written while the array is still a one-voxel stand-in.
+    """
+    path = tmp_path / "keyed.ome.zarr"
+    array = _create(path)
+    array[:] = 3
+
+    group = zarr.open_group(str(path), mode="r")
+    multiscales = dict(group.attrs)["multiscales"][0]
+    dataset_key = multiscales["datasets"][0]["path"]
+    np.testing.assert_array_equal(np.asarray(group[dataset_key][:]), 3)
+
+
+def test_creating_a_store_writes_no_pixel_bytes(tmp_path: Path) -> None:
+    """Describing the store must not cost the volume.
+
+    Handing a writer an array of the target shape, even an empty one, means a pass over every chunk of
+    it before the first real voxel arrives -- around 33 s for a 13.6 GiB field, to produce nothing.
+    Creation has to stay independent of the extent.
+    """
+    path = tmp_path / "bytes.ome.zarr"
+    _create(path, chunks=(3, 4, 5, 6))
+
+    written = sum(item.stat().st_size for item in path.rglob("*") if item.is_file())
+    metadata_only = 64 << 10
+    assert written < metadata_only, f"{written} bytes written for an untouched store"


### PR DESCRIPTION
Three commits closing the gap between the whole-array and streaming OME-Zarr write paths:

- **ngff-zarr writes the streaming-store metadata** — the hand-composed 0.4 multiscales entry meant a DVF came out self-describing when it fit in memory and as an anonymous 3-channel image when streamed (the only path a real one takes). Metadata is described from a one-voxel stand-in (extent-independent for a single level, byte-identical for 0.4 and 0.6; 0.027 s vs 33.4 s for a 13.6 GiB field), the real array is created underneath with the caller's exact region-grid chunking, and three silent failure modes are pinned by tests: version 0.4 explicit (0.5 breaks zarr-python 2), sidecar written after `to_ngff_zarr(overwrite=True)` (which drops attributes — losing Direction is silent), consolidated index rebuilt last.
- **An output can declare what it writes** — the predictor emits arrays, so `data_to_file` never recognised a field; the declaration now travels in the attributes (the same marker a store reports on read-back), and a generic `attributes` mapping lets a config stamp its outputs, applied over inheritance so config wins. Asking for a field where RFC-5 is impossible (zarr 2) raises instead of quietly writing an untyped store.
- **No spill of a resident array** — ngff-zarr's cache path serialises an in-memory array to disk before writing it, triggered by an estimate inflated by itemsize^(ndim-1) (a 13.6 GiB field reported as 868 GiB); `cache=False`, since a peak that already happened cannot be lowered.

`dask` is declared explicitly (imaging/omezarr extras, dev, pixi) — it was imported directly but only reached through ngff-zarr.

Verified: 118 tests green across store creation, displacement-field round-trip and dataset streaming; end to end a region-written field reads back as a `DisplacementFieldTransform`, axes `('c','displacement')`, NGFF 0.6, pixels unchanged.