### PR TITLE
feat(impact-reg): let a preset skip the linear stage

### DIFF
--- a/apps/impact_reg/impact_reg_konfai/models/fireants.py
+++ b/apps/impact_reg/impact_reg_konfai/models/fireants.py
@@ -33,7 +33,7 @@ module is specialised by ``stages``). ``deformable_method`` picks the deformable
 
     "syn"    symmetric diffeomorphic SyN (CC)   — invertible, higher quality, averages cleanly for ensembling
     "greedy" greedy diffeomorphic (CC)          — one-directional, faster / lower VRAM
-    "none"   linear only                        — Rigid+Affine, no deformable (the FireANTs_Affine preset)
+    "none"   no deformable                      — the linear stage IS the transform (FireANTs_Affine)
 
 and ``linear_method`` picks the linear one:
 
@@ -41,8 +41,10 @@ and ``linear_method`` picks the linear one:
     "rigid"         Rigid only                   — no free scale or shear
     "none"          deformable from identity     — for a pair already globally aligned
 
-The two cannot both be "none": that leaves nothing to optimise, and the engine says so rather than
-returning an identity transform.
+They compose, so ``deformable_method="none"`` runs whichever linear stage was asked for rather than
+always Rigid+Affine: with ``linear_method="rigid"`` it is a rigid-only registration. The one
+combination refused is both set to ``"none"`` -- that leaves nothing to optimise, and the engine
+raises ``ValueError`` at build time rather than returning an identity transform.
 
 Masks: the optional Fixed/Moving masks restrict the metric to a region. FireANTs implements this by
 carrying the mask as the last image channel and prefixing the metric with ``masked_``; a mask is only
@@ -79,6 +81,10 @@ from konfai.utils.dataset import Attribute, data_to_image, image_to_data
 from .elastix import _is_local_ref
 
 DIM = 3
+
+#: Linear stages a preset may ask for. The engine checks against this rather than trusting the
+#: ``Literal`` annotation, which only binds a config-driven call and not a direct Python one.
+_LINEAR_METHODS = ("rigid_affine", "rigid", "none")
 
 # Feature-model registry (models.json): the available IMPACT feature models, fetched from HF (NOT bundled).
 # Only consulted by the "impact" deformable metric; ``KONFAI_IMPACT_MODELS_REGISTRY`` (a local path) wins
@@ -466,10 +472,19 @@ class FireANTsEngine:
         self._moments_init = moments_init
         self._linear_method = linear_method
         self._deformable_method = deformable_method
+        # Both checks are at BUILD time, as the missing-feature-model one above is: the stages they
+        # guard run for minutes, and a run that reaches them has already paid for the read.
+        if linear_method not in _LINEAR_METHODS:
+            # Named, not silently ignored. Every unrecognised value would otherwise fall through to
+            # the rigid-then-affine branch, so a typo -- "affine", say -- would register with a stage
+            # the caller did not ask for and produce a perfectly plausible result.
+            raise ValueError(
+                f"Unknown linear_method '{linear_method}' (expected {', '.join(map(repr, _LINEAR_METHODS))})."
+            )
         if linear_method == "none" and deformable_method == "none":
-            # Refused at BUILD time, as the missing-feature-model check above is. Left to run, this
-            # optimises nothing and returns the identity: a Moved equal to the moving image and a
-            # zero field, which no downstream check tells apart from a pair that needed no moving.
+            # Left to run this optimises nothing and returns the identity: a Moved equal to the moving
+            # image and a zero field, which no downstream check tells apart from a pair that needed no
+            # moving.
             raise ValueError(
                 "linear_method='none' with deformable_method='none' leaves nothing to optimise."
             )
