### PR TITLE
refactor(data): the abstractions TRANSFORM needs, each defensible alone

### DIFF
--- a/examples/Segmentation/Config.yml
+++ b/examples/Segmentation/Config.yml
@@ -83,6 +83,7 @@ Trainer:
             - 0.5
             - 0.5
             prob: 1
+            vector_field: false
         nb: 1
     Patch:
       patch_size:
@@ -102,6 +103,12 @@ Trainer:
     batch_size: 8
     validation: 0.2
     validation_augmentations: true
+    shuffle_window: None
+    memory_budget: None
+    num_workers: None
+    pin_memory: false
+    prefetch_factor: None
+    persistent_workers: None
   train_name: SEG_BASELINE
   manual_seed: 32
   epochs: 100
@@ -113,3 +120,4 @@ Trainer:
   data_log: None
   save_checkpoint_mode: BEST
   EarlyStopping: None
+  it_lr_update: None

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -77,6 +77,24 @@ def _format_gib(num_bytes: float) -> str:
     return f"{num_bytes / 2**30:.2f} GiB"
 
 
+@dataclass(frozen=True)
+class MemoryBudget:
+    """A resolved memory budget that knows its own scope.
+
+    The one decision no consumer may make for itself: an ``auto`` budget measures the NODE, so
+    ranks sharing it split it; an explicit budget is the user's per-rank figure, taken as is.
+    Handing consumers a bare number with an ``is_auto`` flag makes each of them re-derive that
+    rule — this object answers it once, through :meth:`per_rank_bytes`.
+    """
+
+    total_bytes: float
+    description: str
+    shared_across_ranks: bool
+
+    def per_rank_bytes(self, world_size: int) -> float:
+        return self.total_bytes / max(1, world_size) if self.shared_across_ranks else self.total_bytes
+
+
 def _parse_memory_budget_bytes(value: str | float) -> int:
     """Parse an explicit memory budget to bytes: a bare number is GiB, a string carries its own unit.
 
@@ -251,8 +269,16 @@ class GroupTransform:
         self.transforms: list[Transform] = []
         self.patch_transforms: list[Transform] = []
         self.is_input = is_input
+        self._prepared = False
 
     def prepare(self, group_src: str, group_dest: str) -> None:
+        # Binds ONCE. A workflow that inspects its chains before handing over to Data.prepare() calls
+        # this first, and Data.prepare() calls it again for every group -- so without the guard every
+        # stage is constructed twice, and anything the workflow attached to the first set is silently
+        # thrown away with it. A stage's __init__ is user code and may not be run twice for free.
+        if self._prepared:
+            return
+        self._prepared = True
         self.transforms = []
         self.patch_transforms = []
         if self._transforms is not None:
@@ -905,22 +931,24 @@ class Data(ABC):
         self._prepared_train_names: list[str] = []
         self._prepared_validation_names: list[str] = []
 
-    def _resolved_budget_bytes(self) -> tuple[float, str, bool]:
-        """The configured memory budget as ``(bytes, description, is_auto)``.
+    def resolved_budget(self) -> MemoryBudget:
+        """The configured memory budget as an object that knows its own scope.
 
         ``None``/``"auto"`` offers ``_AUTO_MEMORY_SAFETY_FRACTION`` of the node's allocatable
         memory — a NODE budget, which ranks sharing the node split; an explicit budget is the
-        caller's own figure, taken as is."""
+        caller's own figure, per rank as declared."""
         if self.memory_budget is None or (
             isinstance(self.memory_budget, str) and self.memory_budget.strip().lower() == "auto"
         ):
             node_bytes, source = available_memory_bytes()
