### PR TITLE
feat(transform): a fifth workflow that reads a dataset, applies a chain, and writes it

### DIFF
--- a/konfai-mcp/konfai_mcp/capabilities.py
+++ b/konfai-mcp/konfai_mcp/capabilities.py
@@ -56,6 +56,7 @@ def describe_konfai_capabilities() -> dict[str, Any]:
             "train": "Config.yml (Trainer:) -> run_train",
             "prediction": "Prediction.yml (Predictor:) -> run_prediction",
             "evaluation": "Evaluation.yml (Evaluator:) -> run_evaluation",
+            "transform": "Transform.yml (Transformer:) -> run_transform (no model: reads, transforms, writes)",
             "schema_tool": "describe_config_schema(workflow)",
         },
         "components": {

--- a/konfai-mcp/konfai_mcp/experiment_state.py
+++ b/konfai-mcp/konfai_mcp/experiment_state.py
@@ -244,6 +244,8 @@ _JOB_KIND_STAGE: dict[str, str] = {
     "evaluate": "evaluation",
     "pipeline": "evaluation",
     "uncertainty": "completed",
+    # A transformed dataset is an input for the next run, not a result to review.
+    "transform": "action_selection",
 }
 
 # What a finished job of each kind must have left in the workspace. A session workflow writes there by

--- a/konfai-mcp/konfai_mcp/guide.py
+++ b/konfai-mcp/konfai_mcp/guide.py
@@ -502,6 +502,26 @@ TOOL_DESCRIPTIONS: dict[str, str] = {
         "Outputs: job payload with resources and next_actions; or, when a prerequisite is missing (dataset path, checkpoint), a blocker payload {ok, blocked, error, missing_paths, next_actions} with no job_id/status. "
         "Next: wait_for_job."
     ),
+    "plan_transform": (
+        "Use BEFORE run_transform, always: it is the dry run, and it writes no data. "
+        "This plans every (case, chain) from the session Transform.yml. The plan is a measurement, not an "
+        "estimate -- it opens and removes a real region-write on each destination -- so its verdict is the one "
+        "the run will act on: STREAM (bounded memory), WHOLE-VOLUME (the case is assembled whole, with the stage "
+        "that refused it named), SKIP (already written), REDUCE, REFUSED. "
+        "Outputs: {ok, report, verdict_counts, budget, needs_attention[], over_budget[]}. A non-empty over_budget "
+        "means run_transform would refuse before writing anything. "
+        "Next: fix what needs_attention names, or run_transform."
+    ),
+    "run_transform": (
+        "Use to apply a transform chain to a dataset with NO model: read, transform, write. "
+        "Read plan_transform first -- this writes a dataset, and the plan is what says how much and how. "
+        "This launches a transform job from the session Transform.yml and returns structured job resources. "
+        "The run replans, stores the plan, and refuses outright when a case can neither stream nor fit "
+        "memory_budget. A case whose output already exists is skipped, so an interrupted run resumes; pass "
+        "overwrite to recompute. "
+        "Outputs: job payload with resources and next_actions; or a blocker payload when a prerequisite is missing. "
+        "Next: wait_for_job then inspect_dataset on what it wrote."
+    ),
     "run_evaluation": (
         "Use after evaluation config review/validation and when required artifacts exist. "
         "This launches an evaluation job and returns structured job resources. "

--- a/konfai-mcp/konfai_mcp/runner.py
+++ b/konfai-mcp/konfai_mcp/runner.py
@@ -156,6 +156,31 @@ def run_api_in_subprocess(target: str, kwargs: dict[str, Any], timeout_s: float 
     return result["payload"]
 
 
+@contextmanager
+def preserved_config(config_path: Path):
+    """Keep the authored config bytes across a child that builds a workflow from them.
+
+    Building materializes every default into the file, and the child puts it back in its own
+    ``finally`` -- which a timeout kill (SIGTERM) never reaches. Only the parent is guaranteed to
+    outlive the child, so the snapshot belongs on this side of the spawn.
+    """
+    backup = config_path.read_text(encoding="utf-8") if config_path.is_file() else None
+    try:
+        yield
+    finally:
+        if backup is not None and config_path.is_file() and config_path.read_text(encoding="utf-8") != backup:
+            # Written aside then renamed, like the restore in validate_workflow_api: this is the last
+            # guard on the file, so a write that fails part-way must leave the config KonfAI rewrote
+            # rather than a fragment of the authored one.
+            staging = config_path.with_name(f".{config_path.name}.{uuid4().hex}.tmp")
+            try:
+                staging.write_text(backup, encoding="utf-8")
+                os.replace(staging, config_path)
+            except OSError:
+                staging.unlink(missing_ok=True)
+                raise
+
+
 _OUTPUT_TAIL = 4000  # enough for a traceback and the lines around it, short enough to hand to an agent
 
 
@@ -776,11 +801,16 @@ def validate_workflow_api(
     validate_root: str | None = None,
     collect_model_outputs: bool = False,
 ) -> dict[str, Any]:
-    """Child entrypoint that builds (and optionally sets up / one-steps) a workflow without side effects.
+    """Child entrypoint that builds (and optionally sets up / one-steps) a workflow, and puts back what it touched.
 
     Levels: 'instantiate' builds the workflow object, 'setup' also builds datasets/dataloaders,
     'train_step' additionally runs one forward+backward on one batch. The authored config bytes are
-    snapshotted and restored, and all outputs go to a throwaway validate root.
+    snapshotted and restored, and all outputs go to a throwaway validate root -- with one exception.
+    ``workflow='transform'`` at ``level='setup'`` runs ``Transformer.setup``, whose plan opens and
+    removes a real region-write probe on every destination the config's Write/Save stages name: those
+    are the author's own stores, not the validate root. A directory store gets a probe case created
+    then removed; a single-file store (h5) is created if it was not already there. ``plan_transform``
+    is the tool for a plan.
     """
     resolved_validate_root = (
         Path(validate_root).resolve()

--- a/konfai-mcp/konfai_mcp/runner.py
+++ b/konfai-mcp/konfai_mcp/runner.py
@@ -29,12 +29,13 @@ import warnings
 from contextlib import contextmanager
 from pathlib import Path
 from queue import Empty
-from typing import Any
+from typing import Any, cast
 from uuid import uuid4
 
 from konfai.evaluator import build_evaluate
 from konfai.predictor import build_predict
 from konfai.trainer import build_train
+from konfai.transformer import build_transform
 from konfai.utils.runtime import State, execute_distributed_object
 
 
@@ -243,6 +244,11 @@ def _build_workflow(
             evaluations_file=resolved_config,
             evaluations_dir=Path("./Evaluations").resolve(),
         )
+    if command == "TRANSFORM":
+        return build_transform(
+            transform_file=resolved_config,
+            transforms_dir=Path("./Transforms").resolve(),
+        )
     raise ValueError(f"Unsupported command: {command}")
 
 
@@ -278,7 +284,7 @@ def run_workflow_api(
     cluster_kwargs: dict[str, Any] | None = None,
     cwd: str | None = None,
 ) -> None:
-    """Child entrypoint that runs one KonfAI workflow (TRAIN/RESUME/PREDICTION/EVALUATION) to completion."""
+    """Child entrypoint that runs one KonfAI workflow (TRAIN/RESUME/PREDICTION/EVALUATION/TRANSFORM)."""
     with _runtime_context(cwd=Path(cwd).resolve() if cwd is not None else None):
         _ensure_local_imports()
         if single_process:
@@ -697,6 +703,68 @@ def _run_one_train_step(workflow_object: Any) -> dict[str, Any]:
     return result
 
 
+def plan_transform_api(
+    *,
+    workspace_dir: str,
+    config: str,
+    cpu: int = 1,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Child entrypoint for the TRANSFORM dry-run: plan every case, write nothing.
+
+    The plan is the workflow's own verdict, not a prediction — it opens and removes a real
+    region-write on each destination — so it is the one thing an agent should read before launching
+    a job that writes a dataset. Runs in a spawn child like every other workflow API: the config is
+    rewritten in place by KonfAI's own binder, so its bytes are snapshotted and restored.
+    """
+    from konfai.transformer import Transformer, build_transform
+
+    config_path = Path(config).resolve()
+    config_backup = config_path.read_text(encoding="utf-8") if config_path.is_file() else None
+    workspace = Path(workspace_dir).resolve()
+    with _runtime_context(cwd=workspace, env_updates={"KONFAI_VERBOSE": "False"}):
+        _ensure_local_imports()
+        _purge_workspace_modules(workspace)
+        try:
+            workflow = cast(
+                Transformer,
+                build_transform(
+                    transform_file=config_path,
+                    transforms_dir=(workspace / "Transforms").resolve(),
+                ),
+            )
+            plan = workflow.compute_plan(max(1, int(cpu)), bool(overwrite))
+        finally:
+            if config_backup is not None:
+                config_path.write_text(config_backup, encoding="utf-8")
+    counts: dict[str, int] = {}
+    for entry in plan.entries:
+        counts[entry.verdict] = counts.get(entry.verdict, 0) + 1
+    return {
+        "ok": True,
+        "config_path": str(config_path),
+        "report": plan.report(),
+        "verdict_counts": counts,
+        "budget_bytes": plan.budget_bytes,
+        "budget": plan.budget_desc,
+        "world_size": plan.world_size,
+        # The entries a reader has to act on. STREAM lines are the expected case and would drown them.
+        "needs_attention": [
+            {
+                "case": entry.case,
+                "group_src": entry.group_src,
+                "group_dest": entry.group_dest,
+                "verdict": entry.verdict,
+                "reason": entry.reason,
+                "working_set_bytes": entry.working_set_bytes,
+            }
+            for entry in plan.entries
+            if entry.verdict in ("WHOLE-VOLUME", "REFUSED")
+        ][:50],
+        "over_budget": [entry.case for entry in plan.budget_violations()],
+    }
+
+
 def validate_workflow_api(
     *,
     workflow: str,
@@ -724,7 +792,14 @@ def validate_workflow_api(
     validate_statistics = resolved_validate_root / "Statistics"
     validate_predictions = resolved_validate_root / "Predictions"
     validate_evaluations = resolved_validate_root / "Evaluations"
-    for path in (validate_checkpoints, validate_statistics, validate_predictions, validate_evaluations):
+    validate_transforms = resolved_validate_root / "Transforms"
+    for path in (
+        validate_checkpoints,
+        validate_statistics,
+        validate_predictions,
+        validate_evaluations,
+        validate_transforms,
+    ):
         path.mkdir(parents=True, exist_ok=True)
     env_updates = {
         "KONFAI_VERBOSE": "False",
@@ -767,6 +842,11 @@ def validate_workflow_api(
                 workflow_object = build_evaluate(
                     evaluations_file=Path(config).resolve(),
                     evaluations_dir=validate_evaluations,
+                )
+            elif workflow == "transform":
+                workflow_object = build_transform(
+                    transform_file=Path(config).resolve(),
+                    transforms_dir=validate_transforms,
                 )
             else:
                 raise ValueError(f"Unsupported validation workflow: {workflow}")

--- a/konfai-mcp/konfai_mcp/server.py
+++ b/konfai-mcp/konfai_mcp/server.py
@@ -55,6 +55,7 @@ from .guide import (
     SOLVE_TASK_PROMPT,
     TOOL_DESCRIPTIONS,
 )
+from .runner import preserved_config
 from .runner import run_api_in_subprocess as _run_api_in_subprocess
 from .server_apps import AppService
 from .server_experiments import SessionService
@@ -3091,15 +3092,16 @@ def plan_transform(
     blocked = SESSION.workflow_blocker("transform")
     if blocked is not None:
         return blocked
-    return _run_api_in_subprocess(
-        "konfai_mcp.runner:plan_transform_api",
-        {
-            "workspace_dir": str(SESSION.workspace_dir()),
-            "config": str(config_path),
-            "cpu": max(1, int(cpu or 1)),
-            "overwrite": bool(overwrite),
-        },
-    )
+    with preserved_config(config_path):
+        return _run_api_in_subprocess(
+            "konfai_mcp.runner:plan_transform_api",
+            {
+                "workspace_dir": str(SESSION.workspace_dir()),
+                "config": str(config_path),
+                "cpu": max(1, int(cpu or 1)),
+                "overwrite": bool(overwrite),
+            },
+        )
 
 
 @mcp.tool(description=(TOOL_DESCRIPTIONS["cancel_job"]))

--- a/konfai-mcp/konfai_mcp/server.py
+++ b/konfai-mcp/konfai_mcp/server.py
@@ -87,7 +87,7 @@ from .server_support import (
     workflow_root_name,
     write_config,
 )
-from .workflows import WORKFLOW_SPECS, JobKind, WorkflowKind
+from .workflows import WORKFLOW_SPECS, JobKind, WorkflowKind, workflow_choice_description
 
 mcp = FastMCP("KonfAI")
 
@@ -1192,9 +1192,7 @@ def describe_konfai_capabilities() -> dict[str, Any]:
 def describe_config_schema(
     workflow: Annotated[
         str,
-        Field(
-            description="Workflow whose schema to describe: 'train', 'prediction', or 'evaluation' (aliases like 'trainer'/'predict'/'eval' accepted)."
-        ),
+        Field(description=workflow_choice_description("Workflow whose schema to describe") + " Aliases accepted."),
     ],
     path: Annotated[
         str | None,
@@ -2327,7 +2325,10 @@ _RUN_OUTPUT_ROOTS: dict[str, tuple[str, ...]] = {
     "prediction": ("Predictions",),
     "evaluation": ("Evaluations",),
     "uncertainty": ("Uncertainties",),
-    "all": ("Statistics", "Checkpoints", "Predictions", "Evaluations", "Uncertainties"),
+    # 'Transforms' holds the run log and the plan; the transformed data itself lives wherever each
+    # Write: pointed, which is the user's own tree and never deleted from here.
+    "transform": ("Transforms",),
+    "all": ("Statistics", "Checkpoints", "Predictions", "Evaluations", "Uncertainties", "Transforms"),
 }
 
 
@@ -2335,10 +2336,11 @@ _RUN_OUTPUT_ROOTS: dict[str, tuple[str, ...]] = {
 def delete_run(
     run_name: Annotated[str, Field(description="The run to delete (a train_name, e.g. 'MR2CT_01').")],
     kind: Annotated[
-        Literal["train", "prediction", "evaluation", "uncertainty", "all"],
+        Literal["train", "prediction", "evaluation", "uncertainty", "transform", "all"],
         Field(
             description="Which output to remove: train (Statistics + Checkpoints), prediction, evaluation, uncertainty, "
-            "or 'all' to remove every output of that run name."
+            "transform (its log and plan only -- never the transformed data), or 'all' to remove every "
+            "output of that run name."
         ),
     ],
 ) -> dict[str, Any]:
@@ -2501,15 +2503,11 @@ def summarize_session(
 def write_workflow_config(
     workflow: Annotated[
         WorkflowKind,
-        Field(
-            description="Which config file to write: train -> Config.yml, prediction -> Prediction.yml, evaluation -> Evaluation.yml."
-        ),
+        Field(description=workflow_choice_description("Which config file to write")),
     ],
     content: Annotated[
         str,
-        Field(
-            description="Full YAML content; the top-level root key must match the workflow (Trainer/Predictor/Evaluator)."
-        ),
+        Field(description="Full YAML content; the top-level root key must match the workflow."),
     ],
     overwrite: Annotated[
         bool, Field(description="Replace an existing config (default True); False raises if the file exists.")
@@ -3039,6 +3037,68 @@ def run_evaluation(
         target=job_spec["target"],
         kwargs=job_spec["kwargs"],
         devices=_job_devices(normalized_gpu, cpu),
+    )
+
+
+@mcp.tool(description=(TOOL_DESCRIPTIONS["run_transform"]))
+def run_transform(
+    cpu: Annotated[int | None, Field(description="Shard the cases over N worker processes (default 1).")] = None,
+    overwrite: Annotated[
+        bool, Field(description="Recompute cases whose output already exists (KonfAI --overwrite).")
+    ] = False,
+    quiet: Annotated[bool, Field(description="Quiet console output (KonfAI --quiet).")] = False,
+    single_process: Annotated[bool, Field(description="Inline, one process (no spawn).")] = False,
+) -> dict[str, Any]:
+    """Launch a dataset transform job from the current session `Transform.yml`. No model involved."""
+    config_path = SESSION.config_path("transform")
+    if not config_path.exists():
+        raise ValueError("Transform.yml not found. Write a transform config first.")
+    blocked = SESSION.workflow_blocker("transform")
+    if blocked is not None:
+        return blocked
+    job_spec = _runtime_job_spec(
+        kind="transform",
+        config_path=config_path,
+        # No GPU: the read transforms run on CPU, so reserving devices would misreport the resource.
+        gpu=None,
+        cpu=cpu,
+        overwrite=overwrite,
+        quiet=quiet,
+        single_process=single_process,
+    )
+    return _launch_job(
+        "transform",
+        job_spec["command"],
+        config_path,
+        extra_manifest={"devices": {"gpu": [], "cpu": cpu}},
+        target=job_spec["target"],
+        kwargs=job_spec["kwargs"],
+        devices=_job_devices(None, cpu),
+    )
+
+
+@mcp.tool(description=(TOOL_DESCRIPTIONS["plan_transform"]))
+def plan_transform(
+    cpu: Annotated[int | None, Field(description="Rank count the plan is sized for (default 1).")] = None,
+    overwrite: Annotated[
+        bool, Field(description="Plan as if --overwrite: cases whose output exists are not counted as SKIP.")
+    ] = False,
+) -> dict[str, Any]:
+    """Plan the transform without running it: per-case verdicts, budget, and what needs attention."""
+    config_path = SESSION.config_path("transform")
+    if not config_path.exists():
+        raise ValueError("Transform.yml not found. Write a transform config first.")
+    blocked = SESSION.workflow_blocker("transform")
+    if blocked is not None:
+        return blocked
+    return _run_api_in_subprocess(
+        "konfai_mcp.runner:plan_transform_api",
+        {
+            "workspace_dir": str(SESSION.workspace_dir()),
+            "config": str(config_path),
+            "cpu": max(1, int(cpu or 1)),
+            "overwrite": bool(overwrite),
+        },
     )
 
 

--- a/konfai-mcp/konfai_mcp/server_experiments.py
+++ b/konfai-mcp/konfai_mcp/server_experiments.py
@@ -20,7 +20,7 @@ import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from konfai.utils.utils import split_path_spec
 from ruamel.yaml import YAML
@@ -41,6 +41,7 @@ from .server_support import (
     template_groups,
     workflow_root_name,
 )
+from .workflows import WORKFLOW_SPECS, WorkflowKind
 
 YAML_SAFE = YAML(typ="safe")
 
@@ -93,6 +94,8 @@ class SessionService(DatasetInspectionMixin, MetricsServiceMixin):
         normalized_workflow = self._normalize_workflow(workflow)
         if normalized_workflow == "train":
             return self.workspace_dir() / "Statistics"
+        if normalized_workflow == "transform":
+            return self.workspace_dir() / "Transforms"
         return {
             "prediction": self.workspace_layout.predictions_dir(),
             "evaluation": self.workspace_layout.evaluations_dir(),
@@ -803,7 +806,7 @@ class SessionService(DatasetInspectionMixin, MetricsServiceMixin):
             "next_checks": next_checks,
         }
 
-    def review_config_semantics(self, workflow: Literal["train", "prediction", "evaluation"]) -> dict[str, Any]:
+    def review_config_semantics(self, workflow: WorkflowKind) -> dict[str, Any]:
         normalized_workflow = self._normalize_workflow(workflow)
         config_path = self.config_path(normalized_workflow)
         if not config_path.exists():
@@ -920,26 +923,22 @@ class SessionService(DatasetInspectionMixin, MetricsServiceMixin):
             path = (self.workspace_dir() / path).resolve()
         return path
 
-    def configured_run_name(self, kind: Literal["train", "prediction", "evaluation"], config_path: Path) -> str | None:
+    def configured_run_name(self, kind: WorkflowKind, config_path: Path) -> str | None:
         if not config_path.exists():
             return None
         data = YAML_SAFE.load(config_path.read_text(encoding="utf-8"))
         if not isinstance(data, dict):
             return None
-        root_key = {
-            "train": "Trainer",
-            "prediction": "Predictor",
-            "evaluation": "Evaluator",
-        }[kind]
-        root = data.get(root_key)
+        root = data.get(WORKFLOW_SPECS[kind].root_key)
         if not isinstance(root, dict):
             return None
-        value = root.get("train_name")
+        # A model-less workflow names its run 'name': there is no training to name it after.
+        value = root.get("train_name", root.get("name"))
         return value if isinstance(value, str) and value not in {"", "None"} else None
 
     def runtime_log_path_for(
         self,
-        kind: Literal["train", "prediction", "evaluation"],
+        kind: WorkflowKind,
         config_path: Path,
     ) -> Path | None:
         run_name = self.configured_run_name(kind, config_path)
@@ -1023,11 +1022,9 @@ class SessionService(DatasetInspectionMixin, MetricsServiceMixin):
         if job.runtime_log_path is not None:
             return job.runtime_log_path
         kind = job.kind
-        # Spelled with != rather than `not in` so every mypy narrows `kind` to the three workflow literals
-        # that configured_run_name accepts (JobKind also carries the app kinds).
-        if kind != "train" and kind != "prediction" and kind != "evaluation":
+        if kind not in WORKFLOW_SPECS:
             return None  # an app job has no session YAML, so there is no configured run to locate
-        run_name = self.configured_run_name(kind, job.config_path)
+        run_name = self.configured_run_name(cast("WorkflowKind", kind), job.config_path)
         if run_name is None:
             return None
         return self._workflow_runtime_root(kind) / run_name / "log_0.txt"

--- a/konfai-mcp/konfai_mcp/server_experiments.py
+++ b/konfai-mcp/konfai_mcp/server_experiments.py
@@ -873,30 +873,24 @@ class SessionService(DatasetInspectionMixin, MetricsServiceMixin):
             blocked["semantic_review"] = semantic_review
             return blocked
 
-        # The child restores the authored config in its own finally, but a timeout kills it with SIGTERM
-        # and that finally never runs. Snapshot in the parent (which outlives the child) and restore
-        # unconditionally, so a slow-model timeout can never leave the agent's config KonfAI-rewritten.
-        config_backup = config_path.read_text(encoding="utf-8") if config_path.is_file() else None
-        try:
-            with tempfile.TemporaryDirectory(prefix=f"konfai_mcp_validate_{normalized_workflow}_") as tmp_dir:
-                # Isolated spawn child: agent-authored code never executes in the server process and
-                # edited workspace modules are always re-imported fresh.
-                payload = mcp_runner.run_api_in_subprocess(
-                    "konfai_mcp.runner:validate_workflow_api",
-                    {
-                        "workflow": normalized_workflow,
-                        "level": level,
-                        "workspace_dir": str(workspace),
-                        "config": str(config_path),
-                        "models": resolved_models or None,
-                        "validate_root": tmp_dir,
-                        "collect_model_outputs": collect_model_outputs,
-                    },
-                )
-        finally:
-            if config_backup is not None and config_path.is_file():
-                if config_path.read_text(encoding="utf-8") != config_backup:
-                    config_path.write_text(config_backup, encoding="utf-8")
+        with (
+            mcp_runner.preserved_config(config_path),
+            tempfile.TemporaryDirectory(prefix=f"konfai_mcp_validate_{normalized_workflow}_") as tmp_dir,
+        ):
+            # Isolated spawn child: agent-authored code never executes in the server process and
+            # edited workspace modules are always re-imported fresh.
+            payload = mcp_runner.run_api_in_subprocess(
+                "konfai_mcp.runner:validate_workflow_api",
+                {
+                    "workflow": normalized_workflow,
+                    "level": level,
+                    "workspace_dir": str(workspace),
+                    "config": str(config_path),
+                    "models": resolved_models or None,
+                    "validate_root": tmp_dir,
+                    "collect_model_outputs": collect_model_outputs,
+                },
+            )
         payload["returncode"] = 0 if payload.get("ok", False) else 1
         payload["semantic_review"] = semantic_review
         return payload

--- a/konfai-mcp/konfai_mcp/server_jobs.py
+++ b/konfai-mcp/konfai_mcp/server_jobs.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from typing import Any, Literal, TextIO, cast
 
 from .experiment_state import job_diagnosis
-from .server_support import WorkspaceLayout
+from .server_support import WORKFLOW_CONFIG_FILES, WorkspaceLayout
 from .workflows import APP_JOB_KINDS, JOB_RETRY_TOOLS, WORKFLOW_DONE_NEXT, JobKind
 
 
@@ -385,7 +385,7 @@ class JobRegistry:
         configs_dir = self.workspace_layout.job_configs_dir(job.job_id)
         configs_dir.mkdir(parents=True, exist_ok=True)
         copied: dict[str, str] = {}
-        for filename in ("Config.yml", "Prediction.yml", "Evaluation.yml"):
+        for filename in WORKFLOW_CONFIG_FILES.values():
             source = job.cwd / filename
             if not source.exists():
                 continue

--- a/konfai-mcp/konfai_mcp/workflows.py
+++ b/konfai-mcp/konfai_mcp/workflows.py
@@ -73,6 +73,16 @@ WORKFLOW_SPECS: dict[str, WorkflowSpec] = {
             "run_evaluation",
             ("eval", "evaluate", "evaluator"),
         ),
+        WorkflowSpec(
+            "transform",
+            "Transform.yml",
+            "Transformer",
+            "konfai.transformer",
+            "Transformer",
+            "TRANSFORM",
+            "run_transform",
+            ("transformer", "process"),
+        ),
     )
 }
 
@@ -98,8 +108,25 @@ WORKFLOW_DONE_NEXT: dict[str, list[str]] = {
     "train": ["run_prediction", "read_training_curves", "summarize_session"],
     "prediction": ["run_evaluation", "summarize_session"],
     "evaluation": ["get_run_metrics", "leaderboard", "compare_runs"],
+    # A transformed dataset is an input, not a result: what follows is using it.
+    "transform": ["inspect_dataset", "summarize_session"],
 }
 
+
+def workflow_choice_description(action: str) -> str:
+    """``"<action>: train -> Config.yml (Trainer), ..."`` — a tool's ``workflow`` parameter, from the table.
+
+    Generated, because these descriptions are the only view an agent has of what a parameter accepts:
+    a workflow missing from the prose is a workflow the agent never tries, whatever the type allows.
+    """
+    options = ", ".join(
+        f"{kind} -> {spec.config_file} ({spec.root_key})" for kind, spec in sorted(WORKFLOW_SPECS.items())
+    )
+    return f"{action}: {options}."
+
+
 # Static mirrors of the table for tool signatures; pinned to it by the drift test.
-WorkflowKind = Literal["train", "prediction", "evaluation"]
-JobKind = Literal["train", "prediction", "evaluation", "infer", "finetune", "evaluate", "uncertainty", "pipeline"]
+WorkflowKind = Literal["train", "prediction", "evaluation", "transform"]
+JobKind = Literal[
+    "train", "prediction", "evaluation", "transform", "infer", "finetune", "evaluate", "uncertainty", "pipeline"
+]

--- a/konfai-mcp/tests/test_mcp_server_tool_index.py
+++ b/konfai-mcp/tests/test_mcp_server_tool_index.py
@@ -53,7 +53,17 @@ def test_job_payload_next_actions_are_registered_tools(
     from konfai_mcp.server_jobs import Job, JobRegistry
 
     registry = JobRegistry({"queued", "running"})
-    for kind in ("train", "prediction", "evaluation", "infer", "finetune", "evaluate", "uncertainty", "pipeline"):
+    for kind in (
+        "train",
+        "prediction",
+        "evaluation",
+        "transform",
+        "infer",
+        "finetune",
+        "evaluate",
+        "uncertainty",
+        "pipeline",
+    ):
         for status in ("running", "done", "error", "killed"):
             job = Job(
                 job_id=f"{kind}-{status}",

--- a/konfai-mcp/tests/test_runner.py
+++ b/konfai-mcp/tests/test_runner.py
@@ -15,12 +15,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """konfai_mcp/runner.py contracts: bounded final join on a wedged spawn child, config-restore
-failures surfaced in the payload, and a non-differentiable loss propagating into the smoke-test
-ok flag."""
+failures surfaced in the payload, the parent-side config guard around a child that may be killed,
+and a non-differentiable loss propagating into the smoke-test ok flag."""
 
 import sys
 import time
+from collections.abc import Callable
 from pathlib import Path
+from types import ModuleType
 from typing import Any
 
 import pytest
@@ -72,6 +74,72 @@ def test_validate_config_restore_failure_is_surfaced(tmp_path: Path, monkeypatch
 
     assert payload["ok"] is True  # the build itself succeeded
     assert payload["config_restore_failed"] == "read-only filesystem"  # the leak is recorded, not hidden
+
+
+def test_preserved_config_puts_back_what_a_child_that_never_returned_rewrote(tmp_path: Path) -> None:
+    """The child restores the config in its own ``finally``, which a timeout kill never reaches.
+
+    Only the parent is guaranteed to outlive the child, so its snapshot is the one that has to hold --
+    including when the call leaves by an exception rather than a return.
+    """
+    config_path = tmp_path / "Transform.yml"
+    authored = "Transformer:\n  name: TEST\n"
+    config_path.write_text(authored, encoding="utf-8")
+
+    with pytest.raises(RuntimeError), runner.preserved_config(config_path):
+        config_path.write_text(f"{authored}  manual_seed: 0\n  Dataset:\n    subset: None\n", encoding="utf-8")
+        raise RuntimeError("Isolated subprocess failed.")
+
+    assert config_path.read_text(encoding="utf-8") == authored
+
+
+def test_a_restore_that_fails_part_way_leaves_a_whole_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Nothing backs this guard up, so a half-written restore is the file the agent is left with.
+
+    The KonfAI-rewritten config is verbose but valid; a fragment of the authored one is neither, and
+    the authored bytes are already off disk by the time the restore starts.
+    """
+    config_path = tmp_path / "Transform.yml"
+    authored = "Transformer:\n  name: TEST\n" + "  # a line the author wrote\n" * 40
+    config_path.write_text(authored, encoding="utf-8")
+    rewritten = "Transformer:\n  name: TEST\n  manual_seed: 0\n"
+
+    def truncate_then_fail(self: Path, *_args: Any, **_kwargs: Any) -> int:
+        # What a real write does when the device fills: the file is opened truncated, then fails.
+        self.write_bytes(b"Transfor")
+        raise OSError("no space left on device")
+
+    with pytest.raises(OSError), runner.preserved_config(config_path):
+        config_path.write_text(rewritten, encoding="utf-8")
+        monkeypatch.setattr(Path, "write_text", truncate_then_fail)
+
+    monkeypatch.undo()
+    assert config_path.read_text(encoding="utf-8") == rewritten
+    assert [entry.name for entry in tmp_path.iterdir()] == ["Transform.yml"]
+
+
+def test_plan_transform_is_covered_by_that_guard(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, load_mcp_server: Callable[[], ModuleType]
+) -> None:
+    """The tool builds a Transformer from the agent's own config, so it needs the guard the validate
+    path already had -- otherwise a plan slower than the timeout returns the config KonfAI-rewritten."""
+    monkeypatch.setenv("KONFAI_MCP_WORKSPACES_ROOT", str(tmp_path / "workspaces"))
+    server = load_mcp_server()
+    config_path = Path(server.SESSION.config_path("transform"))
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    authored = "Transformer:\n  name: TEST\n"
+    config_path.write_text(authored, encoding="utf-8")
+
+    def killed_child(*_args: Any, **_kwargs: Any) -> None:
+        config_path.write_text(f"{authored}  manual_seed: 0\n", encoding="utf-8")
+        raise RuntimeError("Isolated subprocess failed.")
+
+    monkeypatch.setattr(server, "_run_api_in_subprocess", killed_child)
+
+    with pytest.raises(RuntimeError):
+        server.plan_transform(cpu=1)
+
+    assert config_path.read_text(encoding="utf-8") == authored
 
 
 def test_smoke_test_non_differentiable_loss_is_not_ok(tmp_path: Path) -> None:

--- a/konfai/__init__.py
+++ b/konfai/__init__.py
@@ -61,6 +61,11 @@ def statistics_directory() -> Path:
     return Path(_get_env("KONFAI_STATISTICS_DIRECTORY"))
 
 
+def transforms_directory() -> Path:
+    """Return the configured transform output directory."""
+    return Path(_get_env("KONFAI_TRANSFORMS_DIRECTORY"))
+
+
 def config_file() -> Path:
     """Return the active configuration file used by the current workflow."""
     return Path(_get_env("KONFAI_config_file"))

--- a/konfai/data/__init__.py
+++ b/konfai/data/__init__.py
@@ -14,4 +14,75 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Data loading, patching, transform, and augmentation utilities for KonfAI."""
+"""Data loading, patching, transform, and augmentation utilities for KonfAI.
+
+This is the surface for driving KonfAI's data machinery from plain Python — no YAML, no environment
+variables, no workflow. A chain of transforms applied to a dataset, out-of-core, is::
+
+    from konfai.data import Dataset, DatasetManager, Clip, Write
+
+    manager = DatasetManager(
+        index=0, group_src="CT", group_dest="CT", name="CASE_000",
+        dataset=Dataset("./Raw/", "mha"), patch=None,
+        transforms=[Clip(0.0, 400.0), Write("./Out:omezarr")],
+        data_augmentations_list=[],
+    )
+    streamed = manager.materialize()      # True when it never held the volume
+    print(manager.stream_refusal())       # why not, naming the stage, when it is False
+
+``patch=None`` on purpose: out-of-core is not the same thing as patched, and a whole-volume slab
+sweep is both simpler and faster than a tiling at these sizes. Passing ``DatasetPatch()`` instead
+would silently impose a 128³ tiling nobody asked for.
+
+Writing a transform that streams needs :class:`LocalityKind` and :class:`PatchLocality`: a transform
+that declares neither is correct but loads whole volumes, so they are exported here rather than
+buried in the module that happens to define them.
+"""
+
+from konfai.data.data_manager import DataMetric, DataPrediction, DatasetIter, DataTrain, DataTransform
+from konfai.data.patching import DatasetManager, DatasetPatch
+from konfai.data.transform import (
+    Expand,
+    LocalityKind,
+    PatchLocality,
+    Reduce,
+    Save,
+    Transform,
+    TransformInverse,
+    Write,
+)
+from konfai.utils.dataset import Attribute, Dataset
+from konfai.utils.ome_zarr import (
+    append_ome_zarr_levels,
+    create_ome_zarr_store,
+    get_ome_zarr_info,
+    is_displacement_field,
+    read_ome_zarr_data_slice,
+    write_ome_zarr,
+)
+
+__all__ = [
+    "Attribute",
+    "DataMetric",
+    "DataPrediction",
+    "DataTrain",
+    "DataTransform",
+    "Dataset",
+    "DatasetIter",
+    "DatasetManager",
+    "DatasetPatch",
+    "Expand",
+    "LocalityKind",
+    "PatchLocality",
+    "Reduce",
+    "Save",
+    "Transform",
+    "TransformInverse",
+    "Write",
+    "append_ome_zarr_levels",
+    "create_ome_zarr_store",
+    "get_ome_zarr_info",
+    "is_displacement_field",
+    "read_ome_zarr_data_slice",
+    "write_ome_zarr",
+]

--- a/konfai/data/case_reduction.py
+++ b/konfai/data/case_reduction.py
@@ -1,0 +1,475 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reducing a group's cases into one entry, one region at a time.
+
+A :class:`~konfai.data.patching.DatasetManager` IS one case: its name is the name it reads, the name
+it writes, and the name every stage is handed. A reduction has no case name, so it is not a manager
+-- it is a consumer of them, which is why it lives here and not in the patching module.
+
+The loop is the per-case loop turned inside out. Instead of walking cases and, within a case, its
+regions, it walks the OUTPUT's regions and, within a region, the cases: each reads that region
+through its own chain (:meth:`~konfai.data.patching.DatasetManager.read_region`) and the operator
+folds them. Peak memory is N regions, never N volumes -- and two regions, whatever N, once the
+operator can accumulate.
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass, field
+
+import numpy as np
+import torch
+
+from konfai.data.patching import DatasetManager
+from konfai.data.reduction import Reduction
+from konfai.data.transform import LocalityKind, Reduce, Transform
+from konfai.utils.config import apply_config
+from konfai.utils.dataset import Attribute, Dataset, DataStream
+from konfai.utils.errors import ReductionError
+from konfai.utils.utils import get_module
+
+#: Geometry keys compared between cases under ``grid: strict``. Direction is in because a flipped
+#: axis shows in neither extent nor spacing: averaging two volumes that disagree on it mirrors half
+#: the cases into the other half, silently, and the result still looks like a volume.
+_GEOMETRY_KEYS = ("Spacing", "Origin", "Direction")
+
+#: What a stage placed AFTER the reduction may declare. Voxel-local is exact on a region; a
+#: whole-volume statistic is exact too, because the engine seeds it with a pass of its own.
+_POST_KINDS = frozenset({LocalityKind.POINTWISE, LocalityKind.GLOBAL_STAT})
+
+#: Bytes per sample assumed when sizing regions from headers alone, before a dtype is known.
+_ASSUMED_ITEMSIZE = 4
+
+#: Keys the ``Reduce`` stage reads from its own mapping. An operator sharing one of these names
+#: would silently be handed the stage's value, so the collision is refused instead.
+_REDUCE_OWN_KEYS = frozenset({"operator", "output", "grid", "grid_tolerance", "provenance"})
+
+
+@dataclass(frozen=True)
+class ReductionPlan:
+    """What the engine will do, before it does any of it."""
+
+    output: str
+    cases: list[str]
+    spatial: list[int]
+    channels: int
+    slab_rows: int
+    incremental: bool
+    stat_pass: bool
+    refusal: str | None = None
+
+    @property
+    def streams(self) -> bool:
+        return self.refusal is None
+
+    @property
+    def resident_regions(self) -> int:
+        """Regions held at the peak: two for a running accumulator, else one per case plus the
+        output's own. This is what the budget multiplies, and why ``slab_rows`` is derived."""
+        return 2 if self.incremental else len(self.cases) + 1
+
+    @property
+    def region_bytes(self) -> int:
+        return int(self.slab_rows * np.prod(self.spatial[1:], dtype=np.int64) * self.channels * _ASSUMED_ITEMSIZE)
+
+    @property
+    def peak_bytes(self) -> int:
+        # A statistics pass is a second traversal, not a second working set: it holds exactly what
+        # one region holds, so the peak is the same whether there are one or two passes.
+        return self.resident_regions * self.region_bytes
+
+    def describe(self) -> str:
+        verdict = "STREAM" if self.streams else "REFUSED"
+        lines = [f"REDUCE {len(self.cases)} case(s) -> 1 output '{self.output}' -- {verdict}"]
+        if not self.streams:
+            lines.append(f"    refused: {self.refusal}")
+            return "\n".join(lines)
+        regime = "incremental accumulator" if self.incremental else "every case resident per region"
+        lines.append(
+            f"    {self.resident_regions} resident region(s) of {self.slab_rows} row(s)"
+            f" = {self.peak_bytes / (1 << 30):.2f} GiB  ({regime})"
+        )
+        if self.stat_pass:
+            lines.append("    two passes: the first seeds the whole-volume statistics the chain asks of the RESULT")
+        lines.append(f"    cases: {', '.join(self.cases)}")
+        return "\n".join(lines)
+
+
+@dataclass
+class _RunningStatistics:
+    """Min/Max/Mean/Std accumulated over regions, so the volume is never resident.
+
+    Mean and variance come from Welford's recurrence rather than from sums of squares: the naive
+    ``E[x^2] - E[x]^2`` cancels catastrophically once the mean is large next to the spread, and a
+    volume of intensities in the thousands with a spread of ones is exactly that case -- it can
+    return a negative variance.
+    """
+
+    minimum: float = float("inf")
+    maximum: float = float("-inf")
+    mean: float = 0.0
+    _sum_square_deviation: float = 0.0
+    count: int = 0
+
+    def update(self, block: torch.Tensor) -> None:
+        values = block.detach().double()
+        size = values.numel()
+        if size == 0:
+            return
+        self.minimum = min(self.minimum, float(values.min()))
+        self.maximum = max(self.maximum, float(values.max()))
+        batch_mean = float(values.mean())
+        batch_deviation = float(((values - batch_mean) ** 2).sum())
+        delta = batch_mean - self.mean
+        total = self.count + size
+        self._sum_square_deviation += batch_deviation + delta * delta * self.count * size / total
+        self.mean += delta * size / total
+        self.count = total
+
+    def write_into(self, attribute: Attribute) -> None:
+        """Seed the attribute the way the rest of KonfAI already spells these keys: Min/Max bare
+        scalars, Mean/Std one-element arrays. A second convention reads back as a string and fails
+        inside whichever transform consumed it."""
+        if self.count == 0:
+            raise ReductionError("Statistics were requested over an empty volume.", "Check the output extent.")
+        attribute["Min"] = np.float32(self.minimum)
+        attribute["Max"] = np.float32(self.maximum)
+        attribute["Mean"] = np.asarray([self.mean], dtype=np.float32)
+        attribute["Std"] = np.asarray([(self._sum_square_deviation / self.count) ** 0.5], dtype=np.float32)
+
+
+def split_chain(transforms: list[Transform]) -> tuple[list[Transform], Reduce | None, list[Transform]]:
+    """A chain around its ``Reduce``: what runs per case, the stage itself, what runs on the result."""
+    for index, transform in enumerate(transforms):
+        if isinstance(transform, Reduce):
+            return list(transforms[:index]), transform, list(transforms[index + 1 :])
+    return list(transforms), None, []
+
+
+def resolve_operator(reduce: Reduce) -> Reduction:
+    """The operator the stage names, as an instance, refusing one that cannot fold a region.
+
+    Configured like every other extension point: its constructor arguments are bound from the same
+    mapping the ``Reduce`` itself was read from, so a custom operator takes parameters exactly as a
+    custom transform or a custom draw does::
+
+        Reduce:
+          operator: mypkg:TrimmedMean
+          output: template
+          trim: 0.2            # the operator's own parameter
+
+    A chain assembled in Python has no configuration to read, and the operator is then built from
+    its own defaults.
+    """
+    module, name = get_module(reduce.operator_classpath, "konfai.data.reduction")
+    factory = getattr(module, name)
+    shadowed = sorted(set(inspect.signature(factory.__init__).parameters) & _REDUCE_OWN_KEYS)
+    if shadowed:
+        raise ReductionError(
+            f"'{reduce.operator_classpath}' has parameter(s) {shadowed}, which the Reduce stage"
+            " reads for itself from the same mapping.",
+            f"Rename them: {sorted(_REDUCE_OWN_KEYS)} belong to Reduce, everything else in the"
+            " mapping is the operator's.",
+        )
+    try:
+        operator = apply_config(reduce.konfai_args)(factory)()
+    except TypeError as error:
+        raise ReductionError(
+            f"'{reduce.operator_classpath}' could not be built: {error}.",
+            "Give its parameters under the Reduce stage, next to 'operator' and 'output', or give them defaults.",
+        ) from error
+    if not isinstance(operator, Reduction):
+        raise ReductionError(
+            f"'{reduce.operator_classpath}' is not a Reduction.",
+            "Subclass konfai.data.reduction.Reduction, or use Mean / Median / Concat.",
+        )
+    if not operator.voxel_local:
+        raise ReductionError(
+            f"'{reduce.operator_classpath}' does not declare itself voxel-local, so it cannot be"
+            " folded one region at a time.",
+            "Set voxel_local = True when every output voxel depends only on the same voxel of each"
+            " case; an operator reading across space cannot stream.",
+        )
+    return operator
+
+
+def check_post_stages(post: list[Transform], output: str) -> None:
+    """What may follow a ``Reduce`` in the same chain.
+
+    Each stage after the reduction is handed ONE REGION of the result. A stage reading across space
+    -- a halo, a resample, a reorientation -- would take that region for the whole volume and seam
+    at every boundary: a plausible result, and a wrong one. Those are deferred, not forbidden:
+    end the chain, and read the written volume back in a second chain where the ordinary planner can
+    pull regions through it. That is the boundary that already lets a statistic follow a
+    value-changing stage.
+    """
+    for index, stage in enumerate(post):
+        kind = stage.patch_locality(Attribute()).kind
+        if kind in _POST_KINDS:
+            continue
+        name = type(stage).__name__
+        raise ReductionError(
+            f"stage {index} '{name}' follows the Reduce into '{output}' and declares {kind.name},"
+            " which reads across space -- applied one region at a time it would seam at every"
+            " region boundary.",
+            f"Only voxel-local stages can follow a reduction. End this chain, and put '{name}' in a"
+            f" second chain that reads '{output}' back.",
+        )
+
+
+@dataclass
+class CaseReduction:
+    """Fold every case of a group into one entry, region by region.
+
+    It uses only the public read side of each case's manager -- the streaming machinery already
+    planned, accepted or refused per case -- and owns the write side itself, under the output name
+    the chain declared.
+    """
+
+    managers: list[DatasetManager]
+    reduce: Reduce
+    post: list[Transform]
+    destination: Dataset
+    group: str
+    slab_rows: int = 64
+    operator: Reduction = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not self.managers:
+            raise ReductionError(
+                f"The chain reducing into '{self.reduce.output}' has no case to fold.",
+                "Check the dataset and its subset: a reduction over nothing has no result.",
+            )
+        self.slab_rows = max(1, int(self.slab_rows))
+        self.operator = resolve_operator(self.reduce)
+        check_post_stages(self.post, self.reduce.output)
+
+    def fit_budget(self, budget_bytes: float | None, cap: int = 64) -> None:
+        """Size the regions so the resident ones fit ``budget_bytes``.
+
+        The default region height is safe for one case and not for N: a reduction holds one region
+        PER CASE, so the constant that bounds a per-case sweep is off by the number of cases here.
+        Half the budget, because the operator's own output and the write buffer live alongside.
+        Below one row nothing fits; the plan then reports a peak above the budget and the workflow
+        refuses, which is the only honest answer -- there is no whole-volume path to fall back to.
+
+        The budget also goes to the cases' own managers, because a chain crossing a ``Save`` sweeps
+        that cache when first read, and ``read_region`` carries no budget of its own.
+        """
+        for manager in self.managers:
+            manager.set_memory_budget(budget_bytes)
+        if not budget_bytes or budget_bytes <= 0:
+            return
+        plan = self.plan()
+        row_bytes = plan.resident_regions * plan.region_bytes / max(1, plan.slab_rows)
+        if row_bytes <= 0:
+            return
+        self.slab_rows = max(1, min(cap, int(budget_bytes * 0.5 / row_bytes)))
+
+    # ---------------------------------------------------------------- planning
+
+    @property
+    def reference(self) -> DatasetManager:
+        """The case whose geometry the output adopts."""
+        if not self.reduce.grid.startswith("reference:"):
+            return self.managers[0]
+        wanted = self.reduce.grid.split(":", 1)[1]
+        for manager in self.managers:
+            if manager.name == wanted:
+                return manager
+        raise ReductionError(
+            f"grid 'reference:{wanted}' names a case that is not being reduced.",
+            f"The cases are: {', '.join(manager.name for manager in self.managers)}.",
+        )
+
+    def check_grid(self) -> str | None:
+        """Whether the cases agree enough to be folded, or why they do not.
+
+        Compared on the grid each case's chain LANDS on — the folded shape and the plan-evolved
+        geometry — not the stored one: the chain exists precisely to bring disagreeing members onto
+        one grid (a ``Resample`` before the ``Reduce``), and comparing what is on disk would refuse
+        the very cohorts the reduction is for. Read from headers and plans alone, so it costs
+        nothing and happens before the first byte. Nothing anywhere can verify that the members
+        truly share a space, only that they claim to.
+
+        Compared against :attr:`reference`, the case whose geometry the output adopts, and only
+        ``strict`` compares geometry at all: naming a reference is how a cohort says its members
+        disagree on their headers and which one to believe, so demanding they agree would refuse
+        every cohort the policy exists for.
+        """
+        reference = self.reference
+        others = [manager for manager in self.managers if manager is not reference]
+        for manager in others:
+            if list(manager.spatial_shape) != list(reference.spatial_shape):
+                return (
+                    f"case '{manager.name}' lands on extent {list(manager.spatial_shape)}"
+                    f" where '{reference.name}' lands on {list(reference.spatial_shape)}"
+                )
+        if self.reduce.grid != "strict":
+            return None
+        expected = reference.landed_attributes()
+        for manager in others:
+            attribute = manager.landed_attributes()
+            for key in _GEOMETRY_KEYS:
+                if key not in expected or key not in attribute:
+                    continue
+                left = np.asarray(expected.get_np_array(key), dtype=np.float64).ravel()
+                right = np.asarray(attribute.get_np_array(key), dtype=np.float64).ravel()
+                if left.shape != right.shape or not np.allclose(left, right, atol=self.reduce.grid_tolerance):
+                    return (
+                        f"case '{manager.name}' lands on {key} {right.tolist()} where '{reference.name}'"
+                        f" lands on {left.tolist()} (grid: strict, tolerance {self.reduce.grid_tolerance})"
+                    )
+        return None
+
+    def _first_refusal(self) -> str | None:
+        """The first reason this reduction cannot stream: a disagreeing grid, or a case that refuses."""
+        refusal = self.check_grid()
+        if refusal is not None:
+            return refusal
+        for manager in self.managers:
+            case_refusal = manager.stream_refusal(0, apply_augmentations=False)
+            if case_refusal is not None:
+                return f"case '{manager.name}': {case_refusal}"
+        return None
+
+    def _needs_stat_pass(self) -> bool:
+        """Whether a stage after the reduction wants whole-volume statistics OF THE RESULT.
+
+        Those cannot be seeded from disk the usual way -- the reduced volume is stored nowhere yet --
+        so the engine computes them with a pass of its own. Twice the reads, no intermediate volume,
+        and the reduction is deterministic so both passes see the same values.
+        """
+        return any(stage.patch_locality(Attribute()).kind is LocalityKind.GLOBAL_STAT for stage in self.post)
+
+    def plan(self) -> ReductionPlan:
+        reference = self.reference
+        return ReductionPlan(
+            output=self.reduce.output,
+            cases=[manager.name for manager in self.managers],
+            spatial=reference.spatial_shape,
+            # The operator's own channel map, because only it knows the result's leading axis: a
+            # Concat over N cases writes N times the channels, and the plan must probe and size the
+            # shape the run will actually open.
+            channels=self.operator.output_channels(int(reference.base_shape[0]), len(self.managers)),
+            slab_rows=self.slab_rows,
+            incremental=self.operator.incremental,
+            stat_pass=self._needs_stat_pass(),
+            refusal=self._first_refusal(),
+        )
+
+    # --------------------------------------------------------------- execution
+
+    def _regions(self, spatial: list[int]) -> list[tuple[slice, ...]]:
+        """The output's regions: slabs along the first spatial axis, whole in the others."""
+        return [
+            (slice(start, min(start + self.slab_rows, spatial[0])), *(slice(0, extent) for extent in spatial[1:]))
+            for start in range(0, spatial[0], self.slab_rows)
+        ]
+
+    def _fold(self, region: tuple[slice, ...]) -> torch.Tensor:
+        """One region of the reduced volume: every case reads that region, the operator folds them.
+
+        Each region is presented as ``[1, C, *spatial]`` -- the stack-axis layout every operator is
+        written against (see :class:`~konfai.data.reduction.Reduction`) -- and the result comes back
+        without it. The axis matters to any operator that places things side by side.
+        """
+        self.operator.start()
+        for manager in self.managers:
+            self.operator.accumulate(manager.read_region(region).unsqueeze(0))
+        return self.operator.finalize().squeeze(0)
+
+    def _apply_post(self, block: torch.Tensor, attribute: Attribute, rank: int) -> np.ndarray:
+        scope = Attribute(attribute)
+        for stage in self.post:
+            block = stage(self.reduce.output, block, scope)
+        array = block.numpy()
+        if array.ndim != rank:
+            raise ReductionError(
+                f"A stage after the Reduce returned a rank-{array.ndim} region where the"
+                f" channel-first layout needs rank {rank}.",
+                "A transform folding the leading axis must keep it (`keepdim=True`).",
+            )
+        return array
+
+    def _output_attributes(self, plan: ReductionPlan) -> Attribute:
+        # The header is the geometry the reference's chain LANDS on, not the geometry it was stored
+        # with: a cohort resampled onto a template grid by its pre-chain must publish that grid --
+        # seeding the source's own Spacing here would stamp a wrong header on every round of an
+        # atlas build, and nothing about the volume would look wrong.
+        attribute = self.reference.landed_attributes()
+        if self.reduce.provenance:
+            # The deliverable carries its own recipe. A set of cases that changed between two runs
+            # would otherwise write a different volume under the same name -- the worst way this can
+            # fail, because nothing about the output looks wrong.
+            attribute["konfai_reduce_operator"] = self.reduce.operator_classpath
+            attribute["konfai_reduce_cases"] = "|".join(plan.cases)
+        if plan.stat_pass:
+            statistics = _RunningStatistics()
+            for region in self._regions(plan.spatial):
+                statistics.update(self._fold(region))
+            statistics.write_into(attribute)
+        return attribute
+
+    def _open_stream(self, spatial: list[int], array: np.ndarray, attribute: Attribute) -> DataStream:
+        stream = self.destination.open_data_stream(
+            self.group, self.reduce.output, [int(array.shape[0]), *spatial], array.dtype, attribute
+        )
+        if stream is None:
+            raise ReductionError(
+                f"'{self.destination.filename}' cannot serve region writes, so the reduced volume"
+                f" '{self.reduce.output}' could only be written by assembling it in memory.",
+                "Write the reduction to an h5 or omezarr destination.",
+            )
+        return stream
+
+    def materialize(self, rewrite: bool = False) -> bool:
+        """Write the reduced entry, or raise saying why it cannot be written this way.
+
+        There is no whole-volume fallback: assembling every case is exactly what this exists to
+        avoid, and doing it silently would turn a bounded run into an unannounced OOM. A finished
+        output is left alone unless ``rewrite``, which is the resume.
+        """
+        if not rewrite and self.destination.is_dataset_exist(self.group, self.reduce.output):
+            return True
+        plan = self.plan()
+        if not plan.streams:
+            raise ReductionError(
+                f"The reduction into '{self.reduce.output}' cannot stream: {plan.refusal}.",
+                "A reduction has no whole-volume fallback. Fix the refusing stage, or put a Save"
+                " before the Reduce so each case's chain is materialized first.",
+            )
+
+        spatial = plan.spatial
+        attribute = self._output_attributes(plan)
+        rank = len(spatial) + 1
+        stream: DataStream | None = None
+        try:
+            for region in self._regions(spatial):
+                array = self._apply_post(self._fold(region), attribute, rank)
+                if stream is None:
+                    stream = self._open_stream(spatial, array, attribute)
+                    stream.__enter__()
+                stream.write_slice((slice(0, int(array.shape[0])), *region), array)
+            if stream is not None:
+                stream.close()
+        except Exception as exception:
+            if stream is not None:
+                stream.abort(exception)
+            raise
+        return True

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -27,6 +27,7 @@ from collections.abc import Iterator, Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from functools import partial
+from pathlib import Path
 from typing import TypeAlias, cast
 
 import numpy as np
@@ -37,12 +38,21 @@ from torch.utils import data
 from torch.utils.data import DataLoader, Sampler
 
 from konfai import konfai_root, konfai_state
-from konfai.data.augmentation import DataAugmentationsList
+from konfai.data.augmentation import DataAugmentation, DataAugmentationsList
 from konfai.data.patching import DatasetManager, DatasetPatch
-from konfai.data.transform import LocalityKind, Transform, TransformInverse, TransformLoader
+from konfai.data.transform import (
+    Expand,
+    LocalityKind,
+    Reduce,
+    Save,
+    Transform,
+    TransformInverse,
+    TransformLoader,
+    Write,
+)
 from konfai.utils.config import config
 from konfai.utils.dataset import Attribute, Dataset
-from konfai.utils.errors import ConfigError, DatasetManagerError
+from konfai.utils.errors import ConfigError, DatasetManagerError, TransformerError
 from konfai.utils.runtime import (
     State,
     available_memory_bytes,
@@ -348,6 +358,22 @@ class GroupTransformMetric(GroupTransform):
         super().__init__(transforms, {})
 
 
+class GroupTransformOut(GroupTransform):
+    """Transform-workflow group: a plain chain, no patch-time transforms, no ``is_input``.
+
+    Every group of a model-less workflow is an input, so the flag is not a question to ask; and the
+    patch grid is an execution detail the planner owns, so a per-patch transform would make the
+    OUTPUT a function of the declared budget."""
+
+    def __init__(
+        self,
+        transforms: dict[str, TransformLoader] = {
+            "default|Normalize|Standardize|TensorCast|ResampleIsotropic|Write": TransformLoader()
+        },
+    ):
+        super().__init__(transforms, {})
+
+
 class Group(dict[str, GroupTransform]):
     """Mapping of destination group names to transform pipelines."""
 
@@ -364,6 +390,16 @@ class GroupMetric(dict[str, GroupTransformMetric]):
     def __init__(
         self,
         groups_dest: dict[str, GroupTransformMetric] = {"default|group_dest": GroupTransformMetric()},
+    ):
+        super().__init__(groups_dest)
+
+
+class GroupOut(dict[str, GroupTransformOut]):
+    """Transform-workflow variant of :class:`Group`."""
+
+    def __init__(
+        self,
+        groups_dest: dict[str, GroupTransformOut] = {"default|group_dest": GroupTransformOut()},
     ):
         super().__init__(groups_dest)
 
@@ -557,7 +593,7 @@ class DatasetIter(data.Dataset):
         rank: int,
         data: dict[str, list[DatasetManager]],
         mapping: list[tuple[int, int, int]],
-        groups_src: Mapping[str, Group | GroupMetric],
+        groups_src: Mapping[str, Group | GroupMetric | GroupOut],
         inline_augmentations: bool,
         data_augmentations_list: list[DataAugmentationsList],
         patch_size: list[int] | None,
@@ -866,7 +902,7 @@ class Data(ABC):
         return False
 
     @classmethod
-    def _groups_require_single_process_loading(cls, groups_src: Mapping[str, Group | GroupMetric]) -> bool:
+    def _groups_require_single_process_loading(cls, groups_src: Mapping[str, Group | GroupMetric | GroupOut]) -> bool:
         for group in groups_src.values():
             for group_transform in group.values():
                 for configured_transforms in (group_transform._transforms, group_transform._patch_transforms):
@@ -898,7 +934,7 @@ class Data(ABC):
     def __init__(
         self,
         dataset_filenames: list[str],
-        groups_src: Mapping[str, Group | GroupMetric],
+        groups_src: Mapping[str, Group | GroupMetric | GroupOut],
         patch: DatasetPatch | None,
         use_cache: bool,
         subset: Subset,
@@ -1525,7 +1561,10 @@ class Data(ABC):
             return [[] for _ in range(world_size)]
 
         mappings: list[list[tuple[int, int, int]]] = []
-        if konfai_state() == str(State.PREDICTION) or konfai_state() == str(State.EVALUATION):
+        # One-pass workflows shard by CASE; the default branch below is the TRAIN one, whose
+        # duplicate-padding (for DDP) would hand the same case to two ranks — two concurrent writers
+        # of the same output file for a workflow that writes per case.
+        if konfai_state() in (str(State.PREDICTION), str(State.EVALUATION), str(State.TRANSFORM)):
             mapping_by_index: dict[int, list[tuple[int, int, int]]] = {}
             for entry in mapping:
                 mapping_by_index.setdefault(entry[0], []).append(entry)
@@ -1835,3 +1874,185 @@ class DataMetric(Data):
             persistent_workers=False if persistent_workers is None else persistent_workers,
             memory_budget=memory_budget,
         )
+
+
+@config("Dataset")
+class DataTransform(Data):
+    """Dataset configuration used by the transform workflow.
+
+    The amputated grammar, on the DataMetric precedent: no patch (the planner cuts slabs, never the
+    user), no batch, no validation split, no shuffle, and no ``augmentations`` section — a draw is a
+    stage, so it is declared IN the chain, at the place it applies, after an
+    :class:`~konfai.data.transform.Expand` marker. What remains is what the workflow is: sources,
+    chains, a budget. Everything decidable from the config alone is refused here, before a single
+    byte is read.
+    """
+
+    # One pass: each case is read once, a cache is never re-read -- always stream/buffer.
+    _budget_caches_when_fit = False
+
+    def __init__(
+        self,
+        dataset_filenames: list[str] = ["default|./Dataset:mha"],
+        groups_src: dict[str, GroupOut] = {"default": GroupOut()},
+        memory_budget: str | float = "auto",
+        subset: PredictionSubset = PredictionSubset(),
+    ) -> None:
+        super().__init__(
+            dataset_filenames=dataset_filenames,
+            groups_src=groups_src,
+            patch=None,
+            use_cache=False,
+            subset=subset,
+            batch_size=1,
+            validation=None,
+            validation_augmentations=False,
+            inline_augmentations=False,
+            data_augmentations_list={},
+            # The engine is materialize(), never a DataLoader: no torch workers, no FIFO.
+            num_workers=0,
+            pin_memory=False,
+            prefetch_factor=None,
+            persistent_workers=False,
+            memory_budget=memory_budget,
+        )
+        #: The run's seed, set by the workflow before :meth:`prepare`. Stamped onto every ``Expand``
+        #: below, which is where the only randomness of a transform run lives.
+        self.manual_seed = 0
+
+    def prepare(self) -> None:
+        # The chains are bound first and the cardinality checked BEFORE any manager exists: a draw
+        # declared outside a copy has no shape map, so the manager's own fold would die on an
+        # AttributeError naming a method instead of refusing with the place to move the draw to.
+        for group_src in self.groups_src:
+            for group_dest in self.groups_src[group_src]:
+                self.groups_src[group_src][group_dest].prepare(group_src, group_dest)
+        self._validate_expansion()
+        self._seed_expansions()
+        super().prepare()
+        self._validate_write_chains()
+
+    def _seed_expansions(self) -> None:
+        """Hand the run's seed to every ``Expand`` that did not declare one of its own.
+
+        Done before ``super().prepare()``, which is where the managers are built and the copies
+        drawn. Every chain inheriting the same number is what makes an image chain and its mask
+        chain agree: they never meet, they derive from one seed they both hold. A chain that
+        declares ``seed`` keeps it, which is how two chains are asked for different copies.
+        """
+        for group_src in self.groups_src:
+            for group_dest in self.groups_src[group_src]:
+                for transform in self.groups_src[group_src][group_dest].transforms:
+                    if isinstance(transform, Expand) and transform.seed is None:
+                        transform.seed = self.manual_seed
+
+    def _output_destinations(self) -> dict[tuple[str, str], list[tuple[str, str]]]:
+        """Resolved ``(root, group)`` of every Save/Write, keyed by chain — the parse-time view of
+        what the run would write, resolved exactly as ``_save_destination`` will resolve it."""
+        destinations: dict[tuple[str, str], list[tuple[str, str]]] = {}
+        for group_src in self.groups_src:
+            for group_dest, group_transform in self.groups_src[group_src].items():
+                entries = []
+                for transform in group_transform.transforms:
+                    if isinstance(transform, Save) and transform.dataset:
+                        filename, _flag, _file_format = split_path_spec(
+                            transform.dataset, default_format="mha", supported_extensions=SUPPORTED_EXTENSIONS
+                        )
+                        entries.append((str(Path(filename).resolve()), transform.group or group_dest))
+                destinations[(group_src, group_dest)] = entries
+        return destinations
+
+    def _validate_write_chains(self) -> None:
+        """The parse-time refusals: everything below is decidable before any byte is read, so failing
+        later — or worse, succeeding wrongly — would be a silent failure by choice."""
+        write_targets: dict[tuple[str, str], tuple[str, str]] = {}
+        source_roots = {str(Path(filename).resolve()) for filename in self.datasets}
+        destinations = self._output_destinations()
+        for (group_src, group_dest), group_transform in (
+            ((gs, gd), self.groups_src[gs][gd]) for gs in self.groups_src for gd in self.groups_src[gs]
+        ):
+            chain = f"groups_src.{group_src}.groups_dest.{group_dest}"
+            transforms = group_transform.transforms
+            if not transforms or not isinstance(transforms[-1], Write):
+                after = (
+                    f"'{type(transforms[-1]).__name__}' follows the last Write, so its result is written nowhere."
+                    if transforms and any(isinstance(t, Write) for t in transforms)
+                    else "The chain declares no Write, so the run would read everything and write nothing."
+                )
+                raise TransformerError(
+                    f"'{chain}' does not end with a 'Write'. {after}",
+                    "End the chain with Write: {dataset: <path>[:format]}; use 'Save' for intermediate milestones.",
+                )
+            for transform in transforms:
+                if not isinstance(transform, Save) or isinstance(transform, Write):
+                    continue
+                if not transform.dataset:
+                    raise TransformerError(
+                        f"'{chain}' has a 'Save' with no dataset: it would write next to the source.",
+                        "Give the Save its own destination, e.g. Save: {dataset: ./Work:h5}.",
+                    )
+            for root, _group in destinations[(group_src, group_dest)]:
+                for source_root in source_roots:
+                    if root == source_root or Path(root).is_relative_to(source_root):
+                        raise TransformerError(
+                            f"'{chain}' writes into the source dataset ('{root}').",
+                            "Reading is lazy and streaming re-reads the source while writing: an"
+                            " in-place transform would read its own half-written output. Write to a"
+                            " separate directory.",
+                        )
+            terminal = transforms[-1]
+            filename, _flag, _file_format = split_path_spec(
+                terminal.dataset, default_format="mha", supported_extensions=SUPPORTED_EXTENSIONS
+            )
+            target = (str(Path(filename).resolve()), terminal.group or group_dest)
+            if target in write_targets:
+                other = write_targets[target]
+                raise TransformerError(
+                    f"'{chain}' and 'groups_src.{other[0]}.groups_dest.{other[1]}' both write"
+                    f" '{target[1]}' under '{target[0]}'.",
+                    "The second chain would find the first one's output and report the case as"
+                    " already done. Give each Write its own (dataset, group).",
+                )
+            write_targets[target] = (group_src, group_dest)
+
+    def _validate_expansion(self) -> None:
+        """The Expand contract, decidable from the config alone.
+
+        A draw only means something behind a cardinality change: applied once per case it is a
+        random transform, which is not what an augmentation is for and not what a reproducible
+        data-processing pass should contain. So a draw before the marker — or with no marker at
+        all — is refused with the place to move it to.
+        """
+        for (group_src, group_dest), group_transform in (
+            ((gs, gd), self.groups_src[gs][gd]) for gs in self.groups_src for gd in self.groups_src[gs]
+        ):
+            chain = f"groups_src.{group_src}.groups_dest.{group_dest}"
+            transforms = group_transform.transforms
+            expands = [t for t in transforms if isinstance(t, Expand)]
+            if len(expands) > 1:
+                raise TransformerError(
+                    f"'{chain}' declares {len(expands)} Expand markers; a chain changes its cardinality at most once.",
+                    "Keep one Expand per chain. Successive expansions compose across two"
+                    " invocations, the second reading the first one's output back.",
+                )
+            if expands and any(isinstance(t, Reduce) for t in transforms):
+                raise TransformerError(
+                    f"'{chain}' declares both an Expand and a Reduce.",
+                    "One chain changes its cardinality once (1-to-N or N-to-1). Compose the two"
+                    " across invocations, the second reading the first one's output back.",
+                )
+            head = transforms if not expands else transforms[: transforms.index(expands[0])]
+            for stage in head:
+                if isinstance(stage, DataAugmentation):
+                    where = "before the Expand marker" if expands else "but the chain has no Expand marker"
+                    raise TransformerError(
+                        f"'{chain}' declares the draw '{type(stage).__name__}' {where}.",
+                        "A draw makes COPIES, so it belongs after an Expand: transforms: [Clip,"
+                        " Expand: {nb: 8}, Rotate, Write]. Applied once per case it would just be a"
+                        " random transform, and the run would not be reproducible.",
+                    )
+            if expands and not any(isinstance(t, DataAugmentation) for t in transforms):
+                raise TransformerError(
+                    f"'{chain}' declares an Expand but no draw follows it, so every copy would be identical.",
+                    "Put the draws after the marker, e.g. Expand: {nb: 8} then Rotate: {a_min: -15, a_max: 15}.",
+                )

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -1991,7 +1991,8 @@ class DataTransform(Data):
                         f"'{chain}' has a 'Save' with no dataset: it would write next to the source.",
                         "Give the Save its own destination, e.g. Save: {dataset: ./Work:h5}.",
                     )
-            for root, _group in destinations[(group_src, group_dest)]:
+            chain_targets: list[tuple[str, str]] = []
+            for root, group in destinations[(group_src, group_dest)]:
                 for source_root in source_roots:
                     if root == source_root or Path(root).is_relative_to(source_root):
                         raise TransformerError(
@@ -2000,20 +2001,20 @@ class DataTransform(Data):
                             " in-place transform would read its own half-written output. Write to a"
                             " separate directory.",
                         )
-            terminal = transforms[-1]
-            filename, _flag, _file_format = split_path_spec(
-                terminal.dataset, default_format="mha", supported_extensions=SUPPORTED_EXTENSIONS
-            )
-            target = (str(Path(filename).resolve()), terminal.group or group_dest)
-            if target in write_targets:
-                other = write_targets[target]
-                raise TransformerError(
-                    f"'{chain}' and 'groups_src.{other[0]}.groups_dest.{other[1]}' both write"
-                    f" '{target[1]}' under '{target[0]}'.",
-                    "The second chain would find the first one's output and report the case as"
-                    " already done. Give each Write its own (dataset, group).",
-                )
-            write_targets[target] = (group_src, group_dest)
+                if (root, group) in write_targets:
+                    other = write_targets[(root, group)]
+                    raise TransformerError(
+                        f"'{chain}' and 'groups_src.{other[0]}.groups_dest.{other[1]}' both write"
+                        f" '{group}' under '{root}'.",
+                        "A Save is a source boundary keyed by (dataset, group, case) alone, so the"
+                        " second chain would take the first one's entry as satisfied and skip its own"
+                        " prefix. Give each Save and each Write its own (dataset, group).",
+                    )
+                chain_targets.append((root, group))
+            # Registered once the chain is through, not as each target is seen: one chain may name the
+            # same target twice (a Save its terminal Write publishes over); two chains may not.
+            for target in chain_targets:
+                write_targets[target] = (group_src, group_dest)
 
     def _validate_expansion(self) -> None:
         """The Expand contract, decidable from the config alone.

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -2161,6 +2161,7 @@ class DatasetManager:
         self._stream_refusals.clear()
         self._stream_evolved.clear()
         self._swept_entries.clear()
+        self._sweep_failure = None
         self.cache_attributes_bak = copy.deepcopy(self._cache_attributes_pristine)
         self.cache_attributes = copy.deepcopy(self._cache_attributes_pristine)
 

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -16,20 +16,32 @@
 
 """Patch extraction, accumulation, and patch-combination helpers for KonfAI."""
 
+import contextlib
 import copy
+import hashlib
+import random
 import warnings
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass, field
 from itertools import pairwise
-from typing import Protocol, cast
+from typing import Protocol, TypeGuard, cast
 
 import numpy as np
 import torch
 import torch.nn.functional as F
 
 from konfai.data.augmentation import DataAugmentation, DataAugmentationsList
-from konfai.data.transform import LocalityKind, PatchLocality, RegionContext, Resample, Save, Transform
+from konfai.data.transform import (
+    Expand,
+    LocalityKind,
+    PatchLocality,
+    RegionContext,
+    Resample,
+    Save,
+    Transform,
+    split_expand,
+)
 from konfai.utils.config import apply_config, config
 from konfai.utils.dataset import Attribute, Dataset, DataStream
 from konfai.utils.errors import ConfigError, PatchError
@@ -50,8 +62,14 @@ from konfai.utils.utils import (
 _MAX_HALO_FRACTION = 0.5
 
 # Rows per Save-sweep slab: full-plane slabs keep the materialization bounded to a window while the
-# composed region reads stay chunk-friendly. See DatasetManager._materialize_save.
+# composed region reads stay chunk-friendly. A declared memory_budget can only LOWER the height
+# (see DatasetManager._sweep_rows); this constant is the cap and the no-budget default.
 _SWEEP_SLAB_ROWS = 64
+
+# What a sweep holds per row while in flight -- the pulled source slab and the landed block -- and
+# the bytes each element travels as (float32 through the chain). See DatasetManager._sweep_rows.
+_SWEEP_RESIDENT_SLABS = 2
+_SWEEP_ELEMENT_BYTES = 4
 
 
 def _halo_radii(halo: tuple[int, ...], n_axes: int) -> list[int]:
@@ -86,6 +104,54 @@ class Stage(Protocol):
     ) -> torch.Tensor: ...
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor: ...
+
+
+def _is_draw(stage: object) -> TypeGuard[DataAugmentation]:
+    """Whether this chain entry is an augmentation — a stage the manager binds to a copy."""
+    return isinstance(stage, DataAugmentation)
+
+
+@contextlib.contextmanager
+def _drawn_from(*key: object) -> Iterator[None]:
+    """Seed the global RNGs from ``key`` for the duration, then put them back exactly as they were.
+
+    What lets two chains augment a case coherently. Each ``groups_dest`` builds its own transform
+    objects, so an image chain and its mask chain hold different ``Rotate`` instances and cannot
+    coordinate through shared state — and a mask rotated by a different angle than its image is a
+    silently ruined dataset, not an error. Deriving the seed from what the two chains agree on (the
+    Expand's seed, the case, which draw this is) makes them draw the same thing without knowing
+    about each other.
+
+    ``blake2b`` and not ``hash()``: string hashing is salted per process, and the same config must
+    draw the same copies on every run and on every rank of one run.
+
+    The state is restored because it is global: reseeding everything downstream would make every
+    other random decision a function of how many copies were declared.
+    """
+    digest = hashlib.blake2b("|".join(str(part) for part in key).encode(), digest_size=4).digest()
+    seed = int.from_bytes(digest, "big")
+    states = (random.getstate(), np.random.get_state(), torch.random.get_rng_state())
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    try:
+        yield
+    finally:
+        random.setstate(states[0])
+        np.random.set_state(states[1])
+        torch.random.set_rng_state(states[2])
+
+
+def _stage_name(stage: Stage) -> str:
+    """What to CALL a stage in a message: a draw's own class, never the adapter that binds it.
+
+    Every refusal and every regime note names the stage that caused it, and 'AugmentedStage' names
+    nothing a user wrote — the point of saying which stage refused is lost if the answer is the
+    wrapper's name for all of them.
+    """
+    if isinstance(stage, AugmentedStage):
+        return type(stage.augmentation).__name__
+    return type(stage).__name__
 
 
 @dataclass(frozen=True)
@@ -219,10 +285,14 @@ class _PatchStreamSource:
     rest are pointwise, so they run wherever the regions put them. ``pending_sweeps`` are the
     unsatisfied :class:`Save` caches the source reads through: each must be materialized — and the
     source re-resolved from disk — before any patch flows.
+
+    ``entry`` is the entry name read from the source — the case's own, unless the source is a
+    satisfied per-copy cache behind an :class:`Expand`, whose entries carry the copy's name.
     """
 
     dataset: Dataset
     group: str
+    entry: str
     shape: list[int]
     stages: list[Stage]
     stage_plans: tuple[_ReadStagePlan, ...]
@@ -241,17 +311,29 @@ class _PatchStreamSource:
 class _PendingSweep:
     """One unsatisfied :class:`Save` and the segment that feeds it. Materializing reads each slab of
     the Save's own space through the segment — re-planned at sweep time, see ``_materialize_save`` —
-    and region-writes it to ``destination``, after which the Save is a satisfied source boundary."""
+    and region-writes it to ``destination``, after which the Save is a satisfied source boundary.
+
+    ``entry`` names the destination entry (the copy's own behind an :class:`Expand`),
+    ``source_entry`` the entry the segment reads. ``copy_stage_start`` is where the per-copy part of
+    the segment begins — the :class:`Expand` splice point, or ``len(stages)`` for a segment that is
+    entirely shared between copies; the expansion engine reads it to share one read pass across the
+    copies whose per-copy stages are pointwise. ``stage_plans`` are the probe-time plans of the
+    segment, kept for that classification only — the sweep itself re-plans (see
+    ``_materialize_save``)."""
 
     destination: Dataset
     group: str
+    entry: str
     stages: list[Stage]
     source_dataset: Dataset
     source_group: str
+    source_entry: str
     source_shape: list[int]
     out_spatial: tuple[int, ...]
     # The case state the segment replays from (copied per slab).
     base_attributes: Attribute = field(repr=False)
+    copy_stage_start: int = 0
+    stage_plans: tuple[_ReadStagePlan, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -1234,7 +1316,20 @@ class DatasetManager:
         self.augmented_data: dict[int, torch.Tensor] = {}
         self.total_augmentations = 0
 
-        for transform_function in transforms:
+        # The chain around its Expand: pre runs once per case, post once per copy. Without a marker
+        # the split is (everything, None, []) and every fold below reduces to what it always was.
+        self._expand_pre, self._expand, self._expand_post = split_expand(transforms)
+        for transform_function in self._expand_pre:
+            _shape = transform_function.transform_shape(self.group_src, self.name, _shape, cache_attribute)
+        # The grid and case state at the Expand point: what the first per-copy stage is handed.
+        # Snapshots (Attribute copies deeply) -- the live attribute keeps evolving through post.
+        self._shape_at_expand = list(_shape)
+        self._attributes_at_expand = Attribute(cache_attribute)
+        # The un-augmented landing of the per-copy tail. A draw is the identity here, because copy 0
+        # carries none: the real per-copy grids are folded in reset_augmentation, stage by stage.
+        for transform_function in self._expand_post:
+            if _is_draw(transform_function):
+                continue
             _shape = transform_function.transform_shape(self.group_src, self.name, _shape, cache_attribute)
 
         self.patch = (
@@ -1265,13 +1360,23 @@ class DatasetManager:
         self.data_augmentations_list = data_augmentations_list
         self._patch_stream_sources: dict[tuple[int, bool], _PatchStreamSource | None] = {}
         self._stream_refusals: dict[tuple[int, bool], str] = {}
+        self._stream_evolved: dict[tuple[int, bool], Attribute] = {}
         self._stream_attributes_persisted: set[int] = set()
-        self._sweep_failed = False
+        # Why a Save sweep gave up for this case, or None. One field rather than a flag beside a
+        # warning: the flag is what reroutes the case, the sentence is what a caller with no
+        # fallback has to raise with, and they must never disagree.
+        self._sweep_failure: str | None = None
         # Rewrite mode: every satisfied-Save probe answers "not written yet", so the case recomputes
         # from the source and each stream's finalize renames over the old entry. Never the default --
         # the boundary IS the per-case resume.
         self._rewrite_saves = False
-        self._disk_statistics: dict[tuple[Dataset, str, tuple[int, ...] | None], dict[str, float]] = {}
+        # The per-rank budget the sweeps size their slabs against (None = the historical fixed rows).
+        self._sweep_budget_bytes: float | None = None
+        self._disk_statistics: dict[tuple[Dataset, str, str, tuple[int, ...] | None], dict[str, float]] = {}
+        # Save caches already swept by THIS run, keyed by (store, group, entry): under --overwrite the
+        # existence probe answers "not written", and without this ledger every copy of an Expand chain
+        # would re-sweep the same shared pre-Expand cache once per copy.
+        self._swept_entries: set[tuple[str, str, str]] = set()
         # reset_state=False: the first manager built for a case draws (state_init draws a missing
         # index), and every later group's manager reuses that draw -- redrawing here would give each
         # group its own geometry and desynchronise the per-copy patch grids across groups.
@@ -1290,14 +1395,68 @@ class DatasetManager:
         # against the draw the copies actually carry.
         self._patch_stream_sources.clear()
         self._stream_refusals.clear()
+        self._stream_evolved.clear()
         self._stream_attributes_persisted.clear()
         self.total_augmentations = 0
+        if self._expand is not None:
+            self._draw_expand_copies(reset_state)
+        else:
+            self._draw_augmentation_lists(reset_state)
+        self.augmentationLoaded = self.total_augmentations == 0
+
+    def _draw_expand_copies(self, reset_state: bool) -> None:
+        """Draw the :class:`Expand` copies by walking the per-copy tail STAGE BY STAGE.
+
+        This is what makes a draw a stage like any other: each one is parameterised on the grid and
+        the case state the stages before it leave, so a transform between two draws is seen by the
+        second, and a shape-changing draw is seen by the transform after it. Walking the tail once
+        per copy — rather than drawing everything up front and folding the transforms afterwards —
+        is the only order that makes ``T, draw, T, draw`` mean what it reads like.
+
+        Each draw is seeded from ``(Expand.seed, case, draw class, which one of that class it is)``
+        — everything two chains of the same case agree on, and nothing they do not — so an image
+        chain and its mask chain draw the same copies without ever meeting. Keyed on the draw's
+        CLASS and its rank among its own kind, not on its position in the tail: an intensity draw
+        one chain declares and the other has no use for must not shift the geometric draws they
+        share.
+        """
+        expand = self._expand
+        assert expand is not None  # nosec B101 - the caller checked
+        shapes = [list(self._shape_at_expand) for _ in range(expand.nb)]
+        attributes = [copy.deepcopy(self._attributes_at_expand) for _ in range(expand.nb)]
+        drawn: dict[str, int] = {}
+        for stage in self._expand_post:
+            if _is_draw(stage):
+                if reset_state:
+                    stage.reset_state(self.index)
+                kind = type(stage).__name__
+                occurrence = drawn.get(kind, 0)
+                drawn[kind] = occurrence + 1
+                # One draw, every copy at once: state_init IS the per-copy sampler, and it wants the
+                # copies' current grids -- which the stages before it just folded.
+                with _drawn_from(expand.draw_seed, self.index, kind, occurrence):
+                    shapes = stage.state_init(self.index, shapes, attributes)
+                continue
+            for index in range(expand.nb):
+                shapes[index] = [
+                    int(extent)
+                    for extent in stage.transform_shape(self.group_src, self.name, shapes[index], attributes[index])
+                ]
+        for index in range(expand.nb):
+            self.cache_attributes.append(attributes[index])
+            self.shapes.append(list(shapes[index]))
+            self.patch.load(list(shapes[index]), index + 1)
+        self.total_augmentations = expand.nb
+
+    def _draw_augmentation_lists(self, reset_state: bool) -> None:
+        """The training form: copies declared as ``Dataset.augmentations`` lists, applied after the
+        whole chain. Untouched — a chain with no ``Expand`` is exactly what it always was."""
         i = 1
         for data_augmentations in self.data_augmentations_list:
             shape = []
             caches_attribute = []
             for _ in range(data_augmentations.nb):
-                shape.append(self.shapes[0])
+                shape.append(list(self.shapes[0]))
                 caches_attribute.append(copy.deepcopy(self.cache_attributes[0]))
 
             for data_augmentation in data_augmentations.data_augmentations:
@@ -1310,7 +1469,6 @@ class DatasetManager:
                 self.patch.load(s, i)
                 i += 1
             self.total_augmentations += data_augmentations.nb
-        self.augmentationLoaded = self.total_augmentations == 0
 
     def load(
         self,
@@ -1342,21 +1500,28 @@ class DatasetManager:
         data = torch.from_numpy(data)
 
         if len(pre_transform):
-            for transform_function in pre_transform[i:]:
-                data = transform_function(self.name, data, self.cache_attributes[0])
-                if isinstance(transform_function, Save):
-                    dataset, group_dest = _save_destination(transform_function, self.dataset, self.group_dest)
-                    dataset.write(
-                        group_dest,
-                        self.name,
-                        data.numpy(),
-                        self.cache_attributes[0],
-                    )
+            data = self._apply_chain(data, pre_transform[i:], self.cache_attributes[0], self.name)
         self.data.append(data)
 
         for i in range(len(self.cache_attributes) - 1):
             self.cache_attributes[i + 1].update(self.cache_attributes[0])
         self.loaded = True
+
+    def _apply_chain(
+        self, tensor: torch.Tensor, transforms: Sequence[Stage], attribute: Attribute, entry: str
+    ) -> torch.Tensor:
+        """Apply stages in order on an assembled tensor, writing each Save's cache under ``entry``.
+
+        The one whole-volume applicator: ``_load`` drives it with the case's own name, and the
+        expansion fallback with a copy's name -- the entry is the only thing that differs between
+        assembling a case and assembling one of its copies.
+        """
+        for transform_function in transforms:
+            tensor = transform_function(self.name, tensor, attribute)
+            if isinstance(transform_function, Save):
+                dataset, group_dest = _save_destination(transform_function, self.dataset, self.group_dest)
+                dataset.write(group_dest, entry, tensor.numpy(), attribute)
+        return tensor
 
     def _load_augmentation(self, data_augmentations_list: list[DataAugmentationsList]) -> None:
         start_index = 1
@@ -1407,6 +1572,19 @@ class DatasetManager:
             if data_augmentation.groups is None or self.group_dest in data_augmentation.groups
         ]
 
+    def _expand_tail(self, a: int) -> list[Stage]:
+        """The per-copy tail of an :class:`Expand` chain, as copy ``a`` runs it.
+
+        The tail IS the declared order: a transform stays itself, a draw is bound to this copy. The
+        two kinds are the same species to everything downstream — the planner reads one contract,
+        the replay calls one signature — which is why they can be written in any order.
+        """
+        if a == 0:
+            # Copy 0 is the case itself: it carries no draw, so the tail is its transforms alone --
+            # the same landing __init__ folds, and what a probe or a header asks for by default.
+            return [stage for stage in self._expand_post if not _is_draw(stage)]
+        return [AugmentedStage(stage, self.index, a - 1) if _is_draw(stage) else stage for stage in self._expand_post]
+
     def _get_tensor(self, a: int) -> torch.Tensor:
         if a == 0:
             return self.data[0]
@@ -1414,28 +1592,40 @@ class DatasetManager:
             self._load_augmentation_group(*self._augmentation_group(a))
         return self.augmented_data[a]
 
+    def copy_entry(self, a: int) -> str:
+        """The entry name copy ``a`` writes (and resumes) under, behind this chain's ``Expand``.
+
+        Copy 0 is the case itself -- the un-augmented tensor has no draw of its own to name -- and so
+        is every copy of a chain with no ``Expand``, where nothing per-copy is ever written.
+        """
+        if self._expand is None or a == 0:
+            return self.name
+        return self._expand.entry(self.name, a)
+
     def _read_disk_statistics(
         self,
         source_dataset: Dataset,
         source_group: str,
+        source_entry: str,
         channels: list[int] | None,
     ) -> dict[str, float]:
         """Read (and memoise) the whole-volume statistics of one on-disk group for this case.
 
         ``read_data_statistics`` scans the stored volume without materialising it, but it is still a
-        full pass: memoise it per (dataset, group, channels) so a per-patch consumer -- whose
+        full pass: memoise it per (dataset, group, entry, channels) so a per-patch consumer -- whose
         ``inverse()`` pops the seeded keys back out of the cache attribute at prediction time -- does
         not re-scan the volume once per patch.
         """
-        key = (source_dataset, source_group, tuple(channels) if channels is not None else None)
+        key = (source_dataset, source_group, source_entry, tuple(channels) if channels is not None else None)
         if key not in self._disk_statistics:
-            self._disk_statistics[key] = source_dataset.read_data_statistics(source_group, self.name, channels)
+            self._disk_statistics[key] = source_dataset.read_data_statistics(source_group, source_entry, channels)
         return self._disk_statistics[key]
 
     def _ensure_stream_stats(
         self,
         source_dataset: Dataset,
         source_group: str,
+        source_entry: str,
         cache_attribute: Attribute,
         required_stats: set[str],
         channels: list[int] | None = None,
@@ -1444,7 +1634,7 @@ class DatasetManager:
         if not missing_stats:
             return True
 
-        stats = self._read_disk_statistics(source_dataset, source_group, channels)
+        stats = self._read_disk_statistics(source_dataset, source_group, source_entry, channels)
         stats_mapping = {
             "Min": stats["min"],
             "Max": stats["max"],
@@ -1484,6 +1674,7 @@ class DatasetManager:
         stages: list[Stage],
         source_dataset: Dataset,
         source_group: str,
+        source_entry: str,
         cache_attribute: Attribute,
         source_spatial_shape: list[int],
         landing_shape: list[int] | None = None,
@@ -1517,7 +1708,7 @@ class DatasetManager:
         for stage_index, stage in enumerate(stages):
             loc = stage.patch_locality(Attribute(evolved))
             localities.append(loc)
-            label = f"stage {stage_index} '{type(stage).__name__}'"
+            label = f"stage {stage_index} '{_stage_name(stage)}'"
             if loc.kind in (LocalityKind.WHOLE_VOLUME, LocalityKind.SLAB):
                 # SLAB is a write-side contract: its side effect needs the slab's place in the
                 # OUTPUT, which a patch read has no notion of. A stage that is whole-volume only
@@ -1542,7 +1733,7 @@ class DatasetManager:
                         " -- the stored volume's statistic is not this stage's input.",
                     )
                 if seed_statistics and not self._ensure_stream_stats(
-                    source_dataset, source_group, cache_attribute, set(loc.stat_keys), loc.stat_channels
+                    source_dataset, source_group, source_entry, cache_attribute, set(loc.stat_keys), loc.stat_channels
                 ):
                     return (
                         False,
@@ -1610,12 +1801,49 @@ class DatasetManager:
             return _ReadStagePlan(loc.kind, tuple(shape), tuple(out), _ScalePull(scales, list(shape)))
         # ORIENTATION / CROP: the stage's own remap, evaluated on the state the stages before it left.
         pull = _RemapPull(stage.stream_region_source, list(shape), Attribute(evolved))
-        if isinstance(stage, Transform):
-            out = [int(e) for e in stage.transform_shape(self.group_src, self.name, list(shape), Attribute(evolved))]
-        else:
-            out = [int(e) for e in cast(AugmentedStage, stage).stream_shape(list(shape))]
+        out = self._stage_out_shape(stage, shape, Attribute(evolved))
         stage.write_stream_cache_attribute(evolved, list(shape))
         return _ReadStagePlan(loc.kind, tuple(shape), tuple(out), pull)
+
+    def _stage_out_shape(self, stage: Stage, shape: list[int], attribute: Attribute) -> list[int]:
+        """The spatial shape one stage folds ``shape`` to — a transform's map or a draw's own.
+
+        The one dispatch between the two Stage species' shape vocabularies: a ``Transform`` restates
+        its fold as ``transform_shape``, an :class:`AugmentedStage` as its draw's ``stream_shape``.
+        ``attribute`` is used as handed over: a caller that wants the geometry rewrites a transform
+        makes along the way (the write probe) passes the live state, one that must not be touched
+        (the planner) passes a copy.
+        """
+        if isinstance(stage, Transform):
+            return [int(e) for e in stage.transform_shape(self.group_src, self.name, list(shape), attribute)]
+        return [int(e) for e in cast(AugmentedStage, stage).stream_shape(list(shape))]
+
+    def chain_stages(self, a: int = 0) -> list[Stage]:
+        """The ordered stages copy ``a`` is made of — the one definition of what a copy IS.
+
+        Behind an :class:`Expand`, the shared prefix, then the copy's own draw at the marker's
+        position, then the per-copy tail. Without one, the chain itself, with any draw appended
+        last: the training order, where an augmentation is a copy of the chain's whole result.
+        """
+        if self._expand is None:
+            return [*self.transforms, *self._augmentation_stages(a)]
+        return [*self._expand_pre, *self._expand_tail(a)]
+
+    def write_targets(self, a: int = 0) -> list[tuple[Save, list[int], Attribute]]:
+        """Every ``Save`` copy ``a`` writes, with the extent and case state it lands at.
+
+        What a write probe must open to be the run's own verdict: behind an ``Expand`` the stages
+        after the marker fold the COPY's grid, so probing the chain with the marker left in it
+        would validate the pre-draw extent and call a destination good for a shape it never sees.
+        """
+        spatial = [int(extent) for extent in self.base_shape[1:]]
+        attributes = Attribute(self.cache_attributes_bak[0])
+        targets: list[tuple[Save, list[int], Attribute]] = []
+        for stage in self.chain_stages(a):
+            spatial = self._stage_out_shape(stage, spatial, attributes)
+            if isinstance(stage, Save):
+                targets.append((stage, list(spatial), Attribute(attributes)))
+        return targets
 
     def _resolve_patch_stream_source(self, a: int, apply_augmentations: bool = True) -> _PatchStreamSource | None:
         key = (a, apply_augmentations)
@@ -1624,6 +1852,7 @@ class DatasetManager:
 
         source_dataset = self.dataset
         source_group = self.group_src
+        source_entry = self.name
         source_shape = list(self.base_shape)
         # Plan from the case as STORED (the pristine backup), never from the live attribute: the live
         # one carries what earlier patches or epochs wrote (a Resample's target Spacing, a Canonical's
@@ -1633,13 +1862,29 @@ class DatasetManager:
         pending: list[_PendingSweep] = []
         trailing_transforms: list[Stage] = []
         sweep_refusal: str | None = None
+        # The entry name Saves write under: the case's own before the Expand marker, the copy's own
+        # after it. `splice_at` is where the per-copy stages begin WITHIN the current segment (None =
+        # the segment is entirely shared), which the expansion engine reads to share one read pass.
+        entry = self.name
+        splice_at: int | None = None
+        past_expand = False
 
-        for transform in self.transforms:
+        walked: list[Stage] = (
+            list(self.transforms) if self._expand is None else [*self._expand_pre, self._expand, *self._expand_tail(a)]
+        )
+        for transform in walked:
+            if isinstance(transform, Expand):
+                # The marker is replaced by the copy's own draw: everything before it is the case's,
+                # everything after it -- including every Save destination -- is the copy's.
+                splice_at = len(trailing_transforms)
+                past_expand = True
+                entry = self.copy_entry(a)
+                continue
             if isinstance(transform, Save):
                 dataset, group = _save_destination(transform, self.dataset, self.group_dest)
-                if not self._rewrite_saves and dataset.is_dataset_exist(group, self.name):
-                    source_dataset, source_group = dataset, group
-                    source_shape, boundary_attributes = dataset.get_infos(group, self.name)
+                if not self._rewrite_saves and dataset.is_dataset_exist(group, entry):
+                    source_dataset, source_group, source_entry = dataset, group, entry
+                    source_shape, boundary_attributes = dataset.get_infos(group, entry)
                     source_shape = list(source_shape)
                     # Streaming from a Save cache: the stored volume is the cache, so the stages after
                     # the boundary read its geometry -- stacked over the source keys exactly as the
@@ -1649,24 +1894,31 @@ class DatasetManager:
                         stream_cache_attribute[attribute_key] = attribute_value
                     pending.clear()
                     trailing_transforms = []
+                    # A satisfied per-copy cache already holds the draw: the new segment is entirely
+                    # per-copy, which `splice_at = 0` says.
+                    splice_at = 0 if past_expand else None
                     sweep_refusal = None
                     continue
                 planned, planned_attribute, planned_refusal = self._plan_save_sweep(
                     dataset,
                     group,
+                    entry,
                     trailing_transforms,
+                    splice_at if splice_at is not None else len(trailing_transforms),
                     source_dataset,
                     source_group,
+                    source_entry,
                     source_shape,
                     stream_cache_attribute,
                     seed_statistics=not pending,
                 )
                 if planned is not None and planned_attribute is not None:
                     stream_cache_attribute = planned_attribute
-                    source_dataset, source_group = dataset, group
+                    source_dataset, source_group, source_entry = dataset, group, entry
                     source_shape = [source_shape[0], *planned.out_spatial]
                     pending.append(planned)
                     trailing_transforms = []
+                    splice_at = 0 if past_expand else None
                     continue
                 # An unplannable Save stays in the chain, where its WHOLE_VOLUME declaration refuses
                 # the whole plan -- keep the sweep's own reason, or the chain-level one would only
@@ -1675,16 +1927,21 @@ class DatasetManager:
                     sweep_refusal = planned_refusal
             trailing_transforms.append(transform)
 
-        # What copy `a` is: the trailing transforms, then its own draw. The draw is applied to the
-        # transformed volume, so it goes last, and the whole thing is planned as one chain -- a region
-        # transform and a region augmentation are then two regions, which is exactly what they are.
-        stages = trailing_transforms + (self._augmentation_stages(a) if apply_augmentations else [])
+        # What copy `a` is. Without an Expand, the historical order: the trailing transforms, then
+        # its own draw appended last. With one, the draw was spliced at the marker above, and the
+        # whole thing is planned as one chain either way -- a region transform and a region
+        # augmentation are then two regions, which is exactly what they are.
+        if self._expand is None:
+            stages = trailing_transforms + (self._augmentation_stages(a) if apply_augmentations else [])
+        else:
+            stages = trailing_transforms
 
-        streamable, stage_plans, _, chain_refusal = self._plan_stream_region(
+        streamable, stage_plans, evolved, chain_refusal = self._plan_stream_region(
             a,
             stages,
             source_dataset,
             source_group,
+            source_entry,
             stream_cache_attribute,
             list(source_shape[1:]),
             seed_statistics=not pending,
@@ -1697,23 +1954,29 @@ class DatasetManager:
             # patch flows from it -- the sweeps run at first data access, and the source is then
             # re-resolved from the materialized caches (the satisfied-Save path above).
             self._patch_stream_sources[key] = _PatchStreamSource(
-                source_dataset, source_group, source_shape, stages, stage_plans, tuple(pending)
+                source_dataset, source_group, source_entry, source_shape, stages, stage_plans, tuple(pending)
             )
         else:
             self.cache_attributes[a] = Attribute(stream_cache_attribute)
             self.cache_attributes_bak[a] = Attribute(stream_cache_attribute)
             self._patch_stream_sources[key] = _PatchStreamSource(
-                source_dataset, source_group, source_shape, stages, stage_plans
+                source_dataset, source_group, source_entry, source_shape, stages, stage_plans
             )
+        # The state the whole plan lands on, kept for consumers that need the LANDED geometry (a
+        # reduction seeding its output header) without re-walking the chain.
+        self._stream_evolved[key] = Attribute(evolved)
         return self._patch_stream_sources[key]
 
     def _plan_save_sweep(
         self,
         destination: Dataset,
         group: str,
+        entry: str,
         segment: list[Stage],
+        copy_stage_start: int,
         source_dataset: Dataset,
         source_group: str,
+        source_entry: str,
         source_shape: list[int],
         base_attributes: Attribute,
         seed_statistics: bool,
@@ -1724,22 +1987,26 @@ class DatasetManager:
         Returns ``(sweep, evolved, None)`` on success — the pending sweep and the case state its
         cache will carry, which the stages after the Save plan against — and ``(None, None,
         reason)`` on refusal."""
-        if self._sweep_failed:
-            return None, None, "an earlier sweep failed for this case; every Save takes the whole-volume path."
+        if self._sweep_failure is not None:
+            return (
+                None,
+                None,
+                f"an earlier sweep failed for this case, so every Save takes the whole-volume"
+                f" path. {self._sweep_failure}",
+            )
         if not env_flag("KONFAI_STREAMED_WRITES", True):
             return None, None, "KONFAI_STREAMED_WRITES=0 disables streamed writes."
         landing = [int(extent) for extent in source_shape[1:]]
         probe = Attribute(base_attributes)
         for stage in segment:
-            landing = [
-                int(e) for e in cast(Transform, stage).transform_shape(self.group_src, self.name, landing, probe)
-            ]
+            landing = self._stage_out_shape(stage, landing, probe)
         planning = Attribute(base_attributes)
-        streamable, _, evolved, refusal = self._plan_stream_region(
+        streamable, stage_plans, evolved, refusal = self._plan_stream_region(
             0,
             segment,
             source_dataset,
             source_group,
+            source_entry,
             planning,
             [int(extent) for extent in source_shape[1:]],
             landing_shape=landing,
@@ -1757,12 +2024,16 @@ class DatasetManager:
         sweep = _PendingSweep(
             destination,
             group,
+            entry,
             list(segment),
             source_dataset,
             source_group,
+            source_entry,
             list(source_shape),
             tuple(landing),
             planning,
+            min(copy_stage_start, len(segment)),
+            stage_plans,
         )
         return sweep, evolved, None
 
@@ -1793,6 +2064,18 @@ class DatasetManager:
         """
         return Attribute(self.cache_attributes_bak[0])
 
+    def landed_attributes(self, a: int = 0) -> Attribute:
+        """The case state the chain LANDS on: stored geometry folded by every stage's rewrite.
+
+        This is what an output built FROM the chain's result must carry as its header — a Resample's
+        target ``Spacing``, a Canonical's direction — where :attr:`stored_attributes` is the source's
+        own. Resolved from the plan (a probe, never a write); a chain that cannot stream answers with
+        the stored state, the only honest one available without assembling the volume.
+        """
+        self._resolve_patch_stream_source(a, apply_augmentations=False)
+        evolved = self._stream_evolved.get((a, False))
+        return Attribute(evolved) if evolved is not None else self.stored_attributes
+
     def read_region(self, target: tuple[slice, ...], a: int = 0, apply_augmentations: bool = False) -> torch.Tensor:
         """Run this case's chain over one region of its output, reading only what that region pulls.
 
@@ -1814,11 +2097,8 @@ class DatasetManager:
             raise PatchError(
                 f"Case '{self.name}' cannot stream its chain, so it cannot serve a region.",
                 self.stream_refusal(a, apply_augmentations)
-                or (
-                    "A Save this chain reads through could not be swept; see the warning it emitted."
-                    if self._sweep_failed
-                    else "See stream_refusal() for the refusing stage."
-                ),
+                or self._sweep_failure
+                or "See stream_refusal() for the refusing stage.",
             )
         source = self._resolve_patch_stream_source(a, apply_augmentations)
         if source is None:  # pragma: no cover - _stream_ready just resolved it
@@ -1848,31 +2128,316 @@ class DatasetManager:
         the case from the source and every stream's finalize renames over the old entry — the forced
         path behind ``--overwrite``, never the default.
         """
-        if rewrite != self._rewrite_saves:
-            # The memoized plans were probed under the other boundary answer: replan. And replan from
-            # the case as STORED -- an earlier boundary-based plan wrote the OUTPUT's header into the
-            # backup (its Spacing, its Size), and a rewrite planned from that geometry re-writes
-            # untransformed data over the deliverable without an error.
-            self._rewrite_saves = rewrite
-            self._patch_stream_sources.clear()
-            self._stream_refusals.clear()
-            self.cache_attributes_bak = copy.deepcopy(self._cache_attributes_pristine)
-            self.cache_attributes = copy.deepcopy(self._cache_attributes_pristine)
-        if self._stream_ready(a, apply_augmentations=False):
+        self._set_rewrite(rewrite)
+        self.set_memory_budget(fallback_budget_bytes)
+        # A chain with an Expand materializes a COPY, whose draw must be part of the plan; without
+        # one it materializes the case itself, and augmentations have nothing to do with writing.
+        apply_augmentations = self._expand is not None and a > 0
+        if self._stream_ready(a, apply_augmentations=apply_augmentations):
             return True
-        if fallback_budget_bytes is not None:
-            # The plan's promise holds at run time too: a case whose sweep failed here (a refusal the
-            # probe could not see) must not assemble a volume the budget cannot hold.
-            case_bytes = int(np.prod(self.base_shape, dtype=np.int64)) * 4 * 2
-            if case_bytes > fallback_budget_bytes:
-                raise PatchError(
-                    f"Case '{self.name}' fell back to the whole-volume path at run time and its"
-                    f" working set (~{case_bytes / 2**30:.2f} GiB) exceeds the per-rank budget.",
-                    "Nothing was written for this case. Raise 'memory_budget' or make the chain streamable.",
-                )
-        self.load(self.transforms, [], load_augmentations=False)
+        self._enforce_fallback_budget(fallback_budget_bytes)
+        self._assemble_and_write(a)
         self.unload()
         return False
+
+    def set_memory_budget(self, budget_bytes: float | None) -> None:
+        """The per-rank budget this case's streamed sweeps size their slabs against.
+
+        Public because the budget reaches a manager from more than one door: :meth:`materialize`
+        takes it as an argument, while a reduction only ever calls :meth:`read_region` -- which
+        sweeps pending Saves as a side effect and must sweep them under the same bound.
+        """
+        self._sweep_budget_bytes = budget_bytes
+
+    def _set_rewrite(self, rewrite: bool) -> None:
+        if rewrite == self._rewrite_saves:
+            return
+        # The memoized plans were probed under the other boundary answer: replan. And replan from
+        # the case as STORED -- an earlier boundary-based plan wrote the OUTPUT's header into the
+        # backup (its Spacing, its Size), and a rewrite planned from that geometry re-writes
+        # untransformed data over the deliverable without an error.
+        self._rewrite_saves = rewrite
+        self._patch_stream_sources.clear()
+        self._stream_refusals.clear()
+        self._stream_evolved.clear()
+        self._swept_entries.clear()
+        self.cache_attributes_bak = copy.deepcopy(self._cache_attributes_pristine)
+        self.cache_attributes = copy.deepcopy(self._cache_attributes_pristine)
+
+    def _enforce_fallback_budget(self, fallback_budget_bytes: float | None) -> None:
+        if fallback_budget_bytes is None:
+            return
+        # The plan's promise holds at run time too: a case whose sweep failed here (a refusal the
+        # probe could not see) must not assemble a volume the budget cannot hold.
+        case_bytes = int(np.prod(self.base_shape, dtype=np.int64)) * 4 * 2
+        if case_bytes > fallback_budget_bytes:
+            raise PatchError(
+                f"Case '{self.name}' fell back to the whole-volume path at run time and its"
+                f" working set (~{case_bytes / 2**30:.2f} GiB) exceeds the per-rank budget.",
+                "Nothing was written for this case. Raise 'memory_budget' or make the chain streamable.",
+            )
+
+    def _assemble_and_write(self, a: int) -> None:
+        """The whole-volume fallback: assemble and write every Save. The caller releases.
+
+        Without an :class:`Expand` this is the classic load of the full chain. With one, the shared
+        part is assembled once (``load`` keeps it, so the copies of one case reuse the same tensor
+        across calls) and only the copy's draw and the per-copy stages run per copy, writing their
+        Saves under the copy's name.
+        """
+        if self._expand is None:
+            self.load(self.transforms, [], load_augmentations=False)
+            return
+        self.load(self._expand_pre, [], load_augmentations=False)
+        tensor = self.data[0].clone()
+        attribute = Attribute(self.cache_attributes[0])
+        self._apply_chain(tensor, self._expand_tail(a), attribute, self.copy_entry(a))
+
+    def materialize_copies(
+        self,
+        copies: list[int],
+        rewrite: bool = False,
+        fallback_budget_bytes: float | None = None,
+    ) -> dict[int, str]:
+        """Write the :class:`Expand` copies of this case by the cheapest regime each can take.
+
+        The expansion engine, and the reason expansion is not just a loop over
+        :meth:`materialize`: reads are decompression-bound, so N independent sweeps decompress the
+        same source N times. Copies whose per-copy stages are all pointwise share ONE read pass —
+        each slab is read and carried through the shared prefix once, then every copy applies its own
+        draw and writes into its own stream. A copy whose draw reads regions (a rotation's remap, a
+        halo) sweeps its own pass; a copy that cannot stream falls back to the whole volume, whose
+        shared part is assembled once for all such copies. Returns the regime each copy took:
+        ``'stream-shared'`` | ``'stream'`` | ``'whole-volume'``.
+        """
+        if self._expand is None:
+            raise PatchError(
+                f"materialize_copies() on case '{self.name}' whose chain declares no Expand.",
+                "Use materialize() for a 1-to-1 chain; copies only exist behind an Expand marker.",
+            )
+        self._set_rewrite(rewrite)
+        self.set_memory_budget(fallback_budget_bytes)
+        verdicts: dict[int, str] = {}
+        if not copies:
+            return verdicts
+
+        # The caches the copies share (pre-Expand Saves) are swept once, first: every copy's plan
+        # reads through them, and sweeping them inside each copy's own pass would redo the work.
+        first = self._resolve_patch_stream_source(copies[0], apply_augmentations=True)
+        if first is not None:
+            shared_pending = [sweep for sweep in first.pending_sweeps if sweep.entry == self.name]
+            if shared_pending:
+                # Each failure records its own reason; _sweep_failed reads them back.
+                for sweep in shared_pending:
+                    self._materialize_save(sweep)
+                self._invalidate_stream_plans()
+
+        shared: list[tuple[int, _PendingSweep]] = []
+        solo: list[int] = []
+        fallback: list[int] = []
+        for a in copies:
+            source = self._resolve_patch_stream_source(a, apply_augmentations=True)
+            if source is None:
+                fallback.append(a)
+                continue
+            per_copy = [sweep for sweep in source.pending_sweeps if sweep.entry != self.name]
+            if len(per_copy) != len(source.pending_sweeps):
+                # A shared cache is still pending (its sweep failed): the per-copy path will retry
+                # and fall back on its own terms.
+                solo.append(a)
+            elif not per_copy:
+                verdicts[a] = "stream"  # everything this copy writes is already on disk
+            elif len(per_copy) == 1 and self._pointwise_tail(per_copy[0]):
+                shared.append((a, per_copy[0]))
+            else:
+                solo.append(a)
+
+        if len(shared) == 1:
+            # One copy shares with nobody: its own sweep is the same work without the extra clone.
+            solo.append(shared.pop()[0])
+        if shared:
+            written = self._materialize_shared_pass(shared)
+            for a, _sweep in shared:
+                if a in written:
+                    verdicts[a] = "stream-shared"
+                else:
+                    solo.append(a)
+            if written:
+                self._invalidate_stream_plans()
+
+        for a in sorted(solo):
+            verdicts[a] = (
+                "stream"
+                if self.materialize(a, rewrite, fallback_budget_bytes=fallback_budget_bytes)
+                else "whole-volume"
+            )
+        if fallback:
+            self._enforce_fallback_budget(fallback_budget_bytes)
+            for a in fallback:
+                self._assemble_and_write(a)
+                verdicts[a] = "whole-volume"
+        self.unload()
+        return verdicts
+
+    def _pointwise_tail(self, sweep: _PendingSweep) -> bool:
+        """Whether everything per-copy in this sweep is a pure value map on its slab.
+
+        That is the shared-pass criterion: a pointwise tail pulls exactly the slab the shared prefix
+        landed on, so every such copy can consume one read. A region draw pulls its own geometry and
+        a GLOBAL_STAT reads a statistic of ITS input -- both get their own pass.
+        """
+        return all(plan.kind is LocalityKind.POINTWISE for plan in sweep.stage_plans[sweep.copy_stage_start :])
+
+    def expansion_solo_reason(self, a: int) -> str | None:
+        """Why copy ``a`` cannot join the shared read pass — for the plan, never a write.
+
+        ``None`` when it can (or when nothing is pending for it). The reason names the first
+        per-copy stage whose declared locality is not pointwise: that is the stage whose pull makes
+        this copy's read geometry its own.
+        """
+        source = self._resolve_patch_stream_source(a, apply_augmentations=True)
+        if source is None:
+            return None
+        per_copy = [sweep for sweep in source.pending_sweeps if sweep.entry != self.name]
+        if len(per_copy) == 1 and self._pointwise_tail(per_copy[0]):
+            return None
+        if not per_copy:
+            return None
+        if len(per_copy) > 1:
+            return "the copy's chain crosses more than one per-copy Save, so it sweeps its own passes."
+        sweep = per_copy[0]
+        for stage, plan in zip(
+            sweep.stages[sweep.copy_stage_start :], sweep.stage_plans[sweep.copy_stage_start :], strict=False
+        ):
+            if plan.kind is not LocalityKind.POINTWISE:
+                return (
+                    f"stage '{_stage_name(stage)}' of this copy declares {plan.kind.name},"
+                    " so its read geometry is the draw's own and it sweeps its own pass."
+                )
+        return "the copy's plan is incomplete; it sweeps its own pass."
+
+    def _materialize_shared_pass(self, shared: list[tuple[int, _PendingSweep]]) -> set[int]:
+        """One read pass, N write streams: the optimal regime of the expansion engine.
+
+        Each slab of the shared landing is read and computed through the shared prefix ONCE; each
+        copy then applies its pointwise tail to a clone and writes into its own stream. Peak memory
+        is the pulled slab plus one copy's block, whatever N is. On failure every open stream is
+        aborted -- entries publish by rename, so no partial copy survives -- and the copies are
+        handed back to their own passes.
+        """
+        reference = shared[0][1]
+        # Defensive: the regime only holds when every copy lands the same grid from the same source
+        # and writes into the same store. Built that way, but a draw that lies about its shape map
+        # would corrupt N entries at once here, so the mismatch is checked rather than assumed.
+        shared = [
+            (a, sweep)
+            for a, sweep in shared
+            if sweep.out_spatial == reference.out_spatial
+            and str(sweep.source_dataset.filename) == str(reference.source_dataset.filename)
+            and sweep.source_group == reference.source_group
+            and sweep.source_entry == reference.source_entry
+            and str(sweep.destination.filename) == str(reference.destination.filename)
+        ]
+        if not shared:
+            return set()
+        prefix = list(reference.stages[: reference.copy_stage_start])
+        spatial = list(reference.out_spatial)
+        source_spatial = [int(extent) for extent in reference.source_shape[1:]]
+        streamable, prefix_plans, prefix_evolved, _refusal = self._plan_stream_region(
+            0,
+            prefix,
+            reference.source_dataset,
+            reference.source_group,
+            reference.source_entry,
+            Attribute(reference.base_attributes),
+            source_spatial,
+            landing_shape=spatial,
+        )
+        if not streamable:
+            return set()
+        source = _PatchStreamSource(
+            reference.source_dataset,
+            reference.source_group,
+            reference.source_entry,
+            list(reference.source_shape),
+            prefix,
+            prefix_plans,
+        )
+        # Each copy's header is its OWN full-segment plan state: the tail's geometry and inversion
+        # keys belong to the copy, not to the shared prefix.
+        active: list[tuple[int, _PendingSweep, list[Stage], Attribute]] = []
+        for a, sweep in shared:
+            ok, _plans, evolved, _reason = self._plan_stream_region(
+                0,
+                sweep.stages,
+                sweep.source_dataset,
+                sweep.source_group,
+                sweep.source_entry,
+                Attribute(sweep.base_attributes),
+                [int(extent) for extent in sweep.source_shape[1:]],
+                landing_shape=list(sweep.out_spatial),
+            )
+            if ok:
+                active.append((a, sweep, list(sweep.stages[sweep.copy_stage_start :]), evolved))
+        if not active:
+            return set()
+        rows = self._sweep_rows(spatial, int(reference.source_shape[0]))
+        streams: dict[int, DataStream] = {}
+        try:
+            for start in range(0, spatial[0], rows):
+                target = (slice(start, min(start + rows, spatial[0])), *(slice(0, e) for e in spatial[1:]))
+                tensor, slab_attribute, keys_before = self._replay_streamed_region(
+                    source,
+                    target,
+                    Attribute(reference.base_attributes),
+                    Attribute(prefix_evolved) if start == 0 else None,
+                )
+                for a, sweep, tail, evolved in active:
+                    copy_tensor = tensor.clone() if len(active) > 1 else tensor
+                    scope = Attribute(slab_attribute)
+                    for stage in tail:
+                        copy_tensor = stage(self.name, copy_tensor, scope)
+                    block = copy_tensor.numpy()
+                    if block.ndim != len(spatial) + 1:
+                        raise PatchError(
+                            f"A per-copy stage of '{sweep.group}/{sweep.entry}' returned a rank-{block.ndim}"
+                            f" slab where the channel-first layout needs rank {len(spatial) + 1}.",
+                            "A transform that reduces the leading axis must keep it (`keepdim=True`).",
+                        )
+                    if a not in streams:
+                        attributes = Attribute(evolved)
+                        for key in scope.keys():
+                            if key not in keys_before and key not in attributes:
+                                attributes[key] = scope[key]
+                        stream = sweep.destination.open_data_stream(
+                            sweep.group, sweep.entry, [int(block.shape[0]), *spatial], block.dtype, attributes
+                        )
+                        if stream is None:
+                            raise PatchError(
+                                f"destination '{sweep.destination.filename}' refused the region write"
+                                f" of '{sweep.group}/{sweep.entry}' after accepting its plan.",
+                                "h5 and omezarr always serve region writes; mha only with image geometry.",
+                            )
+                        stream.__enter__()
+                        streams[a] = stream
+                    streams[a].write_slice((slice(0, int(block.shape[0])), *target), block)
+            written: set[int] = set()
+            for a, sweep, _tail, _evolved in active:
+                stream = streams.get(a)
+                if stream is not None:
+                    stream.close()
+                    self._swept_entries.add((str(sweep.destination.filename), sweep.group, sweep.entry))
+                    written.add(a)
+            return written
+        except Exception as exception:
+            for stream in streams.values():
+                stream.abort(exception)
+            warnings.warn(
+                f"Shared-pass materialization of case '{self.name}' failed"
+                f" ({type(exception).__name__}: {exception}); its copies take their own passes.",
+                stacklevel=2,
+            )
+            return set()
 
     def _stream_ready(self, a: int, apply_augmentations: bool = True) -> bool:
         """Whether this copy can stream its patches, materializing what that requires.
@@ -1886,13 +2451,21 @@ class DatasetManager:
             return False
         if not source.pending_sweeps:
             return True
-        if not all(self._materialize_save(sweep) for sweep in source.pending_sweeps):
-            self._sweep_failed = True
+        for sweep in source.pending_sweeps:
+            self._materialize_save(sweep)
         # Every copy replans: the pending plans pointed at caches that did not exist yet (or, after a
         # failure, never will -- _sweep_failed reroutes them to the whole-volume path).
+        self._invalidate_stream_plans()
+        return not self._sweep_failed and self._resolve_patch_stream_source(a, apply_augmentations) is not None
+
+    @property
+    def _sweep_failed(self) -> bool:
+        return self._sweep_failure is not None
+
+    def _invalidate_stream_plans(self) -> None:
         self._patch_stream_sources.clear()
         self._stream_refusals.clear()
-        return not self._sweep_failed and self._resolve_patch_stream_source(a, apply_augmentations) is not None
+        self._stream_evolved.clear()
 
     def _materialize_save(self, sweep: _PendingSweep) -> bool:
         """Write one Save cache slab by slab, without ever holding the volume.
@@ -1903,29 +2476,48 @@ class DatasetManager:
         so a GLOBAL_STAT segment matches the classic cache to float rounding — the streamed read's
         own contract — where every other kind matches it exactly). The cache appears only when
         complete (a DataStream renames on finalize), so a concurrent resolve never takes a partial
-        entry as a source boundary; on failure the partial entry is removed and the case falls back
-        to the whole-volume path, which writes the cache classically."""
-        if not self._rewrite_saves and sweep.destination.is_dataset_exist(sweep.group, self.name):
+        entry as a source boundary; on failure the partial entry is removed, ``_sweep_failure``
+        records why, and the case falls back to the whole-volume path, which writes the cache
+        classically. Every ``False`` below leaves that reason behind: a caller with no fallback (a
+        reduction reading through this cache) raises with it, so the answer is not "see the warning
+        it emitted" for a warning a filter may have swallowed."""
+        ledger_key = (str(sweep.destination.filename), sweep.group, sweep.entry)
+        if ledger_key in self._swept_entries:
+            # Already swept by THIS run: under --overwrite the existence probe answers "not written",
+            # and re-sweeping a cache the copies share would redo the same work once per copy.
             return True
-        streamable, stage_plans, evolved, _refusal = self._plan_stream_region(
+        if not self._rewrite_saves and sweep.destination.is_dataset_exist(sweep.group, sweep.entry):
+            return True
+        streamable, stage_plans, evolved, refusal = self._plan_stream_region(
             0,
             sweep.stages,
             sweep.source_dataset,
             sweep.source_group,
+            sweep.source_entry,
             sweep.base_attributes,
             [int(extent) for extent in sweep.source_shape[1:]],
             landing_shape=list(sweep.out_spatial),
         )
         if not streamable:
-            return False
+            # The plan probe said yes and the re-plan against the materialized source says no: that
+            # is new information, and it is the whole reason this case is about to cost a volume.
+            return self._sweep_failed_because(
+                sweep, refusal or "the segment feeding it no longer plans against its materialized source."
+            )
         source = _PatchStreamSource(
-            sweep.source_dataset, sweep.source_group, list(sweep.source_shape), sweep.stages, stage_plans
+            sweep.source_dataset,
+            sweep.source_group,
+            sweep.source_entry,
+            list(sweep.source_shape),
+            sweep.stages,
+            stage_plans,
         )
         spatial = list(sweep.out_spatial)
+        rows = self._sweep_rows(spatial, int(sweep.source_shape[0]))
         stream: DataStream | None = None
         try:
-            for start in range(0, spatial[0], _SWEEP_SLAB_ROWS):
-                target = (slice(start, min(start + _SWEEP_SLAB_ROWS, spatial[0])), *(slice(0, e) for e in spatial[1:]))
+            for start in range(0, spatial[0], rows):
+                target = (slice(start, min(start + rows, spatial[0])), *(slice(0, e) for e in spatial[1:]))
                 # The first slab hands a throwaway case scope to the replay so the region-geometry
                 # check runs: a region stage recording geometry nowhere the case can read refuses the
                 # sweep (PatchError -> whole-volume fallback), exactly as the patch path refuses it.
@@ -1957,24 +2549,53 @@ class DatasetManager:
                         if key not in keys_before and key not in attributes:
                             attributes[key] = slab_attribute[key]
                     stream = sweep.destination.open_data_stream(
-                        sweep.group, self.name, [int(block.shape[0]), *spatial], block.dtype, attributes
+                        sweep.group, sweep.entry, [int(block.shape[0]), *spatial], block.dtype, attributes
                     )
                     if stream is None:
-                        return False
+                        return self._sweep_failed_because(
+                            sweep,
+                            f"destination '{sweep.destination.filename}' refused the region write"
+                            " after accepting its plan.",
+                        )
                     stream.__enter__()
                 stream.write_slice((slice(0, int(block.shape[0])), *target), block)
             if stream is not None:
                 stream.close()
+            self._swept_entries.add(ledger_key)
             return True
         except Exception as exception:
             if stream is not None:
                 stream.abort(exception)
-            warnings.warn(
-                f"Streamed materialization of Save cache '{sweep.group}/{self.name}' failed"
-                f" ({type(exception).__name__}: {exception}); falling back to the whole-volume path.",
-                stacklevel=2,
-            )
-            return False
+            return self._sweep_failed_because(sweep, f"{type(exception).__name__}: {exception}")
+
+    def _sweep_failed_because(self, sweep: _PendingSweep, reason: str) -> bool:
+        """Record why a sweep gave up, warn, and answer ``False`` — the one exit for all of them.
+
+        The reason is kept, not only warned: a caller with a whole-volume fallback treats this as
+        information, but one without (a reduction reading through this cache) has to raise, and it
+        can only be as specific as what was kept here.
+        """
+        self._sweep_failure = f"The Save cache '{sweep.group}/{sweep.entry}' could not be swept: {reason}"
+        warnings.warn(f"{self._sweep_failure} Falling back to the whole-volume path.", stacklevel=3)
+        return False
+
+    def _sweep_rows(self, spatial: list[int], channels: int) -> int:
+        """How many rows one sweep slab holds: the declared budget folded down, never up.
+
+        The historical fixed height is the CAP -- the chunk-friendly default that needs no budget --
+        and a declared ``memory_budget`` can only lower it: a sweep holds the pulled slab and the
+        landed block (plus the write buffer), so half the budget over that working set is the honest
+        height. Below one row nothing fits; the row is the floor, and the fallback budget check is
+        what refuses a case whose single row cannot fit.
+        """
+        cap = max(1, int(_SWEEP_SLAB_ROWS))
+        budget = self._sweep_budget_bytes
+        if not budget or budget <= 0:
+            return cap
+        plane = int(np.prod(spatial[1:], dtype=np.int64)) * max(1, int(channels)) * _SWEEP_ELEMENT_BYTES
+        if plane <= 0:
+            return cap
+        return max(1, min(cap, int(budget * 0.5 / (plane * _SWEEP_RESIDENT_SLABS))))
 
     def _get_streamed_data(
         self,
@@ -1995,7 +2616,9 @@ class DatasetManager:
         if stream_source.region_index is None:
             # POINTWISE / GLOBAL_STAT only: read the exact patch and run the whole chain on it.
             plan = self.patch.get_read_plan(stream_source.shape, index, a, is_input)
-            data, attributes = stream_source.dataset.read_data_slice(stream_source.group, self.name, plan.data_slices)
+            data, attributes = stream_source.dataset.read_data_slice(
+                stream_source.group, stream_source.entry, plan.data_slices
+            )
             tensor = torch.from_numpy(data)
             cache_attribute = Attribute(self.cache_attributes_bak[a])
             cache_attribute.update(attributes)
@@ -2098,7 +2721,7 @@ class DatasetManager:
         spans.reverse()
 
         data_slices = tuple([slice(None)] * n_prefix + spans[0])
-        data, attributes = stream_source.dataset.read_data_slice(stream_source.group, self.name, data_slices)
+        data, attributes = stream_source.dataset.read_data_slice(stream_source.group, stream_source.entry, data_slices)
         tensor = torch.from_numpy(data)
 
         cache_attribute.update(attributes)

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -222,6 +222,15 @@ class Transform(NeedDevice, ABC):
         del region, spatial_shape
         return self(name, tensor, cache_attribute)
 
+    def prepare(self, konfai_args: str) -> None:
+        """Told where this stage's own configuration lives, once, right after it was built.
+
+        The loader knows the subtree a stage read its arguments from; a stage that instantiates
+        something ELSE from configuration — an operator named by classpath — cannot know it, and
+        without this would have to build that object with no arguments at all. The base holds
+        nothing: only a stage with a sub-object of its own overrides it.
+        """
+
     def stream_abort(self, name: str) -> None:
         """Drop whatever ``stream_slab`` holds open for ``name`` after a mid-case failure.
 
@@ -337,11 +346,32 @@ class TransformLoader:
 
     def get_transform(self, classpath: str, konfai_args: str) -> Transform:
         module, name = get_module(classpath, "konfai.data.transform")
+        if not hasattr(module, name) and ":" not in classpath:
+            # A bare name the transform package does not have may be an AUGMENTATION: those are
+            # stages too, and a chain declares them exactly where they apply (see Expand). Looked up
+            # second, so a transform never loses its name to a same-named draw.
+            module, name = get_module(classpath, "konfai.data.augmentation")
         # A key is read as a dotted path, and a classpath naming its module carries dots of its own.
-        transform = apply_config(f"{konfai_args}.{_escape_key_component(classpath)}")(getattr(module, name))()
+        subtree = f"{konfai_args}.{_escape_key_component(classpath)}"
+        transform = apply_config(subtree)(getattr(module, name))()
         if isinstance(transform, Transform):
+            transform.prepare(subtree)
+            return transform
+        if _is_augmentation(transform):
+            # A draw is handed over as itself: the manager binds it to a copy (AugmentedStage) once
+            # it knows which copy it is planning, which is the one thing the loader cannot know.
+            transform.load(1.0)
             return transform
         return Foreign(transform, classpath)
+
+
+def _is_augmentation(candidate: object) -> bool:
+    """Whether this object is a KonfAI draw, asked without importing the augmentation module here.
+
+    ``konfai.data.augmentation`` imports this module, so the dependency only runs one way; the check
+    walks the class's own ancestry instead of using ``isinstance``.
+    """
+    return any(base.__name__ == "DataAugmentation" for base in type(candidate).__mro__)
 
 
 class Foreign(Transform):
@@ -1513,8 +1543,8 @@ class Warp(Transform):
     dark rim around the moved anatomy and nothing else.
 
     ``max_displacement`` is in the same world units as ``Spacing`` (micrometres for these stores).
-    Left at zero, or with no ``Spacing`` on the case, the stage declares ``WHOLE_VOLUME`` and says
-    which of the two is missing -- correct, and as expensive as it sounds.
+    Left at zero, or with no ``Spacing`` on the case, the stage declares ``WHOLE_VOLUME`` and the
+    dispatcher hands it the volume -- correct, and as expensive as it sounds.
     """
 
     def __init__(
@@ -1706,10 +1736,16 @@ class Reduce(Transform):
                 " case.",
             )
         self.operator_classpath = str(operator)
+        # Where this stage was configured from, so its operator binds its own parameters from the
+        # same mapping -- None when the chain was built in Python, where there is no config to read.
+        self.konfai_args: str | None = None
         self.output = str(output).strip()
         self.grid = f"reference:{reference}" if reference else policy
         self.grid_tolerance = float(grid_tolerance)
         self.provenance = bool(provenance)
+
+    def prepare(self, konfai_args: str) -> None:
+        self.konfai_args = konfai_args
 
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
         # A cardinality marker, not a per-case stage: the reduction engine SPLITS it out of the chain
@@ -1723,6 +1759,96 @@ class Reduce(Transform):
             "A chain containing Reduce is run by the reduction engine of the TRANSFORM workflow; it"
             " has no meaning as an ordinary per-case transform.",
         )
+
+
+class Expand(Transform):
+    """Turn one case into ``nb`` copies, at a declared point of the chain — ``Reduce``'s mirror.
+
+    The stage that changes a chain's cardinality the other way. Everything BEFORE it runs once per
+    case (a ``Save`` there is a cache every copy shares); everything AFTER it runs once per copy,
+    and a ``Save``/``Write`` there writes one entry per copy.
+
+    It multiplies, and nothing else: the draws are ordinary stages of the chain, declared where they
+    apply, so transforms and augmentations interleave freely after the marker::
+
+        transforms:
+          Clip:   {min_value: 0.0, max_value: 400.0}   # once per case
+          Expand: {nb: 8, pattern: "{name}_r{a:02d}"}
+          Rotate: {a_min: -15, a_max: 15}              # a draw, per copy
+          ResampleToResolution: {spacing: [2, 2, 2]}   # a transform, per copy
+          Brightness: {b_std: 0.2}                     # another draw, per copy
+          Write:  {dataset: ./Augmented:omezarr}
+
+    Each draw is parameterised on the grid the stages before it leave, so a shape-changing draw hands
+    the next stage its own extent — a chain, exactly like the transforms it sits among.
+
+    ``pattern`` names each copy's entry: ``str.format`` over ``{name}`` (the case) and ``{a}`` (the
+    copy ordinal, 1-based). Both tokens are required — without ``{a}`` every copy of a case writes
+    over the previous one, without ``{name}`` every case does.
+
+    Every draw after this marker is parameterised from ``(seed, case, which draw this is)`` rather
+    than from a shared RNG, whose consumption order two chains cannot agree on. Left unset, ``seed``
+    is the run's ``manual_seed``, so an image chain and its mask chain produce matching copies —
+    copy ``k`` of the mask carries copy ``k`` of the image's rotation. Set it to decouple one chain
+    deliberately: that is the only way to ask two chains for DIFFERENT copies of the same cases.
+    """
+
+    def __init__(self, nb: int = 2, pattern: str = "{name}_{a:02d}", seed: int | None = None) -> None:
+        super().__init__()
+        self.seed = None if seed is None else int(seed)
+        if int(nb) < 1:
+            raise TransformError(
+                f"'Expand' asks for {nb} copies.",
+                "A cardinality is at least one: nb: 8 writes eight entries per case.",
+            )
+        self.nb = int(nb)
+        pattern = str(pattern)
+        try:
+            first, second = pattern.format(name="case", a=1), pattern.format(name="case", a=2)
+        except (KeyError, IndexError, ValueError) as error:
+            raise TransformError(
+                f"'Expand' cannot format its pattern '{pattern}': {error}.",
+                "The pattern is a str.format template over {name} and {a}, e.g. pattern: '{name}_r{a:02d}'.",
+            ) from error
+        if "{name" not in pattern or first == second:
+            raise TransformError(
+                f"'Expand' has a pattern ('{pattern}') that does not vary over "
+                + ("{name}" if "{name" not in pattern else "{a}")
+                + ", so its entries would collide.",
+                "Use both tokens, e.g. pattern: '{name}_r{a:02d}': {name} keeps cases apart,"
+                " {a} keeps a case's copies apart.",
+            )
+        self.pattern = pattern
+
+    @property
+    def draw_seed(self) -> int:
+        """The seed the copies are actually drawn from: this marker's own, or the run's."""
+        return 0 if self.seed is None else self.seed
+
+    def entry(self, name: str, a: int) -> str:
+        """The entry name copy ``a`` of case ``name`` writes under."""
+        return self.pattern.format(name=name, a=a)
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        # A cardinality marker, not a per-case stage: the dispatcher splices the copy's own draw at
+        # this position and never runs the marker itself. This declaration is only the safety net for
+        # a chain that reached a workflow without expansion semantics, where refusing is right.
+        return PatchLocality(LocalityKind.WHOLE_VOLUME)
+
+    def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
+        raise TransformError(
+            "'Expand' was applied to one tensor, which expands nothing.",
+            "A chain containing Expand is run by the TRANSFORM workflow, which replaces the marker"
+            " with each copy's draw; it has no meaning as an ordinary per-case transform.",
+        )
+
+
+def split_expand(transforms: list[Transform]) -> tuple[list[Transform], "Expand | None", list[Transform]]:
+    """A chain around its ``Expand``: what runs once per case, the marker, what runs per copy."""
+    for index, transform in enumerate(transforms):
+        if isinstance(transform, Expand):
+            return list(transforms[:index]), transform, list(transforms[index + 1 :])
+    return list(transforms), None, []
 
 
 class Flatten(Transform):

--- a/konfai/main.py
+++ b/konfai/main.py
@@ -191,6 +191,65 @@ def _run(parser: argparse.ArgumentParser) -> None:
         help="Directory where evaluation outputs are written (default: ./Evaluations/).",
     )
 
+    devices_for_transform = cuda_visible_devices()
+    transform_p = subparsers.add_parser(str(State.TRANSFORM), help="Apply a transform chain to a dataset. No model.")
+    # Deliberately NOT add_common_args: -tb has no scalar to show, so refusing it here is a parse
+    # error, not a silent no-op. --gpu exists for one reason: a KonfAIInference stage runs a nested
+    # inference that does use the device; plain read transforms stay on CPU either way.
+    transform_p.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        default=None,
+        help="Path to the configuration file (YAML). If omitted, Transform.yml is used.",
+    )
+    transform_p.add_argument(
+        "-y",
+        "--overwrite",
+        action="store_true",
+        help="Rewrite outputs that already exist. Without it, a case whose output exists is skipped.",
+    )
+
+    def positive_int_transform(value: str) -> int:
+        ivalue = int(value)
+        if ivalue <= 0:
+            raise argparse.ArgumentTypeError("CPU value must be > 0")
+        return ivalue
+
+    transform_device = transform_p.add_mutually_exclusive_group()
+    transform_device.add_argument(
+        "--gpu",
+        type=int,
+        nargs="+",
+        choices=devices_for_transform,
+        default=[],
+        help="GPU device ids for chains that run a nested inference (KonfAIInference). "
+        "Plain read transforms run on CPU regardless.",
+    )
+    transform_device.add_argument(
+        "--cpu",
+        type=positive_int_transform,
+        default=None,
+        help="Shard the cases over N worker processes (default: 1).",
+    )
+    transform_p.add_argument(
+        "-q", "--quiet", action="store_true", help="Suppress console output for a quieter execution"
+    )
+    transform_p.add_argument(
+        "--plan",
+        action="store_true",
+        help="Print the per-case streaming plan and exit without transforming. The plan probes each"
+        " destination with a real region-write open (created then removed), so it reports the run's"
+        " actual verdict — it touches the output directories even in plan mode.",
+    )
+    transform_p.add_argument(
+        "--transforms-dir",
+        "--transforms_dir",
+        type=str,
+        default="./Transforms/",
+        help="Directory where run logs and the plan are written (default: ./Transforms/).",
+    )
+
     parser.add_argument(
         "--version",
         action="version",
@@ -200,25 +259,41 @@ def _run(parser: argparse.ArgumentParser) -> None:
 
     args = vars(parser.parse_args())
 
-    if args["command"] == "PREDICTION":
+    if args["command"] == str(State.PREDICTION):
         from konfai.predictor import predict
 
         if args["config"] is not None:
             args["prediction_file"] = args.pop("config")
         predict(**args)
-    elif args["command"] == "EVALUATION":
+    elif args["command"] == str(State.EVALUATION):
         from konfai.evaluator import evaluate
 
         if args["config"] is not None:
             args["evaluations_file"] = args.pop("config")
 
         evaluate(**args)
-    else:
+    elif args["command"] == str(State.TRANSFORM):
+        from konfai.transformer import plan_transform, transform
+
+        if args["config"] is not None:
+            args["transform_file"] = args.pop("config")
+        # --plan must SHORT-CIRCUIT here: the distributed wrapper filters kwargs by the entrypoint's
+        # signature, so passing 'plan' through would be dropped and the run would proceed as if the
+        # flag had never been given.
+        if args.pop("plan", False):
+            plan_transform(**args)
+        else:
+            transform(**args)
+    elif args["command"] in (str(State.TRAIN), str(State.RESUME)):
         from konfai.trainer import train
 
         if args["config"] is None:
             del args["config"]
         train(**args)
+    else:
+        # Exhaustive on purpose: the old catch-all silently launched the trainer for any command it
+        # did not know, which is how a new workflow could train a UNet instead of failing.
+        parser.error(f"Unknown command '{args['command']}'.")
 
 
 def main():

--- a/konfai/transformer.py
+++ b/konfai/transformer.py
@@ -1,0 +1,796 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The TRANSFORM workflow: apply a declared transform chain to a dataset. No model.
+
+The engine is :meth:`DatasetManager.materialize` — the streamed Save sweep with its whole-volume
+fallback — and the product is the plan: before a byte is written, every (case, chain) is planned on
+the launcher, each output destination is probed with a real region-write open (created then
+removed, so the printed verdict is the run's own), and the whole thing is printed and kept on disk.
+Nothing here falls back silently: a chain that cannot stream says which stage refused and why, and
+``on_fallback`` decides whether that is information, a warning, or an error.
+"""
+
+import contextlib
+import json
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, cast
+
+import numpy as np
+import tqdm
+from ruamel.yaml import YAML
+
+from konfai import config_file, transforms_directory
+from konfai.data.case_reduction import CaseReduction, split_chain
+from konfai.data.data_manager import DataTransform, _format_gib
+from konfai.data.patching import DatasetManager, _save_destination
+from konfai.data.transform import Save, split_expand
+from konfai.utils.config import apply_config, config
+from konfai.utils.dataset import Attribute, Dataset
+from konfai.utils.errors import ConfigError, TransformerError
+from konfai.utils.runtime import (
+    DistributedObject,
+    State,
+    configure_workflow_environment,
+    run_distributed_app,
+)
+
+#: Working copies the whole-volume fallback holds while a case is in flight: the assembled tensor
+#: plus one transform output. Streamed cases hold a slab instead; this factor sizes the fallback.
+_FALLBACK_INFLIGHT_FACTOR = 2
+_CASE_ELEMENT_BYTES = 4  # volumes travel as float32 through the chain
+_PROBE_ENTRY = "__konfai_plan_probe__"
+
+
+@dataclass(frozen=True)
+class TransformPlanEntry:
+    """One (case, chain) line of the plan: the verdict the run itself will act on."""
+
+    case: str  # the case name, the copy's entry name behind an Expand, or a reduction's output name
+    group_src: str
+    group_dest: str
+    verdict: str  # "STREAM" | "WHOLE-VOLUME" | "SKIP" | "REDUCE" | "REFUSED"
+    reason: str | None
+    case_bytes: int
+    #: The cases folded into one, for a reduction. Empty for an ordinary per-case entry. Printed in
+    #: full: a reduction whose case list silently changed writes a different volume under the same
+    #: name, and nothing about the output would look wrong.
+    reduced: tuple[str, ...] = ()
+    #: The case this entry is an Expand copy of ("" for anything that is not a copy).
+    expanded_from: str = ""
+    #: How a STREAM copy is read: "shared" rides the case's single read pass, "solo" sweeps its own
+    #: (its draw's read geometry is its own). None for non-copy entries and non-STREAM verdicts.
+    regime: str | None = None
+
+    @property
+    def working_set_bytes(self) -> int:
+        """What this entry holds at its peak — the figure the budget bounds.
+
+        A reduction's ``case_bytes`` is already its resident regions (it holds one region per case,
+        not one volume), where a whole-volume fallback holds the case plus one in-flight copy.
+        """
+        return self.case_bytes if self.reduced else self.case_bytes * _FALLBACK_INFLIGHT_FACTOR
+
+
+@dataclass
+class TransformPlan:
+    """The plan as an object — what ``--plan`` prints and ``setup`` enforces."""
+
+    entries: list[TransformPlanEntry]
+    budget_bytes: float
+    budget_desc: str
+    world_size: int
+    dropped_cases: dict[str, int]
+    dtype_hypothesis: str
+
+    @property
+    def fallback_entries(self) -> list[TransformPlanEntry]:
+        return [entry for entry in self.entries if entry.verdict == "WHOLE-VOLUME"]
+
+    @property
+    def refused_entries(self) -> list[TransformPlanEntry]:
+        """Reductions that cannot stream. Unlike a per-case chain they have no whole-volume path to
+        fall back to, so these refuse the run whatever ``on_fallback`` says."""
+        return [entry for entry in self.entries if entry.verdict == "REFUSED"]
+
+    def budget_violations(self) -> list[TransformPlanEntry]:
+        """Entries whose working set exceeds the per-rank budget — the hard constraint.
+
+        Two kinds qualify, and for the same reason: they hold something the budget cannot shrink.
+        A whole-volume fallback holds the case (times the in-flight factor). A reduction holds one
+        region per case, and once its region is down to a single row there is nothing left to fold —
+        so unlike a streamed case, whose slab height simply keeps shrinking, it has to refuse. The
+        estimate is from headers alone and the margin is printed, never hidden: an entry within a
+        few percent of the budget may still exceed it.
+        """
+        candidates = [entry for entry in self.entries if entry.verdict in ("WHOLE-VOLUME", "REDUCE")]
+        return [entry for entry in candidates if entry.working_set_bytes > self.budget_bytes]
+
+    def report(self) -> str:
+        lines = [
+            f"[Transformer] plan over {self.world_size} rank(s) | per-rank budget"
+            f" {_format_gib(self.budget_bytes)} ({self.budget_desc}) | fallback working set = case"
+            f" x {_CASE_ELEMENT_BYTES} B x {_FALLBACK_INFLIGHT_FACTOR} (in-flight copy), headers-only"
+            f" estimate | output dtype/channels assumed {self.dtype_hypothesis} until the first slab"
+        ]
+        for group_src, dropped in sorted(self.dropped_cases.items()):
+            if dropped:
+                lines.append(
+                    f"[Transformer] {dropped} case(s) present in '{group_src}' only are DROPPED:"
+                    " several groups_src keep the intersection of their case names."
+                )
+        by_chain: dict[tuple[str, str], list[TransformPlanEntry]] = {}
+        for entry in self.entries:
+            by_chain.setdefault((entry.group_src, entry.group_dest), []).append(entry)
+        for (group_src, group_dest), entries in by_chain.items():
+            reductions = [entry for entry in entries if entry.reduced]
+            if reductions:
+                for entry in reductions:
+                    lines.append(
+                        f"  {group_src} -> {group_dest}: REDUCE {len(entry.reduced)} case(s) -> 1"
+                        f" output '{entry.case}' -- {entry.verdict}"
+                    )
+                    if entry.reason:
+                        lines.append(f"    {entry.reason}")
+                    if entry.verdict == "REDUCE":
+                        lines.append(
+                            f"    peak ~= {_format_gib(entry.working_set_bytes)} vs per-rank budget"
+                            f" {_format_gib(self.budget_bytes)}"
+                        )
+                    lines.append(f"    cases: {', '.join(entry.reduced)}")
+                continue
+            counts = dict.fromkeys(("STREAM", "WHOLE-VOLUME", "SKIP"), 0)
+            for entry in entries:
+                counts[entry.verdict] += 1
+            expanded = [entry for entry in entries if entry.expanded_from]
+            if expanded:
+                cases = len({entry.expanded_from for entry in expanded})
+                shared = sum(1 for entry in expanded if entry.regime == "shared")
+                solo = sum(1 for entry in expanded if entry.regime == "solo")
+                lines.append(
+                    f"  {group_src} -> {group_dest}: EXPAND {cases} case(s) ->"
+                    f" {len(expanded)} cop(ies) -- {shared} STREAM (shared read pass),"
+                    f" {solo} STREAM (own pass), {counts['WHOLE-VOLUME']} WHOLE-VOLUME,"
+                    f" {counts['SKIP']} SKIP (copy already written)"
+                )
+            else:
+                lines.append(
+                    f"  {group_src} -> {group_dest}: {len(entries)} case(s) --"
+                    f" {counts['STREAM']} STREAM, {counts['WHOLE-VOLUME']} WHOLE-VOLUME,"
+                    f" {counts['SKIP']} SKIP (output already written)"
+                )
+            reasons: dict[str, int] = {}
+            for entry in entries:
+                if entry.reason and (entry.verdict == "WHOLE-VOLUME" or entry.regime == "solo"):
+                    label = "WHOLE-VOLUME" if entry.verdict == "WHOLE-VOLUME" else "own pass"
+                    reasons[f"{label}: {entry.reason}"] = reasons.get(f"{label}: {entry.reason}", 0) + 1
+            for reason, count in reasons.items():
+                lines.append(f"    ({count} cop(ies)) {reason}" if expanded else f"    ({count} case(s)) {reason}")
+            if counts["WHOLE-VOLUME"]:
+                worst = max(entry.working_set_bytes for entry in entries if entry.verdict == "WHOLE-VOLUME")
+                lines.append(
+                    f"    worst fallback case ~= {_format_gib(worst)}"
+                    f" vs per-rank budget {_format_gib(self.budget_bytes)}"
+                )
+        return "\n".join(lines)
+
+
+@config()
+class Transformer(DistributedObject):
+    """Model-less workflow that materializes every chain's ``Write`` outputs, plan first."""
+
+    def __init__(
+        self,
+        name: str = "default|TRANSFORM_01",
+        on_fallback: Literal["allow", "warn", "error"] = "warn",
+        manual_seed: int = 0,
+        dataset: DataTransform = DataTransform(),
+    ) -> None:
+        if os.environ["KONFAI_CONFIG_MODE"] != "Done":
+            raise ConfigError("Transformer requires KONFAI_CONFIG_MODE='Done' before initialization.")
+        super().__init__(name)
+        self.transform_path = transforms_directory() / self.name
+        self.on_fallback = on_fallback
+        self.manual_seed = int(manual_seed)
+        self.dataset = dataset
+        # The seed reaches the Expand draws by DERIVATION, not by seeding a global RNG: each chain
+        # builds its own stage objects, so what a shared RNG hands them depends on the order the
+        # chains happen to be built, and an image and its mask would drift apart. Handed over before
+        # prepare(), which is where the chains are bound and the draws happen.
+        self.dataset.manual_seed = self.manual_seed
+        # prepare() binds the chains and runs every parse-time refusal (terminal Write, output
+        # collisions, writes into the source, inference transforms) before any byte is read.
+        self.dataset.prepare()
+        self._overwrite = False
+        self._budget_bytes: float | None = None
+        self._shards: list[list[int]] = []
+        self._case_names: list[str] = []
+        self._reductions: dict[str, CaseReduction | None] = {}
+
+    def _managers(self) -> dict[str, list[DatasetManager]]:
+        prepared = self.dataset._prepared_data
+        if prepared is None:
+            raise TransformerError("The dataset was not prepared before planning.")
+        return prepared
+
+    def _group_src_of(self, group_dest: str) -> str:
+        for group_src in self.dataset.groups_src:
+            if group_dest in self.dataset.groups_src[group_src]:
+                return group_src
+        return "?"
+
+    @staticmethod
+    def _terminal_destination(manager: DatasetManager) -> tuple[Dataset, str]:
+        # Guarded rather than indexed blindly: an empty chain is refused at parse time, but this
+        # runs on every case of every plan and a bare IndexError would say nothing about why.
+        terminal = manager.transforms[-1] if manager.transforms else None
+        if not isinstance(terminal, Save):
+            raise TransformerError(
+                f"The chain writing '{manager.group_dest}' does not end with a Write, so it has no destination.",
+                "End every chain with Write: {dataset: <path>[:format]}.",
+            )
+        return _save_destination(terminal, manager.dataset, manager.group_dest)
+
+    def _reduction(self, group_dest: str, managers: list[DatasetManager]) -> CaseReduction | None:
+        """The reduction this chain declares, or ``None`` when it is an ordinary per-case chain.
+
+        The cases are re-managed with the PRE-reduction stages only: the prepared managers carry the
+        whole chain, ``Reduce`` included, and a manager holding it would refuse to stream — rightly,
+        since as a per-case stage it cannot run at all.
+
+        Built once per chain and kept, because planning, sharding and running all ask for it and
+        must get the SAME object: the run has to execute the reduction the plan measured, and
+        rebuilding means re-managing every case and re-planning every chain.
+        """
+        if group_dest in self._reductions:
+            return self._reductions[group_dest]
+        reduction = self._build_reduction(group_dest, managers)
+        self._reductions[group_dest] = reduction
+        return reduction
+
+    def _build_reduction(self, group_dest: str, managers: list[DatasetManager]) -> CaseReduction | None:
+        if not managers:
+            return None
+        pre, reduce, post = split_chain(managers[0].transforms)
+        if reduce is None:
+            return None
+        cases = [
+            DatasetManager(
+                index=manager.index,
+                group_src=manager.group_src,
+                group_dest=manager.group_dest,
+                name=manager.name,
+                dataset=manager.dataset,
+                patch=None,
+                transforms=list(pre),
+                data_augmentations_list=[],
+            )
+            for manager in managers
+        ]
+        terminal = post[-1] if post else None
+        if not isinstance(terminal, Save):
+            raise TransformerError(
+                f"The chain reducing into '{reduce.output}' does not end with a Write.",
+                "A reduction writes one entry, so the chain carrying it must say where:"
+                " Write: {dataset: <path>[:format]}.",
+            )
+        destination, group = _save_destination(terminal, managers[0].dataset, group_dest)
+        reduction = CaseReduction(
+            managers=cases,
+            reduce=reduce,
+            post=list(post[:-1]),
+            destination=destination,
+            group=group,
+        )
+        reduction.fit_budget(self._budget_bytes)
+        return reduction
+
+    @staticmethod
+    def _dtype_hypothesis(manager: DatasetManager) -> np.dtype:
+        """The planned output dtype: the last cast's target if the chain declares one, else float32.
+
+        The engine takes the real dtype from the first computed slab; the plan says so instead of
+        pretending to know.
+        """
+        dtype = np.dtype("float32")
+        for transform in manager.transforms:
+            declared = getattr(transform, "dtype", None)
+            if declared is not None:
+                try:
+                    dtype = np.dtype(str(declared).replace("torch.", ""))
+                except TypeError:
+                    pass
+        return dtype
+
+    def _probe_write_destinations(
+        self, manager: DatasetManager, probed: set[tuple[str, str]], a: int = 0
+    ) -> str | None:
+        """Open a real region-write stream on each Save/Write destination, then remove it.
+
+        This is what makes the plan the run's own verdict: ``can_stream_data`` is a capability
+        check, but the refusals that matter (rank, dtype, geometry) live in ``open_data_stream``,
+        which the engine only reaches at the first computed slab. The probe pays one entry creation
+        per destination — removed immediately — so ``--plan`` touches the output directories.
+        """
+        channels = int(manager.base_shape[0])
+        dtype = self._dtype_hypothesis(manager)
+        for transform, spatial, attributes in manager.write_targets(a):
+            destination, group = _save_destination(transform, manager.dataset, manager.group_dest)
+            key = (str(destination.filename), group)
+            if key in probed:
+                continue
+            probed.add(key)
+            failure = self._probe_destination(destination, group, [channels, *spatial], dtype, attributes)
+            if failure is not None:
+                return failure
+        return None
+
+    @staticmethod
+    def _probe_destination(
+        destination: Dataset, group: str, shape: list[int], dtype: np.dtype, attributes: Attribute
+    ) -> str | None:
+        """One real region-write open, removed immediately — the probe both chains and reductions
+        share, so the plan's verdict is the run's own on every kind of output."""
+        try:
+            stream = destination.open_data_stream(group, _PROBE_ENTRY, shape, dtype, attributes)
+        except Exception as error:  # the probe exists to surface exactly these
+            Transformer._remove_probe_entry(destination)
+            return (
+                f"destination '{destination.filename}' refuses a"
+                f" [{', '.join(str(extent) for extent in shape)}] {dtype} region write:"
+                f" {type(error).__name__}: {error}"
+            )
+        if stream is None:
+            Transformer._remove_probe_entry(destination)
+            return (
+                f"destination '{destination.filename}' cannot serve region writes"
+                " (h5 and omezarr always can; mha only with image geometry)."
+            )
+        stream.__enter__()
+        stream.abort(RuntimeError("plan probe"))
+        Transformer._remove_probe_entry(destination)
+        return None
+
+    @staticmethod
+    def _remove_probe_entry(destination: Dataset) -> None:
+        """Take the probe's case directory back out of a directory store.
+
+        Aborting the stream removes the ENTRY, but a directory dataset gives every case a directory
+        of its own (``<root>/<case>/<group>.<ext>``) and that one belongs to the store, not the
+        stream. It has to go too: it is shaped exactly like a case, ``get_names`` lists it as one,
+        and a dry run must leave the output as it found it. ``rmdir``, never ``rmtree`` -- anything
+        actually in there is not the probe's, and then the right move is to leave it alone.
+        """
+        if not destination.is_directory:
+            return
+        with contextlib.suppress(OSError):
+            (Path(destination.filename) / _PROBE_ENTRY).rmdir()
+
+    def output_destinations(self) -> list[dict[str, str]]:
+        """Every chain's terminal ``Write``, as ``{group_src, group_dest, dataset, group, format}``.
+
+        What the run produced, said in the run's own terms. The deliverable never lives under the
+        run directory, so this is how a reader -- a person, Studio's run panel, the next workflow --
+        finds it without parsing the plan or re-reading the config.
+        """
+        destinations: list[dict[str, str]] = []
+        for group_dest, managers in self._managers().items():
+            if not managers:
+                continue
+            destination, group = self._terminal_destination(managers[0])
+            destinations.append(
+                {
+                    "group_src": self._group_src_of(group_dest),
+                    "group_dest": group_dest,
+                    "dataset": str(Path(destination.filename).resolve()),
+                    "group": group,
+                    "format": destination.file_format,
+                }
+            )
+        return destinations
+
+    def compute_plan(self, world_size: int = 1, overwrite: bool = False) -> TransformPlan:
+        """Plan every (case, chain) on the launcher, headers plus one write probe per destination."""
+        budget = self.dataset.resolved_budget()
+        per_rank_budget = budget.per_rank_bytes(world_size)
+        # Resolved before anything is planned, because a reduction sizes its regions against it --
+        # the plan must measure the same run setup() will enforce.
+        self._budget_bytes = per_rank_budget
+        entries: list[TransformPlanEntry] = []
+        probed: set[tuple[str, str]] = set()
+        dtype_hypothesis = "float32 / source channels"
+        for group_dest, managers in self._managers().items():
+            group_src = self._group_src_of(group_dest)
+            reduction = self._reduction(group_dest, managers)
+            if reduction is not None:
+                reduction_plan = reduction.plan()
+                skipped = not overwrite and reduction.destination.is_dataset_exist(
+                    reduction.group, reduction.reduce.output
+                )
+                verdict = "SKIP" if skipped else ("REDUCE" if reduction_plan.streams else "REFUSED")
+                reason = (
+                    reduction_plan.refusal
+                    if not reduction_plan.streams
+                    else reduction_plan.describe().split("\n", 1)[1].strip()
+                )
+                if verdict == "REDUCE":
+                    # A reduction has no whole-volume fallback, so a destination that would refuse
+                    # its stream at the first region refuses the plan -- probed here, like a chain's.
+                    probe_failure = self._probe_destination(
+                        reduction.destination,
+                        reduction.group,
+                        [reduction_plan.channels, *reduction_plan.spatial],
+                        np.dtype("float32"),
+                        reduction.reference.landed_attributes(),
+                    )
+                    if probe_failure is not None:
+                        verdict, reason = "REFUSED", probe_failure
+                entries.append(
+                    TransformPlanEntry(
+                        case=reduction.reduce.output,
+                        group_src=group_src,
+                        group_dest=group_dest,
+                        verdict=verdict,
+                        reason=reason,
+                        case_bytes=reduction_plan.peak_bytes,
+                        reduced=tuple(reduction_plan.cases),
+                    )
+                )
+                continue
+            expansion = split_expand(managers[0].transforms)[1] if managers else None
+            for manager in managers:
+                case_bytes = int(np.prod(manager.base_shape, dtype=np.int64)) * _CASE_ELEMENT_BYTES
+                destination, group = self._terminal_destination(manager)
+                if expansion is not None:
+                    # One line per copy: the copies are the outputs, each with its own resume, its
+                    # own verdict, and -- for STREAM -- the regime that says who pays the reads.
+                    for a in range(1, expansion.nb + 1):
+                        entry_name = manager.copy_entry(a)
+                        regime: str | None = None
+                        if not overwrite and destination.is_dataset_exist(group, entry_name):
+                            verdict, reason = "SKIP", None
+                        elif manager.can_stream_patch(a, apply_augmentations=True):
+                            probe_failure = self._probe_write_destinations(manager, probed, a)
+                            if probe_failure is None:
+                                verdict, reason = "STREAM", manager.expansion_solo_reason(a)
+                                regime = "solo" if reason else "shared"
+                            else:
+                                verdict, reason = "WHOLE-VOLUME", probe_failure
+                        else:
+                            verdict = "WHOLE-VOLUME"
+                            reason = manager.stream_refusal(a, apply_augmentations=True)
+                        entries.append(
+                            TransformPlanEntry(
+                                entry_name,
+                                group_src,
+                                group_dest,
+                                verdict,
+                                reason,
+                                case_bytes,
+                                expanded_from=manager.name,
+                                regime=regime,
+                            )
+                        )
+                    continue
+                if not overwrite and destination.is_dataset_exist(group, manager.name):
+                    verdict, reason = "SKIP", None
+                elif manager.can_stream_patch(0, apply_augmentations=False):
+                    probe_failure = self._probe_write_destinations(manager, probed)
+                    if probe_failure is None:
+                        verdict, reason = "STREAM", None
+                    else:
+                        # The run would fail the sweep at its first slab and fall back: say so now.
+                        verdict, reason = "WHOLE-VOLUME", probe_failure
+                else:
+                    verdict = "WHOLE-VOLUME"
+                    reason = manager.stream_refusal(0, apply_augmentations=False)
+                entries.append(TransformPlanEntry(manager.name, group_src, group_dest, verdict, reason, case_bytes))
+        dropped: dict[str, int] = {}
+        kept = set(self.dataset._prepared_train_names)
+        for group_src in self.dataset.groups_src:
+            available: set[str] = set()
+            for dataset in self.dataset.datasets.values():
+                if dataset.is_group_exist(group_src):
+                    available.update(dataset.get_names(group_src))
+            dropped[group_src] = len(available - kept)
+        return TransformPlan(entries, per_rank_budget, budget.description, world_size, dropped, dtype_hypothesis)
+
+    def setup(self, world_size: int):
+        """Plan, print, enforce, shard — before any spawn, before any byte."""
+        # No overwrite prompt on the run folder: it holds logs, the plan and a config copy, all
+        # rewritten in place -- and prompting here would break the default per-case resume (a second
+        # run would refuse because the first one left its config copy behind).
+        os.makedirs(self.transform_path, exist_ok=True)
+        shutil.copyfile(config_file(), self.transform_path / config_file().name)
+
+        self._overwrite = os.environ.get("KONFAI_OVERWRITE", "False") == "True"
+        plan = self.compute_plan(world_size, self._overwrite)
+        report = plan.report()
+        print(report)
+        # The plan is an artifact, not a log line: Studio filters routine startup lines from the
+        # console stream, and a plan that only ever existed as one is a plan nobody can re-read.
+        (self.transform_path / "plan.txt").write_text(report + "\n")
+        # Where the data went, machine-readable beside the human-readable plan. This run directory
+        # holds a log, a plan and a config copy -- never the deliverable, which lands wherever each
+        # Write pointed. Without this, the one thing a reader wants after the run is the one thing
+        # nothing in the run directory names.
+        (self.transform_path / "outputs.json").write_text(json.dumps(self.output_destinations(), indent=2) + "\n")
+
+        if world_size > 1:
+            for managers in self._managers().values():
+                for transform in managers[0].transforms if managers else []:
+                    if not isinstance(transform, Save):
+                        continue
+                    destination, _group = _save_destination(transform, managers[0].dataset, managers[0].group_dest)
+                    # The question here is NOT concurrent_write_safe(): that one asks whether two
+                    # entries of one shared store may be written at once, and answers no for omezarr
+                    # -- which would refuse the very destination this workflow recommends. Ranks
+                    # shard by CASE, and a directory dataset gives each case its own file or store
+                    # (<root>/<case>/<group>.<ext>), so their writes are disjoint by construction.
+                    # Only a single-file store (h5) puts every case in one handle.
+                    if not destination.is_directory:
+                        raise TransformerError(
+                            f"--cpu {world_size}: destination '{destination.filename}' is a"
+                            " single-file store, and every rank would write into the same file.",
+                            "Use one process, or a directory destination (omezarr, mha, nii.gz).",
+                        )
+
+        inference_chains = sorted(
+            group_dest
+            for group_dest, managers in self._managers().items()
+            if managers and any(type(t).__name__ == "KonfAIInference" for t in managers[0].transforms)
+        )
+        if inference_chains:
+            print(
+                f"[Transformer] NOTE: chain(s) {', '.join(inference_chains)} run a NESTED KonfAI"
+                " inference: its GPU and RAM usage live outside the declared memory_budget, and the"
+                " plan cannot bound them."
+            )
+
+        violations = plan.budget_violations()
+        if violations:
+            worst = max(violations, key=lambda entry: entry.working_set_bytes)
+            what = (
+                f"the reduction into '{worst.case}' folds {len(worst.reduced)} case(s) one region at"
+                " a time, and one region already exceeds the budget"
+                if worst.reduced
+                else f"case '{worst.case}' ({worst.reason or 'the chain cannot stream'})"
+            )
+            remedy = (
+                "Nothing was written. Raise 'memory_budget', reduce fewer cases at once, or use an"
+                " incremental operator (Mean folds one case at a time; Median and Concat cannot)."
+                if worst.reduced
+                else "Nothing was written. Make the chain streamable, raise 'memory_budget', or use"
+                " an h5/omezarr destination."
+            )
+            raise TransformerError(
+                f"{len(violations)} output(s) do not fit the per-rank budget"
+                f" ({_format_gib(plan.budget_bytes)}): worst is"
+                f" ~{_format_gib(worst.working_set_bytes)} -- {what}.",
+                remedy,
+            )
+        if self.on_fallback == "error" and plan.fallback_entries:
+            first = plan.fallback_entries[0]
+            raise TransformerError(
+                f"{len(plan.fallback_entries)} case(s) would take the whole-volume path and"
+                f" on_fallback is 'error'. First: case '{first.case}' ({first.group_src} ->"
+                f" {first.group_dest}): {first.reason or 'the chain cannot stream'}",
+                "Nothing was written. Make the chain streamable, or set on_fallback to 'warn' or"
+                " 'allow' to accept the whole-volume path.",
+            )
+        if plan.refused_entries:
+            first = plan.refused_entries[0]
+            raise TransformerError(
+                f"The reduction into '{first.case}' ({first.group_src} -> {first.group_dest}) cannot"
+                f" stream: {first.reason or 'see the plan'}",
+                "A reduction has no whole-volume path to fall back to -- folding every case in memory"
+                " is what it exists to avoid -- so this refuses the run whatever on_fallback says."
+                " Fix the refusing stage, or put a Save before the Reduce.",
+            )
+        if self.on_fallback == "warn" and plan.fallback_entries:
+            print(
+                f"[Transformer] WARNING: {len(plan.fallback_entries)} case(s) take the whole-volume"
+                " path (reasons above). They fit the budget; set on_fallback: error to refuse them."
+            )
+
+        self._budget_bytes = plan.budget_bytes
+        self._case_names = list(self.dataset._prepared_train_names)
+        # Work items, not cases: an ordinary chain has one per case, a reduction exactly one for all
+        # of them. Each item still writes its own entry, so the disjoint-writes guard above holds.
+        items: list[tuple[str, int]] = []
+        for group_dest, managers in self._managers().items():
+            if self._reduction(group_dest, managers) is not None:
+                items.append((group_dest, -1))
+            else:
+                items.extend((group_dest, index) for index in range(len(managers)))
+        shards = np.array_split(np.arange(len(items)), max(1, world_size))
+        self._items = items
+        self._shards = [[int(index) for index in shard] for shard in shards]
+        self.dataloader = [[] for _ in range(max(1, world_size))]
+
+    def run_process(self, world_size: int, global_rank: int, local_rank: int, dataloaders):
+        """Materialize this rank's cases, one at a time, and say which path wrote each."""
+        del world_size, local_rank, dataloaders
+        managers = self._managers()
+        shard = self._shards[global_rank]
+        counts = {"STREAM": 0, "WHOLE-VOLUME": 0, "SKIP": 0, "REDUCE": 0}
+
+        def description() -> str:
+            return (
+                f"Transform : {counts['STREAM']} streamed | {counts['REDUCE']} reduced"
+                f" | {counts['WHOLE-VOLUME']} whole-volume | {counts['SKIP']} skipped"
+            )
+
+        with tqdm.tqdm(total=len(shard), desc=description(), ncols=0) as progress:
+            for item in shard:
+                group_dest, index = self._items[item]
+                group_managers = managers[group_dest]
+                if index < 0:
+                    reduction = self._reduction(group_dest, group_managers)
+                    assert reduction is not None  # nosec B101 - the item was built from the same predicate
+                    output = reduction.reduce.output
+                    already = reduction.destination.is_dataset_exist(reduction.group, output)
+                    if not self._overwrite and already:
+                        counts["SKIP"] += 1
+                        progress.write(f"[Transformer] '{output}' ({group_dest}): SKIP (already written)")
+                    else:
+                        reduction.materialize(rewrite=self._overwrite)
+                        counts["REDUCE"] += 1
+                        progress.write(
+                            f"[Transformer] '{output}' ({group_dest}): REDUCE {len(reduction.managers)} case(s)"
+                        )
+                else:
+                    manager = group_managers[index]
+                    destination, group = self._terminal_destination(manager)
+                    expansion = split_expand(manager.transforms)[1]
+                    if expansion is not None:
+                        # One item per case, all its copies inside: the engine shares one read pass
+                        # across the copies whose draws allow it, which a per-copy loop could not.
+                        copies = list(range(1, expansion.nb + 1))
+                        todo = [
+                            a
+                            for a in copies
+                            if self._overwrite or not destination.is_dataset_exist(group, manager.copy_entry(a))
+                        ]
+                        counts["SKIP"] += len(copies) - len(todo)
+                        regimes = manager.materialize_copies(
+                            todo, rewrite=self._overwrite, fallback_budget_bytes=self._budget_bytes
+                        )
+                        shared = sum(1 for regime in regimes.values() if regime == "stream-shared")
+                        own = sum(1 for regime in regimes.values() if regime == "stream")
+                        whole = sum(1 for regime in regimes.values() if regime == "whole-volume")
+                        counts["STREAM"] += shared + own
+                        counts["WHOLE-VOLUME"] += whole
+                        progress.write(
+                            f"[Transformer] case '{manager.name}' ({group_dest}): EXPAND"
+                            f" {len(copies)} cop(ies) -- {shared} shared pass, {own} own pass,"
+                            f" {whole} whole-volume, {len(copies) - len(todo)} skipped"
+                        )
+                    elif not self._overwrite and destination.is_dataset_exist(group, manager.name):
+                        counts["SKIP"] += 1
+                        progress.write(f"[Transformer] case '{manager.name}' ({group_dest}): SKIP (already written)")
+                    else:
+                        streamed = manager.materialize(
+                            0, rewrite=self._overwrite, fallback_budget_bytes=self._budget_bytes
+                        )
+                        verdict = "STREAM" if streamed else "WHOLE-VOLUME"
+                        counts[verdict] += 1
+                        progress.write(f"[Transformer] case '{manager.name}' ({group_dest}): {verdict}")
+                progress.set_description(description())
+                progress.update(1)
+
+
+#: The grammar the strict mode accepts, level by level. ``None`` marks free-form levels (group
+#: names, classpaths, transform parameters -- those bind to the transform's own signature).
+_STRICT_GRAMMAR: dict[str, object] = {
+    "name": None,
+    "on_fallback": None,
+    "manual_seed": None,
+    "Dataset": {
+        "dataset_filenames": None,
+        "memory_budget": None,
+        "subset": None,
+        "groups_src": {"*": {"groups_dest": {"*": {"transforms": None}}}},
+    },
+}
+
+
+def _reject_unknown_keys(config_path: Path) -> None:
+    """Strict mode: any key the TRANSFORM grammar does not know is a parse error.
+
+    The binder reads a key when it exists and materializes the default when it does not — a typo'd
+    ``memory_budge:`` silently becomes ``memory_budget: auto``. On this workflow the config IS the
+    product, so an unknown key is refused with its exact path instead of being carried along.
+    """
+    if not config_path.exists():
+        return
+    with open(config_path) as stream:
+        tree = YAML().load(stream)
+    if not isinstance(tree, dict) or "Transformer" not in tree:
+        return
+
+    def walk(node: object, grammar: dict[str, object], path: str) -> None:
+        if not isinstance(node, dict):
+            return
+        for key, value in node.items():
+            child = grammar.get(str(key), grammar.get("*", "unknown"))
+            if child == "unknown":
+                raise ConfigError(
+                    f"Unknown key '{path}.{key}' in the Transformer configuration.",
+                    f"Known keys at this level: {sorted(k for k in grammar if k != '*')}. A typo'd"
+                    " key would otherwise be ignored and its default silently used.",
+                )
+            if isinstance(child, dict):
+                walk(value, child, f"{path}.{key}")
+
+    walk(tree["Transformer"], _STRICT_GRAMMAR, "Transformer")
+
+
+def build_transform(
+    transform_file: Path | str = Path("./Transform.yml").resolve(),
+    transforms_dir: Path | str = Path("./Transforms").resolve(),
+) -> DistributedObject:
+    """Build and return the configured transform workflow without executing it.
+
+    The returned object carries the plan: ``compute_plan()`` is the programmatic dry-run, and
+    ``setup()`` prints and enforces it. This is the in-process surface — ``transform()`` stays
+    ``None``-returning like every workflow entrypoint.
+    """
+    configure_workflow_environment(
+        config_path=transform_file,
+        root="Transformer",
+        state=State.TRANSFORM,
+        path_env={"KONFAI_TRANSFORMS_DIRECTORY": transforms_dir},
+    )
+    os.environ["KONFAI_CONFIG_MODE"] = "Done"
+    _reject_unknown_keys(Path(transform_file))
+    return apply_config()(Transformer)()
+
+
+def plan_transform(
+    overwrite: bool = False,
+    cpu: int = 1,
+    transform_file: Path | str = Path("./Transform.yml").resolve(),
+    transforms_dir: Path | str = Path("./Transforms").resolve(),
+    **_ignored: object,
+) -> TransformPlan:
+    """CLI ``--plan``: build, plan, print, and stop — the workflow never runs.
+
+    The probe opens then removes one region-write entry per destination, so even plan mode touches
+    the output directories: that is the price of a verdict that is the run's own (the printed plan
+    is a measurement, not a prediction).
+    """
+    workflow = build_transform(transform_file=transform_file, transforms_dir=transforms_dir)
+    plan = cast(Transformer, workflow).compute_plan(max(1, int(cpu or 1)), bool(overwrite))
+    print(plan.report())
+    return plan
+
+
+@run_distributed_app
+def transform(
+    overwrite: bool = False,
+    gpu: list[int] | None = None,
+    cpu: int = 1,
+    quiet: bool = False,
+    transform_file: Path | str = Path("./Transform.yml").resolve(),
+    transforms_dir: Path | str = Path("./Transforms").resolve(),
+) -> DistributedObject:
+    """Build and execute the configured transform workflow."""
+    del overwrite, gpu, cpu, quiet
+    return build_transform(transform_file=transform_file, transforms_dir=transforms_dir)

--- a/konfai/transformer.py
+++ b/konfai/transformer.py
@@ -38,7 +38,7 @@ from ruamel.yaml import YAML
 
 from konfai import config_file, transforms_directory
 from konfai.data.case_reduction import CaseReduction, split_chain
-from konfai.data.data_manager import DataTransform, _format_gib
+from konfai.data.data_manager import DataTransform, _format_gib, _node_local_ranks
 from konfai.data.patching import DatasetManager, _save_destination
 from konfai.data.transform import Save, split_expand
 from konfai.utils.config import apply_config, config
@@ -408,17 +408,19 @@ class Transformer(DistributedObject):
     def compute_plan(self, world_size: int = 1, overwrite: bool = False) -> TransformPlan:
         """Plan every (case, chain) on the launcher, headers plus one write probe per destination."""
         budget = self.dataset.resolved_budget()
-        per_rank_budget = budget.per_rank_bytes(world_size)
+        per_rank_budget = budget.per_rank_bytes(_node_local_ranks(world_size))
         # Resolved before anything is planned, because a reduction sizes its regions against it --
         # the plan must measure the same run setup() will enforce.
         self._budget_bytes = per_rank_budget
         entries: list[TransformPlanEntry] = []
         probed: set[tuple[str, str]] = set()
-        dtype_hypothesis = "float32 / source channels"
+        planned_dtypes: set[str] = set()
         for group_dest, managers in self._managers().items():
             group_src = self._group_src_of(group_dest)
             reduction = self._reduction(group_dest, managers)
             if reduction is not None:
+                reduction_dtype = np.dtype("float32")
+                planned_dtypes.add(str(reduction_dtype))
                 reduction_plan = reduction.plan()
                 skipped = not overwrite and reduction.destination.is_dataset_exist(
                     reduction.group, reduction.reduce.output
@@ -436,7 +438,7 @@ class Transformer(DistributedObject):
                         reduction.destination,
                         reduction.group,
                         [reduction_plan.channels, *reduction_plan.spatial],
-                        np.dtype("float32"),
+                        reduction_dtype,
                         reduction.reference.landed_attributes(),
                     )
                     if probe_failure is not None:
@@ -453,6 +455,9 @@ class Transformer(DistributedObject):
                     )
                 )
                 continue
+            if managers:
+                # Every manager of a group shares one chain object, so one of them answers for all.
+                planned_dtypes.add(str(self._dtype_hypothesis(managers[0])))
             expansion = split_expand(managers[0].transforms)[1] if managers else None
             for manager in managers:
                 case_bytes = int(np.prod(manager.base_shape, dtype=np.int64)) * _CASE_ELEMENT_BYTES
@@ -509,6 +514,7 @@ class Transformer(DistributedObject):
                 if dataset.is_group_exist(group_src):
                     available.update(dataset.get_names(group_src))
             dropped[group_src] = len(available - kept)
+        dtype_hypothesis = f"{'/'.join(sorted(planned_dtypes)) or 'float32'} / source channels"
         return TransformPlan(entries, per_rank_budget, budget.description, world_size, dropped, dtype_hypothesis)
 
     def setup(self, world_size: int):

--- a/konfai/utils/errors.py
+++ b/konfai/utils/errors.py
@@ -84,6 +84,12 @@ class TransformError(NamedKonfAIError):
     TYPE = "Transform"
 
 
+class TransformerError(NamedKonfAIError):
+    # One letter from TransformError, deliberately: the invariant is TYPE == root-class name, so the
+    # printed label tells a workflow failure ([Transformer]) from a data-transform one ([Transform]).
+    TYPE = "Transformer"
+
+
 class ReductionError(NamedKonfAIError):
     TYPE = "Reduction"
 

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -59,6 +59,7 @@ from konfai import (
     konfai_state,
     predictions_directory,
     statistics_directory,
+    transforms_directory,
 )
 from konfai.utils.errors import ConfigError
 from konfai.utils.utils import env_flag
@@ -313,6 +314,7 @@ class State(Enum):
     RESUME = "RESUME"
     PREDICTION = "PREDICTION"
     EVALUATION = "EVALUATION"
+    TRANSFORM = "TRANSFORM"
 
     def __str__(self) -> str:
         return self.value
@@ -580,6 +582,8 @@ class Log(MinimalLog):
             path = predictions_directory()
         elif konfai_state() == "EVALUATION":
             path = evaluations_directory()
+        elif konfai_state() == "TRANSFORM":
+            path = transforms_directory()
         else:
             path = statistics_directory()
         # ``name`` is train_name from the config; an absolute path or '..' segments would place the logs

--- a/studio/frontend/src/RightPanel.tsx
+++ b/studio/frontend/src/RightPanel.tsx
@@ -775,7 +775,7 @@ function ExperimentView({
 // Validation reads amber, everything else sage-green — so a metric's train/val lines are told apart at a
 // glance (orange = validation, the one comparison that matters on a training chart).
 // The workflow order runs happen in — drives the sub-tab order (train first, evaluation last).
-const KIND_ORDER: Record<string, number> = { train: 0, finetune: 1, prediction: 2, uncertainty: 3, evaluation: 4 };
+const KIND_ORDER: Record<string, number> = { train: 0, finetune: 1, prediction: 2, uncertainty: 3, evaluation: 4, transform: 5 };
 
 const SAGE = "var(--sage)";
 const AMBER = "var(--working)";
@@ -1364,7 +1364,9 @@ export default function RightPanel({
           ? `Evaluations/${r.run}`
           : r.kind === "uncertainty"
             ? `Uncertainties/${r.run}`
-            : `Statistics/${r.run}`);
+            : r.kind === "transform"
+              ? `Transforms/${r.run}`
+              : `Statistics/${r.run}`);
     const [dir, open] =
       r.kind === "prediction"
         ? [`${root}/Dataset`, "volume"]

--- a/studio/konfai_studio/agent.py
+++ b/studio/konfai_studio/agent.py
@@ -75,7 +75,7 @@ SYSTEM_PROMPT = (
     "  [now] the step the experiment is waiting on. Do it -- unless the user's message asks for something "
     "else, which always wins.\n"
     "  [constraint] a compute restriction to respect exactly.\n\n"
-    "NEVER start training, fine-tuning, prediction or evaluation without asking first. Say in one line "
+    "NEVER start training, fine-tuning, prediction, evaluation or a dataset transform without asking first. Say in one line "
     "what it will cost -- how many cases, on which device, roughly how long -- and wait for a yes. The "
     "only exception is relaunching a run you just corrected after a failure.\n\n"
     "A run is a result only when its job says so. After any run_* or fine_tune_app, wait for the job to "

--- a/studio/konfai_studio/jobs.py
+++ b/studio/konfai_studio/jobs.py
@@ -34,6 +34,7 @@ _RUN_ROOT_KIND = {
     "Predictions": "prediction",
     "Evaluations": "evaluation",
     "Uncertainties": "uncertainty",
+    "Transforms": "transform",
 }
 
 
@@ -161,6 +162,7 @@ def _discover_run_logs(job: dict[str, Any]) -> list[tuple[Path, str, str]]:
         "Predictions/*/log_0.txt",
         "Evaluations/*/log_0.txt",
         "Uncertainties/*/log_0.txt",
+        "Transforms/*/log_0.txt",
     ):
         for log in sorted(base.glob(pattern)):
             if log in seen:
@@ -214,6 +216,32 @@ def _runtime_events(line: str, run: str, kind: str, step: int) -> tuple[list[dic
     return [], step
 
 
+def _run_data_dir(session: str, base: str) -> str:
+    """Where a run's DATA is, when that is not the run directory itself.
+
+    A transform's run directory holds a log, a plan and a config copy — the volumes land wherever each
+    ``Write`` pointed, which the workflow records in ``outputs.json``. Pointing Browse at the run
+    directory would open a YAML file for someone who just asked to see what was produced. Answers ""
+    for every kind whose data IS under its run directory, and the caller keeps its usual path.
+    """
+    manifest = _session_dir(session) / base / "outputs.json"
+    if not manifest.is_file():
+        return ""
+    try:
+        outputs = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return ""
+    if not isinstance(outputs, list) or not outputs or not isinstance(outputs[0], dict):
+        return ""
+    dataset = outputs[0].get("dataset")
+    if not isinstance(dataset, str) or not dataset:
+        return ""
+    # Session-relative when it lives inside the session, so Browse resolves it like every other path.
+    with suppress(ValueError):
+        return str(Path(dataset).relative_to(_session_dir(session)))
+    return dataset
+
+
 def _discover_session_runs(session: str) -> list[tuple[Path, str, str, str, str]]:
     """Every run of the experiment as (log_path, run_name, kind, status, base) — one per runtime log.
 
@@ -260,7 +288,12 @@ def _discover_session_runs(session: str) -> list[tuple[Path, str, str, str, str]
             base = log.parent.name
         found.append((log, run_name, kind, status, base, log.stat().st_mtime))
 
-    for root, kind in (("Statistics", "train"), ("Predictions", "prediction"), ("Evaluations", "evaluation")):
+    for root, kind in (
+        ("Statistics", "train"),
+        ("Predictions", "prediction"),
+        ("Evaluations", "evaluation"),
+        ("Transforms", "transform"),
+    ):
         directory = base_root / root
         if directory.is_dir():
             for log in directory.glob("*/log_0.txt"):

--- a/tests/unit/test_case_expansion.py
+++ b/tests/unit/test_case_expansion.py
@@ -1,0 +1,440 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The 1-to-N cardinality: ``Expand`` as a declared point of the chain, and the engine behind it.
+
+A draw is a stage. It is declared in the chain, where it applies, and it composes with the
+transforms and the other draws around it — ``T, draw, T, draw`` means exactly what it reads like.
+The properties that would fail without any of this: the copies carry their draw and land under
+their own names; a streamed copy equals the whole-volume one; and the copies that can share a read
+pass do share it — the optimisation the engine exists for — while the ones that cannot say why.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from konfai.data.augmentation import Brightness, Flip, Permute, Scale
+from konfai.data.patching import DatasetManager
+from konfai.data.transform import Clip, Expand, Save, TensorCast, Transform, Write, split_expand
+from konfai.utils.dataset import Attribute, Dataset
+from konfai.utils.errors import PatchError, TransformError
+
+pytest.importorskip("SimpleITK")
+
+
+def _image_attributes() -> Attribute:
+    attributes = Attribute()
+    attributes["Origin"] = np.asarray([10.0, 20.0, 30.0])
+    attributes["Spacing"] = np.asarray([0.5, 1.5, 2.0])
+    attributes["Direction"] = np.eye(3, dtype=np.float64).reshape(-1)
+    return attributes
+
+
+def _source(tmp_path: Path, name: str = "CASE_000") -> Dataset:
+    rng = np.random.default_rng(0)
+    dataset = Dataset(tmp_path / "source", "mha")
+    dataset.write("CT", name, (rng.random((1, 12, 10, 8)) * 100).astype(np.float32), _image_attributes())
+    return dataset
+
+
+def _draw(augmentation):
+    """A draw as the chain declares it: an ordinary stage, loaded so it applies to every copy."""
+    augmentation.load(1.0)
+    return augmentation
+
+
+def _drawn_scales(augmentation: Scale, index: int = 0) -> list[torch.Tensor]:
+    """The matrices a ``Scale`` actually drew for one case's copies — the draw itself, not its
+    effect: a scale keeps the grid, so comparing shapes would compare nothing."""
+    return list(augmentation.matrix[index])
+
+
+def _manager(source: Dataset, transforms: list[Transform], name: str = "CASE_000") -> DatasetManager:
+    return DatasetManager(
+        index=0,
+        group_src="CT",
+        group_dest="CT",
+        name=name,
+        dataset=source,
+        patch=None,
+        transforms=transforms,
+        data_augmentations_list=[],
+    )
+
+
+# --------------------------------------------------------------------- the marker
+
+
+def test_expand_refuses_a_pattern_that_cannot_separate_its_entries() -> None:
+    with pytest.raises(TransformError, match=r"\{a\}"):
+        Expand(pattern="{name}_fixed")
+    with pytest.raises(TransformError, match=r"\{name\}"):
+        Expand(pattern="copy_{a:02d}")
+    with pytest.raises(TransformError, match="cannot format"):
+        Expand(pattern="{name}_{nope}")
+
+
+def test_expand_refuses_a_cardinality_below_one() -> None:
+    with pytest.raises(TransformError, match="at least one"):
+        Expand(nb=0)
+
+
+def test_expand_is_never_applied_as_an_ordinary_transform() -> None:
+    with pytest.raises(TransformError, match="expands nothing"):
+        Expand()("CASE_000", torch.zeros(1, 2, 2, 2), Attribute())
+
+
+def test_split_expand_is_the_chain_around_its_marker() -> None:
+    clip, expand, write = Clip(0.0, 50.0), Expand(), Write("./out:h5")
+    assert split_expand([clip, expand, write]) == ([clip], expand, [write])
+    # No marker: everything is the shared part, which is what keeps a 1-to-1 chain untouched.
+    assert split_expand([clip, write]) == ([clip, write], None, [])
+
+
+# ------------------------------------------------------- the declared position
+
+
+def test_copies_are_written_under_their_own_names_and_carry_their_draw(tmp_path: Path) -> None:
+    """With the draw declared after the marker, what lands on disk is AUGMENTED.
+
+    Before this feature the draws lived in a separate section and were applied after the whole
+    chain — that is, after the Write — so every copy's entry held the un-augmented volume.
+    """
+    source = _source(tmp_path)
+    out = Dataset(tmp_path / "out", "h5")
+    manager = _manager(
+        source,
+        [
+            Clip(0.0, 50.0),
+            Expand(nb=2, pattern="{name}_r{a:02d}"),
+            _draw(Flip(f_prob=[0.0, 1.0, 1.0])),
+            Write(f"{tmp_path / 'out'}:h5"),
+        ],
+    )
+
+    assert set(manager.materialize_copies([1, 2])) == {1, 2}
+    assert out.is_dataset_exist("CT", "CASE_000_r01")
+    assert out.is_dataset_exist("CT", "CASE_000_r02")
+    # The case's own name is NOT written: a copy is not the case.
+    assert not out.is_dataset_exist("CT", "CASE_000")
+
+    clipped = np.clip(source.read_data("CT", "CASE_000")[0], 0.0, 50.0)
+    written = out.read_data("CT", "CASE_000_r01")[0]
+    assert not np.array_equal(written, clipped), "the copy carries no draw"
+    np.testing.assert_array_equal(written, clipped[:, :, ::-1, ::-1])
+
+
+def test_a_chain_without_expand_is_untouched(tmp_path: Path) -> None:
+    """The regression guard: with no marker there are no copies at all."""
+    source = _source(tmp_path)
+    manager = _manager(source, [Clip(0.0, 50.0)])
+    assert manager._expand is None
+    assert manager.copy_entry(1) == "CASE_000"
+    assert manager.shapes == [[12, 10, 8]]
+    with pytest.raises(PatchError, match="declares no Expand"):
+        manager.materialize_copies([1])
+
+
+def test_two_chains_of_one_case_draw_the_same_copies(tmp_path: Path) -> None:
+    """Augmenting an image and its mask coherently.
+
+    Every ``groups_dest`` builds its OWN stage objects, so an image chain and a mask chain hold two
+    different ``Scale`` instances and cannot agree on the order they would consume a shared random
+    generator in. They derive from the seed instead. A mask scaled differently from its image is a
+    silently ruined dataset: both outputs look entirely normal on their own.
+    """
+    source = _source(tmp_path)
+    image_draw, mask_draw = _draw(Scale(0.2)), _draw(Scale(0.2))
+    _manager(source, [Expand(nb=4), image_draw], name="CASE_000")
+    _manager(source, [Expand(nb=4), mask_draw], name="CASE_000")
+
+    drawn = _drawn_scales(image_draw)
+    assert len(drawn) == 4 and len({tuple(row.flatten().tolist()) for row in drawn}) == 4
+    for mine, theirs in zip(drawn, _drawn_scales(mask_draw), strict=True):
+        assert torch.equal(mine, theirs)
+
+    # A different seed is a different set of copies -- otherwise "the same" would prove nothing.
+    other_draw = _draw(Scale(0.2))
+    _manager(source, [Expand(nb=4, seed=1), other_draw], name="CASE_000")
+    assert not torch.equal(_drawn_scales(other_draw)[0], drawn[0])
+
+
+def test_an_unrelated_draw_in_one_chain_does_not_shift_the_shared_ones(tmp_path: Path) -> None:
+    """A mask chain has no use for an intensity draw, and dropping it must not desynchronise the
+    geometry. Each draw is keyed on its own class and rank, not on its position in the tail."""
+    source = _source(tmp_path)
+    with_intensity, alone = _draw(Scale(0.2)), _draw(Scale(0.2))
+    _manager(source, [Expand(nb=3), _draw(Brightness(0.2)), with_intensity])
+    _manager(source, [Expand(nb=3), alone])
+
+    for mine, theirs in zip(_drawn_scales(with_intensity), _drawn_scales(alone), strict=True):
+        assert torch.equal(mine, theirs)
+
+
+# --------------------------------------------------- draws chain like transforms
+
+
+def test_a_draw_is_a_stage_that_chains_with_the_transforms_around_it(tmp_path: Path) -> None:
+    """``T, draw, T, draw`` — the order is the declared one, and it is planned as ONE chain.
+
+    The streamed result must equal applying exactly that order by hand on the whole volume.
+    """
+    source = _source(tmp_path)
+    first, second = _draw(Brightness(b_std=0.3)), _draw(Flip(f_prob=[0.0, 1.0, 0.0]))
+    manager = _manager(
+        source,
+        [
+            Clip(0.0, 50.0),
+            Expand(nb=2, pattern="{name}_r{a:02d}"),
+            first,
+            TensorCast(dtype="float32"),
+            second,
+            Write(f"{tmp_path / 'out'}:h5"),
+        ],
+    )
+    tail = manager._expand_tail(1)
+    assert [type(getattr(stage, "augmentation", stage)).__name__ for stage in tail] == [
+        "Brightness",
+        "TensorCast",
+        "Flip",
+        "Write",
+    ]
+
+    assert set(manager.materialize_copies([1, 2]).values()) <= {"stream", "stream-shared"}
+
+    expected = Clip(0.0, 50.0)(
+        "CASE_000", torch.from_numpy(source.read_data("CT", "CASE_000")[0]), Attribute(_image_attributes())
+    )
+    expected = first.compute("CASE_000", 0, 0, expected)
+    expected = TensorCast(dtype="float32")("CASE_000", expected, Attribute())
+    expected = second.compute("CASE_000", 0, 0, expected)
+
+    got = Dataset(tmp_path / "out", "h5").read_data("CT", "CASE_000_r01")[0]
+    np.testing.assert_allclose(got, expected.numpy(), rtol=0, atol=1e-6)
+
+
+def test_a_transform_after_a_shape_changing_draw_folds_on_the_copys_grid(tmp_path: Path) -> None:
+    """A draw that reorders axes hands the NEXT stage its own extent — the chain, both ways."""
+    source = _source(tmp_path)
+    manager = _manager(
+        source,
+        [
+            Clip(0.0, 50.0),
+            Expand(nb=2, pattern="{name}_r{a:02d}"),
+            _draw(Permute(prob_permute=[1.0, 0.0])),
+            TensorCast(dtype="float32"),
+            Write(f"{tmp_path / 'out'}:h5"),
+        ],
+    )
+    assert manager.shapes[0] == [12, 10, 8]
+    assert manager.shapes[1] != manager.shapes[0], "the copy's grid did not follow its draw"
+
+    assert set(manager.materialize_copies([1, 2]).values()) <= {"stream", "stream-shared", "whole-volume"}
+    written = Dataset(tmp_path / "out", "h5").read_data("CT", "CASE_000_r01")[0]
+    assert list(written.shape[1:]) == manager.shapes[1]
+
+
+def test_chain_stages_is_the_one_definition_of_a_copy(tmp_path: Path) -> None:
+    source = _source(tmp_path)
+    clip, write = Clip(0.0, 50.0), Write(f"{tmp_path / 'out'}:h5")
+    manager = _manager(source, [clip, Expand(nb=2), _draw(Brightness(b_std=0.2)), write])
+    # The marker itself is never a stage: it is where the per-copy tail begins.
+    assert manager.chain_stages(1) == [clip, *manager._expand_tail(1)]
+    assert manager.chain_stages(1)[-1] == write
+    # Copy 0 is the case: no draw, so the tail is its transforms alone.
+    assert manager.chain_stages(0) == [clip, write]
+
+
+# ------------------------------------------------- streamed equals whole-volume
+
+
+def test_a_streamed_copy_equals_the_whole_volume_copy(tmp_path: Path) -> None:
+    source = _source(tmp_path)
+    # ONE draw instance in both chains: a draw caches its parameters per case index, so the second
+    # manager reuses the first one's rather than redrawing.
+    draw = _draw(Brightness(b_std=0.3))
+    streamed = _manager(
+        source,
+        [Clip(0.0, 50.0), Expand(nb=3, pattern="{name}_r{a:02d}"), draw, Write(f"{tmp_path / 'streamed'}:h5")],
+    )
+    assert streamed.materialize_copies([1, 2, 3]) == {1: "stream-shared", 2: "stream-shared", 3: "stream-shared"}
+
+    classic = _manager(
+        source,
+        [Clip(0.0, 50.0), Expand(nb=3, pattern="{name}_r{a:02d}"), draw, Write(f"{tmp_path / 'classic'}:h5")],
+    )
+    for a in (1, 2, 3):
+        classic._assemble_and_write(a)
+
+    for a in (1, 2, 3):
+        entry = f"CASE_000_r{a:02d}"
+        got, got_attributes = Dataset(tmp_path / "streamed", "h5").read_data("CT", entry)
+        expected, expected_attributes = Dataset(tmp_path / "classic", "h5").read_data("CT", entry)
+        np.testing.assert_allclose(got, expected, rtol=0, atol=1e-6)
+        for key in ("Origin", "Spacing", "Direction"):
+            np.testing.assert_allclose(
+                got_attributes.get_np_array(key), expected_attributes.get_np_array(key), rtol=0, atol=1e-9
+            )
+
+
+# --------------------------------------------------------------- the regimes
+
+
+def test_the_shared_pass_reads_the_source_once_for_every_copy(tmp_path: Path) -> None:
+    """The optimisation, asserted as a bound rather than inferred from a verdict.
+
+    Reads are decompression-bound, so N copies must not cost N reads. Counting them is the only way
+    to prove it: a per-copy loop would show three times as many.
+    """
+    source = _source(tmp_path)
+    reads: list[tuple] = []
+    original = Dataset.read_data_slice
+
+    def counted(self, groups, name, slices):
+        reads.append((groups, name))
+        return original(self, groups, name, slices)
+
+    manager = _manager(
+        source,
+        [
+            Clip(0.0, 50.0),
+            Expand(nb=3, pattern="{name}_r{a:02d}"),
+            _draw(Brightness(b_std=0.3)),
+            Write(f"{tmp_path / 'out'}:h5"),
+        ],
+    )
+    Dataset.read_data_slice = counted  # type: ignore[method-assign]
+    try:
+        regimes = manager.materialize_copies([1, 2, 3])
+    finally:
+        Dataset.read_data_slice = original  # type: ignore[method-assign]
+
+    assert set(regimes.values()) == {"stream-shared"}
+    source_reads = [entry for entry in reads if entry == ("CT", "CASE_000")]
+    assert len(source_reads) == 1, f"the copies did not share the read pass: {len(source_reads)} reads"
+
+
+def test_a_region_draw_takes_its_own_pass_and_the_plan_names_the_draw(tmp_path: Path) -> None:
+    """A draw reading elsewhere than its target slab cannot ride the shared slab — and says so."""
+    source = _source(tmp_path)
+    manager = _manager(
+        source,
+        [
+            Clip(0.0, 50.0),
+            Expand(nb=2, pattern="{name}_r{a:02d}"),
+            _draw(Flip(f_prob=[0.0, 1.0, 1.0])),
+            Write(f"{tmp_path / 'out'}:h5"),
+        ],
+    )
+    reason = manager.expansion_solo_reason(1)
+    assert reason is not None and "Flip" in reason and "ORIENTATION" in reason
+
+    assert manager.materialize_copies([1, 2]) == {1: "stream", 2: "stream"}
+    out = Dataset(tmp_path / "out", "h5")
+    assert out.is_dataset_exist("CT", "CASE_000_r01") and out.is_dataset_exist("CT", "CASE_000_r02")
+
+
+def test_a_whole_volume_draw_falls_back_per_copy_and_still_writes(tmp_path: Path) -> None:
+    source = _source(tmp_path)
+    manager = _manager(
+        source,
+        [
+            Clip(0.0, 50.0),
+            Expand(nb=2, pattern="{name}_r{a:02d}"),
+            _draw(Scale(s_std=0.1)),  # Scale declares WHOLE_VOLUME on purpose
+            Write(f"{tmp_path / 'out'}:h5"),
+        ],
+    )
+    assert manager.stream_refusal(1, apply_augmentations=True) is not None
+    assert manager.materialize_copies([1, 2]) == {1: "whole-volume", 2: "whole-volume"}
+    out = Dataset(tmp_path / "out", "h5")
+    assert out.is_dataset_exist("CT", "CASE_000_r01") and out.is_dataset_exist("CT", "CASE_000_r02")
+    assert not manager.loaded and not manager.data
+
+
+def test_the_write_probe_targets_the_copys_grid_not_the_cases(tmp_path: Path) -> None:
+    """The plan measures the RUN, so it must probe the extent the copies really write."""
+    source = _source(tmp_path)
+    manager = _manager(
+        source,
+        [
+            Clip(0.0, 50.0),
+            Expand(nb=2, pattern="{name}_r{a:02d}"),
+            _draw(Permute(prob_permute=[1.0, 0.0])),
+            Write(f"{tmp_path / 'out'}:h5"),
+        ],
+    )
+    case_targets = manager.write_targets(0)
+    copy_targets = manager.write_targets(1)
+    assert [shape for _stage, shape, _attributes in copy_targets] == [manager.shapes[1]]
+    assert copy_targets[0][1] != case_targets[0][1], "the probe would validate the pre-draw extent"
+
+
+# --------------------------------------------------------------------- resume
+
+
+def test_a_written_copy_is_not_rewritten_and_overwrite_forces_it(tmp_path: Path) -> None:
+    source = _source(tmp_path)
+
+    def build() -> DatasetManager:
+        return _manager(
+            source,
+            [
+                Clip(0.0, 50.0),
+                Expand(nb=2, pattern="{name}_r{a:02d}"),
+                _draw(Brightness(b_std=0.3)),
+                Write(f"{tmp_path / 'out'}:h5"),
+            ],
+        )
+
+    build().materialize_copies([1, 2])
+    store = tmp_path / "out.h5"
+    stamp = store.stat().st_mtime_ns
+
+    build().materialize_copies([1, 2])
+    assert store.stat().st_mtime_ns == stamp
+
+    build().materialize_copies([1, 2], rewrite=True)
+    assert store.stat().st_mtime_ns != stamp
+
+
+def test_a_shared_cache_before_the_marker_is_swept_once_for_every_copy(tmp_path: Path) -> None:
+    """A Save before the Expand is the copies' shared work: materialized exactly once."""
+    source = _source(tmp_path)
+    manager = _manager(
+        source,
+        [
+            Clip(0.0, 50.0),
+            Save(f"{tmp_path / 'work'}:h5"),
+            Expand(nb=3, pattern="{name}_r{a:02d}"),
+            _draw(Brightness(b_std=0.3)),
+            Write(f"{tmp_path / 'out'}:h5"),
+        ],
+    )
+    manager.materialize_copies([1, 2, 3], rewrite=True)
+
+    work = Dataset(tmp_path / "work", "h5")
+    # The shared cache holds the CASE (no draw), under the case's own name, once.
+    assert work.is_dataset_exist("CT", "CASE_000")
+    assert not work.is_dataset_exist("CT", "CASE_000_r01")
+    clipped = np.clip(source.read_data("CT", "CASE_000")[0], 0.0, 50.0)
+    np.testing.assert_allclose(work.read_data("CT", "CASE_000")[0], clipped, rtol=0, atol=1e-6)
+
+    out = Dataset(tmp_path / "out", "h5")
+    for a in (1, 2, 3):
+        assert out.is_dataset_exist("CT", f"CASE_000_r{a:02d}")

--- a/tests/unit/test_case_expansion.py
+++ b/tests/unit/test_case_expansion.py
@@ -388,8 +388,24 @@ def test_the_write_probe_targets_the_copys_grid_not_the_cases(tmp_path: Path) ->
 # --------------------------------------------------------------------- resume
 
 
-def test_a_written_copy_is_not_rewritten_and_overwrite_forces_it(tmp_path: Path) -> None:
+def test_a_written_copy_is_not_rewritten_and_overwrite_forces_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Resume is per copy: the entry already on disk is the one that is skipped.
+
+    Counted at the store's own door rather than read off the file, because both of those proxies
+    lie in one direction each -- a timestamp two writes share within a tick reads as 'skipped', and
+    so do identical bytes for a draw that is reproducible, which is what this codebase aims at.
+    """
     source = _source(tmp_path)
+    opened: list[str] = []
+    real_open = Dataset.open_data_stream
+
+    def spy(self: Dataset, group: str, entry: str, *args, **kwargs):
+        opened.append(entry)
+        return real_open(self, group, entry, *args, **kwargs)
+
+    monkeypatch.setattr(Dataset, "open_data_stream", spy)
 
     def build() -> DatasetManager:
         return _manager(
@@ -403,14 +419,16 @@ def test_a_written_copy_is_not_rewritten_and_overwrite_forces_it(tmp_path: Path)
         )
 
     build().materialize_copies([1, 2])
-    store = tmp_path / "out.h5"
-    stamp = store.stat().st_mtime_ns
+    written = list(opened)
+    assert len(written) == 2, written
 
+    opened.clear()
     build().materialize_copies([1, 2])
-    assert store.stat().st_mtime_ns == stamp
+    assert opened == [], "a copy already on disk was written again"
 
+    opened.clear()
     build().materialize_copies([1, 2], rewrite=True)
-    assert store.stat().st_mtime_ns != stamp
+    assert opened == written, "rewrite=True did not force both copies"
 
 
 def test_a_shared_cache_before_the_marker_is_swept_once_for_every_copy(tmp_path: Path) -> None:

--- a/tests/unit/test_case_reduction.py
+++ b/tests/unit/test_case_reduction.py
@@ -1,0 +1,389 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The cases engine: N cases folded into one entry, one region at a time.
+
+What matters here is not that the median is right -- it is that it is right while the volumes are
+never assembled, that a cases which does not agree on its grid is refused before anything is read,
+and that a chain continues after the reduction."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from konfai.data.case_reduction import CaseReduction, resolve_operator, split_chain
+from konfai.data.patching import DatasetManager
+from konfai.data.reduction import Mean, Median, Reduction
+from konfai.data.transform import Clip, Dilate, Normalize, Reduce, TensorCast, Transform
+from konfai.utils.dataset import Attribute, Dataset
+from konfai.utils.errors import ReductionError, TransformError
+
+CASES = 4  # even on purpose: an even cases is where a lower-median would show
+
+
+def _attributes(spacing: tuple[float, float, float] = (1.0, 1.0, 2.0)) -> Attribute:
+    attribute = Attribute()
+    attribute["Origin"] = np.asarray([0.0, 0.0, 0.0])
+    attribute["Spacing"] = np.asarray(list(spacing))
+    attribute["Direction"] = np.eye(3, dtype=np.float64).reshape(-1)
+    return attribute
+
+
+def _cohort(tmp_path: Path, count: int = CASES, spacings: list | None = None) -> tuple[Dataset, np.ndarray]:
+    rng = np.random.default_rng(0)
+    volumes = (rng.random((count, 1, 8, 10, 6)) * 100).astype(np.float32)
+    dataset = Dataset(tmp_path / "cases", "h5")
+    for index in range(count):
+        spacing = spacings[index] if spacings else (1.0, 1.0, 2.0)
+        dataset.write("CT", f"CASE_{index:03d}", volumes[index], _attributes(spacing))
+    return dataset, volumes
+
+
+def _managers(dataset: Dataset, pre: list[Transform], count: int = CASES) -> list[DatasetManager]:
+    return [
+        DatasetManager(
+            index=index,
+            group_src="CT",
+            group_dest="CT",
+            name=f"CASE_{index:03d}",
+            dataset=dataset,
+            patch=None,
+            transforms=list(pre),
+            data_augmentations_list=[],
+        )
+        for index in range(count)
+    ]
+
+
+def _run(tmp_path: Path, pre: list[Transform], reduce: Reduce, post: list[Transform], slab_rows: int = 3, **kwargs):
+    dataset, volumes = _cohort(tmp_path, **kwargs)
+    destination = Dataset(tmp_path / "out", "h5")
+    engine = CaseReduction(
+        managers=_managers(dataset, pre, kwargs.get("count", CASES)),
+        reduce=reduce,
+        post=post,
+        destination=destination,
+        group="CT",
+        slab_rows=slab_rows,
+    )
+    return engine, destination, volumes
+
+
+def test_split_chain_finds_the_cardinality_change() -> None:
+    reduce = Reduce(output="t")
+    pre, found, post = split_chain([Clip(0.0, 50.0), reduce, TensorCast("float32")])
+    assert [type(t).__name__ for t in pre] == ["Clip"]
+    assert found is reduce
+    assert [type(t).__name__ for t in post] == ["TensorCast"]
+    plain = [Clip(0.0, 50.0)]
+    assert split_chain(plain) == (plain, None, [])
+
+
+def test_median_of_an_even_cohort_matches_numpy_without_assembling(tmp_path: Path) -> None:
+    engine, destination, volumes = _run(tmp_path, [], Reduce(operator="Median", output="template"), [])
+    assert engine.materialize() is True
+
+    written, _ = destination.read_data("CT", "template")
+    np.testing.assert_allclose(written, np.median(volumes, axis=0), rtol=1e-6)
+    # Never assembled: each case streamed, so no manager ever loaded its volume.
+    assert all(not manager.loaded and not manager.data for manager in engine.managers)
+
+
+def test_mean_is_incremental_so_the_cohort_is_never_resident(tmp_path: Path) -> None:
+    engine, destination, volumes = _run(tmp_path, [], Reduce(operator="Mean", output="avg"), [])
+    plan = engine.plan()
+    assert plan.incremental is True and plan.resident_regions == 2
+
+    engine.materialize()
+    written, _ = destination.read_data("CT", "avg")
+    np.testing.assert_allclose(written, volumes.mean(axis=0), rtol=1e-6)
+
+
+@pytest.mark.parametrize("operator", [Mean(), Median()])
+def test_averaging_keeps_a_floating_dtype_and_widens_an_integer_one(operator: Reduction) -> None:
+    """The predictor is the other caller, and it writes what these hand back.
+
+    A float16 ensemble reduced into float32 doubles every prediction on disk with nothing said; an
+    integer cohort rounded back to integers turns the average of 1 and 2 into 1. Same rule, both
+    directions: a floating input keeps its dtype, an integer one widens and stays widened.
+    """
+    half = [torch.ones(1, 1, 2, 2, dtype=torch.float16), torch.full((1, 1, 2, 2), 2.0, dtype=torch.float16)]
+    assert operator(half).dtype is torch.float16
+    assert operator([half[0]]).dtype is torch.float16
+
+    whole = [torch.ones(1, 1, 2, 2, dtype=torch.int16), torch.full((1, 1, 2, 2), 2, dtype=torch.int16)]
+    assert operator(whole).dtype is torch.float32
+    assert float(operator(whole).flatten()[0]) == pytest.approx(1.5)
+
+
+def test_a_non_incremental_operator_holds_the_whole_cohort_per_region(tmp_path: Path) -> None:
+    engine, _destination, _volumes = _run(tmp_path, [], Reduce(operator="Median", output="t"), [])
+    plan = engine.plan()
+    assert plan.incremental is False
+    assert plan.resident_regions == CASES + 1
+    assert "resident region" in plan.describe() and "CASE_000" in plan.describe()
+
+
+def test_per_member_stages_run_on_each_member_separately(tmp_path: Path) -> None:
+    """The whole point of cases being cases: a GLOBAL_STAT before the reduction seeds from the
+    case's OWN volume, so a cases of different dynamics normalises per specimen."""
+    rng = np.random.default_rng(1)
+    dataset = Dataset(tmp_path / "cases", "h5")
+    volumes = []
+    for index, scale in enumerate((1.0, 10.0, 100.0, 1000.0)):
+        volume = (rng.random((1, 8, 10, 6)) * scale).astype(np.float32)
+        volumes.append(volume)
+        dataset.write("CT", f"CASE_{index:03d}", volume, _attributes())
+    destination = Dataset(tmp_path / "out", "h5")
+
+    engine = CaseReduction(
+        managers=_managers(dataset, [Normalize(min_value=0.0, max_value=1.0)]),
+        reduce=Reduce(operator="Median", output="template"),
+        post=[],
+        destination=destination,
+        group="CT",
+        slab_rows=3,
+    )
+    engine.materialize()
+
+    written, _ = destination.read_data("CT", "template")
+    expected = np.median(
+        np.stack([(v - v.min()) / (v.max() - v.min()) for v in volumes], axis=0).astype(np.float32), axis=0
+    )
+    np.testing.assert_allclose(written, expected, rtol=1e-5, atol=1e-6)
+
+
+def test_a_chain_continues_after_the_reduction(tmp_path: Path) -> None:
+    engine, destination, volumes = _run(
+        tmp_path, [], Reduce(operator="Mean", output="avg"), [Clip(min_value=0.0, max_value=50.0)]
+    )
+    engine.materialize()
+
+    written, _ = destination.read_data("CT", "avg")
+    np.testing.assert_allclose(written, np.clip(volumes.mean(axis=0), 0.0, 50.0), rtol=1e-6)
+
+
+def test_a_statistic_of_the_result_is_seeded_by_a_first_pass(tmp_path: Path) -> None:
+    """`Normalize` after the reduction wants the Min/Max of a volume that is stored nowhere. The
+    engine computes them by reducing once without writing, then reduces again to apply them --
+    twice the reads, no intermediate volume."""
+    engine, destination, volumes = _run(
+        tmp_path, [], Reduce(operator="Mean", output="avg"), [Normalize(min_value=0.0, max_value=1.0)]
+    )
+    assert engine.plan().stat_pass is True
+    engine.materialize()
+
+    written, _ = destination.read_data("CT", "avg")
+    reference = volumes.mean(axis=0)
+    expected = (reference - reference.min()) / (reference.max() - reference.min())
+    np.testing.assert_allclose(written, expected, rtol=1e-5, atol=1e-6)
+
+
+def test_a_cohort_that_disagrees_on_geometry_is_refused_before_reading(tmp_path: Path) -> None:
+    engine, _destination, _volumes = _run(
+        tmp_path,
+        [],
+        Reduce(operator="Mean", output="avg"),
+        [],
+        spacings=[(1.0, 1.0, 2.0), (1.0, 1.0, 2.0), (1.0, 1.0, 9.0), (1.0, 1.0, 2.0)],
+    )
+    refusal = engine.check_grid()
+    assert refusal is not None and "Spacing" in refusal and "CASE_002" in refusal
+    with pytest.raises(ReductionError, match="cannot stream"):
+        engine.materialize()
+
+
+def test_shape_only_accepts_approximate_headers(tmp_path: Path) -> None:
+    engine, destination, volumes = _run(
+        tmp_path,
+        [],
+        Reduce(operator="Mean", output="avg", grid="shape_only"),
+        [],
+        spacings=[(1.0, 1.0, 2.0), (1.0, 1.0, 2.0), (1.0, 1.0, 9.0), (1.0, 1.0, 2.0)],
+    )
+    assert engine.check_grid() is None
+    engine.materialize()
+    written, _ = destination.read_data("CT", "avg")
+    np.testing.assert_allclose(written, volumes.mean(axis=0), rtol=1e-6)
+
+
+def test_a_named_reference_adopts_its_geometry_instead_of_demanding_agreement(tmp_path: Path) -> None:
+    """``reference:<case>`` is how a cohort says its members disagree and which one to believe.
+
+    It was running the ``strict`` geometry comparison anyway, and against the FIRST case rather than
+    the named one -- so the policy refused exactly the cohorts it exists for, and named the wrong
+    case when it did. Its documented contract is equal extents, and that member's geometry.
+    """
+    engine, destination, volumes = _run(
+        tmp_path,
+        [],
+        Reduce(operator="Mean", output="avg", grid="reference:CASE_002"),
+        [],
+        spacings=[(1.0, 1.0, 2.0), (1.0, 1.0, 2.0), (1.0, 1.0, 9.0), (1.0, 1.0, 2.0)],
+    )
+
+    assert engine.check_grid() is None
+    assert engine.reference.name == "CASE_002"
+    engine.materialize()
+
+    written, attribute = destination.read_data("CT", "avg")
+    np.testing.assert_allclose(written, volumes.mean(axis=0), rtol=1e-6)
+    # The output carries the NAMED member's geometry, which is the whole point of naming one.
+    np.testing.assert_allclose(attribute.get_np_array("Spacing"), [1.0, 1.0, 9.0])
+
+
+def test_a_named_reference_still_demands_equal_extents(tmp_path: Path) -> None:
+    engine, _destination, _volumes = _run(
+        tmp_path, [], Reduce(operator="Mean", output="avg", grid="reference:CASE_001"), []
+    )
+    engine.managers[2].shapes[0] = [4, 10, 6]
+
+    refusal = engine.check_grid()
+    assert refusal is not None and "CASE_002" in refusal and "CASE_001" in refusal
+
+
+def test_concat_plans_the_channel_count_it_will_actually_write(tmp_path: Path) -> None:
+    """A ``Concat`` writes ``cases x channels``, and only the operator can say so.
+
+    ``transform_shape`` maps spatial extents and says nothing about the leading axis, so the planner
+    took the source's channel count -- which sized the regions at a quarter of what a four-case
+    Concat holds, and had the write probe validate a shape the run never opens.
+    """
+    engine, destination, volumes = _run(tmp_path, [], Reduce(operator="Concat", output="stacked"), [])
+
+    assert engine.plan().channels == CASES
+    engine.materialize()
+    written, _attribute = destination.read_data("CT", "stacked")
+    assert written.shape[0] == CASES
+    np.testing.assert_allclose(written, np.concatenate(list(volumes), axis=0), rtol=1e-6)
+
+
+def test_the_deliverable_carries_its_own_recipe(tmp_path: Path) -> None:
+    engine, destination, _volumes = _run(tmp_path, [], Reduce(operator="Median", output="template"), [])
+    engine.materialize()
+
+    _data, attribute = destination.read_data("CT", "template")
+    assert attribute["konfai_reduce_operator"] == "Median"
+    assert attribute["konfai_reduce_cases"] == "CASE_000|CASE_001|CASE_002|CASE_003"
+
+
+def test_reduce_refuses_to_be_used_as_an_ordinary_transform() -> None:
+    with pytest.raises(TransformError, match="reduces nothing"):
+        Reduce(output="t")("CASE_000", torch.zeros(1, 2, 2, 2), Attribute())
+
+
+def test_reduce_without_an_output_is_refused_at_construction() -> None:
+    with pytest.raises(TransformError, match="needs an 'output'"):
+        Reduce(operator="Mean")
+
+
+def test_an_unknown_grid_policy_is_refused_at_construction() -> None:
+    with pytest.raises(TransformError, match="unknown grid policy"):
+        Reduce(output="t", grid="whatever")
+
+
+def test_a_non_voxel_local_operator_is_refused(tmp_path: Path) -> None:
+    engine, _destination, _volumes = _run(tmp_path, [], Reduce(operator="Median", output="t"), [])
+    engine.operator = Median()
+    object.__setattr__(engine.operator, "voxel_local", False)
+    from konfai.data import case_reduction as reduction_module
+
+    class Spatial(Mean):
+        voxel_local = False
+
+    reduction_module.__dict__.setdefault("_Spatial", Spatial)
+    with pytest.raises(ReductionError, match="voxel-local"):
+        from konfai.data.case_reduction import resolve_operator
+
+        resolve_operator(Reduce(operator="konfai.data.case_reduction:_Spatial", output="t"))
+
+
+def test_a_second_run_skips_the_finished_reduction(tmp_path: Path) -> None:
+    engine, destination, _volumes = _run(tmp_path, [], Reduce(operator="Mean", output="avg"), [])
+    engine.materialize()
+    written, _ = destination.read_data("CT", "avg")
+    store = next(path for path in tmp_path.iterdir() if path.name.startswith("out"))
+    stamp = store.stat().st_mtime_ns
+
+    engine.materialize()
+    again, _ = destination.read_data("CT", "avg")
+    np.testing.assert_array_equal(again, written)
+    assert store.stat().st_mtime_ns == stamp
+
+
+def test_a_region_stage_after_the_reduction_is_refused_not_seamed(tmp_path: Path) -> None:
+    """A halo applied to one region at a time would seam at every boundary -- plausible and wrong.
+
+    It is deferred, not forbidden: materialize the reduction and read it back in a second chain."""
+    dataset, _volumes = _cohort(tmp_path)
+    with pytest.raises(ReductionError, match="reads across space"):
+        CaseReduction(
+            managers=_managers(dataset, []),
+            reduce=Reduce(operator="Mean", output="avg"),
+            post=[Dilate(2)],
+            destination=Dataset(tmp_path / "out", "h5"),
+            group="CT",
+            slab_rows=3,
+        )
+
+
+# ------------------------------------------------ a custom operator, configured
+
+
+class _Weighted(Reduction):
+    """A custom operator with a parameter — the extension point, exercised."""
+
+    voxel_local = True
+
+    def __init__(self, weight: float = 1.0) -> None:
+        self.weight = weight
+
+    def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
+        return torch.stack(tensors, dim=0).float().mean(dim=0) * self.weight
+
+
+class _Shadowing(Reduction):
+    voxel_local = True
+
+    def __init__(self, output: str = "x") -> None:
+        self.output = output
+
+    def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
+        return tensors[0]
+
+
+class _NotVoxelLocal(Reduction):
+    def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
+        return tensors[0]
+
+
+def test_a_custom_operator_resolves_and_keeps_its_defaults_without_config() -> None:
+    """A chain built in Python has no configuration to read: the operator uses its own defaults."""
+    operator = resolve_operator(Reduce(operator=f"{__name__}:_Weighted", output="t"))
+    assert isinstance(operator, _Weighted) and operator.weight == 1.0
+
+
+def test_a_custom_operator_is_refused_when_it_cannot_fold_a_region() -> None:
+    with pytest.raises(ReductionError, match="voxel-local"):
+        resolve_operator(Reduce(operator=f"{__name__}:_NotVoxelLocal", output="t"))
+
+
+def test_an_operator_shadowing_a_reduce_key_is_refused() -> None:
+    """Operator parameters and Reduce's own keys share one mapping, so a collision is refused
+    rather than silently handing the stage's value to the operator."""
+    with pytest.raises(ReductionError, match="reads for itself"):
+        resolve_operator(Reduce(operator=f"{__name__}:_Shadowing", output="t"))

--- a/tests/unit/test_materialize_driver.py
+++ b/tests/unit/test_materialize_driver.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""``DatasetManager.materialize`` writes a case's chain without ever going through ``get_data``.
+
+Two branches, and the caller is told which one ran: the sweep when the chain streams, the classic
+load when it cannot. Both must leave the same bytes, and the streamed one must leave the volume on
+disk — never in memory, which is what a whole-volume patch through ``get_data`` would have done."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from konfai.data.patching import DatasetManager
+from konfai.data.transform import Clip, Permute, Save, Standardize, Transform
+from konfai.utils.dataset import Attribute, Dataset
+
+pytest.importorskip("SimpleITK")
+
+
+def _image_attributes() -> Attribute:
+    attributes = Attribute()
+    attributes["Origin"] = np.asarray([10.0, 20.0, 30.0])
+    attributes["Spacing"] = np.asarray([0.5, 1.5, 2.0])
+    attributes["Direction"] = np.eye(3, dtype=np.float64).reshape(-1)
+    return attributes
+
+
+def _source(tmp_path: Path) -> Dataset:
+    rng = np.random.default_rng(0)
+    volume = (rng.random((1, 12, 10, 8)) * 100).astype(np.float32)
+    dataset = Dataset(tmp_path / "source", "mha")
+    dataset.write("CT", "CASE_000", volume, _image_attributes())
+    return dataset
+
+
+def _manager(source: Dataset, transforms: list[Transform]) -> DatasetManager:
+    # No patch declared: this is exactly the TRANSFORM case, where get_data would cut one
+    # whole-volume patch and read back what materialize just wrote.
+    return DatasetManager(
+        index=0,
+        group_src="CT",
+        group_dest="CT",
+        name="CASE_000",
+        dataset=source,
+        patch=None,
+        transforms=transforms,
+        data_augmentations_list=[],
+    )
+
+
+def test_streamed_branch_writes_without_holding_the_volume(tmp_path: Path) -> None:
+    source = _source(tmp_path)
+    manager = _manager(source, [Clip(0.0, 50.0), Save(str(tmp_path / "out"))])
+
+    assert manager.materialize() is True
+    assert Dataset(tmp_path / "out", "mha").is_dataset_exist("CT", "CASE_000")
+    # The volume was never assembled: the sweep read regions and wrote regions.
+    assert not manager.loaded
+    assert not manager.data
+
+
+def test_streamed_branch_writes_the_same_bytes_as_the_classic_load(tmp_path: Path) -> None:
+    source = _source(tmp_path)
+    classic = [Permute("2|1|0"), Clip(0.0, 50.0), Save(str(tmp_path / "classic"))]
+    swept = [Permute("2|1|0"), Clip(0.0, 50.0), Save(str(tmp_path / "swept"))]
+
+    _manager(source, classic).load(classic, [], load_augmentations=False)
+    assert _manager(source, swept).materialize() is True
+
+    expected, expected_attributes = Dataset(tmp_path / "classic", "mha").read_data("CT", "CASE_000")
+    result, result_attributes = Dataset(tmp_path / "swept", "mha").read_data("CT", "CASE_000")
+    np.testing.assert_array_equal(result, expected)
+    for key in ("Origin", "Spacing", "Direction"):
+        np.testing.assert_allclose(
+            result_attributes.get_np_array(key), expected_attributes.get_np_array(key), err_msg=key
+        )
+
+
+def test_whole_volume_branch_still_writes_and_says_so(tmp_path: Path) -> None:
+    """A statistic taken after a value-changing stage cannot stream: the stored volume's statistic
+    is not Standardize's input, so the chain falls back.
+
+    This is the case the driver exists for — ``_stream_ready`` alone would have returned False and
+    written nothing at all, silently."""
+    source = _source(tmp_path)
+    manager = _manager(source, [Clip(0.0, 50.0), Standardize(inverse=False), Save(str(tmp_path / "out"))])
+
+    assert manager.can_stream_patch(0) is False
+    assert manager.materialize() is False
+    assert Dataset(tmp_path / "out", "mha").is_dataset_exist("CT", "CASE_000")
+    # The fallback assembled the volume, but released it before returning.
+    assert not manager.data
+
+
+def test_unstreamable_destination_falls_back_and_writes(tmp_path: Path) -> None:
+    # nii.gz cannot serve region writes: the sweep refuses, the classic load writes it anyway.
+    source = _source(tmp_path)
+    manager = _manager(source, [Clip(0.0, 50.0), Save(f"{tmp_path / 'out'}:nii.gz")])
+
+    assert manager.materialize() is False
+    assert Dataset(tmp_path / "out", "nii.gz").is_dataset_exist("CT", "CASE_000")
+
+
+def test_materialize_never_reads_the_volume_back(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The memory bound, asserted as a bound: the streamed branch must not call the whole-volume read.
+
+    Equality of values would pass even if the streamed path loaded everything; only forbidding the
+    full read proves the case never landed in memory."""
+    source = _source(tmp_path)
+    manager = _manager(source, [Clip(0.0, 50.0), Save(str(tmp_path / "out"))])
+
+    def refuse(*args: object, **kwargs: object) -> None:
+        raise AssertionError("materialize() read the whole volume")
+
+    monkeypatch.setattr(Dataset, "read_data", refuse)
+    assert manager.materialize() is True
+
+
+def test_second_run_skips_the_case(tmp_path: Path) -> None:
+    """Per-case resume, for free: the Save boundary answers, so nothing is recomputed or rewritten."""
+    source = _source(tmp_path)
+    transforms = [Clip(0.0, 50.0), Save(str(tmp_path / "out"))]
+    assert _manager(source, transforms).materialize() is True
+
+    written = Dataset(tmp_path / "out", "mha")
+    before, _ = written.read_data("CT", "CASE_000")
+    stamp = next((tmp_path / "out").glob("**/*")).stat().st_mtime_ns
+
+    manager = _manager(source, transforms)
+    assert manager.materialize() is True
+    after, _ = written.read_data("CT", "CASE_000")
+    np.testing.assert_array_equal(after, before)
+    assert next((tmp_path / "out").glob("**/*")).stat().st_mtime_ns == stamp

--- a/tests/unit/test_ome_zarr_data_surface.py
+++ b/tests/unit/test_ome_zarr_data_surface.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The public data surface: the OME-Zarr readers and the pyramid writer, as a capsule uses them.
+
+These cover what a hand-rolled store reader gets wrong, which is never the happy path: a big-endian
+source, a pyramid level that does not exist, and a downsampling default that changes the pixels."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("zarr")
+pytest.importorskip("ngff_zarr")
+
+from konfai.data import (
+    append_ome_zarr_levels,
+    create_ome_zarr_store,
+    get_ome_zarr_info,
+    read_ome_zarr_data_slice,
+    write_ome_zarr,
+)
+from konfai.utils.errors import DatasetManagerError
+
+
+def _volume(dtype: str = "<f4") -> np.ndarray:
+    rng = np.random.default_rng(0)
+    return (rng.random((1, 8, 12, 16)) * 1000).astype(dtype)
+
+
+def _big_endian_store(path: Path, volume: np.ndarray) -> Path:
+    """A store that genuinely holds big-endian samples, as a light-sheet source does.
+
+    Written through create_ome_zarr_store, because that is the one path that keeps the dtype it is
+    given: write_ome_zarr would hand the array to ngff-zarr, which normalises on the way in and so
+    could never exercise the reader.
+    """
+    array = create_ome_zarr_store(path, volume.shape, ">f4", spacing=[2.0, 1.0, 1.0])
+    array[:] = volume.astype(">f4")
+    return path
+
+
+def test_the_public_surface_is_importable_from_konfai_data() -> None:
+    """The locality vocabulary is the framework's distinctive feature; a user who cannot import it
+    cannot make their transform stream at all."""
+    import konfai.data as kd
+
+    assert kd.PatchLocality(kd.LocalityKind.HALO, halo=(2,)).halo == (2,)
+    for name in ("DatasetManager", "Transform", "Write", "Dataset", "LocalityKind", "PatchLocality"):
+        assert name in kd.__all__ and hasattr(kd, name), name
+
+
+def test_reader_returns_native_byte_order(tmp_path: Path) -> None:
+    """Light-sheet sources are big-endian. A non-native array is refused outright by
+    torch.from_numpy, and silently reinterpreted by anything that touches the raw buffer."""
+    volume = _volume()
+    store = _big_endian_store(tmp_path / "big_endian.ome.zarr", volume)
+
+    patch, _ = read_ome_zarr_data_slice(store, (slice(None), slice(0, 4), slice(None), slice(None)))
+    assert patch.dtype.isnative
+    import torch
+
+    torch.from_numpy(patch)  # the loud half of the bug: this raises on a non-native array
+    np.testing.assert_array_equal(patch, volume[:, :4])
+
+
+def test_info_publishes_the_shape_the_reader_indexes(tmp_path: Path) -> None:
+    """`shape` is the store's own axis order and `canonical_shape` is the reader's; sizing slices
+    from the wrong one reads a transposed region with the right rank and no error."""
+    store = tmp_path / "v.ome.zarr"
+    write_ome_zarr(store, _volume(), spacing=[2.0, 1.0, 1.0])
+    info = get_ome_zarr_info(store)
+
+    assert info["canonical_shape"] == [1, 8, 12, 16]
+    patch, _ = read_ome_zarr_data_slice(store, tuple(slice(0, s) for s in info["canonical_shape"]))
+    assert list(patch.shape) == info["canonical_shape"]
+
+
+def test_out_of_range_level_says_so_instead_of_blaming_the_store(tmp_path: Path) -> None:
+    store = tmp_path / "pyramid.ome.zarr"
+    write_ome_zarr(store, _volume(), spacing=[2.0, 1.0, 1.0], scale_factors=[2])
+
+    with pytest.raises(DatasetManagerError, match="level 5 is out of range"):
+        get_ome_zarr_info(store, 5)
+
+
+def test_write_ome_zarr_builds_a_pyramid_by_position(tmp_path: Path) -> None:
+    store = tmp_path / "pyramid.ome.zarr"
+    # spacing arrives (x, y, z) SimpleITK-style, so this is x=2 um, y=1, z=1 -- and the metadata
+    # below is read back (c, z, y, x). The two orders meeting here is the whole reason to assert it.
+    write_ome_zarr(store, _volume(), spacing=[2.0, 1.0, 1.0], scale_factors=[2])
+
+    assert get_ome_zarr_info(store)["n_levels"] == 2
+    fine, coarse = get_ome_zarr_info(store, 0), get_ome_zarr_info(store, 1)
+    assert coarse["canonical_shape"] == [1, 4, 6, 8]
+    # Level 1 is level 0 halved, and carries its OWN spacing -- a consumer indexing by position gets
+    # a coarser image, not the same image mislabelled.
+    assert [round(s, 6) for s in fine["scale"]] == [1.0, 1.0, 1.0, 2.0]
+    assert [round(s, 6) for s in coarse["scale"]] == [1.0, 2.0, 2.0, 4.0]
+    # And its origin is shifted by HALF the spacing delta, per axis: these stores use a
+    # centre-of-voxel convention, so the coarse first voxel sits at the centre of the block it
+    # averages. Reusing the fine origin biases every voxel and still looks like a plausible image.
+    assert [round(t, 6) for t in coarse["translation"]] == [0.0, 0.5, 0.5, 1.0]
+
+
+def test_default_downsampling_is_a_block_mean_not_a_gaussian(tmp_path: Path) -> None:
+    """The default must not change the pixels: BIN_SHRINK is the block mean a capsule writes by
+    hand, where ngff-zarr's own ITKWASM_GAUSSIAN default smooths and crushes the peak."""
+    volume = _volume()
+    store = tmp_path / "shrunk.ome.zarr"
+    write_ome_zarr(store, volume, spacing=[1.0, 1.0, 1.0], scale_factors=[2])
+
+    coarse, _ = read_ome_zarr_data_slice(store, (slice(None),) * 4, level=1)
+    blocks = volume[:, :8, :12, :16].reshape(1, 4, 2, 6, 2, 8, 2)
+    np.testing.assert_allclose(coarse, blocks.mean(axis=(2, 4, 6)), rtol=1e-6)
+
+
+def test_unknown_downsample_method_names_the_valid_ones(tmp_path: Path) -> None:
+    with pytest.raises(DatasetManagerError, match="ITKWASM_BIN_SHRINK"):
+        write_ome_zarr(
+            tmp_path / "x.ome.zarr", _volume(), spacing=[1.0] * 3, scale_factors=[2], downsample_method="NOPE"
+        )
+
+
+def test_append_levels_turns_a_streamed_store_into_a_pyramid(tmp_path: Path) -> None:
+    """The region-written path cannot take scale_factors up front — no level exists until the last
+    region lands — so the pyramid is derived afterwards, and level 0 must survive it untouched."""
+    volume = _volume()
+    store = tmp_path / "streamed.ome.zarr"
+    write_ome_zarr(store, volume, spacing=[2.0, 1.0, 1.0], attributes={"Direction": [1, 0, 0, 0, 1, 0, 0, 0, 1]})
+    assert get_ome_zarr_info(store)["n_levels"] == 1
+
+    append_ome_zarr_levels(store, [2])
+
+    assert get_ome_zarr_info(store)["n_levels"] == 2
+    level0, _ = read_ome_zarr_data_slice(store, (slice(None),) * 4, level=0)
+    np.testing.assert_array_equal(level0, volume)
+    # The sidecar survives the rewrite: losing Direction is silent, the reader falls back to identity.
+    assert get_ome_zarr_info(store)["attributes"]["Direction"] == [1, 0, 0, 0, 1, 0, 0, 0, 1]
+
+
+def test_append_levels_without_factors_is_a_no_op(tmp_path: Path) -> None:
+    store = tmp_path / "v.ome.zarr"
+    write_ome_zarr(store, _volume(), spacing=[1.0] * 3)
+    append_ome_zarr_levels(store, [])
+    assert get_ome_zarr_info(store)["n_levels"] == 1

--- a/tests/unit/test_read_region_sweeps_pending_saves.py
+++ b/tests/unit/test_read_region_sweeps_pending_saves.py
@@ -28,6 +28,7 @@ optimisation of memory, never of meaning.
 """
 
 import numpy as np
+import pytest
 import torch
 from konfai.data.patching import DatasetManager
 from konfai.data.transform import Clip, Save, Standardize
@@ -93,3 +94,31 @@ def test_the_swept_cache_is_written_where_the_save_named_it(tmp_path):
     )
     manager.read_region((slice(0, 2), slice(0, 8), slice(0, 8)), 0, False)
     assert Dataset(tmp_path / "work", "h5").is_dataset_exist("CT", "CASE_000")
+
+
+def test_a_sweep_failure_does_not_survive_the_flip_to_rewriting_saves(tmp_path, monkeypatch):
+    """A failed sweep is a verdict about one boundary answer, and ``--overwrite`` asks the other.
+
+    Kept across the flip it condemns every Save of the new mode to the whole-volume path -- the one
+    path a case too large to assemble cannot take.
+    """
+    _source(tmp_path)
+    chain = [
+        Clip(min_value=-50.0, max_value=50.0),
+        Save(dataset=f"{tmp_path / 'work'}:h5"),
+        Standardize(),
+    ]
+    manager = _manager(tmp_path, chain)
+
+    monkeypatch.setattr(
+        manager,
+        "_materialize_save",
+        lambda sweep: manager._sweep_failed_because(sweep, "OSError: no space left on device"),
+    )
+    with pytest.warns(UserWarning, match="could not be swept"):
+        assert not manager._stream_ready(0, apply_augmentations=False)
+    monkeypatch.undo()
+
+    manager._set_rewrite(True)
+
+    assert manager._stream_ready(0, apply_augmentations=False)

--- a/tests/unit/test_save_streaming.py
+++ b/tests/unit/test_save_streaming.py
@@ -158,7 +158,7 @@ def test_failed_multi_slab_sweep_leaves_no_partial_cache(tmp_path: Path, monkeyp
         real_write(self, slices, data)
 
     monkeypatch.setattr(dataset_module._MhaDataStream, "write_slice", failing_after_first)
-    with pytest.warns(UserWarning, match="falling back to the whole-volume path"):
+    with pytest.warns(UserWarning, match="Falling back to the whole-volume path"):
         patch = manager.get_data(0, 0, [], True)
     monkeypatch.setattr(dataset_module._MhaDataStream, "write_slice", real_write)
 
@@ -238,15 +238,54 @@ def test_failed_sweep_falls_back_to_the_whole_volume_path(tmp_path: Path, monkey
         raise OSError("disk full")
 
     monkeypatch.setattr(dataset_module._MhaDataStream, "write_slice", broken_write)
-    with pytest.warns(UserWarning, match="falling back to the whole-volume path"):
+    with pytest.warns(UserWarning, match="Falling back to the whole-volume path"):
         patch = manager.get_data(0, 0, [], True)
     monkeypatch.undo()
 
     assert manager._sweep_failed
+    # The reason is KEPT, not only warned: a caller with no whole-volume path to fall back to (a
+    # reduction reading through this cache) has to raise, and "see the warning it emitted" is no
+    # answer for a warning a filter may have swallowed.
+    assert manager._sweep_failure is not None
+    assert "CT/CASE_000" in manager._sweep_failure and "disk full" in manager._sweep_failure
     assert torch.equal(patch, reference[0])
     # The aborted sweep left no debris; the whole-volume fallback wrote the cache classically.
     assert not list((tmp_path / "cache").glob("**/*.tmp"))
     assert Dataset(tmp_path / "cache", "mha").is_dataset_exist("CT", "CASE_000")
+
+
+def test_a_rank_dropping_stage_refuses_instead_of_writing_a_broadcast_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`Sum(dim=0)` drops the leading axis, so its slab is no longer C[Z]YX.
+
+    Written anyway, the header takes the slab's first spatial extent for a channel count and
+    publishes that many broadcast copies -- a store whose rank disagrees with the whole-volume path,
+    with no exception raised. It must refuse and fall back instead."""
+    from konfai.data import patching as patching_module
+    from konfai.data.transform import Sum
+
+    monkeypatch.setattr(patching_module, "_SWEEP_SLAB_ROWS", 2)
+    rng = np.random.default_rng(0)
+    volume = rng.random((5, 12, 10, 8)).astype(np.float32)
+    source = Dataset(tmp_path / "source", "h5")
+    source.write("CT", "CASE_000", volume, Attribute())
+
+    manager = DatasetManager(
+        index=0,
+        group_src="CT",
+        group_dest="CT",
+        name="CASE_000",
+        dataset=source,
+        patch=None,
+        transforms=[Sum(dim=0), Save(f"{tmp_path / 'out'}:h5")],
+        data_augmentations_list=[],
+    )
+    with pytest.warns(UserWarning, match="Falling back to the whole-volume path"):
+        assert manager.materialize() is False
+
+    written, _ = Dataset(tmp_path / "out", "h5").read_data("CT", "CASE_000")
+    np.testing.assert_allclose(written, volume.sum(axis=0), rtol=1e-6)
 
 
 def test_kill_switch_keeps_the_whole_volume_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_transform_locality_contract.py
+++ b/tests/unit/test_transform_locality_contract.py
@@ -160,6 +160,16 @@ _CASES: dict[str, list[_Case]] = {
     "ResampleToShape": [_Case(ResampleToShape([12, 8, 14]), atol=_RESCALE_ATOL)],
     "ResampleTransform": [_Case(ResampleTransform({"transform": True}))],
     "Save": [_Case(Save("Dataset"))],
+    # Warp needs a field on disk to run, which this registry cannot build: with no declared
+    # displacement it declares WHOLE_VOLUME, so it stays out of the equivalence sweep below. Its
+    # streamed-equals-whole-volume proof lives in test_warp.py, where a field exists.
+    "Warp": [_Case(Warp(field="Dataset:h5", group="DVF"))],
+    # Reduce is a cardinality marker the cohort engine splits out of the chain, never a per-case
+    # stage: it declares WHOLE_VOLUME so a chain reaching the ordinary planner refuses rather than
+    # streams, which is what puts it out of the equivalence sweep below.
+    "Reduce": [_Case(Reduce(output="reduced"))],
+    # Write is Save with a required destination: same boundary, same WHOLE_VOLUME declaration.
+    "Write": [_Case(Write("Dataset"))],
     "SegmentationDisagreement": [_Case(SegmentationDisagreement(), group="Ensemble")],
     "SelectLabel": [_Case(SelectLabel(["(1,2)", "(3,1)"]), group="Labels")],
     "Softmax": [_Case(Softmax(0), group="Ensemble")],
@@ -168,16 +178,6 @@ _CASES: dict[str, list[_Case]] = {
     "StandardDeviation": [_Case(StandardDeviation(), group="Ensemble")],
     "Sum": [_Case(Sum(0), group="Ensemble")],
     "Variance": [_Case(Variance(), group="Ensemble")],
-    # Warp needs a field on disk to run, which this registry cannot build: with no declared
-    # displacement it declares WHOLE_VOLUME, so it stays out of the equivalence sweep below. Its
-    # streamed-equals-whole-volume proof lives in test_warp.py, where a field exists.
-    "Warp": [_Case(Warp(field="Dataset:h5", group="DVF"))],
-    # Reduce is a cardinality marker a cohort engine splits out of the chain, never a per-case
-    # stage: it declares WHOLE_VOLUME so a chain reaching the ordinary planner refuses rather than
-    # streams, which is what puts it out of the equivalence sweep below.
-    "Reduce": [_Case(Reduce(output="reduced"))],
-    # Write is Save with a required destination: same boundary, same WHOLE_VOLUME declaration.
-    "Write": [_Case(Write("Dataset"))],
 }
 
 

--- a/tests/unit/test_transformer_workflow.py
+++ b/tests/unit/test_transformer_workflow.py
@@ -270,6 +270,91 @@ def test_two_chains_writing_the_same_target_are_refused(tmp_path: Path) -> None:
         _build(tmp_path)
 
 
+def test_two_chains_sharing_an_intermediate_save_are_refused(tmp_path: Path) -> None:
+    """The terminal Write is not the only boundary two chains can collide on.
+
+    A Save is keyed by (dataset, group, case) and nothing else, so the second chain finds the first
+    one's cache already written, adopts it as its own source, and skips its own prefix -- producing a
+    deliverable computed from another chain's transforms, with no warning and no failed case.
+    """
+    _write_source(tmp_path)
+    source = tmp_path / "source"
+    (tmp_path / "Transform.yml").write_text(
+        "Transformer:\n"
+        "  name: TEST\n"
+        "  Dataset:\n"
+        "    dataset_filenames:\n"
+        f"      - {source}:mha\n"
+        "    groups_src:\n"
+        "      CT:\n"
+        "        groups_dest:\n"
+        "          A:\n"
+        "            transforms:\n"
+        "              Clip:\n"
+        "                min_value: 0.0\n"
+        "                max_value: 50.0\n"
+        "              Save:\n"
+        f"                dataset: {tmp_path / 'work'}:h5\n"
+        "                group: shared\n"
+        "              Write:\n"
+        f"                dataset: {tmp_path / 'out_a'}:h5\n"
+        "          B:\n"
+        "            transforms:\n"
+        "              Clip:\n"
+        "                min_value: 0.0\n"
+        "                max_value: 10.0\n"
+        "              Save:\n"
+        f"                dataset: {tmp_path / 'work'}:h5\n"
+        "                group: shared\n"
+        "              Write:\n"
+        f"                dataset: {tmp_path / 'out_b'}:h5\n"
+    )
+    with pytest.raises(TransformerError, match="both write"):
+        _build(tmp_path)
+
+
+def test_one_chain_may_publish_its_own_save_through_its_write(tmp_path: Path) -> None:
+    """The refusal is about two chains, not two stages: a chain's Write over its own Save is legal."""
+    _write_source(tmp_path)
+    _write_config(
+        tmp_path,
+        "              Save:\n"
+        f"                dataset: {tmp_path / 'out'}:h5\n"
+        "                group: same\n"
+        "              Write:\n"
+        f"                dataset: {tmp_path / 'out'}:h5\n"
+        "                group: same\n",
+    )
+
+    assert _build(tmp_path) is not None
+
+
+_CAST_CHAIN = """\
+              Clip:
+                min_value: 0.0
+                max_value: 50.0
+              TensorCast:
+                dtype: uint8
+              Write:
+                dataset: {out}:h5
+"""
+
+
+def test_the_plan_reports_the_dtype_it_probed_the_destinations_with(tmp_path: Path) -> None:
+    """The report is the probe's own answer, not a constant beside it.
+
+    The write probe already opens with the chain's last declared cast; a report that says float32
+    whatever the chain casts to describes a run nobody asked for -- and a destination that refuses
+    uint8 would have been caught by the probe while the plan claimed float32 was fine.
+    """
+    _write_source(tmp_path)
+    _write_config(tmp_path, _CAST_CHAIN.format(out=tmp_path / "out"))
+
+    plan = _build(tmp_path).compute_plan(1, overwrite=False)
+
+    assert "assumed uint8 / source channels" in plan.report()
+
+
 def test_unknown_key_is_refused_with_its_path(tmp_path: Path) -> None:
     """The strict mode: a typo'd key is a parse error, never a silently-used default."""
     _write_source(tmp_path)

--- a/tests/unit/test_transformer_workflow.py
+++ b/tests/unit/test_transformer_workflow.py
@@ -1,0 +1,669 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The TRANSFORM workflow end to end, through its real YAML: parse-time refusals, the plan as the
+run's own verdict, the two-branch engine, per-case resume, forced rewrite, and the memory bound."""
+
+import pickle
+from pathlib import Path
+
+import numpy as np
+import pytest
+from konfai.utils.dataset import Attribute, Dataset
+from konfai.utils.errors import ConfigError, TransformerError
+
+pytest.importorskip("SimpleITK")
+
+_ENV_KEYS = (
+    "KONFAI_config_file",
+    "KONFAI_ROOT",
+    "KONFAI_STATE",
+    "KONFAI_CONFIG_MODE",
+    "KONFAI_TRANSFORMS_DIRECTORY",
+    "KONFAI_OVERWRITE",
+)
+
+
+@pytest.fixture(autouse=True)
+def _workflow_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    # build_transform writes the workflow environment directly into os.environ; pin every key it
+    # touches so the test's values are restored whatever the test does.
+    for key in _ENV_KEYS:
+        monkeypatch.setenv(key, "sentinel")
+        monkeypatch.delenv(key)
+
+
+def _image_attributes() -> Attribute:
+    attributes = Attribute()
+    attributes["Origin"] = np.asarray([10.0, 20.0, 30.0])
+    attributes["Spacing"] = np.asarray([0.5, 1.5, 2.0])
+    attributes["Direction"] = np.eye(3, dtype=np.float64).reshape(-1)
+    return attributes
+
+
+def _write_source(tmp_path: Path, cases: int = 2) -> Path:
+    rng = np.random.default_rng(0)
+    dataset = Dataset(tmp_path / "source", "mha")
+    for index in range(cases):
+        volume = (rng.random((1, 12, 10, 8)) * 100).astype(np.float32)
+        dataset.write("CT", f"CASE_{index:03d}", volume, _image_attributes())
+    return tmp_path / "source"
+
+
+def _write_config(tmp_path: Path, transforms_yaml: str, header: str = "  on_fallback: warn\n") -> Path:
+    source = tmp_path / "source"
+    config_path = tmp_path / "Transform.yml"
+    config_path.write_text(
+        "Transformer:\n"
+        "  name: TEST\n"
+        f"{header}"
+        "  Dataset:\n"
+        "    dataset_filenames:\n"
+        f"      - {source}:mha\n"
+        "    memory_budget: auto\n"
+        "    groups_src:\n"
+        "      CT:\n"
+        "        groups_dest:\n"
+        "          CT_out:\n"
+        "            transforms:\n"
+        f"{transforms_yaml}"
+    )
+    return config_path
+
+
+def _build(tmp_path: Path):
+    from konfai.transformer import build_transform
+
+    return build_transform(transform_file=tmp_path / "Transform.yml", transforms_dir=tmp_path / "Transforms")
+
+
+_STREAMABLE = """\
+              Clip:
+                min_value: 0.0
+                max_value: 50.0
+              Write:
+                dataset: {out}:h5
+"""
+
+_UNSTREAMABLE = """\
+              Clip:
+                min_value: 0.0
+                max_value: 50.0
+              Standardize:
+                inverse: false
+              Write:
+                dataset: {out}:h5
+"""
+
+
+def test_streamable_chain_plans_streams_and_writes(tmp_path: Path) -> None:
+    _write_source(tmp_path)
+    _write_config(tmp_path, _STREAMABLE.format(out=tmp_path / "out"))
+    workflow = _build(tmp_path)
+
+    plan = workflow.compute_plan(1, overwrite=False)
+    assert [entry.verdict for entry in plan.entries] == ["STREAM", "STREAM"]
+    # The probe opened then removed its entry: no probe debris in the output.
+    out = Dataset(tmp_path / "out", "h5")
+    assert not out.is_dataset_exist("CT_out", "__konfai_plan_probe__")
+
+    workflow.setup(1)
+    workflow.run_process(1, 0, 0, [])
+    assert out.is_dataset_exist("CT_out", "CASE_000")
+    assert out.is_dataset_exist("CT_out", "CASE_001")
+    assert (tmp_path / "Transforms" / "TEST" / "plan.txt").read_text().count("STREAM")
+
+
+_REGION_CHAIN = """\
+              ResampleToResolution:
+                spacing: [1.0, 1.0, 1.0]
+              Write:
+                dataset: {out}:h5
+"""
+
+_DIRECTORY_CHAIN = """\
+              Clip:
+                min_value: 0.0
+                max_value: 50.0
+              Write:
+                dataset: {out}:omezarr
+"""
+
+
+def test_plan_leaves_no_probe_case_in_a_directory_store(tmp_path: Path) -> None:
+    """A dry run must leave the output directory as it found it.
+
+    Aborting the probe stream drops the entry, but a directory dataset gives every case a directory
+    of its own, and that one outlived the stream: ``--plan`` left ``__konfai_plan_probe__/`` sitting
+    in the output root, shaped exactly like a case and listed as one by ``get_names``.
+    """
+    _write_source(tmp_path)
+    _write_config(tmp_path, _DIRECTORY_CHAIN.format(out=tmp_path / "out"))
+
+    _build(tmp_path).compute_plan(1, overwrite=False)
+
+    assert not (tmp_path / "out" / "__konfai_plan_probe__").exists()
+    assert Dataset(tmp_path / "out", "omezarr").get_names("CT_out") == []
+
+
+def test_a_planned_workflow_survives_the_spawn_that_runs_it(tmp_path: Path) -> None:
+    """``setup`` runs on the launcher and ``mp.spawn`` then pickles the workflow whole.
+
+    So everything planning leaves behind — the memoized stream sources, the region stages' pull
+    maps — has to cross a process boundary, and anything unpicklable in there kills every chain the
+    plan just called STREAM before its first byte. The round-trip below is that boundary; the other
+    tests call ``run_process`` in-process and cannot see it.
+    """
+    _write_source(tmp_path)
+    _write_config(tmp_path, _REGION_CHAIN.format(out=tmp_path / "out"))
+    workflow = _build(tmp_path)
+
+    plan = workflow.compute_plan(1, overwrite=False)
+    assert [entry.verdict for entry in plan.entries] == ["STREAM", "STREAM"]
+    workflow.setup(1)
+
+    restored = pickle.loads(pickle.dumps(workflow))  # nosec B301 - our own object, round-tripped
+    restored.run_process(1, 0, 0, [])
+    assert Dataset(tmp_path / "out", "h5").is_dataset_exist("CT_out", "CASE_000")
+
+
+def test_unstreamable_chain_says_why_and_still_writes(tmp_path: Path) -> None:
+    _write_source(tmp_path)
+    _write_config(tmp_path, _UNSTREAMABLE.format(out=tmp_path / "out"))
+    workflow = _build(tmp_path)
+
+    plan = workflow.compute_plan(1, overwrite=False)
+    assert all(entry.verdict == "WHOLE-VOLUME" for entry in plan.entries)
+    assert all(entry.reason and "Standardize" in entry.reason for entry in plan.entries)
+
+    workflow.setup(1)
+    workflow.run_process(1, 0, 0, [])
+    assert Dataset(tmp_path / "out", "h5").is_dataset_exist("CT_out", "CASE_000")
+
+
+def test_on_fallback_error_refuses_before_any_byte(tmp_path: Path) -> None:
+    _write_source(tmp_path)
+    _write_config(tmp_path, _UNSTREAMABLE.format(out=tmp_path / "out"), header="  on_fallback: error\n")
+    workflow = _build(tmp_path)
+
+    with pytest.raises(TransformerError, match="whole-volume"):
+        workflow.setup(1)
+    assert not Dataset(tmp_path / "out", "h5").is_dataset_exist("CT_out", "CASE_000")
+
+
+def test_budget_is_a_hard_constraint_for_fallback_cases(tmp_path: Path) -> None:
+    """A case that cannot stream and does not fit the declared budget refuses globally, before any
+    byte — never 40 cases written then a crash at the 41st."""
+    _write_source(tmp_path)
+    config_path = _write_config(tmp_path, _UNSTREAMABLE.format(out=tmp_path / "out"))
+    config_path.write_text(config_path.read_text().replace("memory_budget: auto", "memory_budget: 1b"))
+    workflow = _build(tmp_path)
+
+    with pytest.raises(TransformerError, match="budget"):
+        workflow.setup(1)
+    assert not Dataset(tmp_path / "out", "h5").is_dataset_exist("CT_out", "CASE_000")
+
+
+def test_chain_without_write_is_refused_at_parse(tmp_path: Path) -> None:
+    _write_source(tmp_path)
+    _write_config(tmp_path, "              Clip:\n                min_value: 0.0\n                max_value: 50.0\n")
+    with pytest.raises(TransformerError, match="does not end with a 'Write'"):
+        _build(tmp_path)
+
+
+def test_transform_after_the_terminal_write_is_refused(tmp_path: Path) -> None:
+    _write_source(tmp_path)
+    _write_config(
+        tmp_path,
+        "              Write:\n"
+        f"                dataset: {tmp_path / 'out'}:h5\n"
+        "              Clip:\n                min_value: 0.0\n                max_value: 50.0\n",
+    )
+    with pytest.raises(TransformerError, match="follows the last Write"):
+        _build(tmp_path)
+
+
+def test_writing_into_the_source_is_refused(tmp_path: Path) -> None:
+    _write_source(tmp_path)
+    _write_config(tmp_path, _STREAMABLE.format(out=tmp_path / "source"))
+    with pytest.raises(TransformerError, match="source"):
+        _build(tmp_path)
+
+
+def test_two_chains_writing_the_same_target_are_refused(tmp_path: Path) -> None:
+    _write_source(tmp_path)
+    source = tmp_path / "source"
+    (tmp_path / "Transform.yml").write_text(
+        "Transformer:\n"
+        "  name: TEST\n"
+        "  Dataset:\n"
+        "    dataset_filenames:\n"
+        f"      - {source}:mha\n"
+        "    groups_src:\n"
+        "      CT:\n"
+        "        groups_dest:\n"
+        "          A:\n"
+        "            transforms:\n"
+        "              Write:\n"
+        f"                dataset: {tmp_path / 'out'}:h5\n"
+        "                group: same\n"
+        "          B:\n"
+        "            transforms:\n"
+        "              Write:\n"
+        f"                dataset: {tmp_path / 'out'}:h5\n"
+        "                group: same\n"
+    )
+    with pytest.raises(TransformerError, match="both write"):
+        _build(tmp_path)
+
+
+def test_unknown_key_is_refused_with_its_path(tmp_path: Path) -> None:
+    """The strict mode: a typo'd key is a parse error, never a silently-used default."""
+    _write_source(tmp_path)
+    config_path = _write_config(tmp_path, _STREAMABLE.format(out=tmp_path / "out"))
+    config_path.write_text(config_path.read_text().replace("memory_budget: auto", "memory_budge: auto"))
+    with pytest.raises(ConfigError, match="memory_budge"):
+        _build(tmp_path)
+
+
+def test_second_run_skips_and_overwrite_rewrites(tmp_path: Path) -> None:
+    _write_source(tmp_path)
+    _write_config(tmp_path, _STREAMABLE.format(out=tmp_path / "out"))
+    workflow = _build(tmp_path)
+    workflow.setup(1)
+    workflow.run_process(1, 0, 0, [])
+    before, _ = Dataset(tmp_path / "out", "h5").read_data("CT_out", "CASE_000")
+
+    # Second run, same config: every case is planned SKIP and nothing is recomputed.
+    workflow = _build(tmp_path)
+    plan = workflow.compute_plan(1, overwrite=False)
+    assert [entry.verdict for entry in plan.entries] == ["SKIP", "SKIP"]
+
+    # Forced rewrite: the boundary probes answer "not written", finalize renames over the entries.
+    import os
+
+    os.environ["KONFAI_OVERWRITE"] = "True"
+    workflow = _build(tmp_path)
+    workflow.setup(1)
+    workflow.run_process(1, 0, 0, [])
+    after, _ = Dataset(tmp_path / "out", "h5").read_data("CT_out", "CASE_000")
+    np.testing.assert_array_equal(after, before)
+
+
+def test_multi_rank_accepts_a_directory_store_and_refuses_a_single_file(tmp_path: Path) -> None:
+    """Ranks shard by CASE, and a directory dataset gives each case its own store, so their writes
+    are disjoint. Only a single-file h5 puts every case in one handle."""
+    _write_source(tmp_path)
+    _write_config(
+        tmp_path,
+        "              Clip:\n                min_value: 0.0\n                max_value: 50.0\n"
+        "              Write:\n"
+        f"                dataset: {tmp_path / 'out_dir'}/:omezarr\n",
+    )
+    _build(tmp_path).setup(4)  # a directory store must NOT be refused
+
+    _write_config(tmp_path, _STREAMABLE.format(out=tmp_path / "out_file"))
+    with pytest.raises(TransformerError, match="single-file store"):
+        _build(tmp_path).setup(4)
+
+
+def test_overwrite_rewrites_a_geometry_changing_chain_correctly(tmp_path: Path) -> None:
+    """The bak-poisoning regression: planning a second run reads the OUTPUT's header through the
+    satisfied boundary, and a rewrite replanned from that geometry would resample by a factor of 1 —
+    silently overwriting the deliverable with untransformed data."""
+    import os
+
+    _write_source(tmp_path)
+    _write_config(
+        tmp_path,
+        "              ResampleToResolution:\n"
+        "                spacing: [1.0, 3.0, 4.0]\n"
+        "              Write:\n"
+        f"                dataset: {tmp_path / 'out'}:h5\n",
+    )
+    workflow = _build(tmp_path)
+    workflow.setup(1)
+    workflow.run_process(1, 0, 0, [])
+    before, _ = Dataset(tmp_path / "out", "h5").read_data("CT_out", "CASE_000")
+
+    os.environ["KONFAI_OVERWRITE"] = "True"
+    workflow = _build(tmp_path)
+    workflow.setup(1)
+    workflow.run_process(1, 0, 0, [])
+    after, _ = Dataset(tmp_path / "out", "h5").read_data("CT_out", "CASE_000")
+    # The rewrite must land on the TARGET grid again, not the source's.
+    assert after.shape == before.shape
+    np.testing.assert_array_equal(after, before)
+
+
+def test_plan_flag_stops_before_transforming(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--plan`` must SHORT-CIRCUIT in the CLI dispatch.
+
+    The distributed wrapper filters kwargs by the entrypoint's signature, so a 'plan' flag merely
+    passed through would be dropped and the run would proceed as if the flag had never been given --
+    printing a plan and then transforming anyway.
+    """
+    _write_source(tmp_path)
+    _write_config(tmp_path, _STREAMABLE.format(out=tmp_path / "out"))
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "konfai",
+            "TRANSFORM",
+            "--config",
+            str(tmp_path / "Transform.yml"),
+            "--plan",
+            "--transforms-dir",
+            "Transforms",
+        ],
+    )
+    from konfai.main import main
+
+    main()
+    # The plan ran; the transform did not.
+    assert not Dataset(tmp_path / "out", "h5").is_dataset_exist("CT_out", "CASE_000")
+
+
+def test_streamed_run_never_reads_a_whole_volume(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The memory bound, asserted as a bound over the WHOLE workflow: plan, setup and run of a
+    streamable chain must never assemble a volume. Value equivalence alone would pass even if the
+    streamed path loaded everything."""
+    _write_source(tmp_path)
+    _write_config(tmp_path, _STREAMABLE.format(out=tmp_path / "out"))
+    workflow = _build(tmp_path)
+
+    def refuse(*args: object, **kwargs: object) -> None:
+        raise AssertionError("the transform workflow read a whole volume")
+
+    monkeypatch.setattr(Dataset, "read_data", refuse)
+    workflow.setup(1)
+    workflow.run_process(1, 0, 0, [])
+    monkeypatch.undo()
+    assert Dataset(tmp_path / "out", "h5").is_dataset_exist("CT_out", "CASE_000")
+
+
+def test_a_reduction_declared_in_yaml_folds_every_case_into_one_output(tmp_path: Path) -> None:
+    """The whole point of the wiring: N cases -> 1 entry, declared in YAML, planned and run."""
+    _write_source(tmp_path, cases=4)
+    _write_config(
+        tmp_path,
+        "              Clip:\n                min_value: 0.0\n                max_value: 50.0\n"
+        "              Reduce:\n"
+        "                operator: Median\n"
+        "                output: atlas\n"
+        "              Write:\n"
+        f"                dataset: {tmp_path / 'out'}:h5\n",
+    )
+    transformer = _build(tmp_path)
+    plan = transformer.compute_plan(1)
+
+    entry = next(entry for entry in plan.entries if entry.reduced)
+    assert entry.case == "atlas" and entry.verdict == "REDUCE" and len(entry.reduced) == 4
+    assert "REDUCE 4 case(s) -> 1 output 'atlas'" in plan.report()
+    assert "cases: " in plan.report()
+
+    transformer.setup(1)
+    transformer.run_process(1, 0, 0, None)
+
+    written, attribute = Dataset(tmp_path / "out", "h5").read_data("CT_out", "atlas")
+    sources = [
+        np.clip(Dataset(tmp_path / "source", "mha").read_data("CT", name)[0].astype(np.float32), 0.0, 50.0)
+        for name in sorted(Dataset(tmp_path / "source", "mha").get_names("CT"))
+    ]
+    np.testing.assert_allclose(written, np.median(np.stack(sources), axis=0), rtol=1e-6)
+    assert attribute["konfai_reduce_cases"].count("|") == 3
+
+
+def test_a_reduction_that_cannot_stream_refuses_whatever_on_fallback_says(tmp_path: Path) -> None:
+    """A reduction has no whole-volume path, so `allow` cannot wave it through."""
+    _write_source(tmp_path, cases=2)
+    _write_config(
+        tmp_path,
+        "              Clip:\n                min_value: 0.0\n                max_value: 50.0\n"
+        "              Standardize:\n                inverse: false\n"
+        "              Reduce:\n                operator: Mean\n                output: atlas\n"
+        "              Write:\n"
+        f"                dataset: {tmp_path / 'out'}:h5\n",
+        header="  on_fallback: allow\n",
+    )
+    with pytest.raises(TransformerError, match="no whole-volume path to fall back to"):
+        _build(tmp_path).setup(1)
+
+
+def test_a_finished_reduction_is_skipped_on_the_second_run(tmp_path: Path) -> None:
+    _write_source(tmp_path, cases=3)
+    _write_config(
+        tmp_path,
+        "              Reduce:\n                operator: Mean\n                output: atlas\n"
+        "              Write:\n"
+        f"                dataset: {tmp_path / 'out'}:h5\n",
+    )
+    transformer = _build(tmp_path)
+    transformer.setup(1)
+    transformer.run_process(1, 0, 0, None)
+    first, _ = Dataset(tmp_path / "out", "h5").read_data("CT_out", "atlas")
+
+    again = _build(tmp_path)
+    plan = again.compute_plan(1)
+    assert next(entry for entry in plan.entries if entry.reduced).verdict == "SKIP"
+    again.setup(1)
+    again.run_process(1, 0, 0, None)
+    second, _ = Dataset(tmp_path / "out", "h5").read_data("CT_out", "atlas")
+    np.testing.assert_array_equal(second, first)
+
+
+# --------------------------------------------------------------- 1-to-N expansion
+
+_EXPAND_HEADER = """\
+  on_fallback: warn
+  manual_seed: 7
+"""
+
+
+def _write_expand_config(tmp_path: Path, transforms_yaml: str) -> Path:
+    source = tmp_path / "source"
+    config_path = tmp_path / "Transform.yml"
+    config_path.write_text(
+        "Transformer:\n"
+        "  name: TEST\n"
+        f"{_EXPAND_HEADER}"
+        "  Dataset:\n"
+        "    dataset_filenames:\n"
+        f"      - {source}:mha\n"
+        "    memory_budget: auto\n"
+        "    groups_src:\n"
+        "      CT:\n"
+        "        groups_dest:\n"
+        "          CT_out:\n"
+        "            transforms:\n"
+        f"{transforms_yaml}"
+    )
+    return config_path
+
+
+_EXPAND_CHAIN = """\
+              Clip:
+                min_value: 0.0
+                max_value: 50.0
+              Expand:
+                nb: 3
+                pattern: "{{name}}_r{{a:02d}}"
+              Brightness:
+                b_std: 0.3
+              Write:
+                dataset: {out}:h5
+"""
+
+
+def test_the_run_seed_reaches_the_draws_through_the_real_config(tmp_path: Path) -> None:
+    """``manual_seed`` is declared on the workflow and consumed by the draws, four layers down.
+
+    Through the real YAML on purpose: the chains are bound by the workflow (to check cardinality
+    before any manager exists) and again by ``Data.prepare``, so a seed stamped on the first set of
+    stage objects reaches nothing unless binding is idempotent. Every layer in between has to hold.
+    """
+    _write_source(tmp_path, cases=1)
+    _write_expand_config(tmp_path, _EXPAND_CHAIN.format(out=tmp_path / "out"))
+    workflow = _build(tmp_path)
+
+    manager = workflow.dataset._prepared_data["CT_out"][0]
+    assert manager._expand is not None
+    assert manager._expand.draw_seed == 7  # _EXPAND_HEADER declares manual_seed: 7
+
+
+def test_an_expansion_plans_and_writes_one_entry_per_copy(tmp_path: Path) -> None:
+    _write_source(tmp_path, cases=2)
+    _write_expand_config(tmp_path, _EXPAND_CHAIN.format(out=tmp_path / "out"))
+    workflow = _build(tmp_path)
+
+    plan = workflow.compute_plan(1, overwrite=False)
+    # Two cases x three copies: the copies ARE the plan's lines, each with its own resume.
+    assert len(plan.entries) == 6
+    assert {entry.expanded_from for entry in plan.entries} == {"CASE_000", "CASE_001"}
+    assert [entry.case for entry in plan.entries if entry.expanded_from == "CASE_000"] == [
+        "CASE_000_r01",
+        "CASE_000_r02",
+        "CASE_000_r03",
+    ]
+    assert {entry.verdict for entry in plan.entries} == {"STREAM"}
+    # A pointwise draw rides the case's single read pass -- the regime the engine exists for.
+    assert {entry.regime for entry in plan.entries} == {"shared"}
+    assert "EXPAND 2 case(s) -> 6 cop(ies)" in plan.report()
+    assert "shared read pass" in plan.report()
+
+    workflow.setup(1)
+    workflow.run_process(1, 0, 0, [])
+    out = Dataset(tmp_path / "out", "h5")
+    for case in ("CASE_000", "CASE_001"):
+        for a in range(1, 4):
+            assert out.is_dataset_exist("CT_out", f"{case}_r{a:02d}")
+        assert not out.is_dataset_exist("CT_out", case)
+
+
+def test_an_expanded_copy_carries_its_draw_and_resumes_per_copy(tmp_path: Path) -> None:
+    _write_source(tmp_path, cases=1)
+    _write_expand_config(tmp_path, _EXPAND_CHAIN.format(out=tmp_path / "out"))
+    workflow = _build(tmp_path)
+    workflow.setup(1)
+    workflow.run_process(1, 0, 0, [])
+
+    out = Dataset(tmp_path / "out", "h5")
+    source = Dataset(tmp_path / "source", "mha").read_data("CT", "CASE_000")[0]
+    clipped = np.clip(source, 0.0, 50.0)
+    copies = [out.read_data("CT_out", f"CASE_000_r{a:02d}")[0] for a in range(1, 4)]
+    # Each copy is a DIFFERENT draw of the clipped case: identical copies would mean the draw was
+    # applied at the wrong place (or not at all).
+    assert not any(np.array_equal(copy, clipped) for copy in copies)
+    assert not np.array_equal(copies[0], copies[1])
+
+    again = _build(tmp_path)
+    plan = again.compute_plan(1)
+    assert {entry.verdict for entry in plan.entries} == {"SKIP"}
+    stamp = (tmp_path / "out.h5").stat().st_mtime_ns
+    again.setup(1)
+    again.run_process(1, 0, 0, [])
+    assert (tmp_path / "out.h5").stat().st_mtime_ns == stamp
+
+
+def test_transforms_and_draws_interleave_after_the_marker(tmp_path: Path) -> None:
+    """`T, draw, T, draw` is expressible, which is the point of declaring draws in the chain."""
+    _write_source(tmp_path, cases=1)
+    _write_expand_config(
+        tmp_path,
+        "              Expand:\n                nb: 2\n"
+        '                pattern: "{name}_r{a:02d}"\n'
+        "              Brightness:\n                b_std: 0.2\n"
+        "              TensorCast:\n                dtype: float32\n"
+        "              Flip:\n                f_prob: [0, 1, 0]\n"
+        "              Write:\n"
+        f"                dataset: {tmp_path / 'out'}:h5\n",
+    )
+    workflow = _build(tmp_path)
+    chain = workflow.dataset.groups_src["CT"]["CT_out"].transforms
+    assert [type(stage).__name__ for stage in chain] == [
+        "Expand",
+        "Brightness",
+        "TensorCast",
+        "Flip",
+        "Write",
+    ]
+    workflow.setup(1)
+    workflow.run_process(1, 0, 0, [])
+    out = Dataset(tmp_path / "out", "h5")
+    assert out.is_dataset_exist("CT_out", "CASE_000_r01")
+    assert out.is_dataset_exist("CT_out", "CASE_000_r02")
+
+
+def test_a_draw_before_the_marker_is_refused(tmp_path: Path) -> None:
+    _write_source(tmp_path, cases=1)
+    _write_expand_config(
+        tmp_path,
+        "              Brightness:\n                b_std: 0.2\n"
+        "              Expand:\n                nb: 2\n"
+        '                pattern: "{name}_r{a:02d}"\n'
+        "              Write:\n"
+        f"                dataset: {tmp_path / 'out'}:h5\n",
+    )
+    with pytest.raises(TransformerError, match="before the Expand marker"):
+        _build(tmp_path)
+
+
+def test_an_expand_with_no_draw_after_it_is_refused(tmp_path: Path) -> None:
+    _write_source(tmp_path, cases=1)
+    _write_expand_config(
+        tmp_path,
+        "              Expand:\n                nb: 2\n"
+        '                pattern: "{name}_r{a:02d}"\n'
+        "              Write:\n"
+        f"                dataset: {tmp_path / 'out'}:h5\n",
+    )
+    with pytest.raises(TransformerError, match="every copy would be"):
+        _build(tmp_path)
+
+
+def test_expand_and_reduce_in_one_chain_are_refused(tmp_path: Path) -> None:
+    _write_source(tmp_path, cases=2)
+    _write_expand_config(
+        tmp_path,
+        "              Expand:\n                nb: 2\n"
+        '                pattern: "{name}_r{a:02d}"\n'
+        "              Brightness:\n                b_std: 0.2\n"
+        "              Reduce:\n                operator: Mean\n                output: atlas\n"
+        "              Write:\n"
+        f"                dataset: {tmp_path / 'out'}:h5\n",
+    )
+    with pytest.raises(TransformerError, match="both an Expand and a Reduce"):
+        _build(tmp_path)
+
+
+def test_an_expanded_run_never_reads_a_whole_volume(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The memory bound, as a bound: a streamed expansion must never assemble a case."""
+    _write_source(tmp_path, cases=2)
+    _write_expand_config(tmp_path, _EXPAND_CHAIN.format(out=tmp_path / "out"))
+    workflow = _build(tmp_path)
+
+    def refuse(*args, **kwargs):
+        raise AssertionError("the expanded run read a whole volume")
+
+    monkeypatch.setattr(Dataset, "read_data", refuse)
+    workflow.setup(1)
+    workflow.run_process(1, 0, 0, [])
+    monkeypatch.undo()
+
+    out = Dataset(tmp_path / "out", "h5")
+    assert out.is_dataset_exist("CT_out", "CASE_000_r01")
+    assert out.is_dataset_exist("CT_out", "CASE_001_r03")

--- a/tests/unit/test_warp.py
+++ b/tests/unit/test_warp.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""``Warp`` resamples a case through a displacement field, region by region.
+
+The claim under test is the one that matters for a volume larger than memory: the streamed result
+equals the whole-volume one, and the declared displacement bound is verified rather than trusted."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from konfai.data.patching import DatasetManager
+from konfai.data.transform import LocalityKind, RegionContext, Save, Warp
+from konfai.utils.dataset import Attribute, Dataset
+from konfai.utils.errors import TransformError
+
+pytest.importorskip("SimpleITK")
+
+SPACING = (2.0, 1.0, 1.0)  # (x, y, z) SimpleITK order
+
+
+def _attributes() -> Attribute:
+    attribute = Attribute()
+    attribute["Origin"] = np.asarray([0.0, 0.0, 0.0])
+    attribute["Spacing"] = np.asarray(list(SPACING))
+    attribute["Direction"] = np.eye(3, dtype=np.float64).reshape(-1)
+    return attribute
+
+
+def _fixture(
+    tmp_path: Path, shift_um: tuple[float, float, float] = (0.0, 0.0, 4.0)
+) -> tuple[Dataset, Dataset, np.ndarray]:
+    """A case and a CONSTANT displacement field: a constant shift is the one warp whose answer can
+    be written down independently, which is what makes it a reference rather than a re-run."""
+    rng = np.random.default_rng(0)
+    volume = (rng.random((1, 10, 12, 14)) * 100).astype(np.float32)
+    source = Dataset(tmp_path / "src", "h5")
+    source.write("CT", "CASE_000", volume, _attributes())
+
+    field = np.zeros((3, 10, 12, 14), dtype=np.float32)
+    for component, value in enumerate(shift_um):  # component order is (x, y, z)
+        field[component] = value
+    fields = Dataset(tmp_path / "dvf", "h5")
+    fields.write("DVF", "CASE_000", field, _attributes())
+    return source, fields, volume
+
+
+def _manager(source: Dataset, transforms: list) -> DatasetManager:
+    return DatasetManager(
+        index=0,
+        group_src="CT",
+        group_dest="CT",
+        name="CASE_000",
+        dataset=source,
+        patch=None,
+        transforms=transforms,
+        data_augmentations_list=[],
+    )
+
+
+def test_declares_a_halo_sized_by_the_declared_displacement() -> None:
+    warp = Warp(field="./x:h5", group="DVF", max_displacement=4.0)
+    locality = warp.patch_locality(_attributes())
+    # Spacing is (x=2, y=1, z=1) so in array order (z, y, x) it is (1, 1, 2): 4 um is 4, 4 and 2 voxels.
+    assert locality.kind is LocalityKind.HALO
+    assert locality.halo == (4, 4, 2)
+
+
+def test_without_a_declared_bound_it_refuses_to_stream() -> None:
+    """The safety net: an undeclared reach is an unbounded read, so the whole volume it is."""
+    assert Warp(field="./x:h5", group="DVF").patch_locality(_attributes()).kind is LocalityKind.WHOLE_VOLUME
+    assert Warp(field="./x:h5", group="DVF", max_displacement=4.0).patch_locality(Attribute()).kind is (
+        LocalityKind.WHOLE_VOLUME
+    )
+
+
+def test_a_constant_shift_moves_the_volume_by_that_many_voxels(tmp_path: Path) -> None:
+    _source, _fields, volume = _fixture(tmp_path, shift_um=(0.0, 0.0, 3.0))
+    warp = Warp(field=f"{tmp_path / 'dvf'}:h5", group="DVF", max_displacement=3.0)
+
+    moved = warp("CASE_000", torch.from_numpy(volume), _attributes()).numpy()
+
+    # d = +3 um along z, spacing z = 1 um: output(z) = input(z + 3).
+    np.testing.assert_allclose(moved[:, :-3], volume[:, 3:], rtol=1e-5, atol=1e-4)
+
+
+def test_streamed_equals_whole_volume(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The claim that matters: the same answer, region by region, with several regions."""
+    from konfai.data import patching as patching_module
+
+    monkeypatch.setattr(patching_module, "_SWEEP_SLAB_ROWS", 3)
+    source, _fields, volume = _fixture(tmp_path, shift_um=(1.0, 2.0, 3.0))
+    warp = Warp(field=f"{tmp_path / 'dvf'}:h5", group="DVF", max_displacement=4.0)
+
+    reference = warp("CASE_000", torch.from_numpy(volume), _attributes()).numpy()
+
+    manager = _manager(source, [warp, Save(f"{tmp_path / 'out'}:h5")])
+    assert manager.can_stream_patch(0, apply_augmentations=False)
+    assert manager.materialize() is True
+    streamed, _ = Dataset(tmp_path / "out", "h5").read_data("CT", "CASE_000")
+
+    np.testing.assert_allclose(streamed, reference, rtol=1e-5, atol=1e-4)
+
+
+def test_a_field_beyond_the_declared_bound_raises(tmp_path: Path) -> None:
+    """Declared, then verified: sampling outside what was read would show as a dark rim and nothing
+    else, so the mismatch is raised instead."""
+    _source, _fields, volume = _fixture(tmp_path, shift_um=(0.0, 0.0, 9.0))
+    warp = Warp(field=f"{tmp_path / 'dvf'}:h5", group="DVF", max_displacement=1.0)
+
+    with pytest.raises(TransformError, match="beyond the declared"):
+        whole = (slice(0, 10), slice(0, 12), slice(0, 14))
+        warp.stream_region(
+            "CASE_000",
+            torch.from_numpy(volume),
+            RegionContext(whole, whole, (10, 12, 14), (10, 12, 14)),
+            _attributes(),
+        )
+
+
+def test_a_field_with_the_wrong_component_count_is_named(tmp_path: Path) -> None:
+    rng = np.random.default_rng(1)
+    Dataset(tmp_path / "src", "h5").write("CT", "CASE_000", rng.random((1, 4, 4, 4)).astype(np.float32), _attributes())
+    Dataset(tmp_path / "dvf", "h5").write("DVF", "CASE_000", np.zeros((2, 4, 4, 4), np.float32), _attributes())
+    warp = Warp(field=f"{tmp_path / 'dvf'}:h5", group="DVF", max_displacement=1.0)
+
+    with pytest.raises(TransformError, match="component"):
+        warp("CASE_000", torch.zeros(1, 4, 4, 4), _attributes())
+
+
+def test_warp_without_a_field_is_refused_at_construction() -> None:
+    with pytest.raises(TransformError, match="needs a 'field'"):
+        Warp(field="")
+
+
+def test_unknown_interpolation_is_refused_at_construction() -> None:
+    with pytest.raises(TransformError, match="unknown interpolation"):
+        Warp(field="./x:h5", interpolation="cubic")


### PR DESCRIPTION
Base : #78.

`konfai TRANSFORM` applique une chaîne de transforms à un dataset, sans modèle. Une chaîne est déclarée par couple `(group_src, group_dest)` et se termine par un `Write` ; le moteur est `DatasetManager.materialize`, donc un cas s'écrit dalle par dalle et le volume n'est jamais tenu.

**Le plan est le produit.** Avant qu'un octet soit écrit, chaque `(cas, chaîne)` est planifié sur le lanceur et chaque destination est sondée par une vraie ouverture d'écriture par région, créée puis retirée : `STREAM`, `WHOLE-VOLUME` avec l'étage qui a refusé, `SKIP`, `REDUCE`, `REFUSED`. Une entrée dont l'ensemble de travail dépasse le `memory_budget` par rang refuse tout le run avant la première écriture.

**Trois cardinalités, une grammaire.** 1→1 par cas ; N→1 par `Reduce`, qui replie une cohorte une région à la fois, donc un pic à N régions et jamais N volumes ; 1→N par `Expand`, qui multiplie à un point déclaré de la chaîne et laisse les tirages s'intercaler parmi les transforms — les copies dont tous les étages sont ponctuels partagent **une** passe de lecture, les lectures étant bornées par la décompression. Les tirages sont paramétrés depuis `(manual_seed, cas, quel tirage)`, jamais depuis l'ordre de consommation d'un générateur : une chaîne image et sa chaîne masque produisent des copies concordantes sans se connaître.

**Refus au parse**, tout ce qui est décidable depuis la config seule : chaîne sans `Write` terminal, étage après le `Write`, deux chaînes visant la même cible, `Write` dans une source, tirage hors copie, et toute clé que la grammaire ignore.

Le workflow est également pilotable par un agent : `plan_transform` puis `run_transform` côté MCP, et un run transform apparaît dans Studio avec ses volumes accessibles.

**Ordre de lecture suggéré** : `konfai/transformer.py` (le workflow et le plan), puis `konfai/data/case_reduction.py` (le moteur N→1), puis la machinerie `Expand` dans `patching.py`. `konfai/utils/runtime.py` entrera en conflit trivial avec #76 sur le bloc d'imports ; les autres hunks sont disjoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added model-free dataset transformation workflows with configurable transforms, expansion, reduction, streaming, and output writing.
  * Added planning mode with memory-budget checks, fallback reporting, and refusal details.
  * Added command-line and tool support for planning and running transformations, including resume and overwrite options.
  * Added transform logs and workspace browsing under the Transforms output directory.
  * Expanded public data and OME-Zarr utilities.

* **Bug Fixes**
  * Improved transform state transitions, validation, cleanup, and resumable output handling.
  * Added confirmation before starting dataset transformations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->