@@ -832,7 +847,9 @@ class RegistrationNet(network.Network):
         ] = "rigid_affine",
         deformable_method: Annotated[
             Literal["none", "syn", "greedy"],
-            "Deformable algorithm: 'syn' (symmetric diffeomorphic), 'greedy', or 'none' to stop after the affine stage.",
+            "Deformable algorithm: 'syn' (symmetric diffeomorphic), 'greedy', or 'none' to stop after the linear "
+            "stage, whichever 'linear_method' selected -- with linear_method='rigid' that is a rigid-only "
+            "registration. Both set to 'none' is refused: it would optimise nothing.",
         ] = "syn",
         deformable_metric: Annotated[
             Literal["cc", "mi", "mse", "impact"],

--- a/apps/impact_reg/impact_reg_konfai/models/fireants.py
+++ b/apps/impact_reg/impact_reg_konfai/models/fireants.py
@@ -28,13 +28,21 @@ composable stages (GPU, Riemannian Adam), each seeding the next like ANTs' ``-t`
 
     Rigid (MI, centre-of-mass init) -> Affine (MI, seeded by the rigid) -> deformable
 
-The deformable stage is selected by ``deformable_method`` — the ONE knob that specialises this shared
-module into the different presets (exactly as ConvexAdam's shared module is specialised by
-``stages``):
+Two mirrored knobs specialise this shared module into the different presets (as ConvexAdam's shared
+module is specialised by ``stages``). ``deformable_method`` picks the deformable stage:
 
     "syn"    symmetric diffeomorphic SyN (CC)   — invertible, higher quality, averages cleanly for ensembling
     "greedy" greedy diffeomorphic (CC)          — one-directional, faster / lower VRAM
     "none"   linear only                        — Rigid+Affine, no deformable (the FireANTs_Affine preset)
+
+and ``linear_method`` picks the linear one:
+
+    "rigid_affine"  Rigid then Affine, as ANTs   — the default
+    "rigid"         Rigid only                   — no free scale or shear
+    "none"          deformable from identity     — for a pair already globally aligned
+
+The two cannot both be "none": that leaves nothing to optimise, and the engine says so rather than
+returning an identity transform.
 
 Masks: the optional Fixed/Moving masks restrict the metric to a region. FireANTs implements this by
 carrying the mask as the last image channel and prefixing the metric with ``masked_``; a mask is only
@@ -439,6 +447,7 @@ class FireANTsEngine:
         affine_metric: str,
         affine_lr: float,
         moments_init: str,
+        linear_method: str,
         deformable_method: str,
         deformable_metric: str,
         deformable_lr: float,
@@ -455,7 +464,15 @@ class FireANTsEngine:
         self._affine_metric = affine_metric
         self._affine_lr = float(affine_lr)
         self._moments_init = moments_init
+        self._linear_method = linear_method
         self._deformable_method = deformable_method
+        if linear_method == "none" and deformable_method == "none":
+            # Refused at BUILD time, as the missing-feature-model check above is. Left to run, this
+            # optimises nothing and returns the identity: a Moved equal to the moving image and a
+            # zero field, which no downstream check tells apart from a pair that needed no moving.
+            raise ValueError(
+                "linear_method='none' with deformable_method='none' leaves nothing to optimise."
+            )
         self._deformable_metric = deformable_metric
         self._deformable_lr = float(deformable_lr)
         self._integrator_n = int(integrator_n)
@@ -590,45 +607,60 @@ class FireANTsEngine:
         # Linear: Rigid(MI) -> Affine(MI, seeded by the rigid), mirroring ANTs. The affine seeds the
         # deformable stage (or is the whole transform when deformable_method == "none").
         #
-        # The rigid's starting translation mirrors ANTs' ``-r [fixed,moving,N]``: "cof" is the centre
-        # of FRAME (N=0), "com" the centre of MASS (N=1). "cof" aligns the image frames, not the
-        # subjects, so a subject sitting off its frame centre starts the whole chain misplaced.
-        init_translation: "str | torch.Tensor" = "cof"
-        if self._moments_init == "com":
-            init_translation = self._center_of_mass_translation(
-                fixed,
-                moving,
-                fixed_mask if use_fixed_mask else None,
-                moving_mask if use_moving_mask else None,
-                device,
+        # ``linear_method`` is ``deformable_method``'s mirror. "none" skips the linear stage entirely
+        # and starts the deformable from identity: for a pair already globally aligned -- a tiled
+        # refinement at full resolution, where each patch sees only local anatomy, so a per-patch
+        # rigid has no global meaning and neighbouring patches would each estimate a different one
+        # and tear the blended field at the seams.
+        affine_matrix: "torch.Tensor | None"
+        if self._linear_method == "none":
+            affine_matrix = None  # the deformable stage builds its own identity init
+        else:
+            # The rigid's starting translation mirrors ANTs' ``-r [fixed,moving,N]``: "cof" is the
+            # centre of FRAME (N=0), "com" the centre of MASS (N=1). "cof" aligns the image frames,
+            # not the subjects, so a subject sitting off its frame centre starts the chain misplaced.
+            init_translation: "str | torch.Tensor" = "cof"
+            if self._moments_init == "com":
+                init_translation = self._center_of_mass_translation(
+                    fixed,
+                    moving,
+                    fixed_mask if use_fixed_mask else None,
+                    moving_mask if use_moving_mask else None,
+                    device,
+                )
+            rigid = RigidRegistration(
+                scales=self._scales,
+                iterations=self._affine_iterations,
+                fixed_images=bf,
+                moving_images=bm,
+                loss_type=affine_loss,
+                optimizer="Adam",
+                optimizer_lr=self._affine_lr,
+                cc_kernel_size=self._cc_kernel,
+                init_translation=init_translation,
             )
-        rigid = RigidRegistration(
-            scales=self._scales,
-            iterations=self._affine_iterations,
-            fixed_images=bf,
-            moving_images=bm,
-            loss_type=affine_loss,
-            optimizer="Adam",
-            optimizer_lr=self._affine_lr,
-            cc_kernel_size=self._cc_kernel,
-            init_translation=init_translation,
-        )
-        rigid.optimize()
-        rigid_matrix = rigid.get_rigid_matrix().detach()
+            rigid.optimize()
+            rigid_matrix = rigid.get_rigid_matrix().detach()
 
-        affine = AffineRegistration(
-            scales=self._scales,
-            iterations=self._affine_iterations,
-            fixed_images=bf,
-            moving_images=bm,
-            loss_type=affine_loss,
-            optimizer="Adam",
-            optimizer_lr=self._affine_lr,
-            cc_kernel_size=self._cc_kernel,
-            init_rigid=rigid_matrix,
-        )
-        affine.optimize()
-        affine_matrix = affine.get_affine_matrix().detach()
+            if self._linear_method == "rigid":
+                # The rigid -- rotation and translation, no scale or shear -- IS the linear transform.
+                # For inspecting the linear stage without the affine's free scale, and for a pair whose
+                # scale difference is known to be nothing the affine should be free to invent.
+                affine_matrix = rigid_matrix
+            else:
+                affine = AffineRegistration(
+                    scales=self._scales,
+                    iterations=self._affine_iterations,
+                    fixed_images=bf,
+                    moving_images=bm,
+                    loss_type=affine_loss,
+                    optimizer="Adam",
+                    optimizer_lr=self._affine_lr,
+                    cc_kernel_size=self._cc_kernel,
+                    init_rigid=rigid_matrix,
+                )
+                affine.optimize()
+                affine_matrix = affine.get_affine_matrix().detach()
 
         # Deformable stage (or none). SyN and Greedy share the same constructor surface; both warm-start
         # from the affine so their TOTAL transform already bakes in the linear pre-align.
@@ -791,6 +823,13 @@ class RegistrationNet(network.Network):
             "of frame (N=0), 'com' = intensity-weighted centre of mass (N=1). Prefer 'com' when the subject "
             "sits off its frame centre, where aligning frames starts the chain misplaced.",
         ] = "cof",
+        linear_method: Annotated[
+            Literal["rigid_affine", "rigid", "none"],
+            "Linear stage before the deformable: 'rigid_affine' (rigid then affine, as ANTs), 'rigid' to stop "
+            "after the rigid and leave scale and shear alone, or 'none' to skip it and start the deformable "
+            "from identity. Use 'none' only on a pair already globally aligned -- a tiled pass at full "
+            "resolution, where a patch sees no global context and a per-patch linear has no global meaning.",
+        ] = "rigid_affine",
         deformable_method: Annotated[
             Literal["none", "syn", "greedy"],
             "Deformable algorithm: 'syn' (symmetric diffeomorphic), 'greedy', or 'none' to stop after the affine stage.",
@@ -843,6 +882,7 @@ class RegistrationNet(network.Network):
             affine_metric,
             affine_lr,
             moments_init,
+            linear_method,
             deformable_method,
             deformable_metric,
             deformable_lr,

--- a/apps/impact_reg/tests/unit/test_engine_contracts.py
+++ b/apps/impact_reg/tests/unit/test_engine_contracts.py
@@ -87,6 +87,16 @@ def test_fireants_linear_method_reaches_the_engine() -> None:
         assert net["Registration"]._engine._linear_method == method
 
 
+def test_fireants_refuses_an_unknown_linear_method() -> None:
+    # Every unrecognised value would otherwise fall through to the rigid-then-affine branch, so a
+    # typo registers with a stage the caller did not ask for and returns a plausible result. The
+    # Literal annotation only guards a config-driven call; a direct Python one reaches the engine.
+    from impact_reg_konfai.models.fireants import RegistrationNet
+
+    with pytest.raises(ValueError, match="Unknown linear_method 'affine'"):
+        RegistrationNet(linear_method="affine")
+
+
 def test_fireants_refuses_a_registration_with_no_stage_at_all() -> None:
     # linear_method='none' and deformable_method='none' together optimise nothing. Left to run it
     # would return the identity: a Moved equal to the moving image and a zero field, which no

--- a/apps/impact_reg/tests/unit/test_engine_contracts.py
+++ b/apps/impact_reg/tests/unit/test_engine_contracts.py
@@ -74,3 +74,25 @@ def test_fireants_impact_metric_requires_a_feature_model() -> None:
 
     with pytest.raises(ValueError, match="requires at least one feature model"):
         RegistrationNet(deformable_metric="impact", models={})
+
+
+def test_fireants_linear_method_reaches_the_engine() -> None:
+    # The knob is only useful if it survives the config binding: a value that stops at RegistrationNet
+    # leaves the engine on its default, and a tiled pass would run the per-patch linear it asked to
+    # skip -- silently, because the run still produces a plausible field.
+    from impact_reg_konfai.models.fireants import RegistrationNet
+
+    for method in ("rigid_affine", "rigid", "none"):
+        net = RegistrationNet(linear_method=method)
+        assert net["Registration"]._engine._linear_method == method
+
+
+def test_fireants_refuses_a_registration_with_no_stage_at_all() -> None:
+    # linear_method='none' and deformable_method='none' together optimise nothing. Left to run it
+    # would return the identity: a Moved equal to the moving image and a zero field, which no
+    # downstream check tells apart from a pair that needed no moving. Refused at build time, like the
+    # missing-feature-model case, rather than after the stages have burned minutes.
+    from impact_reg_konfai.models.fireants import RegistrationNet
+
+    with pytest.raises(ValueError, match="leaves nothing to optimise"):
+        RegistrationNet(linear_method="none", deformable_method="none")


### PR DESCRIPTION
## What

`deformable_method` has had a `"none"` since the beginning — linear only, which is what the
`FireANTs_Affine` preset is. Its mirror was missing: there was no way to say *deformable only*.

`linear_method` adds it:

| value | stage |
|---|---|
| `rigid_affine` | Rigid then Affine, as ANTs — **the default, unchanged** |
| `rigid` | Rigid only, no free scale or shear |
| `none` | deformable from identity |

## Why

A tiled pass at full resolution needs exactly that. Each patch sees a few hundred voxels and no
global context, so a per-patch rigid has no global meaning: neighbouring patches each estimate a
different one and the blended field tears at the seams. The pose is solved once, globally, by the
pass before it, and must not be revisited per patch.

## What it refuses

`linear_method="none"` with `deformable_method="none"` raises at **build** time, as the
missing-feature-model check already does. Left to run they optimise nothing and return the identity —
a `Moved` equal to the moving image and a zero field, which no downstream check tells apart from a
pair that needed no moving.

## Compatibility

Nothing changes for a preset that does not set it: the default runs the same Rigid → Affine it always
did. No published preset in the ImpactReg bundle sets it.

## Motivation

This is the last knob keeping the ExaSPIM capsules on a vendored copy of this module. They carry 653
lines of `Model.py` in three capsules and name it `Model:RegistrationNet`, where every published
preset names `impact_reg_konfai.models.fireants:RegistrationNet` and ships no `Model.py` at all.
With this they can do the same — three copies deleted, one line changed each.

(`moments_init`, the other knob those copies carried, already landed upstream.)

## Tests

`apps/impact_reg/tests/unit/` — 40 passed. Two added: the knob reaches the engine for all three
values, and the no-stage combination raises at construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added independent controls for linear and deformable registration methods.
  - Linear registration supports rigid-plus-affine, rigid-only, or disabled modes.
  - Deformable registration supports SyN, greedy, or disabled modes.
  - Registration can continue from rigid results or start from identity initialization.

- **Bug Fixes**
  - Configurations disabling both registration stages now fail early with a clear validation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->