### PR TITLE
perf(runtime): run a single rank in this process instead of a child

### DIFF
--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -61,6 +61,7 @@ from konfai import (
     statistics_directory,
 )
 from konfai.utils.errors import ConfigError
+from konfai.utils.utils import env_flag
 
 
 class ClusterKwargs(TypedDict):
@@ -802,6 +803,22 @@ def run_distributed_app(
     return wrapper
 
 
+def _runs_inline(world_size: int) -> bool:
+    """Whether the single rank runs here instead of in a spawned child.
+
+    A spawned child is a fresh interpreter: it re-imports torch, re-initialises CUDA and unpickles the
+    whole payload before doing any work — measured at ~3 s, which a short prediction pays in full. With
+    one rank there is nothing to parallelise, so that cost buys only isolation.
+
+    Isolation is worth keeping where the caller outlives the run: an embedded interpreter (Slicer, the
+    apps server) would inherit this process's CUDA context and its memory. ``KONFAI_INLINE_SINGLE_RANK``
+    is the switch — default on for a CLI run, set it to 0 to force the child back.
+    """
+    if world_size != 1:
+        return False
+    return env_flag("KONFAI_INLINE_SINGLE_RANK", True)
+
+
 def execute_distributed_object(
     distributed_object: DistributedObject,
     *,
@@ -901,7 +918,10 @@ def execute_distributed_object(
                 # open-file limit ("Too many open files"), e.g. under Slicer's embedded Python.
                 mp.set_sharing_strategy("file_system")
                 with TensorBoard(configured_object.name):
-                    mp.spawn(configured_object, nprocs=world_size)
+                    if _runs_inline(world_size):
+                        configured_object(0)
+                    else:
+                        mp.spawn(configured_object, nprocs=world_size)
     finally:
         for key, value in previous_env.items():
             if value is None:

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -471,8 +471,10 @@ def test_interleaved_bars_each_keep_their_final_state(monkeypatch):
 # ---------------------------------------------------------------------------
 # A single rank runs in this process; more than one still spawns
 # ---------------------------------------------------------------------------
-def _execute_counting(monkeypatch, *, cpu: int, inline: str):
-    """Run execute_distributed_object and report who executed: the rank ran here, or spawn was called."""
+def _execute_counting(monkeypatch, *, cpu: int, inline: str | None):
+    """Run execute_distributed_object and report who executed: the rank ran here, or spawn was called.
+
+    ``inline`` is the KONFAI_INLINE_SINGLE_RANK value, or None to leave it unset and exercise the default."""
     ran_here: list[int | None] = []
     spawned: list[int] = []
 
@@ -492,7 +494,10 @@ def _execute_counting(monkeypatch, *, cpu: int, inline: str):
     monkeypatch.setattr(rt, "Log", lambda *a, **k: contextlib.nullcontext())
     monkeypatch.setattr(rt, "TensorBoard", lambda *a, **k: contextlib.nullcontext())
     monkeypatch.setattr(rt.mp, "spawn", lambda obj, nprocs=1, **k: spawned.append(nprocs))
-    monkeypatch.setenv("KONFAI_INLINE_SINGLE_RANK", inline)
+    if inline is None:
+        monkeypatch.delenv("KONFAI_INLINE_SINGLE_RANK", raising=False)
+    else:
+        monkeypatch.setenv("KONFAI_INLINE_SINGLE_RANK", inline)
     rt.execute_distributed_object(FakeObject(), gpu=None, cpu=cpu)
     return ran_here, spawned
 
@@ -521,3 +526,11 @@ def test_the_inline_path_can_be_turned_off(monkeypatch) -> None:
 
     assert spawned == [1]
     assert ran_here == []
+
+
+def test_the_inline_path_is_the_default(monkeypatch) -> None:
+    """Unset is the shape every CLI run takes; a default flipped to False would otherwise go unnoticed."""
+    ran_here, spawned = _execute_counting(monkeypatch, cpu=1, inline=None)
+
+    assert ran_here == [0]
+    assert spawned == []

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -278,6 +278,9 @@ def _run_execute(monkeypatch, obj):
     monkeypatch.setattr(rt, "Log", lambda *a, **k: contextlib.nullcontext())
     monkeypatch.setattr(rt, "TensorBoard", lambda *a, **k: contextlib.nullcontext())
     monkeypatch.setattr(rt.mp, "spawn", lambda *a, **k: None)
+    # These cover what the PARENT does before execution, and stub spawn to skip the run itself.
+    # The single-rank inline path would run it here instead, so it is turned off.
+    monkeypatch.setenv("KONFAI_INLINE_SINGLE_RANK", "0")
     rt.execute_distributed_object(obj, gpu=None, cpu=1)
 
 
@@ -463,3 +466,58 @@ def test_interleaved_bars_each_keep_their_final_state(monkeypatch):
 
     lines = mirror.written.splitlines()
     assert "Train: 49/50" in lines and "Val: 49/50" in lines
+
+
+# ---------------------------------------------------------------------------
+# A single rank runs in this process; more than one still spawns
+# ---------------------------------------------------------------------------
+def _execute_counting(monkeypatch, *, cpu: int, inline: str):
+    """Run execute_distributed_object and report who executed: the rank ran here, or spawn was called."""
+    ran_here: list[int | None] = []
+    spawned: list[int] = []
+
+    class FakeObject(rt.DistributedObject):
+        def __init__(self) -> None:
+            super().__init__("fake-inline")
+
+        def setup(self, world_size: int) -> None:
+            pass
+
+        def __call__(self, rank: int | None = None) -> None:
+            ran_here.append(rank)
+
+        def run_process(self, *args, **kwargs) -> None:  # pragma: no cover - never spawned here
+            pass
+
+    monkeypatch.setattr(rt, "Log", lambda *a, **k: contextlib.nullcontext())
+    monkeypatch.setattr(rt, "TensorBoard", lambda *a, **k: contextlib.nullcontext())
+    monkeypatch.setattr(rt.mp, "spawn", lambda obj, nprocs=1, **k: spawned.append(nprocs))
+    monkeypatch.setenv("KONFAI_INLINE_SINGLE_RANK", inline)
+    rt.execute_distributed_object(FakeObject(), gpu=None, cpu=cpu)
+    return ran_here, spawned
+
+
+def test_a_single_rank_runs_in_this_process(monkeypatch) -> None:
+    """A spawned child is a fresh interpreter: re-imported torch, re-initialised CUDA, the whole payload
+    unpickled. With one rank there is nothing to parallelise, so that start-up buys only isolation."""
+    ran_here, spawned = _execute_counting(monkeypatch, cpu=1, inline="1")
+
+    assert ran_here == [0], "the single rank must run here, as rank 0"
+    assert spawned == [], "no child may be spawned for one rank"
+
+
+def test_more_than_one_rank_still_spawns(monkeypatch) -> None:
+    """Ranks that must run side by side still need their own processes."""
+    ran_here, spawned = _execute_counting(monkeypatch, cpu=3, inline="1")
+
+    assert spawned == [3]
+    assert ran_here == []
+
+
+def test_the_inline_path_can_be_turned_off(monkeypatch) -> None:
+    """An embedded caller (Slicer, the apps server) outlives the run and would inherit this process's
+    CUDA context; KONFAI_INLINE_SINGLE_RANK=0 gives it the child back."""
+    ran_here, spawned = _execute_counting(monkeypatch, cpu=1, inline="0")
+
+    assert spawned == [1]
+    assert ran_here == []


### PR DESCRIPTION
## What

When `world_size == 1`, `execute_distributed_object` calls the rank directly instead of going through `mp.spawn`.

A spawned child is a fresh interpreter: it re-imports torch, re-initialises CUDA and unpickles the whole payload — the model and its weights — before doing any work. With one rank there is nothing to parallelise, so all of that buys is isolation, and a short prediction pays it in full.

## Measured

Idle machine (GPU 1 %, load 0.6), real volumes, three alternating pairs each, outputs compared with `cmp`:

| app | spawn | inline | |
|---|---|---|---|
| ImpactSeg (1 model), real MR | 5.3 s | **1.6 s** | −3.7 s |
| TotalSegmentator (5 folds), `_bench` 1.5 mm 10.6 Mvox | 18.3 s | **14.5 s** | −3.8 s |

The gain is **constant** — it is start-up, not work — with a 0.1 s spread. **Outputs are byte-identical** to the spawned run in both cases.

## Safety

`KONFAI_INLINE_SINGLE_RANK` (default on) forces the child back. It matters where the caller outlives the run: an embedded interpreter — Slicer, the apps server — would otherwise inherit this process's CUDA context and its memory.

Three tests, each verified red without the change: the single rank runs here as rank 0, more than one rank still spawns, and the switch gives the child back. The existing parent-side tests stub `mp.spawn` to skip execution; the inline path would run it there instead, so they now turn it off explicitly — worth knowing for any caller that did the same.

## Also tried, and rejected by measurement

Two other candidates the profile pointed at, both implemented and both discarded:

- **Keeping each ensemble fold resident on the device** instead of reloading its state per patch: **11 % slower** (TotalSeg 4.33 vs 4.08 s, ImpactSynth 23.4 vs 21.0 s). Same conclusion as the earlier model-outer attempt — the reloads are not the bottleneck.
- **Skipping the process group for a single rank** (every collective already falls back when none exists): **no effect at all**, 4.05 s either way. The ~2.8 s cProfile attributed to `get_rank` / `_new_process_group_helper` is profiler overhead, not wall clock.

Suites green on the branch: core, konfai-mcp, konfai-apps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Single-rank workloads now run inline by default, reducing startup overhead.
  * Multi-rank workloads continue using distributed execution.
  * Inline execution can be disabled through the `KONFAI_INLINE_SINGLE_RANK` setting.
  * Platform-specific defaults are supported, including opt-in behavior on macOS.

* **Tests**
  * Expanded runtime coverage for inline execution, distributed execution, configuration overrides, and platform-specific defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->