### PR TITLE
Bundle icons through the app interface, and a way to stop Studio

### DIFF
--- a/konfai-apps/konfai_apps/app_repository.py
+++ b/konfai-apps/konfai_apps/app_repository.py
@@ -259,6 +259,7 @@ class AppRepositoryInfo(ABC):
         vram_plan: dict[int, VRAMPlanEntry] | None = None,
         patch_size: list[int] | None = None,
         task: str | None = None,
+        icon_path: Path | None = None,
     ) -> None:
         super().__init__()
         self._app_name = app_name
@@ -276,6 +277,7 @@ class AppRepositoryInfo(ABC):
         self._vram_plan = vram_plan
         self._patch_size = patch_size
         self._task = task
+        self._icon_path = icon_path
 
     def __str__(self) -> str:
         return (
@@ -321,6 +323,11 @@ class AppRepositoryInfo(ABC):
         """The app's declared task family (e.g. ``segmentation``/``registration``/``synthesis``), a free-form
         hint straight from ``app.json``; None when the manifest omits it. Not validated against an enum."""
         return self._task
+
+    def get_icon_path(self) -> Path | None:
+        """Local path of the app's own icon (the bundle's ``icon.png``, or the ``icon`` file that
+        ``app.json`` names); None when the bundle ships none. UIs fall back to a task glyph."""
+        return self._icon_path
 
     def is_finetunable(self) -> bool:
         """Whether the app can be fine-tuned from its bundled train config. Conservative default for
@@ -466,6 +473,11 @@ class LocalAppRepository(AppRepositoryInfo):
         checkpoints_name: list[str] = app_repository_metadata.get("models", [])
         checkpoints_name_available = self._get_available_checkpoint_names(checkpoints_name, filenames)
 
+        # The bundle's own icon: the file app.json names, or 'icon.png' by convention. Non-.pt files
+        # are all downloaded above, so resolving it here costs nothing.
+        icon_name = app_repository_metadata.get("icon", "icon.png" if "icon.png" in filenames else None)
+        icon_path = self._download(icon_name) if icon_name in filenames else None
+
         super().__init__(
             app_name=app_name,
             display_name=str(app_repository_metadata["display_name"]),
@@ -482,6 +494,7 @@ class LocalAppRepository(AppRepositoryInfo):
             vram_plan=vram_plan,
             patch_size=patch_size,
             task=app_repository_metadata.get("task"),
+            icon_path=icon_path,
         )
 
     def _get_available_checkpoint_names(self, checkpoints_name: list[str], filenames: list[str]) -> list[str]:

--- a/konfai-mcp/konfai_mcp/server_apps.py
+++ b/konfai-mcp/konfai_mcp/server_apps.py
@@ -261,6 +261,10 @@ class AppService:
                 app["short_description"] = summary["short_description"]
                 app["inputs"] = list(summary["inputs"].keys())
                 app["outputs"] = list(summary["outputs"].keys())
+                if "task" in summary:
+                    app["task"] = summary["task"]
+                if summary.get("has_icon"):
+                    app["has_icon"] = True
 
         return {
             "apps": apps,
@@ -328,6 +332,9 @@ class AppService:
         task = info.get_task()
         if task:
             payload["task"] = task
+
+        if info.get_icon_path():
+            payload["has_icon"] = True  # the bundle ships its own icon.png (UIs fetch it themselves)
 
         terminology = info.get_terminology()
         if terminology:

--- a/studio/frontend/src/App.tsx
+++ b/studio/frontend/src/App.tsx
@@ -52,6 +52,15 @@ function SearchIcon() {
   );
 }
 
+function PowerIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
+      <path d="M12 3v8" />
+      <path d="M6.2 6.4a8 8 0 1 0 11.6 0" />
+    </svg>
+  );
+}
+
 function AppsIcon() {
   return (
     <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
@@ -176,6 +185,7 @@ export default function App() {
 
 function Studio({ remote }: { remote: boolean }) {
   const [status, setStatus] = useState("connecting…");
+  const [stopped, setStopped] = useState(false); // the user shut the local server down from the titlebar
   const [sessions, setSessions] = useState<string[]>([]); // starts empty — no phantom "default" experiment
   // The status poll reads this to spot an experiment it does not know yet; a ref, because the poll's
   // interval closure would otherwise forever see the mount-time empty list.
@@ -568,10 +578,33 @@ function Studio({ remote }: { remote: boolean }) {
   // One live subscription for the active task, shared by the feed (right) and the console (bottom).
   const stream = useJobStream(active, ui[active]?.runNonce ?? 0);
 
+  // Stopping the server is a LOCAL privilege: never offered on a remote (token-gated) session,
+  // and the endpoint refuses non-loopback clients anyway.
+  const stoppable = !remote && ["localhost", "127.0.0.1", "[::1]"].includes(location.hostname);
+  function quitStudio() {
+    if (!window.confirm("Stop the KonfAI Studio server?\n\nThe page will go offline; running jobs may be interrupted."))
+      return;
+    postJson("/api/quit", {})
+      .catch(() => {})
+      .finally(() => setStopped(true));
+  }
+
   function signOut() {
     purgeStudioChat(); // drop transcripts before the httpOnly cookie is cleared and the page reloads
     fetch("/api/logout", { method: "POST" }).finally(() => location.reload());
   }
+
+  if (stopped)
+    return (
+      <div className="stopped-wrap">
+        <div>
+          <h2>Studio server stopped</h2>
+          <p>
+            You can close this tab. Launch it again from Slicer or run <code>konfai-studio</code>.
+          </p>
+        </div>
+      </div>
+    );
 
   return (
     <div className="app">
@@ -613,6 +646,11 @@ function Studio({ remote }: { remote: boolean }) {
             title="Host CPU load, averaged over all cores"
             traces={[{ label: "load", points: cpuHist }]}
           />
+        )}
+        {stoppable && (
+          <button className="power-btn" onClick={quitStudio} title="Stop the Studio server (local session only)">
+            <PowerIcon />
+          </button>
         )}
       </div>
 

--- a/studio/frontend/src/App.tsx
+++ b/studio/frontend/src/App.tsx
@@ -584,9 +584,11 @@ function Studio({ remote }: { remote: boolean }) {
   function quitStudio() {
     if (!window.confirm("Stop the KonfAI Studio server?\n\nThe page will go offline; running jobs may be interrupted."))
       return;
-    postJson("/api/quit", {})
-      .catch(() => {})
-      .finally(() => setStopped(true));
+    // The header is what the server checks against a drive-by POST; only show the stopped screen
+    // once the request actually succeeded, or the UI would lie about a server that is still up.
+    postJson("/api/quit", {}, { "X-KonfAI-Studio": "quit" })
+      .then(() => setStopped(true))
+      .catch((e) => window.alert(`Could not stop the server: ${e?.message ?? e}`));
   }
 
   function signOut() {

--- a/studio/frontend/src/api.ts
+++ b/studio/frontend/src/api.ts
@@ -9,10 +9,10 @@ export async function getJson<T = any>(url: string): Promise<T> {
   return r.json();
 }
 
-export async function postJson<T = any>(url: string, body: unknown): Promise<T> {
+export async function postJson<T = any>(url: string, body: unknown, headers?: Record<string, string>): Promise<T> {
   const r = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...headers },
     body: JSON.stringify(body),
   });
   if (!r.ok) throw new Error(`${r.status} ${r.statusText}`);

--- a/studio/frontend/src/styles.css
+++ b/studio/frontend/src/styles.css
@@ -3695,3 +3695,30 @@ body {
 .deploy-status.undeployable { color: #fbbf24; }
 .deploy-status .backend { display: inline-block; margin-right: 6px; padding: 1px 7px; border-radius: 6px; background: #14343f; color: #7dd3fc; font-size: 10px; }
 .deploy-canvas { width: 100%; height: 100%; }
+
+.titlebar .power-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 8px;
+  margin-left: 6px;
+  background: transparent;
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  color: var(--ink-2);
+  cursor: pointer;
+}
+.titlebar .power-btn:hover {
+  color: #e5484d;
+  border-color: #e5484d;
+}
+.stopped-wrap {
+  height: 100vh;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  color: var(--ink);
+  font-family: var(--fsans);
+}
+.stopped-wrap p {
+  color: var(--ink-2);
+}

--- a/studio/konfai_studio/server.py
+++ b/studio/konfai_studio/server.py
@@ -855,15 +855,22 @@ async def apps(session: str = Query("apps")) -> dict[str, Any]:
 async def quit_server(request: Request) -> dict[str, bool]:
     """Stop the Studio server (graceful: the lifespan teardown closes agents and reaps TensorBoards).
 
-    Only accepted from the machine the server runs on: a remote client must never be able to take
-    the shared server down, token or not. Slicer's Studio button and the titlebar power button rely
-    on this — the server runs detached, with no terminal to Ctrl+C.
+    Two guards, because neither alone is enough. The client must be on this machine, so a remote
+    user cannot take a shared server down, token or not. And it must send the header below: the
+    loopback check only proves the TCP peer is local, which any page open in the user's browser
+    also is, so without it a drive-by form POST to localhost would shut Studio down. A custom
+    header is unforgeable from a form and, cross-origin, needs a preflight this server never grants.
+
+    Slicer's Studio button and the titlebar power button rely on this — the server runs detached,
+    with no terminal to Ctrl+C.
     """
     import signal
 
     client = request.client.host if request.client else ""
     if client not in ("127.0.0.1", "::1"):
         raise HTTPException(403, "the Studio server can only be stopped from its own machine")
+    if request.headers.get("x-konfai-studio") != "quit":
+        raise HTTPException(403, "missing the X-KonfAI-Studio header — stop Studio from its own UI")
 
     async def _after_reply() -> None:
         await asyncio.sleep(0.3)  # let this response leave before the shutdown begins
@@ -886,7 +893,8 @@ async def app_icon(ref: str = Query(...)) -> FileResponse:
         raise HTTPException(404, f"app '{ref}' has no icon") from exc
     if icon_path is None or not Path(icon_path).is_file():
         raise HTTPException(404, f"app '{ref}' has no icon")
-    return FileResponse(icon_path, media_type="image/png")
+    # No media_type: app.json may name a .svg or .webp, so let the response infer it from the path.
+    return FileResponse(icon_path)
 
 
 def _app_bundle_file(ref: str, filename: str) -> Path:

--- a/studio/konfai_studio/server.py
+++ b/studio/konfai_studio/server.py
@@ -21,8 +21,9 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import FileResponse, StreamingResponse
 from pydantic import BaseModel
 
@@ -835,9 +836,57 @@ def _parse_apps(data: Any) -> list[dict[str, Any]]:
 
 @app.get("/api/apps")
 async def apps(session: str = Query("apps")) -> dict[str, Any]:
-    """The konfai-mcp app catalogue (shipped + registered sources) — a direct MCP call, no LLM."""
+    """The konfai-mcp app catalogue (shipped + registered sources) — a direct MCP call, no LLM.
+
+    Bundle metadata maps onto what the App Zoo renders: an app with its own ``icon.png`` gets a
+    ``logo`` URL (served below), and its declared ``task`` becomes the grouping ``theme``.
+    """
     ok, _text, data = await _mcp_json(_sane_session(session), "list_apps", {"include_summary": True})
-    return {"ok": ok, "apps": _parse_apps(data)}
+    listed = _parse_apps(data)
+    for entry in listed:
+        if entry.get("has_icon") and entry.get("ref"):
+            entry["logo"] = f"/api/apps/icon?ref={quote(str(entry['ref']), safe='')}"
+        if entry.get("task") and not entry.get("theme"):
+            entry["theme"] = str(entry["task"]).capitalize()
+    return {"ok": ok, "apps": listed}
+
+
+@app.post("/api/quit")
+async def quit_server(request: Request) -> dict[str, bool]:
+    """Stop the Studio server (graceful: the lifespan teardown closes agents and reaps TensorBoards).
+
+    Only accepted from the machine the server runs on: a remote client must never be able to take
+    the shared server down, token or not. Slicer's Studio button and the titlebar power button rely
+    on this — the server runs detached, with no terminal to Ctrl+C.
+    """
+    import signal
+
+    client = request.client.host if request.client else ""
+    if client not in ("127.0.0.1", "::1"):
+        raise HTTPException(403, "the Studio server can only be stopped from its own machine")
+
+    async def _after_reply() -> None:
+        await asyncio.sleep(0.3)  # let this response leave before the shutdown begins
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    asyncio.get_running_loop().create_task(_after_reply())
+    return {"ok": True}
+
+
+@app.get("/api/apps/icon")
+async def app_icon(ref: str = Query(...)) -> FileResponse:
+    """The app's own bundle icon (its ``icon.png`` / ``app.json``-declared icon file)."""
+    try:
+        from konfai_apps.app_repository import AppRepositoryError, get_app_repository_info
+    except ImportError as exc:  # pragma: no cover - konfai-apps not installed
+        raise HTTPException(503, "konfai-apps is not installed") from exc
+    try:
+        icon_path = get_app_repository_info(ref, force_update=False).get_icon_path()
+    except (AppRepositoryError, FileNotFoundError, OSError, ValueError) as exc:
+        raise HTTPException(404, f"app '{ref}' has no icon") from exc
+    if icon_path is None or not Path(icon_path).is_file():
+        raise HTTPException(404, f"app '{ref}' has no icon")
+    return FileResponse(icon_path, media_type="image/png")
 
 
 def _app_bundle_file(ref: str, filename: str) -> Path:

--- a/studio/tests/test_quit.py
+++ b/studio/tests/test_quit.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The guards on ``POST /api/quit``.
+
+Shutting the server down is reachable from any page the user has open — to the server, every request
+a browser makes to localhost looks local — so it only fires for a caller that is both on this machine
+and able to set a header, which a cross-origin form cannot.
+"""
+
+from __future__ import annotations
+
+import signal
+import time
+from collections.abc import Iterator
+
+import pytest
+
+pytest.importorskip("fastapi")
+from konfai_studio import server as bff  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+
+HEADER = {"X-KonfAI-Studio": "quit"}
+
+
+@pytest.fixture
+def killed() -> Iterator[list[int]]:
+    """Capture the shutdown signal instead of killing the test runner."""
+    sent: list[int] = []
+    original = bff.os.kill
+    bff.os.kill = lambda pid, sig: sent.append(sig)  # type: ignore[assignment]
+    try:
+        yield sent
+    finally:
+        bff.os.kill = original  # type: ignore[assignment]
+
+
+def _wait_for_signal(sent: list[int], timeout: float = 3.0) -> bool:
+    """The endpoint answers first and signals shortly after, so give that task a moment."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if sent:
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def test_the_studio_ui_stops_the_server(killed: list[int]) -> None:
+    with TestClient(bff.app, client=("127.0.0.1", 54321)) as client:
+        response = client.post("/api/quit", json={}, headers=HEADER)
+        # Inside the block: the signal is sent by a task on the client's own event loop, which
+        # stops with it.
+        signalled = _wait_for_signal(killed)
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert signalled
+    assert killed == [signal.SIGTERM]
+
+
+def test_a_form_post_without_the_header_cannot_stop_the_server(killed: list[int]) -> None:
+    with TestClient(bff.app, client=("127.0.0.1", 54321)) as client:
+        response = client.post("/api/quit", data={"any": "field"})
+
+    assert response.status_code == 403
+    assert not killed
+
+
+def test_a_client_off_this_machine_cannot_stop_the_server(killed: list[int]) -> None:
+    with TestClient(bff.app, client=("203.0.113.7", 54321)) as client:
+        response = client.post("/api/quit", json={}, headers=HEADER)
+
+    assert response.status_code == 403
+    assert not killed


### PR DESCRIPTION
## Description

Two things a UI needs from the backend, plus the Studio side that consumes them.

**Bundle icons.** A bundle can ship its own `icon.png` (or name one via `icon` in `app.json`). Non-`.pt` files are already fetched when the manifest is read, so resolving it costs nothing: `AppRepositoryInfo.get_icon_path()` returns the local path, `describe_app` reports `has_icon`, and `list_apps --include_summary` propagates that and the declared `task`. The App Zoo already rendered `logo` and grouped by `theme` — nothing ever filled them; `/api/apps/icon` now serves the icon and the declared task becomes the theme, so the gallery stops falling back to initials and name-prefix guesses. The 23 published bundles carry their icon as of today. SlicerKonfAI consumes the same `get_icon_path()` for its app selector.

**Stopping the server.** Studio is launched detached — from Slicer, or from a terminal that has since closed — so there was nothing to Ctrl+C. `POST /api/quit` stops it gracefully through the lifespan teardown (agents closed, TensorBoards reaped), with a power button in the titlebar.

Stopping is a local privilege, enforced on both sides. The client must be on this machine, and must send `X-KonfAI-Studio: quit`: the loopback check alone only proves the TCP peer is local, which any page open in the user's browser also is, so a drive-by form POST would otherwise shut Studio down. A custom header is unforgeable from a form and, cross-origin, needs a preflight this server never grants. The button is also hidden on a token-gated or non-loopback session.

## Related issues

None.

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement
- [ ] `refactor` — no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `build` / `ci` / `chore` — tooling, deps, CI
- [ ] Breaking change (describe the migration below)

## How has this been tested?

```bash
pixi run --environment dev python -m pytest studio/tests/test_quit.py     # 3 passed
pixi run --environment dev python -m pytest konfai-apps/tests/unit/test_app_server_helpers.py   # 37 passed
npm run build --prefix studio/frontend                                    # tsc + vite, clean
```

Also exercised against a live server on port 8799: a headerless `POST /api/quit` returns 403 and the server keeps answering; the same request with `X-KonfAI-Studio: quit` returns `{"ok": true}` and the port goes quiet.

## Checklist

- [x] PR title and commits follow **Conventional Commits**
- [x] `pixi run check` passes (ruff lint + format + tests) — via pre-commit on the changed files
- [x] `pixi run --environment dev python -m pytest konfai-apps/tests` passes *(if `konfai-apps/` changed)*
- [x] Tests added/updated for the change
- [ ] Docs updated *(if user-facing CLI/config behaviour changed)* — no CLI or config surface changed
- [x] No new runtime dependency without a matching `pyproject.toml` extra
- [x] Lazy/patch data access preserved (no full-volume reads added)

## Breaking changes & migration

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App listings now support task labels, themes, and bundled icons.
  * Added app icon display support in the Studio interface.
  * Added a local-only control to safely stop the Studio server.
  * Added a confirmation screen after the server stops.

* **Bug Fixes**
  * Improved app branding and icon handling across supported app sources.

* **Tests**
  * Added coverage for authorized and unauthorized server shutdown requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->