-            return (
+            return MemoryBudget(
                 node_bytes * _AUTO_MEMORY_SAFETY_FRACTION,
                 f"auto: {_format_gib(node_bytes)} {source} x {_AUTO_MEMORY_SAFETY_FRACTION:.0%}",
-                True,
+                shared_across_ranks=True,
             )
-        return float(_parse_memory_budget_bytes(self.memory_budget)), f"{self.memory_budget!r}", False
+        return MemoryBudget(
+            float(_parse_memory_budget_bytes(self.memory_budget)), f"{self.memory_budget!r}", shared_across_ranks=False
+        )
 
     def _configure_data_loading(self, use_cache: bool) -> None:
         """Build the loader from the cache regime: the DatasetIter factory and the worker settings.
@@ -1012,9 +1040,9 @@ class Data(ABC):
         dataset_bytes = self._estimate_cached_bytes()
         per_rank_bytes = dataset_bytes / world_size
 
-        budget, budget_desc, is_auto = self._resolved_budget_bytes()
-        per_rank_budget = budget / world_size if is_auto else budget
-        budget_desc = f"{budget_desc}, per-rank"
+        budget = self.resolved_budget()
+        per_rank_budget = budget.per_rank_bytes(world_size)
+        budget_desc = f"{budget.description}, per-rank"
 
         use_cache = per_rank_bytes <= per_rank_budget
         self._configure_data_loading(use_cache)
@@ -1732,16 +1760,14 @@ class DataMetric(Data):
             spatial_by_name,
             key=lambda name: channels_by_name[name] * int(np.prod(spatial_by_name[name], dtype=np.int64)),
         )
-        budget, _budget_desc, is_auto = self._resolved_budget_bytes()
-        if is_auto:
-            # The auto budget is the NODE's memory, shared by every rank evaluating on it. Sizing runs
-            # at build time -- before the spawn where world_size exists -- so the launcher leaves the
-            # per-node rank count in the environment (an explicit budget is per-rank by contract, and a
-            # caller without the launcher -- or with a garbled variable -- keeps the undivided default).
-            try:
-                budget //= max(1, int(os.environ.get("KONFAI_LOCAL_RANKS", "1")))
-            except ValueError:
-                pass
+        # Sizing runs at build time -- before the spawn where world_size exists -- so the launcher
+        # leaves the per-node rank count in the environment (a caller without the launcher, or with
+        # a garbled variable, keeps the undivided default).
+        try:
+            local_ranks = max(1, int(os.environ.get("KONFAI_LOCAL_RANKS", "1")))
+        except ValueError:
+            local_ranks = 1
+        budget = self.resolved_budget().per_rank_bytes(local_ranks)
         sized = resolve_patch(
             [0] * len(spatial_by_name[worst]),
             spatial_by_name[worst],

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -95,6 +95,22 @@ class MemoryBudget:
         return self.total_bytes / max(1, world_size) if self.shared_across_ranks else self.total_bytes
 
 
+def _node_local_ranks(world_size: int | None = None) -> int:
+    """How many ranks of this run share ONE node's RAM -- the divisor a node-scoped budget needs.
+
+    The launcher publishes the count in ``KONFAI_LOCAL_RANKS``, because a budget is often sized before
+    the spawn where a world size exists at all. Without it -- direct API use, a garbled value -- the
+    world size stands in: exact on a single node, conservative everywhere else.
+    """
+    try:
+        local = int(os.environ.get("KONFAI_LOCAL_RANKS", "0"))
+    except ValueError:
+        local = 0
+    if local <= 0:
+        return max(1, world_size or 1)
+    return min(local, world_size) if world_size else local
+
+
 def _parse_memory_budget_bytes(value: str | float) -> int:
     """Parse an explicit memory budget to bytes: a bare number is GiB, a string carries its own unit.
 
@@ -1027,9 +1043,9 @@ class Data(ABC):
         The cache is chosen iff the per-rank dataset (``dataset / world_size`` -- ``Data._split``
         shards cases across ranks) fits the per-rank budget: an explicit budget is taken as declared
         per rank; ``"auto"`` -- also what an absent key means -- divides the detected node memory
-        (cgroup-capped) by the ranks sharing it, so its ``world_size`` cancels and it reduces to
-        "does the whole dataset fit the node". The decision is logged once here -- ``get_data`` runs
-        on the launcher alone, before any worker is spawned.
+        (cgroup-capped) by the ranks sharing THAT node, so on a single node the two divisions cancel
+        and the test reduces to "does the whole dataset fit the node". The decision is logged once
+        here -- ``get_data`` runs on the launcher alone, before any worker is spawned.
         """
         if not self._budget_caches_when_fit:
             # One-pass workflows (prediction, evaluation) read each case exactly once: a cache is
@@ -1041,7 +1057,7 @@ class Data(ABC):
         per_rank_bytes = dataset_bytes / world_size
 
         budget = self.resolved_budget()
-        per_rank_budget = budget.per_rank_bytes(world_size)
+        per_rank_budget = budget.per_rank_bytes(_node_local_ranks(world_size))
         budget_desc = f"{budget.description}, per-rank"
 
         use_cache = per_rank_bytes <= per_rank_budget
@@ -1760,14 +1776,7 @@ class DataMetric(Data):
             spatial_by_name,
             key=lambda name: channels_by_name[name] * int(np.prod(spatial_by_name[name], dtype=np.int64)),
         )
-        # Sizing runs at build time -- before the spawn where world_size exists -- so the launcher
-        # leaves the per-node rank count in the environment (a caller without the launcher, or with
-        # a garbled variable, keeps the undivided default).
-        try:
-            local_ranks = max(1, int(os.environ.get("KONFAI_LOCAL_RANKS", "1")))
-        except ValueError:
-            local_ranks = 1
-        budget = self.resolved_budget().per_rank_bytes(local_ranks)
+        budget = self.resolved_budget().per_rank_bytes(_node_local_ranks())
         sized = resolve_patch(
             [0] * len(spatial_by_name[worst]),
             spatial_by_name[worst],

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -1520,8 +1520,15 @@ class DatasetManager:
             label = f"stage {stage_index} '{type(stage).__name__}'"
             if loc.kind in (LocalityKind.WHOLE_VOLUME, LocalityKind.SLAB):
                 # SLAB is a write-side contract: its side effect needs the slab's place in the
-                # OUTPUT, which a patch read has no notion of.
-                return False, (), evolved, f"{label} declares {loc.kind.name}: it needs the whole volume."
+                # OUTPUT, which a patch read has no notion of. A stage that is whole-volume only
+                # because something was left undeclared says so itself (PatchLocality.reason), so
+                # the reader is told what to change instead of what happened.
+                return (
+                    False,
+                    (),
+                    evolved,
+                    f"{label} declares {loc.kind.name}: {loc.reason or 'it needs the whole volume'}.",
+                )
             if loc.kind is LocalityKind.GLOBAL_STAT:
                 # The seed is the STORED volume's statistic, which is this transform's input only when
                 # every earlier stage preserves it; otherwise ([Clip(-200, 400), Standardize()]) every

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -134,38 +134,46 @@ class AugmentedStage:
 _REGION_KINDS = (LocalityKind.HALO, LocalityKind.ORIENTATION, LocalityKind.CROP, LocalityKind.RESCALE)
 
 
-def _halo_pull(radii: list[int], shape: list[int]) -> Callable[[tuple[slice, ...]], list[slice]]:
+# The pull maps are callable dataclasses, not closures, because a plan crosses a process boundary:
+# the launcher plans every case, `mp.spawn` then pickles the workflow object whole, and a local
+# function cannot be pickled. Everything a plan memoizes must survive that trip.
+
+
+@dataclass(frozen=True)
+class _HaloPull:
     """A halo stage's pull map: the region enlarged by the radius, clamped to the volume."""
 
-    def pull(target: tuple[slice, ...]) -> list[slice]:
+    radii: list[int]
+    shape: list[int]
+
+    def __call__(self, target: tuple[slice, ...]) -> list[slice]:
         return [
             slice(max(0, t.start - radius), min(extent, t.stop + radius))
-            for t, radius, extent in zip(target, radii, shape, strict=False)
+            for t, radius, extent in zip(target, self.radii, self.shape, strict=False)
         ]
 
-    return pull
 
-
-def _remap_pull(
-    remap: Callable[[tuple[slice, ...], list[int], Attribute], list[slice]],
-    shape: list[int],
-    attribute: Attribute,
-) -> Callable[[tuple[slice, ...]], list[slice]]:
+@dataclass(frozen=True)
+class _RemapPull:
     """An index-remap stage's pull map, bound to the case state the stages before it left."""
 
-    def pull(target: tuple[slice, ...]) -> list[slice]:
-        return remap(target, list(shape), Attribute(attribute))
+    remap: Callable[[tuple[slice, ...], list[int], Attribute], list[slice]]
+    shape: list[int]
+    attribute: Attribute
 
-    return pull
+    def __call__(self, target: tuple[slice, ...]) -> list[slice]:
+        return self.remap(target, list(self.shape), Attribute(self.attribute))
 
 
-def _scale_pull(scales: list[float], shape: list[int]) -> Callable[[tuple[slice, ...]], list[slice]]:
+@dataclass(frozen=True)
+class _ScalePull:
     """A rescale stage's pull map: the source window of the scale mapping plus its interpolation halo."""
 
-    def pull(target: tuple[slice, ...]) -> list[slice]:
-        return Resample.source_window(target, scales, shape)
+    scales: list[float]
+    shape: list[int]
 
-    return pull
+    def __call__(self, target: tuple[slice, ...]) -> list[slice]:
+        return Resample.source_window(target, self.scales, self.shape)
 
 
 @dataclass(frozen=True)
@@ -1585,16 +1593,16 @@ class DatasetManager:
             return _ReadStagePlan(loc.kind, tuple(shape), tuple(shape), None)
         if loc.kind is LocalityKind.HALO:
             return _ReadStagePlan(
-                loc.kind, tuple(shape), tuple(shape), _halo_pull(_halo_radii(loc.halo, len(shape)), list(shape))
+                loc.kind, tuple(shape), tuple(shape), _HaloPull(_halo_radii(loc.halo, len(shape)), list(shape))
             )
         if loc.kind is LocalityKind.RESCALE:
             resample = cast(Resample, stage)
             out = [int(e) for e in resample.transform_shape(self.group_src, self.name, list(shape), Attribute(evolved))]
             scales = [shape[k] / out[k] for k in range(len(shape))]
             resample.write_stream_cache_attribute(evolved, list(shape))
-            return _ReadStagePlan(loc.kind, tuple(shape), tuple(out), _scale_pull(scales, list(shape)))
+            return _ReadStagePlan(loc.kind, tuple(shape), tuple(out), _ScalePull(scales, list(shape)))
         # ORIENTATION / CROP: the stage's own remap, evaluated on the state the stages before it left.
-        pull = _remap_pull(stage.stream_region_source, list(shape), Attribute(evolved))
+        pull = _RemapPull(stage.stream_region_source, list(shape), Attribute(evolved))
         if isinstance(stage, Transform):
             out = [int(e) for e in stage.transform_shape(self.group_src, self.name, list(shape), Attribute(evolved))]
         else:

--- a/konfai/data/reduction.py
+++ b/konfai/data/reduction.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Operators that aggregate several tensors into one, and the contract that lets them stream.
+
+Two callers, one vocabulary. The predictor reduces the copies of ONE case — an ensemble's models,
+a TTA draw's augmentations. The transform workflow reduces one region across N CASES. Both fold a
+leading axis at fixed voxel, which is why both can run region by region and neither ever has to
+hold a whole volume.
+
+A reduction is a KonfAI extension point: subclass :class:`Reduction`, reference it by classpath.
+"""
+
+from abc import ABC, abstractmethod
+
+import torch
+
+from konfai.utils.errors import ReductionError
+
+
+class Reduction(ABC):
+    """Aggregate a list of tensors, one per case, into one.
+
+    Implement :meth:`__call__`. Override the incremental protocol as well when the operator can
+    accumulate, which is what keeps a large number of them from being resident all at once.
+
+    **The layout both engines hand over is** ``[1, K, C, *spatial]``: a singleton stack axis, then
+    whatever axis distinguishes the things being folded (the models of an ensemble; for a cohort
+    there is one per case, so ``K`` is the case's channels), then the volume. One convention,
+    because ``Concat`` puts the folded things SIDE BY SIDE — that means naming an axis, and an
+    operator cannot name one that its callers disagree about.
+    """
+
+    #: Streamed contract. ``True`` declares this a **pure per-voxel** operation over the case axis:
+    #: every output voxel depends only on the SAME voxel of each input, never on a spatial neighbour.
+    #: The streamed gates read this to decide whether a chain may run region by region.
+    #:
+    #: Rules for a custom reduction:
+    #:
+    #: - **Default False.** Leave it False unless you are sure: an unknown reduction then takes the
+    #:   whole-volume path, costing the streaming optimisation but never correctness.
+    #: - **Set True only if voxel-local.** Reducing/stacking along the case axis (dim 0) or the
+    #:   channel axis (dim 1) is fine — both are orthogonal to the spatial axes. Anything reading
+    #:   across spatial positions (a blur, a resample, a global argmax over Z) must stay False.
+    #: - **A wrong True corrupts the streamed output** (each region would be reduced with only its
+    #:   own cases); the gate trusts this flag and checks nothing else.
+    voxel_local: bool = False
+
+    #: Whether :meth:`accumulate` can fold cases one at a time. ``True`` bounds the working set at
+    #: two regions however many cases there are; ``False`` keeps all N resident until :meth:`finalize`.
+    #: A planner reads this to size its regions, so a wrong ``True`` is a wrong plan, and a
+    #: wrong ``False`` only costs memory.
+    incremental: bool = False
+
+    @abstractmethod
+    def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
+        raise NotImplementedError()
+
+    def output_channels(self, channels: int, cases: int) -> int:
+        """How many channels folding ``cases`` volumes of ``channels`` leaves. Same by default.
+
+        The one thing about the result's SHAPE that only the operator knows. Nothing else can:
+        ``transform_shape`` maps spatial extents and says nothing about the leading axis, so a
+        planner asked to size the output has no way to tell an averaging operator from a stacking
+        one. Overriding it wrongly costs a plan that probes a shape the run never writes, never a
+        wrong volume -- the write opens on the block it actually holds.
+        """
+        del cases
+        return channels
+
+    def start(self) -> None:
+        """Begin one region. The default buffers, so a non-incremental operator needs nothing."""
+        self._buffer: list[torch.Tensor] = []
+
+    def accumulate(self, tensor: torch.Tensor) -> None:
+        """Fold one case's region in. The default keeps it, which is what ``__call__`` expects."""
+        self._buffer.append(tensor)
+
+    def finalize(self) -> torch.Tensor:
+        """The reduced region, and the end of this region's state."""
+        result = self(self._buffer)
+        self._buffer = []
+        return result
+
+
+def _averaged_dtype(reference: torch.dtype) -> torch.dtype:
+    """The dtype an average of ``reference`` values belongs in.
+
+    Floating inputs keep their own: an ensemble of float16 predictions must not silently double the
+    bytes its output takes on disk. Integer inputs widen and stay widened, because the mean of 1 and
+    2 is not 1 -- rounding an average back into an integer grid is a wrong number, not a narrower one.
+    """
+    return reference if reference.is_floating_point else torch.float32
+
+
+class Mean(Reduction):
+    """Average the cases element-wise.
+
+    Accumulated in float32 whatever the inputs are, then returned as :func:`_averaged_dtype` says.
+    """
+
+    voxel_local = True
+    incremental = True
+
+    def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
+        if len(tensors) == 1:
+            # Its own mean: skip the clone-and-accumulate, which for a whole-volume multi-class
+            # output is a large no-op allocation.
+            return tensors[0].to(_averaged_dtype(tensors[0].dtype))
+        accumulator = tensors[0].float().clone()
+        for tensor in tensors[1:]:
+            accumulator.add_(tensor.float())
+        return accumulator.div_(len(tensors)).to(_averaged_dtype(tensors[0].dtype))
+
+    def start(self) -> None:
+        self._total: torch.Tensor | None = None
+        self._dtype: torch.dtype = torch.float32
+        self._count = 0
+
+    def accumulate(self, tensor: torch.Tensor) -> None:
+        # A running total, so the inputs are never all resident: peak is one accumulator plus the
+        # case being read, whatever N is. This is the whole point of `incremental`.
+        if self._total is None:
+            self._total, self._dtype = tensor.float().clone(), tensor.dtype
+        else:
+            self._total.add_(tensor.float())
+        self._count += 1
+
+    def finalize(self) -> torch.Tensor:
+        if self._total is None:
+            raise ReductionError("Mean.finalize() with no case accumulated.", "Accumulate at least one case.")
+        result = self._total.div_(self._count).to(_averaged_dtype(self._dtype))
+        self._total, self._count = None, 0
+        return result
+
+
+class Median(Reduction):
+    """The element-wise median across cases.
+
+    ``torch.median`` returns the LOWER of the two middle values for an even count, where a median is
+    their average — over two cases it hands back the element-wise minimum, which is not a median
+    of anything. An even number of cases is ordinary, so this averages the middle pair as
+    ``numpy.median`` does; on an odd count the two agree and nothing changes.
+
+    Not incremental, and cannot be: a median needs every case before it can name the middle one.
+    Its working set is therefore every case at one region, which is what bounds the region size
+    rather than the volume.
+    """
+
+    voxel_local = True
+
+    def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
+        if len(tensors) == 1:
+            return tensors[0].to(_averaged_dtype(tensors[0].dtype))
+        middle = torch.quantile(torch.stack(tensors, dim=0).float(), 0.5, dim=0)
+        return middle.to(_averaged_dtype(tensors[0].dtype))
+
+
+class Concat(Reduction):
+    """Concatenate the cases along the channel dimension."""
+
+    # Cats along the channel axis, orthogonal to the spatial axes -- per-voxel, so region-local.
+    voxel_local = True
+
+    def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
+        return torch.cat(tensors, dim=1)
+
+    def output_channels(self, channels: int, cases: int) -> int:
+        # The one operator that does not keep the channel count: the cases end up side by side.
+        return channels * cases

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -114,6 +114,8 @@ class PatchLocality:
     tuple broadcasts to every axis. ``stat_keys`` are the ``Attribute`` keys a ``GLOBAL_STAT``
     transform reads before running (a subset of ``Min``/``Max``/``Mean``/``Std``). ``stat_channels``
     restricts the statistic to those channels (``Normalize.channels``).
+
+    ``reason`` is how a ``WHOLE_VOLUME`` declaration explains itself.
     """
 
     kind: LocalityKind
@@ -124,6 +126,12 @@ class PatchLocality:
     # that maps no value (TensorCast to a float dtype) may declare True so a later GLOBAL_STAT can
     # still seed from the stored volume.
     preserves_statistics: bool | None = None
+    #: Why this stage needs the whole volume, in the words the plan prints. A stage that is
+    #: INHERENTLY whole-volume (it changes the tensor's rank) leaves this None and the planner says
+    #: so generically. A stage that is whole-volume only because something was left undeclared owes
+    #: the reader that sentence: "it needs the whole volume" reads as a property of the transform
+    #: when it is in fact a property of the configuration, and the reader then has nothing to change.
+    reason: str | None = None
 
     @property
     def statistics_preserving(self) -> bool:
@@ -1505,8 +1513,8 @@ class Warp(Transform):
     dark rim around the moved anatomy and nothing else.
 
     ``max_displacement`` is in the same world units as ``Spacing`` (micrometres for these stores).
-    Left at zero, or with no ``Spacing`` on the case, the stage declares ``WHOLE_VOLUME`` and the
-    dispatcher hands it the volume -- correct, and as expensive as it sounds.
+    Left at zero, or with no ``Spacing`` on the case, the stage declares ``WHOLE_VOLUME`` and says
+    which of the two is missing -- correct, and as expensive as it sounds.
     """
 
     def __init__(
@@ -1542,8 +1550,26 @@ class Warp(Transform):
 
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
         spacing = self._spacing(cache_attribute)
-        if self.max_displacement <= 0.0 or spacing is None:
-            return PatchLocality(LocalityKind.WHOLE_VOLUME)
+        # Both fallbacks say what is missing. A Warp that silently costs the whole volume is the
+        # expensive failure of this stage: the result is right, so nothing looks wrong -- only the
+        # peak memory, which is the one thing the reader was trying to control by streaming.
+        if self.max_displacement <= 0.0:
+            return PatchLocality(
+                LocalityKind.WHOLE_VOLUME,
+                reason=(
+                    "no 'max_displacement' is declared, so how far this warp reaches into its source"
+                    " is unknown and the region it must read is unbounded. Declare it in the case's"
+                    " world units (e.g. max_displacement: 250.0) to stream with a halo"
+                ),
+            )
+        if spacing is None:
+            return PatchLocality(
+                LocalityKind.WHOLE_VOLUME,
+                reason=(
+                    "the case carries no 'Spacing', so a 'max_displacement' in world units cannot be"
+                    " turned into a halo in voxels"
+                ),
+            )
         halo = tuple(int(np.ceil(self.max_displacement / extent)) if extent > 0 else 0 for extent in spacing)
         return PatchLocality(LocalityKind.HALO, halo=halo)
 

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -50,10 +50,10 @@ from konfai.data.patching import (
     SlabAligner,
     SlabRegionStream,
     StreamingAccumulator,
-    _halo_pull,
     _halo_radii,
-    _remap_pull,
-    _scale_pull,
+    _HaloPull,
+    _RemapPull,
+    _ScalePull,
     blend_overlap,
 )
 from konfai.data.transform import (
@@ -1009,7 +1009,7 @@ class OutSameAsGroupDataset(OutputDataset):
                 kinds.append(locality.kind)
                 snapshot = Attribute(walking)
                 if locality.kind is LocalityKind.HALO:
-                    pull_fns.append(_halo_pull(_halo_radii(locality.halo, len(shape)), shape))
+                    pull_fns.append(_HaloPull(_halo_radii(locality.halo, len(shape)), shape))
                     shapes.append(list(shape))
                     probe = stage(name, probe, walking)
                 elif locality.kind is LocalityKind.RESCALE:
@@ -1024,7 +1024,7 @@ class OutSameAsGroupDataset(OutputDataset):
                         return None
                     resample = cast(Resample, stage.transform)
                     if stage.inverted:
-                        pull_fns.append(_remap_pull(resample.stream_region_target, shape, snapshot))
+                        pull_fns.append(_RemapPull(resample.stream_region_target, shape, snapshot))
                         out = resample._inverse_geometry(walking)
                     else:
                         out = [
@@ -1034,16 +1034,16 @@ class OutSameAsGroupDataset(OutputDataset):
                             )
                         ]
                         scales = [shape[k] / out[k] for k in range(len(shape))]
-                        pull_fns.append(_scale_pull(scales, shape))
+                        pull_fns.append(_ScalePull(scales, shape))
                         resample.write_stream_cache_attribute(walking, shape)
                     shapes.append([int(extent) for extent in out])
                 elif locality.kind in _REGION_KINDS:
                     if stage.inverted:
                         remapper = cast(TransformInverse, stage.transform)
-                        pull_fns.append(_remap_pull(remapper.stream_region_target, shape, snapshot))
+                        pull_fns.append(_RemapPull(remapper.stream_region_target, shape, snapshot))
                         out = remapper.inverse_transform_shape(list(shape), Attribute(walking))
                     else:
-                        pull_fns.append(_remap_pull(stage.transform.stream_region_source, shape, snapshot))
+                        pull_fns.append(_RemapPull(stage.transform.stream_region_source, shape, snapshot))
                         out = stage.transform.transform_shape(self.group_src, name, list(shape), Attribute(walking))
                     shapes.append([int(extent) for extent in out])
                     # The stage's attribute transition, on a one-voxel corner: a crop's tensor answer

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -56,6 +56,11 @@ from konfai.data.patching import (
     _ScalePull,
     blend_overlap,
 )
+
+# Re-exported: the operators moved to konfai.data.reduction, where the transform workflow can
+# reach them without importing the predictor. Existing configs name them by the classpath
+# `konfai.predictor.Median`, so the names must stay resolvable here.
+from konfai.data.reduction import Concat, Mean, Median, Reduction
 from konfai.data.transform import (
     LocalityKind,
     PatchLocality,
@@ -82,73 +87,6 @@ from konfai.utils.runtime import (
 )
 from konfai.utils.utils import concretize_patch_size, env_flag, get_module, size_free_axes, split_path_spec
 from konfai.utils.vram import next_patch_candidate, usable_vram
-
-
-class Reduction(ABC):
-    """Aggregate a list of predictions (one per model in an ensemble, or per TTA augmentation) into one.
-
-    A ``Reduction`` is a KonfAI extension point: subclass it and reference it by classpath in the
-    ``OutputDataset`` config. ``__call__`` receives the stacked predictions and returns the aggregate.
-    """
-
-    #: Streamed-write contract. ``True`` declares this reduction a **pure per-voxel** operation over the
-    #: model/TTA (stack) axis — every output voxel depends only on the SAME voxel of each input, never on
-    #: a spatial neighbour. The streamed-write gate reads this flag to decide whether the finalize chain
-    #: may run slab by slab.
-    #:
-    #: Rules for a custom reduction:
-    #: - **Default False.** Leave it False unless you are sure: an unknown reduction then takes the
-    #:   whole-volume path, costing the streaming optimisation but never correctness.
-    #: - **Set True only if voxel-local.** Reducing/stacking along the stack axis (dim 0) or the channel
-    #:   axis (dim 1) is fine — those are orthogonal to the spatial slab axis. Anything that reads across
-    #:   spatial positions (a spatial blur, a resample, a global-argmax over Z) must stay False.
-    #: - **A wrong True corrupts the streamed output** (each slab would be reduced with only its own data);
-    #:   the gate trusts this flag and checks nothing else.
-    voxel_local: bool = False
-
-    @abstractmethod
-    def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
-        raise NotImplementedError()
-
-
-class Mean(Reduction):
-    """Average ensemble or augmentation predictions element-wise."""
-
-    voxel_local = True
-
-    def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
-        # A single element (no TTA / a lone model) is its own mean; skip the float32 clone + accumulate,
-        # which for a whole-volume multi-class output is a large no-op allocation (fp16->fp32 round-trips
-        # to the same values). Returns the same values as the general path.
-        if len(tensors) == 1:
-            return tensors[0]
-        acc = tensors[0].float().clone()
-        for t in tensors[1:]:
-            acc.add_(t.float())
-        acc.div_(len(tensors))
-        return acc.to(dtype=tensors[0].dtype)
-
-
-class Median(Reduction):
-    """Compute the element-wise median across prediction tensors."""
-
-    voxel_local = True
-
-    def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
-        # A single element is its own median; skip the float32 stack (a large no-op for whole volumes).
-        if len(tensors) == 1:
-            return tensors[0]
-        return torch.median(torch.stack(tensors, dim=0).float(), dim=0).values.to(tensors[0].dtype)
-
-
-class Concat(Reduction):
-    """Concatenate prediction tensors along the channel dimension."""
-
-    # Cats along the channel axis, orthogonal to the spatial slab axis -- per-voxel, so slab-local.
-    voxel_local = True
-
-    def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
-        return torch.cat(tensors, dim=1)
 
 
 class _AsyncWriter:

--- a/konfai/utils/errors.py
+++ b/konfai/utils/errors.py
@@ -84,6 +84,10 @@ class TransformError(NamedKonfAIError):
     TYPE = "Transform"
 
 
+class ReductionError(NamedKonfAIError):
+    TYPE = "Reduction"
+
+
 class AppRepositoryError(NamedKonfAIError):
     TYPE = "App repository"
 

--- a/tests/unit/test_memory_budget.py
+++ b/tests/unit/test_memory_budget.py
@@ -228,6 +228,24 @@ def test_budget_is_per_rank_so_world_size_flips_the_decision() -> None:
     assert sharded.use_cache is True
 
 
+def test_an_auto_budget_is_split_across_one_node_not_the_whole_cluster(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Four nodes of four GPUs each: a rank shares its RAM with three others, not fifteen.
+
+    Dividing the node by the global world size makes every rank believe it has a sixteenth of one
+    node, and the chooser then declines a cache that fits four times over.
+    """
+    # A node that offers half the dataset: a rank's sixteenth fits its quarter of that four times
+    # over, while a sixteenth of it would be half of what the rank has to hold.
+    node = _DATASET_BYTES / (2 * _AUTO_MEMORY_SAFETY_FRACTION)
+    monkeypatch.setattr(data_manager, "available_memory_bytes", lambda: (node, "host"))
+    monkeypatch.setenv("KONFAI_LOCAL_RANKS", "4")
+
+    data = _make_train(None)
+    data._resolve_cache_regime(world_size=16)
+
+    assert data.use_cache is True
+
+
 # --------------------------------------------------------------------------------------
 # The evaluation auto-patch -- an AUTO budget is a NODE budget, split across the local ranks
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
Base : #77. Cinq changements de la couche données, livrés avant le workflow qui les utilise pour que chacun se relise seul.

**`MemoryBudget`** — un budget résolu porte désormais sa portée. Un budget `auto` mesure le nœud, donc les rangs le divisent ; un budget explicite est la valeur par rang telle quelle. La règle vivait recopiée sur trois sites.

**Un groupe lie sa chaîne une seule fois.** `Data.prepare` lie chaque groupe, et un workflow qui inspecte ses chaînes avant de lui passer la main les lie d'abord : le second appel reconstruisait chaque étage et jetait le premier lot. Un `__init__` d'étage est du code utilisateur.

**Les cartes de tirage d'un plan de lecture sont picklables.** Un plan est calculé sur le lanceur puis `mp.spawn` pickle l'objet workflow entier ; des closures locales ne traversent pas. Un `_ReadStagePlan` est de la donnée, et se décrit comme tel.
> Interagit avec #76 : une fois qu'un rang unique tourne en place, cela ne concerne plus que `--cpu 2+`.

**Une déclaration `WHOLE_VOLUME` peut dire pourquoi.** `PatchLocality` porte une `reason` que le planificateur imprime. Pour `Warp` sans `max_displacement`, le coût du volume entier vient de la configuration, pas de l'étage : le résultat est correct, seul le pic mémoire trahit.

**Les opérateurs de réduction quittent le predictor** pour `konfai.data.reduction`, ré-exportés pour que `konfai.predictor.Median` continue de résoudre. Deux comportements corrigés au passage : `Median` moyenne la paire centrale sur un compte pair (`torch.median` rend la plus basse, soit le minimum élément par élément sur deux entrées), et la règle de dtype est énoncée une fois — flottant en entrée, même dtype en sortie ; entier en entrée, élargi et laissé élargi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable reduction operations for streamed data, including mean, median, and channel concatenation.
  * Added memory-budget details for total and per-rank processing.
  * Added clearer reduction-specific error reporting.

* **Improvements**
  * Improved automatic memory sizing for distributed processing.
  * Enhanced whole-volume processing messages with explanatory details.
  * Improved reliability and compatibility for streamed patch processing.
  * Made repeated preparation safely idempotent.
  * Expanded example segmentation configuration for data loading and augmentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->