### PR TITLE
fix(transform): the release review — refuse earlier, say it once, say it in the present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,38 +1,65 @@
 # Changelog
 
-Generated from the commit history by [Commitizen](https://commitizen-tools.github.io/commitizen/) —
-every entry is a conventional commit, and each version's section is exactly what the GitHub Release
-for that tag carries. Regenerate with:
+Generated from the commit history by [Commitizen](https://commitizen-tools.github.io/commitizen/).
+Each version's section is what the GitHub Release for that tag carries. Regenerate with:
 
 ```bash
 cz changelog --start-rev v1.5.8
 ```
 
-`--start-rev` is not a preference: Conventional Commits only took hold at `v1.5.9`, so rendering
-further back produces version headings with nothing under them. What came before is described below.
+Conventional Commits started at `v1.5.9`; rendering further back produces empty version headings.
 
-## v1.8.0 (2026-08-01)
+## v1.8.0 (2026-08-04)
 
 ### ✨ Features
 
+- **data**: give a chain a per-component statistic, and a shape update that uses it
 - **transform**: let Warp read the bound the fields recorded, with max_displacement: auto
 - **studio**: show a transform run, and point Browse at the data rather than its log
 - **mcp**: let an agent plan and run a transform, and read the table for what it accepts
 - **transform**: a fifth workflow that reads a dataset, applies a chain, and writes it
 - **data**: declare an OME-Zarr pyramid from a Write, and let a field carry its own bound
 - **impact-reg**: seed the rigid from the centre of mass, not only the frame
+- **studio**: bundle icons through the app interface, and a way to stop Studio (#75)
 
 ### 🐛 Bug Fixes
 
+- **transform**: refuse a stage key that names something not a class
+- **transform**: print the plan's reduction and dropped lines once
+- **transform**: give refusals their true remedy and name
+- **transform**: hold on_fallback error at run time too
+- **transform**: refuse unknown roots and typo'd stage arguments
+- **mcp**: name the launcher from the normalized workflow, and plan a transform first
+- **mcp**: offer the workflow a session actually wrote, not the one the stage table names
+- **data**: refuse two chains that name the same destination group
+- **studio**: actually carry a transform's data directory to the panel
+- **transform**: keep the auto bound scan's header reads inside its own guard
+- **mcp**: guard plan_transform's config from a child that never returns
+- **transform**: report the dtype the plan probed with, not a constant beside it
+- **transform**: refuse two chains that share an intermediate Save
+- **budget**: size the transform plan against the node's ranks, not the cluster's
+- **patching**: drop a recorded sweep failure when the Save boundary flips
+- **budget**: split a node-scoped auto budget across the node's ranks, not the cluster's
 - **transform**: let a WHOLE_VOLUME declaration say why, and make Warp use it
 - **data**: make a read plan's pull maps picklable, so a plan can cross the spawn
 - **data**: bind a group's chain once, however often prepare is called
+- **metric**: let Dice and FocalLoss take the integer label map a segmentation target is
+- **transform**: refuse a Reduce grid policy that names no reference case
+- **omezarr**: publish derived levels by rename, so the original is never the gap
+- **transform**: ask a field store for its groups by the name Dataset exposes
+- **dataset**: record a long array whole instead of NumPy's elided print
 - **config**: refuse a nested block where a value is expected, instead of binding its repr
 - **dataset**: normalize an attribute's value at construction, not only on assignment
 - **data**: sweep a chain's pending Saves before serving a region, not after failing on one
 
+### ⚡ Performance
+
+- **data**: chunk a store on the region shape its writer declares
+- **runtime**: run a single rank in this process instead of a child (#76)
+
 ### ♻️ Refactoring
 
+- **data**: share the fallback constants and the Welford kernel
 - **data**: move the reduction operators out of the predictor, into one shared vocabulary
 - **data**: give the resolved memory budget a type that knows its own scope
 
@@ -291,10 +318,8 @@ further back produces version headings with nothing under them. What came before
 
 ## Earlier releases (v1.0.0 – v1.5.8)
 
-Not generated, and not reconstructed. The history before `v1.5.9` predates Conventional Commits, so
-there is no structure to render — and inventing one would describe a history that never happened.
-
-What those commit messages announce themselves:
+The history before `v1.5.9` predates Conventional Commits and is not rendered here. The main
+releases, as announced by their commit messages:
 
 | Version | Date | Announced as |
 | --- | --- | --- |
@@ -302,8 +327,4 @@ What those commit messages announce themselves:
 | `1.4.0` | 2025-11-26 | Enable Windows inference and improve konfai-apps |
 | `1.0.0` | 2025-06-02 | First functional version of KonfAI |
 
-For anything finer, read the log:
-
-```bash
-git log --oneline v1.5.8
-```
+For anything finer: `git log --oneline v1.5.8`.

--- a/docs/source/config_guide/transform.md
+++ b/docs/source/config_guide/transform.md
@@ -195,6 +195,64 @@ One chain changes its cardinality at most once. Composing the two — augment a
 cohort, then fold it — is two invocations, the second reading the first one's
 output back.
 
+### `Reduce`: N cases, one volume
+
+Everything before the marker runs once per case, `Reduce` folds the cohort at
+fixed voxel, and everything after it runs once on the result. The chain is
+driven by the reduction engine — it walks the *output's* regions and, within a
+region, the cases — so peak memory is a few regions, never N volumes:
+
+```yaml
+transforms:
+  Clip: {min_value: 0.0, max_value: 400.0}
+  Reduce:
+    operator: Mean
+    output: template
+  Write: {dataset: ./Atlas:h5}
+```
+
+That writes **one** entry named `template`, whatever the cohort's size.
+
+| Field | Default | Effect |
+| --- | --- | --- |
+| `operator` | `Median` | A classpath resolved against `konfai.data.reduction`: `Mean`, `Median`, `Concat`, or your own `Reduction` subclass. An operator's own parameters go in the same mapping, next to `operator`. |
+| `output` | — | **Required**: the entry name the single result is written under. |
+| `grid` | `strict` | How much agreement between members is demanded before a byte is read (below). |
+| `grid_tolerance` | `1e-6` | The tolerance `strict` compares geometry within. |
+| `provenance` | `true` | Record the operator and the folded case list in the output's header — a cohort that silently changed between two runs writes a different volume under the same name, and nothing about the output would look wrong. |
+
+**Operators.** `Mean` folds one case at a time, so its working set is two
+regions whatever N is. `Median` needs every case per region — N + 1 resident
+regions, which is what `memory_budget` sizes and refuses. `Concat` puts the
+cases side by side: the output carries `N × C` channels. A custom operator must
+declare `voxel_local = True` — one that reads across space cannot stream and is
+refused outright.
+
+**`grid` decides what counts as "the same space"**, compared on the grid each
+case's chain *lands* on (a `Resample` before the `Reduce` counts):
+
+- `strict` (default) — equal extents **and** equal `Spacing`/`Origin`/
+  `Direction` within `grid_tolerance`.
+- `shape_only` — equal extents alone: the escape hatch for volumes already
+  resampled together but carrying approximate headers.
+- `reference:<case>` — equal extents, and the output adopts that member's
+  geometry: how a cohort says its members disagree on their headers and which
+  one to believe.
+
+```{warning}
+Nothing can verify that the members truly live in a common space — only that
+they claim to. `shape_only` and `reference:` will happily average misaligned
+volumes; the result still looks like a volume and is an artefact. Resample the
+cohort onto one grid first if it is not co-registered.
+```
+
+**A reduction has no whole-volume fallback.** Folding every case in memory is
+what it exists to avoid, so a `Reduce` that cannot stream refuses the run
+whatever `on_fallback` says — the plan prints `REFUSED` and the reason. Only
+voxel-local stages (and statistics, seeded by an extra pass of the engine's
+own) may follow the `Reduce` in the same chain: anything reading across space
+belongs in a second chain that reads the written output back.
+
 ### `Expand`: one case, N copies
 
 `Expand` multiplies, and nothing else. The draws are **ordinary stages of the

--- a/docs/source/config_guide/transform.md
+++ b/docs/source/config_guide/transform.md
@@ -92,7 +92,7 @@ few percent of the budget can still exceed it.
 | --- | --- |
 | `allow` | Take the whole-volume path silently — but the plan still names it. |
 | `warn` (default) | Same, plus a warning line after the plan. |
-| `error` | Refuse the run. Nothing is written. |
+| `error` | Refuse the run. Nothing is written. A fallback only discovered mid-run (a failed sweep, a `Warp` bound exceeded) stops at that case — earlier cases stay written, and the per-case resume covers the rerun. |
 
 Independently of `on_fallback`, a case that **cannot stream and does not fit
 `memory_budget`** always refuses the whole run, before the first byte. Writing
@@ -143,9 +143,11 @@ a byte is read:
   streaming re-reads the source while writing, so an in-place transform would
   read its own half-written output;
 - a `Save` with no `dataset` of its own, which would write next to the source;
-- **any key this page does not document.** A typo'd `memory_budge:` would
-  otherwise be ignored and its default used silently; here it is an error naming
-  the exact path.
+- **any key this page does not document — a stage's arguments included.** A
+  typo'd `memory_budge:` or `Clip: {min_val: …}` would otherwise be ignored and
+  its default used silently; here it is an error naming the exact path and the
+  legal keys. (A stage that takes `**kwargs` or resolves nowhere is left to the
+  loader's own error.)
 
 ## Fields
 

--- a/docs/source/reference/cli.md
+++ b/docs/source/reference/cli.md
@@ -100,9 +100,10 @@ after a run your YAML will contain the resolved defaults. See
   inference that does use the device. Plain read transforms run on CPU either
   way. There is no `-tb`: the workflow emits no scalars.
 - `--plan` short-circuits before the distributed wrapper, so it runs in one
-  process and spawns no ranks. `--cpu` is still read: it is the rank count the
-  plan divides the `memory_budget` by, so `--plan --cpu 4` reports the per-rank
-  budget a four-process run would actually get.
+  process and spawns no ranks. `--cpu` is still read: an `auto` budget is the
+  node's memory split across that many ranks, so `--plan --cpu 4` reports the
+  per-rank budget a four-process run would actually get. An explicit
+  `memory_budget` is already per rank and is not divided.
 
 ```{note}
 **Device selection quirks.** The CLI default is **CPU** (`--gpu` defaults to an

--- a/konfai-mcp/konfai_mcp/experiment_state.py
+++ b/konfai-mcp/konfai_mcp/experiment_state.py
@@ -116,8 +116,8 @@ STAGE_ACTIONS: dict[str, list[str]] = {
 }
 
 # Which config file each launcher needs, so an action is never offered for a workflow this session has
-# not written. A session holding only a Transform.yml was told to "run train" -- an action naming a file
-# that is not there -- while the workflow it could actually run was offered by nothing.
+# not written. Without the gate, a session holding only a Transform.yml is told to "run train" -- an
+# action naming a file that is not there -- while the workflow it could run is offered by nothing.
 _LAUNCHER_CONFIG: dict[str, str] = {
     "run_train": "Config.yml",
     "run_prediction": "Prediction.yml",

--- a/konfai/data/case_reduction.py
+++ b/konfai/data/case_reduction.py
@@ -39,7 +39,13 @@ from konfai.data.patching import DatasetManager
 from konfai.data.reduction import Reduction
 from konfai.data.transform import LocalityKind, Reduce, Transform
 from konfai.utils.config import apply_config
-from konfai.utils.dataset import Attribute, Dataset, DataStream
+from konfai.utils.dataset import (
+    Attribute,
+    Dataset,
+    DataStream,
+    _finalize_running_statistics,
+    _update_running_statistics,
+)
 from konfai.utils.errors import ReductionError
 from konfai.utils.utils import get_module
 
@@ -114,43 +120,26 @@ class ReductionPlan:
 class _RunningStatistics:
     """Min/Max/Mean/Std accumulated over regions, so the volume is never resident.
 
-    Mean and variance come from Welford's recurrence rather than from sums of squares: the naive
-    ``E[x^2] - E[x]^2`` cancels catastrophically once the mean is large next to the spread, and a
-    volume of intensities in the thousands with a spread of ones is exactly that case -- it can
-    return a negative variance.
+    The store-scan recurrence (:func:`konfai.utils.dataset._update_running_statistics`) is the one
+    Welford kernel; this feeds it blocks and writes the keys in KonfAI's own spelling.
     """
 
-    minimum: float = float("inf")
-    maximum: float = float("-inf")
-    mean: float = 0.0
-    _sum_square_deviation: float = 0.0
-    count: int = 0
+    _state: dict | None = None
 
     def update(self, block: torch.Tensor) -> None:
-        values = block.detach().double()
-        size = values.numel()
-        if size == 0:
-            return
-        self.minimum = min(self.minimum, float(values.min()))
-        self.maximum = max(self.maximum, float(values.max()))
-        batch_mean = float(values.mean())
-        batch_deviation = float(((values - batch_mean) ** 2).sum())
-        delta = batch_mean - self.mean
-        total = self.count + size
-        self._sum_square_deviation += batch_deviation + delta * delta * self.count * size / total
-        self.mean += delta * size / total
-        self.count = total
+        self._state = _update_running_statistics(self._state, block.detach().cpu().numpy().reshape(1, -1))
 
     def write_into(self, attribute: Attribute) -> None:
         """Seed the attribute the way the rest of KonfAI already spells these keys: Min/Max bare
         scalars, Mean/Std one-element arrays. A second convention reads back as a string and fails
         inside whichever transform consumed it."""
-        if self.count == 0:
+        if self._state is None or not self._state["count"]:
             raise ReductionError("Statistics were requested over an empty volume.", "Check the output extent.")
-        attribute["Min"] = np.float32(self.minimum)
-        attribute["Max"] = np.float32(self.maximum)
-        attribute["Mean"] = np.asarray([self.mean], dtype=np.float32)
-        attribute["Std"] = np.asarray([(self._sum_square_deviation / self.count) ** 0.5], dtype=np.float32)
+        statistics = _finalize_running_statistics(self._state)
+        attribute["Min"] = np.float32(statistics["min"])
+        attribute["Max"] = np.float32(statistics["max"])
+        attribute["Mean"] = np.asarray([statistics["mean"]], dtype=np.float32)
+        attribute["Std"] = np.asarray([statistics["std"]], dtype=np.float32)
 
 
 def split_chain(transforms: list[Transform]) -> tuple[list[Transform], Reduce | None, list[Transform]]:
@@ -454,11 +443,17 @@ class CaseReduction:
             return True
         plan = self.plan()
         if not plan.streams:
-            raise ReductionError(
-                f"The reduction into '{self.reduce.output}' cannot stream: {plan.refusal}.",
-                "A reduction has no whole-volume fallback. Fix the refusing stage, or put a Save"
-                " before the Reduce so each case's chain is materialized first.",
+            # A grid disagreement gets its own remedy: a Save changes nothing about the grids, so
+            # the generic advice would send the reader in a circle.
+            remedy = (
+                "The members do not land on one grid: resample them onto a common grid before the"
+                " Reduce, or declare grid: reference:<case> / shape_only if the cohort is already"
+                " aligned."
+                if self.check_grid() is not None
+                else "A reduction has no whole-volume fallback. Fix the refusing stage, or put a Save"
+                " before the Reduce so each case's chain is materialized first."
             )
+            raise ReductionError(f"The reduction into '{self.reduce.output}' cannot stream: {plan.refusal}.", remedy)
 
         spatial = plan.spatial
         attribute = self._output_attributes(plan)

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -1128,9 +1128,9 @@ class Data(ABC):
         """A destination group names ONE chain, whatever source group it reads.
 
         It is the key everything downstream indexes by: the prepared managers, the sample handed to
-        a model, the plan's lines. Two source groups declaring the same destination name silently
-        kept only the last one -- the first chain was built, then dropped, and nothing anywhere
-        looked wrong. Naming the chain is free: what a chain WRITES is the ``Write``'s own ``group``,
+        a model, the plan's lines. Two source groups declaring the same destination name would
+        silently keep only the last one -- the first chain built, then dropped, with nothing
+        anywhere looking wrong. Naming the chain is free: what a chain WRITES is the ``Write``'s own ``group``,
         which is a separate word for a separate thing.
         """
         owner: dict[str, str] = {}

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -1334,7 +1334,7 @@ class DatasetManager:
         self.total_augmentations = 0
 
         # The chain around its Expand: pre runs once per case, post once per copy. Without a marker
-        # the split is (everything, None, []) and every fold below reduces to what it always was.
+        # the split is (everything, None, []) and every fold below reduces to the plain per-case chain.
         self._expand_pre, self._expand, self._expand_post = split_expand(transforms)
         for transform_function in self._expand_pre:
             _shape = _spatial(transform_function.transform_shape(self.group_src, self.name, _shape, cache_attribute))
@@ -1387,7 +1387,7 @@ class DatasetManager:
         # from the source and each stream's finalize renames over the old entry. Never the default --
         # the boundary IS the per-case resume.
         self._rewrite_saves = False
-        # The per-rank budget the sweeps size their slabs against (None = the historical fixed rows).
+        # The per-rank budget the sweeps size their slabs against (None = the fixed _SWEEP_SLAB_ROWS).
         self._sweep_budget_bytes: float | None = None
         self._disk_statistics: dict[tuple[Dataset, str, str, tuple[int, ...] | None], dict[str, float]] = {}
         # Save caches already swept by THIS run, keyed by (store, group, entry): under --overwrite the
@@ -1467,7 +1467,7 @@ class DatasetManager:
 
     def _draw_augmentation_lists(self, reset_state: bool) -> None:
         """The training form: copies declared as ``Dataset.augmentations`` lists, applied after the
-        whole chain. Untouched — a chain with no ``Expand`` is exactly what it always was."""
+        whole chain."""
         i = 1
         for data_augmentations in self.data_augmentations_list:
             shape = []
@@ -1712,9 +1712,9 @@ class DatasetManager:
         """Validate a chain's locality declarations and plan its region stages, which compose.
 
         Returns ``(streamable, stage_plans, evolved, refusal)`` — ``refusal`` naming the stage and
-        the reason when the chain cannot stream (``None`` when it can): the identity of the stage is
-        in hand at the exact moment each check fails, and dropping it is what made every fallback
-        silent. ``evolved`` is the case state the plan
+        the reason when the chain cannot stream (``None`` when it can): the stage's identity is only
+        in hand at the moment each check fails, so the reason is built here -- dropping it would
+        leave every fallback silent. ``evolved`` is the case state the plan
         leaves, which a :class:`Save` sweep writes as its cache header. The chain streams when every
         stage is pointwise, a region kind (``HALO``/``ORIENTATION``/``CROP``/``RESCALE`` — any
         number, each pulling through the one before it), or a ``GLOBAL_STAT`` with a pre-populated
@@ -1956,7 +1956,7 @@ class DatasetManager:
                     sweep_refusal = planned_refusal
             trailing_transforms.append(transform)
 
-        # What copy `a` is. Without an Expand, the historical order: the trailing transforms, then
+        # What copy `a` is. Without an Expand, the training order: the trailing transforms, then
         # its own draw appended last. With one, the draw was spliced at the marker above, and the
         # whole thing is planned as one chain either way -- a region transform and a region
         # augmentation are then two regions, which is exactly what they are.
@@ -2117,10 +2117,8 @@ class DatasetManager:
         :meth:`stream_refusal` gives the reason before committing to this path.
 
         Goes through :meth:`_stream_ready`, so a chain reading through an unwritten ``Save`` gets it
-        swept first, exactly as the DataLoader path does. Resolving the source directly instead --
-        which this did -- planned green against caches that did not exist yet and then failed at the
-        first region, which is precisely the remedy KonfAI recommends in its own refusal messages
-        ("put a Save before the Reduce"): the advice was sound and the path under it was not.
+        swept first, exactly as the DataLoader path does -- resolving the source directly would plan
+        green against caches that do not exist yet and fail at the first region.
         """
         if not self._stream_ready(a, apply_augmentations):
             raise PatchError(
@@ -2208,12 +2206,36 @@ class DatasetManager:
         self.cache_attributes_bak = copy.deepcopy(self._cache_attributes_pristine)
         self.cache_attributes = copy.deepcopy(self._cache_attributes_pristine)
 
+    def peak_case_bytes(self) -> int:
+        """The largest single tensor the whole-volume path holds, from the chain's declared shapes.
+
+        The stored extent is a floor, not the answer: a chain that pads or resamples upward holds
+        its LARGEST intermediate, and that is the one a budget has to cover. Every stage declares
+        that extent through ``transform_shape``, so the fold is exact for the stages that know their
+        own geometry and identity for the rest -- it can only bring the figure closer, never lower.
+
+        Headers-only still, and still a floor for the one thing it cannot see: a stage that widens
+        the dtype beyond what it declares.
+        """
+        spatial = [int(extent) for extent in self.base_shape[1:]]
+        channels = int(self.base_shape[0])
+        peak = int(np.prod(self.base_shape, dtype=np.int64))
+        attributes = Attribute(self.stored_attributes)
+        for stage in self.transforms:
+            if not isinstance(stage, Transform):
+                continue
+            source = list(spatial)
+            spatial = [int(extent) for extent in stage.transform_shape(self.group_src, self.name, source, attributes)]
+            stage.write_stream_cache_attribute(attributes, source)
+            peak = max(peak, channels * int(np.prod(spatial, dtype=np.int64)))
+        return peak * _CASE_ELEMENT_BYTES
+
     def _enforce_fallback_budget(self, fallback_budget_bytes: float | None) -> None:
         if fallback_budget_bytes is None:
             return
         # The plan's promise holds at run time too: a case whose sweep failed here (a refusal the
         # probe could not see) must not assemble a volume the budget cannot hold.
-        case_bytes = int(np.prod(self.base_shape, dtype=np.int64)) * _CASE_ELEMENT_BYTES * _FALLBACK_INFLIGHT_FACTOR
+        case_bytes = self.peak_case_bytes() * _FALLBACK_INFLIGHT_FACTOR
         if case_bytes > fallback_budget_bytes:
             raise PatchError(
                 f"Case '{self.name}' fell back to the whole-volume path at run time and its"
@@ -2645,7 +2667,7 @@ class DatasetManager:
     def _sweep_rows(self, spatial: list[int], channels: int) -> int:
         """How many rows one sweep slab holds: the declared budget folded down, never up.
 
-        The historical fixed height is the CAP -- the chunk-friendly default that needs no budget --
+        The fixed default height is the CAP -- chunk-friendly, needing no budget --
         and a declared ``memory_budget`` can only lower it: a sweep holds the pulled slab and the
         landed block (plus the write buffer), so half the budget over that working set is the honest
         height. Below one row nothing fits; the row is the floor, and the fallback budget check is

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -71,6 +71,12 @@ _SWEEP_SLAB_ROWS = 64
 _SWEEP_RESIDENT_SLABS = 2
 _SWEEP_ELEMENT_BYTES = 4
 
+# What a whole-volume fallback holds while a case is in flight -- the assembled tensor plus one
+# transform output -- and the bytes each element travels as. The transform plan and the run-time
+# budget check (_enforce_fallback_budget) must agree on this figure.
+_FALLBACK_INFLIGHT_FACTOR = 2
+_CASE_ELEMENT_BYTES = 4
+
 
 def _halo_radii(halo: tuple[int, ...], n_axes: int) -> list[int]:
     """The per-axis radius a declared halo means, in array order (one radius covers every axis)."""
@@ -2132,7 +2138,13 @@ class DatasetManager:
         tensor, _attribute, _keys = self._replay_streamed_region(source, target, self.stored_attributes, None)
         return tensor
 
-    def materialize(self, a: int = 0, rewrite: bool = False, fallback_budget_bytes: float | None = None) -> bool:
+    def materialize(
+        self,
+        a: int = 0,
+        rewrite: bool = False,
+        fallback_budget_bytes: float | None = None,
+        allow_fallback: bool = True,
+    ) -> bool:
         """Write this case's chain to disk by the cheapest path that can, and say which one it took.
 
         Two branches, and they are the whole write side: the streamed one sweeps every unsatisfied
@@ -2141,6 +2153,8 @@ class DatasetManager:
         writes the same caches from the assembled volume. The bytes are the same either way; only
         the peak memory differs, which is why the caller must be told the answer rather than left to
         assume the cheap one. Returns whether the streamed path wrote the case.
+        ``allow_fallback=False`` raises instead of taking the second branch, for a caller whose
+        contract is that a fallback refuses rather than costs a volume.
 
         Never routed through :meth:`get_data`: a case with no declared patch is a single
         whole-volume patch, so asking for data would read back the volume this just wrote. The
@@ -2158,6 +2172,12 @@ class DatasetManager:
         apply_augmentations = self._expand is not None and a > 0
         if self._stream_ready(a, apply_augmentations=apply_augmentations):
             return True
+        if not allow_fallback:
+            raise PatchError(
+                f"Case '{self.name}' would take the whole-volume path at run time.",
+                self.stream_refusal(a, apply_augmentations) or self._sweep_failure or "the chain cannot stream.",
+                "Nothing was written for this case; the caller forbids the whole-volume fallback.",
+            )
         self._enforce_fallback_budget(fallback_budget_bytes)
         self._assemble_and_write(a)
         self.unload()
@@ -2193,7 +2213,7 @@ class DatasetManager:
             return
         # The plan's promise holds at run time too: a case whose sweep failed here (a refusal the
         # probe could not see) must not assemble a volume the budget cannot hold.
-        case_bytes = int(np.prod(self.base_shape, dtype=np.int64)) * 4 * 2
+        case_bytes = int(np.prod(self.base_shape, dtype=np.int64)) * _CASE_ELEMENT_BYTES * _FALLBACK_INFLIGHT_FACTOR
         if case_bytes > fallback_budget_bytes:
             raise PatchError(
                 f"Case '{self.name}' fell back to the whole-volume path at run time and its"
@@ -2222,6 +2242,7 @@ class DatasetManager:
         copies: list[int],
         rewrite: bool = False,
         fallback_budget_bytes: float | None = None,
+        allow_fallback: bool = True,
     ) -> dict[int, str]:
         """Write the :class:`Expand` copies of this case by the cheapest regime each can take.
 
@@ -2292,10 +2313,18 @@ class DatasetManager:
         for a in sorted(solo):
             verdicts[a] = (
                 "stream"
-                if self.materialize(a, rewrite, fallback_budget_bytes=fallback_budget_bytes)
+                if self.materialize(
+                    a, rewrite, fallback_budget_bytes=fallback_budget_bytes, allow_fallback=allow_fallback
+                )
                 else "whole-volume"
             )
         if fallback:
+            if not allow_fallback:
+                raise PatchError(
+                    f"{len(fallback)} cop(ies) of case '{self.name}' would take the whole-volume path at run time.",
+                    self.stream_refusal(fallback[0], apply_augmentations=True) or "the copies' chains cannot stream.",
+                    "Nothing was written for these copies; the caller forbids the whole-volume fallback.",
+                )
             self._enforce_fallback_budget(fallback_budget_bytes)
             for a in fallback:
                 self._assemble_and_write(a)
@@ -2609,7 +2638,7 @@ class DatasetManager:
         information, but one without (a reduction reading through this cache) has to raise, and it
         can only be as specific as what was kept here.
         """
-        self._sweep_failure = f"The Save cache '{sweep.group}/{sweep.entry}' could not be swept: {reason}"
+        self._sweep_failure = f"'{sweep.group}/{sweep.entry}' could not be written region by region: {reason}"
         warnings.warn(f"{self._sweep_failure} Falling back to the whole-volume path.", stacklevel=3)
         return False
 

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -351,6 +351,13 @@ class TransformLoader:
             # stages too, and a chain declares them exactly where they apply (see Expand). Looked up
             # second, so a transform never loses its name to a same-named draw.
             module, name = get_module(classpath, "konfai.data.augmentation")
+            if not hasattr(module, name):
+                raise TransformError(
+                    f"No transform or augmentation is named '{name}'.",
+                    self._closest_stage_name(name)
+                    + "A bare name resolves in konfai.data.transform, then konfai.data.augmentation;"
+                    " use 'module:Class' for a class anywhere else.",
+                )
         # A key is read as a dotted path, and a classpath naming its module carries dots of its own.
         subtree = f"{konfai_args}.{_escape_key_component(classpath)}"
         transform = apply_config(subtree)(getattr(module, name))()
@@ -363,6 +370,25 @@ class TransformLoader:
             transform.load(1.0)
             return transform
         return Foreign(transform, classpath)
+
+    @staticmethod
+    def _closest_stage_name(name: str) -> str:
+        """A 'did you mean' over BOTH stage namespaces, so the suggestion is never Python's own
+        guess from whichever module happened to fail last."""
+        import difflib
+
+        from konfai.data import augmentation
+
+        candidates = {
+            candidate
+            for namespace in (globals(), vars(augmentation))
+            for candidate, obj in namespace.items()
+            if isinstance(obj, type)
+            and not candidate.startswith("_")
+            and any(base.__name__ in ("Transform", "DataAugmentation") for base in obj.__mro__)
+        }
+        closest = difflib.get_close_matches(name, sorted(candidates), n=1)
+        return f"Closest name: '{closest[0]}'. " if closest else ""
 
 
 def _is_augmentation(candidate: object) -> bool:

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -358,9 +358,22 @@ class TransformLoader:
                     + "A bare name resolves in konfai.data.transform, then konfai.data.augmentation;"
                     " use 'module:Class' for a class anywhere else.",
                 )
+        if not hasattr(module, name):
+            # The qualified form reaches here: the module imported, the class in it did not exist.
+            raise TransformError(
+                f"'{classpath}' names no '{name}' in module '{module.__name__}'.",
+                "Check the class name, or drop the module to resolve a KonfAI stage by name alone.",
+            )
+        factory = getattr(module, name)
+        if not isinstance(factory, type):
+            raise TransformError(
+                f"'{classpath}' names a {type(factory).__name__}, not a stage class.",
+                "A chain stage is a class -- a Transform, a DataAugmentation, or a foreign class to"
+                " wrap. Name one, e.g. 'Clip' or 'monai.transforms:ScaleIntensity'.",
+            )
         # A key is read as a dotted path, and a classpath naming its module carries dots of its own.
         subtree = f"{konfai_args}.{_escape_key_component(classpath)}"
-        transform = apply_config(subtree)(getattr(module, name))()
+        transform = apply_config(subtree)(factory)()
         if isinstance(transform, Transform):
             transform.prepare(subtree)
             return transform

--- a/konfai/main.py
+++ b/konfai/main.py
@@ -291,8 +291,8 @@ def _run(parser: argparse.ArgumentParser) -> None:
             del args["config"]
         train(**args)
     else:
-        # Exhaustive on purpose: the old catch-all silently launched the trainer for any command it
-        # did not know, which is how a new workflow could train a UNet instead of failing.
+        # Exhaustive on purpose: a catch-all else would silently launch the trainer for any command
+        # it does not know -- a new workflow would train a UNet instead of failing.
         parser.error(f"Unknown command '{args['command']}'.")
 
 

--- a/konfai/transformer.py
+++ b/konfai/transformer.py
@@ -25,6 +25,7 @@ Nothing here falls back silently: a chain that cannot stream says which stage re
 """
 
 import contextlib
+import inspect
 import json
 import os
 import shutil
@@ -39,8 +40,8 @@ from ruamel.yaml import YAML
 from konfai import config_file, transforms_directory
 from konfai.data.case_reduction import CaseReduction, split_chain
 from konfai.data.data_manager import DataTransform, _format_gib, _node_local_ranks
-from konfai.data.patching import DatasetManager, _save_destination
-from konfai.data.transform import Save, split_expand
+from konfai.data.patching import _CASE_ELEMENT_BYTES, _FALLBACK_INFLIGHT_FACTOR, DatasetManager, _save_destination
+from konfai.data.transform import Reduce, Save, split_expand
 from konfai.utils.config import apply_config, config
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import ConfigError, TransformerError
@@ -50,11 +51,8 @@ from konfai.utils.runtime import (
     configure_workflow_environment,
     run_distributed_app,
 )
+from konfai.utils.utils import get_module
 
-#: Working copies the whole-volume fallback holds while a case is in flight: the assembled tensor
-#: plus one transform output. Streamed cases hold a slab instead; this factor sizes the fallback.
-_FALLBACK_INFLIGHT_FACTOR = 2
-_CASE_ELEMENT_BYTES = 4  # volumes travel as float32 through the chain
 _PROBE_ENTRY = "__konfai_plan_probe__"
 
 
@@ -602,12 +600,22 @@ class Transformer(DistributedObject):
             )
         if plan.refused_entries:
             first = plan.refused_entries[0]
+            reduction = self._reduction(first.group_dest, self._managers().get(first.group_dest, []))
+            # A grid disagreement gets its own remedy: a Save changes nothing about the grids, so
+            # the generic advice would send the reader in a circle.
+            remedy = (
+                "The members do not land on one grid: resample them onto a common grid before the"
+                " Reduce, or declare grid: reference:<case> / shape_only if the cohort is already"
+                " aligned."
+                if reduction is not None and reduction.check_grid() is not None
+                else "A reduction has no whole-volume path to fall back to -- folding every case in"
+                " memory is what it exists to avoid -- so this refuses the run whatever on_fallback"
+                " says. Fix the refusing stage, or put a Save before the Reduce."
+            )
             raise TransformerError(
                 f"The reduction into '{first.case}' ({first.group_src} -> {first.group_dest}) cannot"
                 f" stream: {first.reason or 'see the plan'}",
-                "A reduction has no whole-volume path to fall back to -- folding every case in memory"
-                " is what it exists to avoid -- so this refuses the run whatever on_fallback says."
-                " Fix the refusing stage, or put a Save before the Reduce.",
+                remedy,
             )
         if self.on_fallback == "warn" and plan.fallback_entries:
             print(
@@ -636,6 +644,9 @@ class Transformer(DistributedObject):
         managers = self._managers()
         shard = self._shards[global_rank]
         counts = {"STREAM": 0, "WHOLE-VOLUME": 0, "SKIP": 0, "REDUCE": 0}
+        # 'error' holds at run time too: a fallback the plan could not see (a sweep that fails, a
+        # Warp bound exceeded) raises at that case instead of quietly costing a volume.
+        allow_fallback = self.on_fallback != "error"
 
         def description() -> str:
             return (
@@ -676,7 +687,10 @@ class Transformer(DistributedObject):
                         ]
                         counts["SKIP"] += len(copies) - len(todo)
                         regimes = manager.materialize_copies(
-                            todo, rewrite=self._overwrite, fallback_budget_bytes=self._budget_bytes
+                            todo,
+                            rewrite=self._overwrite,
+                            fallback_budget_bytes=self._budget_bytes,
+                            allow_fallback=allow_fallback,
                         )
                         shared = sum(1 for regime in regimes.values() if regime == "stream-shared")
                         own = sum(1 for regime in regimes.values() if regime == "stream")
@@ -693,7 +707,10 @@ class Transformer(DistributedObject):
                         progress.write(f"[Transformer] case '{manager.name}' ({group_dest}): SKIP (already written)")
                     else:
                         streamed = manager.materialize(
-                            0, rewrite=self._overwrite, fallback_budget_bytes=self._budget_bytes
+                            0,
+                            rewrite=self._overwrite,
+                            fallback_budget_bytes=self._budget_bytes,
+                            allow_fallback=allow_fallback,
                         )
                         verdict = "STREAM" if streamed else "WHOLE-VOLUME"
                         counts[verdict] += 1
@@ -703,7 +720,8 @@ class Transformer(DistributedObject):
 
 
 #: The grammar the strict mode accepts, level by level. ``None`` marks free-form levels (group
-#: names, classpaths, transform parameters -- those bind to the transform's own signature).
+#: names); ``"chain"`` marks a transforms mapping, whose keys are classpaths and whose arguments
+#: are checked against each stage's own signature.
 _STRICT_GRAMMAR: dict[str, object] = {
     "name": None,
     "on_fallback": None,
@@ -712,9 +730,80 @@ _STRICT_GRAMMAR: dict[str, object] = {
         "dataset_filenames": None,
         "memory_budget": None,
         "subset": None,
-        "groups_src": {"*": {"groups_dest": {"*": {"transforms": None}}}},
+        "groups_src": {"*": {"groups_dest": {"*": {"transforms": "chain"}}}},
     },
 }
+
+
+def _stage_class(classpath: str, default_classpath: str = "konfai.data.transform") -> type | None:
+    """The class a chain stage's key names, resolved exactly as ``TransformLoader`` will resolve it.
+
+    ``None`` when it resolves nowhere: the loader raises its own error for that case, and refusing
+    the arguments of a class that does not exist would report the wrong problem.
+    """
+    try:
+        module, name = get_module(classpath, default_classpath)
+        if not hasattr(module, name) and ":" not in classpath and default_classpath == "konfai.data.transform":
+            module, name = get_module(classpath, "konfai.data.augmentation")
+        candidate = getattr(module, name, None)
+    except Exception:  # an unresolvable stage is the loader's error to raise, with its own message
+        return None
+    return candidate if isinstance(candidate, type) else None
+
+
+def _stage_arguments(classpath: str, mapping: dict) -> set[str] | None:
+    """The argument names one stage accepts, or ``None`` when they cannot be known from here.
+
+    A ``Reduce`` also accepts its operator's own parameters -- ``resolve_operator`` binds them from
+    the same mapping -- so its allowed set is the union of the two signatures.
+    """
+    stage = _stage_class(str(classpath))
+    if stage is None:
+        return None
+    classes = [stage]
+    if issubclass(stage, Reduce):
+        operator = _stage_class(str(mapping.get("operator", "Median")), "konfai.data.reduction")
+        if operator is None:
+            return None
+        classes.append(operator)
+    allowed: set[str] = set()
+    for cls in classes:
+        if all("__init__" not in vars(base) for base in cls.__mro__ if base is not object):
+            # No __init__ anywhere in the MRO: the class takes no arguments at all, and object's
+            # own (*args, **kwargs) signature must not read as "accepts anything".
+            continue
+        try:
+            parameters = dict(inspect.signature(cls).parameters)
+        except (TypeError, ValueError):
+            return None
+        if any(p.kind in (p.VAR_KEYWORD, p.VAR_POSITIONAL) for p in parameters.values()):
+            return None
+        allowed |= set(parameters)
+    return allowed
+
+
+def _reject_unknown_stage_arguments(chain: object, path: str) -> None:
+    """A typo'd stage argument is refused like a typo'd structural key.
+
+    The binder reads only the parameters a stage's signature names and materializes the default
+    beside anything else -- ``Clip: {min_val: 0}`` clips at -1024 and exits 0. A stage that resolves
+    nowhere, takes ``**kwargs`` or hides its signature is left to the loader's own error.
+    """
+    if not isinstance(chain, dict):
+        return
+    for classpath, arguments in chain.items():
+        if not isinstance(arguments, dict):
+            continue
+        allowed = _stage_arguments(str(classpath), arguments)
+        if allowed is None:
+            continue
+        for argument in arguments:
+            if str(argument) not in allowed:
+                raise ConfigError(
+                    f"Unknown argument '{argument}' for '{classpath}' at '{path}.{classpath}'.",
+                    f"'{classpath}' takes: {sorted(allowed)}. A typo'd argument would otherwise be"
+                    " ignored and its default silently used in its place.",
+                )
 
 
 def _reject_unknown_keys(config_path: Path) -> None:
@@ -722,14 +811,21 @@ def _reject_unknown_keys(config_path: Path) -> None:
 
     The binder reads a key when it exists and materializes the default when it does not — a typo'd
     ``memory_budge:`` silently becomes ``memory_budget: auto``. On this workflow the config IS the
-    product, so an unknown key is refused with its exact path instead of being carried along.
+    product, so an unknown key is refused with its exact path instead of being carried along. The
+    same bar holds inside a chain: a stage's arguments are checked against its own signature.
     """
     if not config_path.exists():
         return
     with open(config_path) as stream:
         tree = YAML().load(stream)
-    if not isinstance(tree, dict) or "Transformer" not in tree:
+    if not isinstance(tree, dict):
         return
+    if "Transformer" not in tree:
+        raise ConfigError(
+            f"'{config_path}' declares no 'Transformer' root (found: {sorted(str(key) for key in tree)}).",
+            "The TRANSFORM workflow reads the 'Transformer:' block; anything else would be ignored"
+            " and a full default block appended to the file in its place.",
+        )
 
     def walk(node: object, grammar: dict[str, object], path: str) -> None:
         if not isinstance(node, dict):
@@ -742,7 +838,9 @@ def _reject_unknown_keys(config_path: Path) -> None:
                     f"Known keys at this level: {sorted(k for k in grammar if k != '*')}. A typo'd"
                     " key would otherwise be ignored and its default silently used.",
                 )
-            if isinstance(child, dict):
+            if child == "chain":
+                _reject_unknown_stage_arguments(value, f"{path}.{key}")
+            elif isinstance(child, dict):
                 walk(value, child, f"{path}.{key}")
 
     walk(tree["Transformer"], _STRICT_GRAMMAR, "Transformer")

--- a/konfai/transformer.py
+++ b/konfai/transformer.py
@@ -130,8 +130,8 @@ class TransformPlan:
         for group_src, dropped in sorted(self.dropped_cases.items()):
             if dropped:
                 lines.append(
-                    f"[Transformer] {dropped} case(s) present in '{group_src}' only are DROPPED:"
-                    " several groups_src keep the intersection of their case names."
+                    f"[Transformer] {dropped} case(s) of '{group_src}' are DROPPED: the run keeps"
+                    " the cases every groups_src shares, minus what 'subset' excludes."
                 )
         by_chain: dict[tuple[str, str], list[TransformPlanEntry]] = {}
         for entry in self.entries:
@@ -427,7 +427,9 @@ class Transformer(DistributedObject):
                 reason = (
                     reduction_plan.refusal
                     if not reduction_plan.streams
-                    else reduction_plan.describe().split("\n", 1)[1].strip()
+                    # All of describe() but its header and its trailing case list, which report()
+                    # prints on lines of its own.
+                    else "\n".join(reduction_plan.describe().splitlines()[1:-1]).strip()
                 )
                 if verdict == "REDUCE":
                     # A reduction has no whole-volume fallback, so a destination that would refuse

--- a/konfai/transformer.py
+++ b/konfai/transformer.py
@@ -460,7 +460,7 @@ class Transformer(DistributedObject):
                 planned_dtypes.add(str(self._dtype_hypothesis(managers[0])))
             expansion = split_expand(managers[0].transforms)[1] if managers else None
             for manager in managers:
-                case_bytes = int(np.prod(manager.base_shape, dtype=np.int64)) * _CASE_ELEMENT_BYTES
+                case_bytes = manager.peak_case_bytes()
                 destination, group = self._terminal_destination(manager)
                 if expansion is not None:
                     # One line per copy: the copies are the outputs, each with its own resume, its

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -1494,9 +1494,7 @@ class Dataset:
 
         ``scale_factors`` is the WRITE-side counterpart: it makes the store this backend writes a
         pyramid instead of a single level. Reading indexes a pyramid BY POSITION, so a producer that
-        writes one and a consumer that asks for ``@1`` are two halves of the same contract -- and
-        until this parameter existed only the whole-array path could honour it, so a volume too large
-        to assemble came out single-level exactly when its pyramid was most needed.
+        writes one and a consumer that asks for ``@1`` are two halves of the same contract.
         """
 
         def __init__(
@@ -1687,12 +1685,11 @@ class Dataset:
             shape = [axis_sizes.get("c", 1), *[axis_sizes[axis] for axis in ("z", "y", "x") if axis in axis_sizes]]
             metadata["shape"] = shape
             attributes = self._attributes(metadata)
-            # Marked on the HEADERS path, so a field stays a field on the streamed one too. file_to_data
-            # marks it as well, but only there -- so an entry read region by region lost its RFC-5 type
-            # on the way in, and the store written from those regions came out an ordinary 3-channel
-            # image: read streamed, write streamed, and a displacement field silently stopped declaring
-            # itself. This is the once-per-case call (Dataset caches it), not the per-patch one, which
-            # is why the check belongs here and not in file_to_data_slice.
+            # Marked on the HEADERS path, so a field stays a field on the streamed read too --
+            # file_to_data marks it only on the whole-volume read, and a store written from unmarked
+            # regions is an ordinary 3-channel image. This is the once-per-case call (Dataset caches
+            # it), not the per-patch one, which is why the check belongs here and not in
+            # file_to_data_slice.
             if is_displacement_field(self._path(name)):
                 attributes[DISPLACEMENT_FIELD_ATTRIBUTE] = "true"
             return shape, attributes

--- a/tests/unit/test_case_expansion.py
+++ b/tests/unit/test_case_expansion.py
@@ -112,8 +112,8 @@ def test_split_expand_is_the_chain_around_its_marker() -> None:
 def test_copies_are_written_under_their_own_names_and_carry_their_draw(tmp_path: Path) -> None:
     """With the draw declared after the marker, what lands on disk is AUGMENTED.
 
-    Before this feature the draws lived in a separate section and were applied after the whole
-    chain — that is, after the Write — so every copy's entry held the un-augmented volume.
+    Draws declared in a separate section would apply after the whole chain — after the Write —
+    and every copy's entry would hold the un-augmented volume.
     """
     source = _source(tmp_path)
     out = Dataset(tmp_path / "out", "h5")

--- a/tests/unit/test_case_reduction.py
+++ b/tests/unit/test_case_reduction.py
@@ -103,11 +103,14 @@ def test_median_of_an_even_cohort_matches_numpy_without_assembling(tmp_path: Pat
     assert all(not manager.loaded and not manager.data for manager in engine.managers)
 
 
-def test_mean_is_incremental_so_the_cohort_is_never_resident(tmp_path: Path) -> None:
+def test_mean_is_incremental_so_the_cohort_is_never_resident(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     engine, destination, volumes = _run(tmp_path, [], Reduce(operator="Mean", output="avg"), [])
     plan = engine.plan()
     assert plan.incremental is True and plan.resident_regions == 2
 
+    # The bound, not the declaration: the base protocol BUFFERS, so a Mean that falls back to it
+    # holds the whole cohort per region while still declaring itself incremental.
+    monkeypatch.setattr(Reduction, "accumulate", lambda self, tensor: pytest.fail("Mean buffered the cohort"))
     engine.materialize()
     written, _ = destination.read_data("CT", "avg")
     np.testing.assert_allclose(written, volumes.mean(axis=0), rtol=1e-6)
@@ -297,22 +300,6 @@ def test_reduce_without_an_output_is_refused_at_construction() -> None:
 def test_an_unknown_grid_policy_is_refused_at_construction() -> None:
     with pytest.raises(TransformError, match="unknown grid policy"):
         Reduce(output="t", grid="whatever")
-
-
-def test_a_non_voxel_local_operator_is_refused(tmp_path: Path) -> None:
-    engine, _destination, _volumes = _run(tmp_path, [], Reduce(operator="Median", output="t"), [])
-    engine.operator = Median()
-    object.__setattr__(engine.operator, "voxel_local", False)
-    from konfai.data import case_reduction as reduction_module
-
-    class Spatial(Mean):
-        voxel_local = False
-
-    reduction_module.__dict__.setdefault("_Spatial", Spatial)
-    with pytest.raises(ReductionError, match="voxel-local"):
-        from konfai.data.case_reduction import resolve_operator
-
-        resolve_operator(Reduce(operator="konfai.data.case_reduction:_Spatial", output="t"))
 
 
 def test_a_second_run_skips_the_finished_reduction(tmp_path: Path) -> None:

--- a/tests/unit/test_case_reduction.py
+++ b/tests/unit/test_case_reduction.py
@@ -203,8 +203,11 @@ def test_a_cohort_that_disagrees_on_geometry_is_refused_before_reading(tmp_path:
     )
     refusal = engine.check_grid()
     assert refusal is not None and "Spacing" in refusal and "CASE_002" in refusal
-    with pytest.raises(ReductionError, match="cannot stream"):
+    with pytest.raises(ReductionError, match="cannot stream") as excinfo:
         engine.materialize()
+    # The remedy must address the GRID: a Save changes nothing about the members' geometry, so the
+    # generic put-a-Save advice would send the reader in a circle.
+    assert "resample them onto a common grid" in str(excinfo.value)
 
 
 def test_shape_only_accepts_approximate_headers(tmp_path: Path) -> None:

--- a/tests/unit/test_case_reduction.py
+++ b/tests/unit/test_case_reduction.py
@@ -230,9 +230,8 @@ def test_shape_only_accepts_approximate_headers(tmp_path: Path) -> None:
 def test_a_named_reference_adopts_its_geometry_instead_of_demanding_agreement(tmp_path: Path) -> None:
     """``reference:<case>`` is how a cohort says its members disagree and which one to believe.
 
-    It was running the ``strict`` geometry comparison anyway, and against the FIRST case rather than
-    the named one -- so the policy refused exactly the cohorts it exists for, and named the wrong
-    case when it did. Its documented contract is equal extents, and that member's geometry.
+    Its contract is exactly two checks: equal extents across the cohort, and the NAMED member's
+    geometry on the output -- no strict header comparison, whichever case happens to come first.
     """
     engine, destination, volumes = _run(
         tmp_path,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -354,12 +354,11 @@ def test_apply_config_union_keeps_the_value_type_over_lossy_coercion(write_confi
 
 
 def test_apply_config_refuses_a_nested_block_where_a_value_is_expected(write_config) -> None:
-    """``subset:`` is the one that bit: documented as a mapping, and ``str`` swallows any mapping.
+    """A mapping where the annotation says ``str`` is a parse error, not a stringified mapping.
 
-    ``str(CommentedMap)`` never fails, so the binder walked its union in declaration order, bound
-    ``subset`` to the literal text ``"{'CT': ['CASE_000']}"``, and the run died much later with
-    "All data entries were excluded" -- which reads as a matching problem and is a parsing one. The
-    config file was even rewritten with the mapping intact, so nothing ever looked wrong.
+    ``str(CommentedMap)`` never fails, so a union containing ``str`` would otherwise bind a nested
+    block to its repr, and the failure would surface far from the config line that caused it ("All
+    data entries were excluded" -- a matching symptom for a parsing cause).
     """
     write_config("Root:\n  subset:\n    CT:\n      - CASE_000\n      - CASE_001\n")
 

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -76,9 +76,9 @@ def test_attribute_repeated_set_returns_latest_version() -> None:
 def test_attribute_built_from_a_store_sidecar_holds_text_a_writer_accepts() -> None:
     """An OME-Zarr sidecar is JSON, so it hands back live lists -- ``MaxDisplacement`` is one.
 
-    Construction used to deep-copy values through untouched while ``__setitem__`` normalized them,
-    so an entry read back from its own store carried a ``list`` that ``Image.SetMetaData`` refuses
-    ("argument 3 of type 'std::string const &'"): a field could be written and never reopened.
+    Both doors normalize to text, construction included: a value deep-copied through construction
+    untouched reaches ``Image.SetMetaData``, which accepts only ``std::string`` -- a field that
+    can be written but never reopened.
     """
     attribute = Attribute({"MaxDisplacement": [1.19, 2.39, 3.59], "Spacing": (1.5, 1.5, 2.0)})
 

--- a/tests/unit/test_read_region_sweeps_pending_saves.py
+++ b/tests/unit/test_read_region_sweeps_pending_saves.py
@@ -115,7 +115,7 @@ def test_a_sweep_failure_does_not_survive_the_flip_to_rewriting_saves(tmp_path, 
         "_materialize_save",
         lambda sweep: manager._sweep_failed_because(sweep, "OSError: no space left on device"),
     )
-    with pytest.warns(UserWarning, match="could not be swept"):
+    with pytest.warns(UserWarning, match="could not be written region by region"):
         assert not manager._stream_ready(0, apply_augmentations=False)
     monkeypatch.undo()
 

--- a/tests/unit/test_read_region_sweeps_pending_saves.py
+++ b/tests/unit/test_read_region_sweeps_pending_saves.py
@@ -18,10 +18,9 @@
 
 ``Save`` is the remedy KonfAI recommends in its own refusal messages -- a statistic that follows a
 value-changing stage cannot stream, and cutting the chain with a ``Save`` makes the cache the source
-the statistic seeds from. That advice was sound, and the region path under it was not: ``read_region``
-resolved its stream source and replayed it directly, so the pending sweeps the source carried were
-never consumed. The chain planned STREAM and then failed at the first region -- the worst shape of
-answer, because the plan is what a caller reads before committing.
+the statistic seeds from. A ``read_region`` that replayed its stream source
+directly, without consuming the pending sweeps it carries, would plan STREAM and fail at the first
+region -- the worst shape of answer, because the plan is what a caller reads before committing.
 
 The whole-volume result is the reference here, as everywhere on this path: streaming is an
 optimisation of memory, never of meaning.

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -829,3 +829,23 @@ def test_an_unknown_stage_name_names_both_namespaces_and_the_closest_match() -> 
     with pytest.raises(TransformError, match="No transform or augmentation is named 'Clipp'") as excinfo:
         TransformLoader().get_transform("Clipp", "X")
     assert "Closest name: 'Clip'" in str(excinfo.value)
+
+
+def test_a_qualified_stage_key_whose_class_is_missing_is_refused_the_same_way() -> None:
+    """The bare form is refused by KonfAI; the qualified one fell through to a raw AttributeError.
+
+    Both are the same authoring mistake, and only one of them told the author what to do about it.
+    """
+    from konfai.data.transform import TransformLoader
+
+    with pytest.raises(TransformError, match="names no 'Missing' in module"):
+        TransformLoader().get_transform("konfai.data.transform:Missing", "X")
+
+
+def test_a_stage_key_naming_a_function_is_refused_as_not_a_class() -> None:
+    """A module attribute that is not a class cannot be a stage: building it would call it bare and
+    die far away on whatever it returns."""
+    from konfai.data.transform import TransformLoader
+
+    with pytest.raises(TransformError, match="names a function, not a stage class"):
+        TransformLoader().get_transform("split_expand", "X")

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -819,3 +819,13 @@ def test_reduce_reads_a_reference_case_through_the_space_yaml_leaves() -> None:
     assert Reduce(operator="konfai.data.reduction:Mean", output="template", grid="reference: CASE_000").grid == (
         "reference:CASE_000"
     )
+
+
+def test_an_unknown_stage_name_names_both_namespaces_and_the_closest_match() -> None:
+    """A misspelled bare stage name is a KonfAI refusal naming the two searched namespaces, never a
+    raw AttributeError blaming an internal module with Python's own (wrong) suggestion."""
+    from konfai.data.transform import TransformLoader
+
+    with pytest.raises(TransformError, match="No transform or augmentation is named 'Clipp'") as excinfo:
+        TransformLoader().get_transform("Clipp", "X")
+    assert "Closest name: 'Clip'" in str(excinfo.value)

--- a/tests/unit/test_transformer_workflow.py
+++ b/tests/unit/test_transformer_workflow.py
@@ -147,8 +147,8 @@ def test_plan_leaves_no_probe_case_in_a_directory_store(tmp_path: Path) -> None:
     """A dry run must leave the output directory as it found it.
 
     Aborting the probe stream drops the entry, but a directory dataset gives every case a directory
-    of its own, and that one outlived the stream: ``--plan`` left ``__konfai_plan_probe__/`` sitting
-    in the output root, shaped exactly like a case and listed as one by ``get_names``.
+    of its own, and that one outlives the stream: left behind, ``__konfai_plan_probe__/`` sits in
+    the output root shaped exactly like a case, and ``get_names`` lists it as one.
     """
     _write_source(tmp_path)
     _write_config(tmp_path, _DIRECTORY_CHAIN.format(out=tmp_path / "out"))
@@ -215,6 +215,33 @@ def test_budget_is_a_hard_constraint_for_fallback_cases(tmp_path: Path) -> None:
     with pytest.raises(TransformerError, match="budget"):
         workflow.setup(1)
     assert not Dataset(tmp_path / "out", "h5").is_dataset_exist("CT_out", "CASE_000")
+
+
+_PADS_THEN_FALLS_BACK = """\
+              Padding:
+                padding: [0, 0, 0, 0, 12, 12]
+              Standardize:
+                inverse: false
+              Write:
+                dataset: {out}:h5
+"""
+
+
+def test_the_budget_measures_the_largest_intermediate_not_the_stored_case(tmp_path: Path) -> None:
+    """A whole-volume fallback holds its BIGGEST tensor, which the chain decides, not the store.
+
+    Padding to twice the depth doubles what has to be resident, and Standardize is what sends the
+    case down the fallback path. Sized on the stored extent the case looks half as heavy as it is,
+    passes the budget it does not fit, and is OOM-killed with nothing written.
+    """
+    _write_source(tmp_path)
+    config_path = _write_config(tmp_path, _PADS_THEN_FALLS_BACK.format(out=tmp_path / "out"))
+    stored = 1 * 12 * 10 * 8 * 4 * 2  # [1, 12, 10, 8] float32, times the in-flight copy
+    # A budget the stored case fits and the padded one does not.
+    config_path.write_text(config_path.read_text().replace("memory_budget: auto", f"memory_budget: {stored + 1}b"))
+
+    with pytest.raises(TransformerError, match="budget"):
+        _build(tmp_path).setup(1)
 
 
 def test_chain_without_write_is_refused_at_parse(tmp_path: Path) -> None:
@@ -421,9 +448,9 @@ def test_multi_rank_accepts_a_directory_store_and_refuses_a_single_file(tmp_path
 
 
 def test_overwrite_rewrites_a_geometry_changing_chain_correctly(tmp_path: Path) -> None:
-    """The bak-poisoning regression: planning a second run reads the OUTPUT's header through the
-    satisfied boundary, and a rewrite replanned from that geometry would resample by a factor of 1 —
-    silently overwriting the deliverable with untransformed data."""
+    """A forced rewrite replans from the case as STORED, never from the satisfied boundary:
+    planning a second run reads the OUTPUT's header, and a rewrite replanned from that geometry
+    would resample by a factor of 1 and overwrite the deliverable with untransformed data."""
     import os
 
     _write_source(tmp_path)

--- a/tests/unit/test_transformer_workflow.py
+++ b/tests/unit/test_transformer_workflow.py
@@ -340,19 +340,32 @@ _CAST_CHAIN = """\
 """
 
 
-def test_the_plan_reports_the_dtype_it_probed_the_destinations_with(tmp_path: Path) -> None:
+def test_the_plan_reports_the_dtype_it_probed_the_destinations_with(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The report is the probe's own answer, not a constant beside it.
 
-    The write probe already opens with the chain's last declared cast; a report that says float32
-    whatever the chain casts to describes a run nobody asked for -- and a destination that refuses
-    uint8 would have been caught by the probe while the plan claimed float32 was fine.
+    The write probe must open with the chain's last declared cast: a report that says float32
+    whatever the chain casts to describes a run nobody asked for, and a destination that refuses
+    uint8 would be green-lit by a probe that still opened float32.
     """
+    from konfai.transformer import Transformer
+
     _write_source(tmp_path)
     _write_config(tmp_path, _CAST_CHAIN.format(out=tmp_path / "out"))
 
+    probed: list[np.dtype] = []
+    original = Transformer._probe_destination
+
+    def spy(destination, group, shape, dtype, attributes):
+        probed.append(np.dtype(dtype))
+        return original(destination, group, shape, dtype, attributes)
+
+    monkeypatch.setattr(Transformer, "_probe_destination", staticmethod(spy))
     plan = _build(tmp_path).compute_plan(1, overwrite=False)
 
     assert "assumed uint8 / source channels" in plan.report()
+    assert probed and all(dtype == np.dtype("uint8") for dtype in probed)
 
 
 def test_unknown_key_is_refused_with_its_path(tmp_path: Path) -> None:
@@ -383,7 +396,9 @@ def test_second_run_skips_and_overwrite_rewrites(tmp_path: Path) -> None:
     os.environ["KONFAI_OVERWRITE"] = "True"
     workflow = _build(tmp_path)
     workflow.setup(1)
+    stamp = (tmp_path / "out.h5").stat().st_mtime_ns
     workflow.run_process(1, 0, 0, [])
+    assert (tmp_path / "out.h5").stat().st_mtime_ns != stamp, "the forced rewrite never wrote"
     after, _ = Dataset(tmp_path / "out", "h5").read_data("CT_out", "CASE_000")
     np.testing.assert_array_equal(after, before)
 
@@ -840,3 +855,41 @@ def test_on_fallback_error_holds_at_run_time_too(tmp_path: Path, monkeypatch: py
     with pytest.raises(PatchError, match="whole-volume path at run time"), pytest.warns(UserWarning):
         workflow.run_process(1, 0, 0, [])
     assert not Dataset(tmp_path / "out", "h5").is_dataset_exist("CT_out", "CASE_000")
+
+
+def test_the_strict_grammar_knows_every_key_the_binder_can_read() -> None:
+    """The grammar mirrors the two __init__ signatures: a parameter added to either without a
+    grammar entry would be refused in every config that sets it."""
+    import inspect
+
+    from konfai.data.data_manager import DataTransform
+    from konfai.transformer import _STRICT_GRAMMAR, Transformer
+
+    workflow_params = set(inspect.signature(Transformer.__init__).parameters) - {"self", "dataset"}
+    assert workflow_params | {"Dataset"} == set(_STRICT_GRAMMAR)
+    dataset_grammar = _STRICT_GRAMMAR["Dataset"]
+    assert isinstance(dataset_grammar, dict)
+    dataset_params = set(inspect.signature(DataTransform.__init__).parameters) - {"self"}
+    assert dataset_params == set(dataset_grammar)
+
+
+def test_two_ranks_partition_the_cases_and_every_output_is_written_once(tmp_path: Path) -> None:
+    """The DDP contract, executed: the shards partition the work items, and running each rank's
+    shard writes every case exactly once -- a case in no shard (or in two) is a wrong dataset
+    delivered with exit code 0."""
+    _write_source(tmp_path, cases=3)
+    _write_config(
+        tmp_path,
+        "              Clip:\n                min_value: 0.0\n                max_value: 50.0\n"
+        "              Write:\n"
+        f"                dataset: {tmp_path / 'out_dir'}/:omezarr\n",
+    )
+    workflow = _build(tmp_path)
+    workflow.setup(2)
+    flattened = sorted(index for shard in workflow._shards for index in shard)
+    assert flattened == list(range(3)), "the shards must partition the work items exactly"
+    workflow.run_process(2, 0, 0, [])
+    workflow.run_process(2, 1, 1, [])
+    out = Dataset(f"{tmp_path / 'out_dir'}/", "omezarr")
+    for index in range(3):
+        assert out.is_dataset_exist("CT_out", f"CASE_{index:03d}")

--- a/tests/unit/test_transformer_workflow.py
+++ b/tests/unit/test_transformer_workflow.py
@@ -665,7 +665,13 @@ def test_an_expanded_copy_carries_its_draw_and_resumes_per_copy(tmp_path: Path) 
 
 
 def test_transforms_and_draws_interleave_after_the_marker(tmp_path: Path) -> None:
-    """`T, draw, T, draw` is expressible, which is the point of declaring draws in the chain."""
+    """`draw, T, draw` is expressible, which is the point of declaring draws in the chain.
+
+    `Rotate` and not a bare `Flip`: two classes carry that name and the loader resolves the
+    TRANSFORM first, so a bare `Flip` in a chain is the deterministic axis flip, not the draw.
+    """
+    from konfai.data.augmentation import DataAugmentation
+
     _write_source(tmp_path, cases=1)
     _write_expand_config(
         tmp_path,
@@ -673,7 +679,7 @@ def test_transforms_and_draws_interleave_after_the_marker(tmp_path: Path) -> Non
         '                pattern: "{name}_r{a:02d}"\n'
         "              Brightness:\n                b_std: 0.2\n"
         "              TensorCast:\n                dtype: float32\n"
-        "              Flip:\n                f_prob: [0, 1, 0]\n"
+        "              Rotate:\n                is_quarter: true\n"
         "              Write:\n"
         f"                dataset: {tmp_path / 'out'}:h5\n",
     )
@@ -683,9 +689,10 @@ def test_transforms_and_draws_interleave_after_the_marker(tmp_path: Path) -> Non
         "Expand",
         "Brightness",
         "TensorCast",
-        "Flip",
+        "Rotate",
         "Write",
     ]
+    assert isinstance(chain[1], DataAugmentation) and isinstance(chain[3], DataAugmentation)
     workflow.setup(1)
     workflow.run_process(1, 0, 0, [])
     out = Dataset(tmp_path / "out", "h5")
@@ -752,3 +759,84 @@ def test_an_expanded_run_never_reads_a_whole_volume(tmp_path: Path, monkeypatch:
     out = Dataset(tmp_path / "out", "h5")
     assert out.is_dataset_exist("CT_out", "CASE_000_r01")
     assert out.is_dataset_exist("CT_out", "CASE_001_r03")
+
+
+def test_a_config_without_the_transformer_root_is_refused(tmp_path: Path) -> None:
+    """A typo'd root ('Transformr:') must not bind an all-defaults workflow over the user's file."""
+    from konfai.transformer import _reject_unknown_keys
+
+    config = tmp_path / "Transform.yml"
+    config.write_text("Transformr:\n  name: X\n")
+    with pytest.raises(ConfigError, match="no 'Transformer' root"):
+        _reject_unknown_keys(config)
+
+
+def test_a_typo_stage_argument_is_refused_instead_of_binding_its_default(tmp_path: Path) -> None:
+    """A stage argument the signature does not name is a parse error: the binder would otherwise
+    materialize the default beside the typo, and `Clip: {min_val: 0}` would clip at -1024, exit 0."""
+    from konfai.transformer import _reject_unknown_keys
+
+    config = tmp_path / "Transform.yml"
+    config.write_text(
+        "Transformer:\n  Dataset:\n    groups_src:\n      CT:\n        groups_dest:\n"
+        "          CT_out:\n            transforms:\n"
+        "              Clip: {min_val: 0.0, max_value: 400.0}\n"
+        "              Write: {dataset: ./Out:h5}\n"
+    )
+    with pytest.raises(ConfigError, match=r"Unknown argument 'min_val' for 'Clip'"):
+        _reject_unknown_keys(config)
+
+
+def test_a_reduce_mapping_carries_its_operator_arguments_and_refuses_a_typo(tmp_path: Path) -> None:
+    """A Reduce's mapping legitimately holds its operator's own parameters (resolve_operator binds
+    them from the same mapping); only a key neither signature names is refused."""
+    from konfai.transformer import _reject_unknown_keys
+
+    config = tmp_path / "Transform.yml"
+    template = (
+        "Transformer:\n  Dataset:\n    groups_src:\n      CT:\n        groups_dest:\n"
+        "          CT_out:\n            transforms:\n"
+        "              Reduce: {{operator: Mean, output: atlas{extra}}}\n"
+        "              Write: {{dataset: ./Out:h5}}\n"
+    )
+    config.write_text(template.format(extra=", grid: shape_only"))
+    _reject_unknown_keys(config)
+    config.write_text(template.format(extra=", grib: shape_only"))
+    with pytest.raises(ConfigError, match=r"Unknown argument 'grib' for 'Reduce'"):
+        _reject_unknown_keys(config)
+
+
+def test_a_stage_that_resolves_nowhere_is_left_to_the_loader(tmp_path: Path) -> None:
+    """An unresolvable stage name must not be reported as a wrong ARGUMENT: the loader owns that
+    refusal and names the searched packages."""
+    from konfai.transformer import _reject_unknown_keys
+
+    config = tmp_path / "Transform.yml"
+    config.write_text(
+        "Transformer:\n  Dataset:\n    groups_src:\n      CT:\n        groups_dest:\n"
+        "          CT_out:\n            transforms:\n"
+        "              Clipp: {min_value: 0.0}\n"
+        "              Write: {dataset: ./Out:h5}\n"
+    )
+    _reject_unknown_keys(config)
+
+
+def test_on_fallback_error_holds_at_run_time_too(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """'error' means nothing is quietly written by the whole-volume path: a fallback only discovered
+    mid-run (here, a sweep that fails after a green plan) raises at that case instead of costing an
+    unannounced volume."""
+    from konfai.data.patching import DatasetManager
+    from konfai.utils.errors import PatchError
+
+    _write_source(tmp_path)
+    _write_config(tmp_path, _STREAMABLE.format(out=tmp_path / "out"), header="  on_fallback: error\n")
+    workflow = _build(tmp_path)
+    workflow.setup(1)
+    monkeypatch.setattr(
+        DatasetManager,
+        "_materialize_save",
+        lambda self, sweep: self._sweep_failed_because(sweep, "OSError: no space left on device"),
+    )
+    with pytest.raises(PatchError, match="whole-volume path at run time"), pytest.warns(UserWarning):
+        workflow.run_process(1, 0, 0, [])
+    assert not Dataset(tmp_path / "out", "h5").is_dataset_exist("CT_out", "CASE_000")


### PR DESCRIPTION
Stacked on #82. This is the last review pass before the release, run over everything between
`v1.7.0` and the tip of the stack — 52 commits, ~4 500 lines of production code.

**Refuse at parse time what would only surface at run time.** An unknown root, a typo'd stage
argument, and a stage key naming something that is not a class all parsed clean and failed much
later — or worse, ran. Each is decidable from the config alone, so each is decided there.
`on_fallback: error` is now held at run time too: a chain that falls back *after* the plan said it
would stream has to stop for the same reason the plan would have stopped it.

**Say it once, and say what to do.** The plan repeated its reduction and dropped-case lines per
chain. Refusals carried a remedy that did not always match the refusal — a refusal a reader cannot
act on is a failure with extra steps.

**Assert the write, not the call.** The tests now check the bytes that land, the shards they land
in, and the dtype the probe actually opened with, rather than the arguments a mock was handed.

**Documentation in the present tense.** A reader has no diff in hand, so a sentence about what the
code used to do is a sentence about nothing. Plus the `Reduce` page that was missing, a corrected
budget claim beside it, and the 1.8.0 changelog.

Shared rather than restated: the fallback constants and the Welford kernel.

1318 unit tests pass, ruff and ruff-format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `Reduce` transform stage with configurable operators, output naming, tolerances, streaming, and grid compatibility options.
  * Improved transform planning with clearer reduction, memory-budget, and dropped-case details.
* **Bug Fixes**
  * Added stricter validation for unknown, misspelled, missing, or invalid transform stages and arguments.
  * Improved fallback handling, memory-limit enforcement, and grid-mismatch guidance.
  * Prevented unexpected fallback processing when configured to error.
* **Documentation**
  * Updated configuration, CLI, OME-Zarr, and release-history documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->