### PR TITLE
feat(impact-reg): give the orchestrator its working directory, and let a preset declare only its field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,10 @@ written replaces it.
   a caller whose system temp directory is a tmpfs can now stage volume-sized intermediates on real disk
   instead of overriding `TMPDIR` from outside; the same change also writes the moved image and the
   displacement field once per run instead of twice
+- **impact-reg**: a preset may declare only its displacement field — `register` derives the moved image
+  from it rather than requiring every preset to write a second output. Reading the moving image now
+  handles an OME-Zarr store as well as an ITK file, which also fixes the ensemble path: averaging
+  several presets over OME-Zarr inputs failed there, and nowhere else, on `sitk.ReadImage`
 - **studio**: bundle icons through the app interface, and a way to stop Studio (#75)
 - **examples**: a Transform example -- a template folded out of a cohort, and drawn copies of a case
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,10 +152,12 @@ written replaces it.
   a caller whose system temp directory is a tmpfs can now stage volume-sized intermediates on real disk
   instead of overriding `TMPDIR` from outside; the same change also writes the moved image and the
   displacement field once per run instead of twice
-- **impact-reg**: a preset may declare only its displacement field — `register` derives the moved image
-  from it rather than requiring every preset to write a second output. Reading the moving image now
-  handles an OME-Zarr store as well as an ITK file, which also fixes the ensemble path: averaging
-  several presets over OME-Zarr inputs failed there, and nowhere else, on `sitk.ReadImage`
+- **impact-reg**: a registration preset now owes exactly one output, its displacement field, in whatever
+  format it declares — `register` derives the moved image from it instead of expecting a second output.
+  A preset can drop `MovedImage` entirely, which for a tiled one also drops blending a full-size moved
+  across every patch seam for a caller that has the field. Reading the moving image handles an OME-Zarr
+  store as well as an ITK file, which fixes the ensemble path too: averaging several presets over
+  OME-Zarr inputs failed there, and nowhere else, on `sitk.ReadImage`
 - **studio**: bundle icons through the app interface, and a way to stop Studio (#75)
 - **examples**: a Transform example -- a template folded out of a cohort, and drawn copies of a case
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,10 @@ written replaces it.
 - **data**: Vote, the reduction operator that folds segmentations without inventing a label
 - **data**: declare an OME-Zarr pyramid from a Write, and let a field carry its own bound
 - **impact-reg**: seed the rigid from the centre of mass, not only the frame
+- **impact-reg**: `--tmp-dir` on register/eval/uncertainty, the option the other app CLIs already carry —
+  a caller whose system temp directory is a tmpfs can now stage volume-sized intermediates on real disk
+  instead of overriding `TMPDIR` from outside; the same change also writes the moved image and the
+  displacement field once per run instead of twice
 - **studio**: bundle icons through the app interface, and a way to stop Studio (#75)
 - **examples**: a Transform example -- a template folded out of a cohort, and drawn copies of a case
 

--- a/apps/impact_reg/impact_reg_konfai/cli.py
+++ b/apps/impact_reg/impact_reg_konfai/cli.py
@@ -44,6 +44,24 @@ def _default_preset() -> str:
     return presets[0]
 
 
+def _add_tmp_dir(parser: argparse.ArgumentParser) -> None:
+    """Add ``--tmp-dir``, the option every other KonfAI app CLI exposes through ``build_app_cli``.
+
+    Left unset the command stages under the system temporary directory, as before. It is worth naming
+    when that directory is the wrong medium: what is staged is volume-sized (the moved image and the
+    displacement field, written before being collected into ``--output``), so a tmpfs TMPDIR charges it
+    to RAM. Pointing this beside ``--output`` also puts the intermediates on the results' own filesystem.
+    """
+    parser.add_argument(
+        "--tmp-dir",
+        "--tmp_dir",
+        dest="tmp_dir",
+        type=_paths,
+        default=None,
+        help="Directory for intermediates (default: the system temporary directory).",
+    )
+
+
 def _add_device(parser: argparse.ArgumentParser, download: bool = True) -> None:
     """Add the shared device / verbosity / download options to a sub-parser."""
     device = parser.add_mutually_exclusive_group()
@@ -109,6 +127,7 @@ def main() -> None:
         "e.g. --set iterations=300 (repeatable).",
     )
     _add_device(reg)
+    _add_tmp_dir(reg)
 
     # eval -------------------------------------------------------------------
     ev = subparsers.add_parser(
@@ -145,6 +164,7 @@ def main() -> None:
     )
     ev.add_argument("-o", "--output", type=_paths, default=Path("./Output").resolve(), help="Output directory.")
     _add_device(ev)
+    _add_tmp_dir(ev)
 
     # uncertainty ------------------------------------------------------------
     unc = subparsers.add_parser(
@@ -166,6 +186,7 @@ def main() -> None:
     )
     unc.add_argument("-o", "--output", type=_paths, default=Path("./Output").resolve(), help="Output directory.")
     _add_device(unc)
+    _add_tmp_dir(unc)
 
     args = parser.parse_args()
     app = ImpactRegKonfAIApp(
@@ -187,6 +208,7 @@ def main() -> None:
             tta=args.tta,
             keep_dvf=args.uncertainty,
             config_overrides=args.config_overrides,
+            tmp_dir=args.tmp_dir,
         )
 
     elif args.command == "eval":
@@ -214,6 +236,7 @@ def main() -> None:
             gpu=gpu,
             cpu=args.cpu,
             quiet=args.quiet,
+            tmp_dir=args.tmp_dir,
         )
 
     elif args.command == "uncertainty":
@@ -225,6 +248,7 @@ def main() -> None:
             gpu=gpu,
             cpu=args.cpu,
             quiet=args.quiet,
+            tmp_dir=args.tmp_dir,
         )
 
 

--- a/apps/impact_reg/impact_reg_konfai/impact_reg.py
+++ b/apps/impact_reg/impact_reg_konfai/impact_reg.py
@@ -17,8 +17,10 @@
 """Orchestrator for IMPACT-Reg.
 
 Each IMPACT-Reg *preset* is a self-contained KonfAI app on ``VBoussot/ImpactReg`` (one preset = one app):
-its model produces, on the FIXED grid, the moving image resampled onto the fixed image (``MovedImage``)
-and the displacement field (``DisplacementField``). This orchestrator adds the registration-specific
+its model produces the displacement field (``DisplacementField``) on the FIXED grid, and optionally the
+moving image resampled onto the fixed one (``MovedImage``). The field is what a registration preset must
+declare; the moved image IS that field applied to the moving, so a preset that leaves it out is complete
+and this orchestrator derives it. This layer adds the registration-specific
 logic that does not fit the generic ``konfai-apps`` pipeline, split into three composable operations
 (mirroring ``konfai-apps`` infer/eval/uncertainty) so a UI/CLI can run them independently:
 
@@ -79,8 +81,13 @@ def get_available_presets(force_update: bool = False) -> list[str]:
     return list(get_available_apps_on_hf_repo(IMPACT_REG_KONFAI_REPO, force_update))
 
 
-def _find_output(root: Path, stem: str) -> Path:
+def _find_output(root: Path, stem: str, required: bool = True) -> Path | None:
     """Locate the single output named ``stem`` under ``root``, whatever form the preset wrote it in.
+
+    ``required=False`` returns None instead of raising, for an output a preset may legitimately not
+    declare: the displacement field is what a registration preset must produce, and the moved image is
+    that field applied to the moving -- derivable here (see :func:`_derive_moved`) rather than a second
+    thing every preset has to remember to write.
 
     Matched on the name rather than on a fixed filename: a displacement field may come out as an ITK
     image or as an OME-Zarr store, and a store is a DIRECTORY whose ``Path.stem`` is "DVF.ome" -- so a
@@ -88,6 +95,8 @@ def _find_output(root: Path, stem: str) -> Path:
     """
     matches = sorted(root.rglob(f"{stem}.*"))
     if not matches:
+        if not required:
+            return None
         raise FileNotFoundError(f"Preset inference did not produce '{stem}' under {root}.")
     return matches[0]
 
@@ -158,6 +167,74 @@ def _write_displacement_field(field: sitk.Image, dest: Path) -> None:
         )
     else:
         sitk.WriteImage(field, str(dest))
+
+
+def _read_image(path: Path) -> sitk.Image:
+    """An image, from an ITK file OR an OME-Zarr store — the input side of :func:`_write_image`.
+
+    ``sitk.ReadImage`` cannot open a store, so any path that re-reads an input has to know both forms
+    or silently only work for one. This is the one place that knows, mirroring konfai's
+    ``read_displacement_field`` for fields.
+    """
+    if not path.is_dir():
+        return sitk.ReadImage(str(path))
+    from konfai.utils.dataset import data_to_image, ome_zarr_attributes
+    from konfai.utils.ome_zarr import get_ome_zarr_info, read_ome_zarr_data_slice
+
+    axes = get_ome_zarr_info(path)["axes"]
+    n_axes = 1 + sum(axis in axes for axis in ("z", "y", "x"))  # channel-first C[Z]YX
+    data, metadata = read_ome_zarr_data_slice(path, tuple(slice(None) for _ in range(n_axes)))
+    # Origin, Spacing and Direction together: NGFF scale/translation alone cannot express the
+    # direction matrix, so the geometry comes from the konfai sidecar through data_to_image.
+    return data_to_image(data, ome_zarr_attributes(metadata))
+
+
+def _write_image(image: sitk.Image, dest: Path) -> None:
+    """Write an image in the form ``dest`` names — the scalar counterpart of
+    :func:`_write_displacement_field`."""
+    if "".join(dest.suffixes).endswith(".ome.zarr"):
+        from konfai.utils.dataset import image_to_data
+        from konfai.utils.ome_zarr import write_ome_zarr
+
+        data, attributes = image_to_data(image)
+        write_ome_zarr(
+            dest, data, spacing=image.GetSpacing(), origin=image.GetOrigin(), attributes=dict(attributes)
+        )
+    else:
+        sitk.WriteImage(image, str(dest))
+
+
+def _derive_moved(moving_image: Path, dvf_path: Path, dest_dir: Path, field: sitk.Image | None = None) -> Path:
+    """The moved image, resampled from the moving through the displacement field.
+
+    A preset that emits only a field is complete: the moved image IS that field applied to the moving,
+    so deriving it belongs to the orchestrator rather than being a second output every preset has to
+    remember to declare.
+
+    FORMAT IN, SAME FORMAT OUT. Both ends go through the dispatch above, so an OME-Zarr moving yields
+    an OME-Zarr moved and an ITK one an ITK file; the resample never decides the format. Reading the
+    moving with ``sitk.ReadImage`` instead -- what this replaces -- cannot open a store at all, which
+    is why the ensemble path could not be used with OME-Zarr inputs.
+
+    Resampled through SimpleITK for the reason konfai's own ``ResampleTransform`` gives: the stored
+    displacement is in world (x, y, z) units, and adding it onto a (z, y, x) voxel grid by hand
+    transposes the axes and reads millimetres as voxels. The output grid is the field's own -- a
+    displacement field is defined ON the fixed grid, so that is where the moved image belongs.
+    """
+    if field is None:
+        field = read_displacement_field(dvf_path)
+    # Read the grid off the field BEFORE the transform takes it: DisplacementFieldTransform assumes
+    # ownership of the image it is given and leaves it empty behind.
+    size, origin = field.GetSize(), field.GetOrigin()
+    spacing, direction = field.GetSpacing(), field.GetDirection()
+    transform = sitk.DisplacementFieldTransform(field)
+    moving = _read_image(moving_image)
+    moved = sitk.Resample(
+        moving, size, transform, sitk.sitkLinear, origin, spacing, direction, 0.0, moving.GetPixelID()
+    )
+    dest = _output_path(dest_dir, "Moved", "".join(dvf_path.suffixes))
+    _write_image(moved, dest)
+    return dest
 
 
 def _displacement_transform(dvf_path: Path) -> sitk.Transform:
@@ -241,7 +318,7 @@ class ImpactRegKonfAIApp:
         subprocess.run(command, check=True)  # nosec B603
         # The model emits both the moved image and the displacement field on the fixed grid; reusing them
         # (rather than re-resampling here) keeps the single-preset path free of any extra image read/write.
-        return _find_output(out, "Moved"), _find_output(out, "DVF")
+        return _find_output(out, "Moved", required=False), _find_output(out, "DVF")
 
     def register(
         self,
@@ -301,23 +378,26 @@ class ImpactRegKonfAIApp:
                     dvf_paths.append(dvf)
 
                 if len(presets) == 1:
-                    # One preset: the model already produced the moved image AND the displacement field on
-                    # the fixed grid — reuse them verbatim. No input re-read, no re-resample, and the input
-                    # format is whatever the model handled (OME-Zarr included).
-                    _copy_output(moved_paths[0], case_out, "Moved")
                     dvf_out = _copy_output(dvf_paths[0], case_out, "DVF")
+                    if moved_paths[0] is not None:
+                        # The model already produced the moved image on the fixed grid — reuse it
+                        # verbatim. No input re-read, no re-resample, and the input format is whatever
+                        # the model handled (OME-Zarr included).
+                        _copy_output(moved_paths[0], case_out, "Moved")
+                    else:
+                        # A preset that declares only a field is complete: the moved image is that
+                        # field applied to the moving, and producing it belongs here.
+                        _derive_moved(moving_image, dvf_out, case_out)
                 else:
                     # Ensemble: average the presets' displacement fields (all on the fixed grid) and warp the
                     # moving image once with that averaged field — the one output no single preset produced.
                     avg_dvf = self._average_displacement(dvf_paths)
                     dvf_out = _output_path(case_out, "DVF", "".join(dvf_paths[0].suffixes))
                     _write_displacement_field(avg_dvf, dvf_out)
-                    transform = sitk.DisplacementFieldTransform(sitk.Cast(avg_dvf, sitk.sitkVectorFloat64))
-                    moving = sitk.ReadImage(str(moving_image))
-                    sitk.WriteImage(
-                        sitk.Resample(moving, avg_dvf, transform, sitk.sitkLinear, 0.0, moving.GetPixelID()),
-                        str(_output_path(case_out, "Moved", ".mha")),
-                    )
+                    # Through the same derivation as the single-preset path, which reads the moving in
+                    # either form: the sitk.ReadImage this replaces cannot open a store at all, so an
+                    # ensemble of OME-Zarr inputs failed here and nowhere else.
+                    _derive_moved(moving_image, dvf_out, case_out, field=sitk.Cast(avg_dvf, sitk.sitkVectorFloat64))
 
                 # Transform.h5 (consumed by `evaluate` and SlicerImpactReg): the fixed-grid displacement
                 # field as a SimpleITK transform.

--- a/apps/impact_reg/impact_reg_konfai/impact_reg.py
+++ b/apps/impact_reg/impact_reg_konfai/impact_reg.py
@@ -38,6 +38,7 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import SimpleITK as sitk
@@ -169,39 +170,41 @@ def _write_displacement_field(field: sitk.Image, dest: Path) -> None:
         sitk.WriteImage(field, str(dest))
 
 
-def _read_image(path: Path) -> sitk.Image:
-    """An image, from an ITK file OR an OME-Zarr store — the input side of :func:`_write_image`.
+def _dataset_entry(path: Path) -> tuple[Any, str, str]:
+    """Address one file or store as a konfai ``Dataset`` entry: ``(dataset, group, name)``.
 
-    ``sitk.ReadImage`` cannot open a store, so any path that re-reads an input has to know both forms
-    or silently only work for one. This is the one place that knows, mirroring konfai's
-    ``read_displacement_field`` for fields.
+    Dataset is the layer that already knows every format konfai supports -- h5, DICOM, OME-Zarr, and
+    every ITK extension through SitkFile, which probes them itself. Going through it is what makes
+    this orchestrator format-agnostic without owning a dispatch of its own: a hand-written
+    ``if path.is_dir()`` knows exactly the two formats whoever wrote it thought of.
+
+    A dataset addresses ``{root}/{name}/{group}.{ext}``. An orchestrator input is a bare path, so the
+    case is empty: the parent directory is the root and the stem is the entry. The extension only
+    seeds the format token -- Dataset normalises it (``.ome.zarr`` / ``.zarr`` -> ``omezarr``) and
+    re-detects a directory store from disk regardless of what the token said.
     """
-    if not path.is_dir():
-        return sitk.ReadImage(str(path))
-    from konfai.utils.dataset import data_to_image, ome_zarr_attributes
-    from konfai.utils.ome_zarr import get_ome_zarr_info, read_ome_zarr_data_slice
+    from konfai.utils.dataset import Dataset
 
-    axes = get_ome_zarr_info(path)["axes"]
-    n_axes = 1 + sum(axis in axes for axis in ("z", "y", "x"))  # channel-first C[Z]YX
-    data, metadata = read_ome_zarr_data_slice(path, tuple(slice(None) for _ in range(n_axes)))
-    # Origin, Spacing and Direction together: NGFF scale/translation alone cannot express the
-    # direction matrix, so the geometry comes from the konfai sidecar through data_to_image.
-    return data_to_image(data, ome_zarr_attributes(metadata))
+    suffixes = "".join(path.suffixes)
+    stem = path.name[: len(path.name) - len(suffixes)] if suffixes else path.name
+    file_format = "omezarr" if suffixes.lower().endswith((".ome.zarr", ".zarr")) else suffixes.lstrip(".")
+    return Dataset(path.parent, file_format or "mha"), stem, ""
+
+
+def _read_image(path: Path) -> sitk.Image:
+    """An image, in whatever format it is stored — read through konfai's Dataset."""
+    dataset, group, name = _dataset_entry(path)
+    return dataset.read_image(group, name)
 
 
 def _write_image(image: sitk.Image, dest: Path) -> None:
-    """Write an image in the form ``dest`` names — the scalar counterpart of
-    :func:`_write_displacement_field`."""
-    if "".join(dest.suffixes).endswith(".ome.zarr"):
-        from konfai.utils.dataset import image_to_data
-        from konfai.utils.ome_zarr import write_ome_zarr
+    """Write an image in the form ``dest`` names — through the same layer that read it.
 
-        data, attributes = image_to_data(image)
-        write_ome_zarr(
-            dest, data, spacing=image.GetSpacing(), origin=image.GetOrigin(), attributes=dict(attributes)
-        )
-    else:
-        sitk.WriteImage(image, str(dest))
+    So the format out is the format in, for every format konfai writes, and not only for the two an
+    ``if`` here would have enumerated.
+    """
+    dataset, group, name = _dataset_entry(dest)
+    dataset.write(group, name, image)
 
 
 def _derive_moved(moving_image: Path, dvf_path: Path, dest_dir: Path, field: sitk.Image | None = None) -> Path:
@@ -454,10 +457,10 @@ class ImpactRegKonfAIApp:
             try:
                 # Image: moving resampled onto the fixed grid vs fixed (MAE). Mask is optional.
                 if index < len(fixed_images) and index < len(moving_images):
-                    fixed = sitk.ReadImage(str(fixed_images[index]))
+                    fixed = _read_image(fixed_images[index])
                     moved = work / "moved_image.nii.gz"
                     sitk.WriteImage(
-                        sitk.Resample(sitk.ReadImage(str(moving_images[index])), fixed, transform), str(moved)
+                        sitk.Resample(_read_image(moving_images[index]), fixed, transform), str(moved)
                     )
                     app.evaluate(
                         inputs=[[fixed_images[index]]],
@@ -473,11 +476,11 @@ class ImpactRegKonfAIApp:
 
                 # Segmentation: moving seg warped onto fixed vs fixed seg (Dice).
                 if index < len(gt_fixed_seg) and index < len(gt_moving_seg):
-                    fixed_seg = sitk.ReadImage(str(gt_fixed_seg[index]))
+                    fixed_seg = _read_image(gt_fixed_seg[index])
                     moved_seg = work / "moved_seg.nii.gz"
                     sitk.WriteImage(
                         sitk.Resample(
-                            sitk.ReadImage(str(gt_moving_seg[index])), fixed_seg, transform, sitk.sitkNearestNeighbor
+                            _read_image(gt_moving_seg[index]), fixed_seg, transform, sitk.sitkNearestNeighbor
                         ),
                         str(moved_seg),
                     )

--- a/apps/impact_reg/impact_reg_konfai/impact_reg.py
+++ b/apps/impact_reg/impact_reg_konfai/impact_reg.py
@@ -104,6 +104,28 @@ def _output_path(dest_dir: Path, stem: str, suffixes: str) -> Path:
     return dest_dir / (stem + suffixes)
 
 
+def _work_dir(tmp_dir: Path | None, prefix: str) -> Path:
+    """A private scratch directory for one command's intermediates.
+
+    Under ``tmp_dir`` when the caller named one, under ``tempfile.gettempdir()`` otherwise — which is
+    the same contract every other KonfAI app CLI offers through ``--tmp-dir``.
+
+    THE DEFAULT IS NOT ALWAYS A GOOD PLACE, WHICH IS WHY THE OPTION EXISTS. What is staged here is
+    volume-sized: the moved image and the displacement field are written before being collected into
+    ``--output``. Where TMPDIR is a tmpfs that traffic is charged to RAM, on top of the volumes the run
+    already holds; on a large 3D case that is what fills memory or the temp quota mid-run. A caller who
+    knows better — a pipeline node with its results on real disk — names a directory here instead of
+    overriding ``TMPDIR`` from outside, which would also move things TMPDIR legitimately owns (torch's
+    DataLoader opens its worker sockets there, and AF_UNIX addresses cap at ~108 bytes).
+
+    The directory returned is always freshly created and owned by the caller of this function, never
+    ``tmp_dir`` itself: the command removes what it made and leaves the directory it was given.
+    """
+    if tmp_dir is not None:
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+    return Path(tempfile.mkdtemp(prefix=prefix, dir=str(tmp_dir) if tmp_dir is not None else None))
+
+
 def _copy_output(src: Path, dest_dir: Path, stem: str) -> Path:
     """Copy an output beside the results, keeping the form the preset produced (file or store)."""
     dest = _output_path(dest_dir, stem, "".join(src.suffixes))
@@ -194,6 +216,13 @@ class ImpactRegKonfAIApp:
             command += ["-i", str(fixed_mask or _neutral_mask(work / "FixedMask.mha"))]
             command += ["-i", str(moving_mask or _neutral_mask(work / "MovingMask.mha"))]
         command += ["-o", str(out)]
+        # Hand konfai-apps a workspace we own, which is what every other app CLI does by exposing
+        # --tmp-dir. Without it konfai-apps auto-creates one under TMPDIR, writes the prediction to
+        # ./Predictions inside it, and copies that into `-o` before deleting it: one extra full-size
+        # write of the moved image AND the displacement field, on whatever filesystem TMPDIR names.
+        # Given a caller-owned workspace it writes straight into `-o` (see konfai_apps
+        # _stage_result_dir / _collect_result), so the copy disappears and `out` is where it always was.
+        command += ["--tmp-dir", str(out)]
         if tta:
             command += ["--tta", str(tta)]
         # Preset-parameter tuning: forwarded verbatim to `konfai-apps infer --set` (applies to every preset).
@@ -228,11 +257,14 @@ class ImpactRegKonfAIApp:
         tta: int = 0,
         keep_dvf: bool = False,
         config_overrides: list[str] | None = None,
+        tmp_dir: Path | None = None,
     ) -> None:
         """Register each fixed/moving pair with the selected presets and ensemble their DVFs.
 
         Masks are optional and restrict the metric region; when omitted a whole-image mask is auto-filled,
         so every preset app always receives the four inputs (fixed, moving, fixed mask, moving mask) it declares.
+
+        ``tmp_dir`` names where the intermediates are staged; see :func:`_work_dir`.
         """
         for index, (fixed_image, moving_image) in enumerate(zip(fixed_images, moving_images, strict=True)):
             case_out = output / f"P{index:03d}"
@@ -241,7 +273,7 @@ class ImpactRegKonfAIApp:
             # caller asks, so `uncertainty` can measure the ensemble spread afterwards.
             if keep_dvf:
                 (case_out / _ENSEMBLE_DIR).mkdir(parents=True, exist_ok=True)
-            work = Path(tempfile.mkdtemp(prefix="impact_reg_"))
+            work = _work_dir(tmp_dir, "impact_reg_")
             try:
                 # Masks are optional (they restrict the metric region); pass only those the caller gave and
                 # let konfai-apps fill the rest with an all-ones default — no input read on the no-mask path.
@@ -324,6 +356,7 @@ class ImpactRegKonfAIApp:
         gpu: list[int] = [],
         cpu: int | None = None,
         quiet: bool = False,
+        tmp_dir: Path | None = None,
     ) -> None:
         """Evaluate a registration on any subset of modalities (image MAE, seg Dice, landmark TRE).
 
@@ -337,7 +370,7 @@ class ImpactRegKonfAIApp:
             transform_path = transforms[index] if index < len(transforms) else None
             transform = sitk.ReadTransform(str(transform_path)) if transform_path else sitk.Transform()
             eval_out = output / f"P{index:03d}" / "Evaluation"
-            work = Path(tempfile.mkdtemp(prefix="impact_reg_eval_"))
+            work = _work_dir(tmp_dir, "impact_reg_eval_")
             try:
                 # Image: moving resampled onto the fixed grid vs fixed (MAE). Mask is optional.
                 if index < len(fixed_images) and index < len(moving_images):
@@ -409,6 +442,7 @@ class ImpactRegKonfAIApp:
         gpu: list[int] = [],
         cpu: int | None = None,
         quiet: bool = False,
+        tmp_dir: Path | None = None,
     ) -> None:
         """Estimate registration uncertainty as the voxel-wise spread of an ensemble of displacement fields.
 
@@ -419,7 +453,7 @@ class ImpactRegKonfAIApp:
         """
         if len(dvfs) < 2:
             raise ValueError("Uncertainty needs at least two ensemble displacement fields.")
-        work = Path(tempfile.mkdtemp(prefix="impact_reg_unc_"))
+        work = _work_dir(tmp_dir, "impact_reg_unc_")
         try:
             reference = read_displacement_field(dvfs[0])
             rank = reference.GetDimension()

--- a/apps/impact_reg/impact_reg_konfai/impact_reg.py
+++ b/apps/impact_reg/impact_reg_konfai/impact_reg.py
@@ -17,10 +17,10 @@
 """Orchestrator for IMPACT-Reg.
 
 Each IMPACT-Reg *preset* is a self-contained KonfAI app on ``VBoussot/ImpactReg`` (one preset = one app):
-its model produces the displacement field (``DisplacementField``) on the FIXED grid, and optionally the
-moving image resampled onto the fixed one (``MovedImage``). The field is what a registration preset must
-declare; the moved image IS that field applied to the moving, so a preset that leaves it out is complete
-and this orchestrator derives it. This layer adds the registration-specific
+its model produces one thing: the displacement field (``DisplacementField``) on the FIXED grid, in
+whatever format it declares. That is the whole contract. The moved image IS that field applied to the
+moving, so this orchestrator derives it rather than asking every preset to write it as well. This layer
+adds the registration-specific
 logic that does not fit the generic ``konfai-apps`` pipeline, split into three composable operations
 (mirroring ``konfai-apps`` infer/eval/uncertainty) so a UI/CLI can run them independently:
 
@@ -82,13 +82,8 @@ def get_available_presets(force_update: bool = False) -> list[str]:
     return list(get_available_apps_on_hf_repo(IMPACT_REG_KONFAI_REPO, force_update))
 
 
-def _find_output(root: Path, stem: str, required: bool = True) -> Path | None:
+def _find_output(root: Path, stem: str) -> Path:
     """Locate the single output named ``stem`` under ``root``, whatever form the preset wrote it in.
-
-    ``required=False`` returns None instead of raising, for an output a preset may legitimately not
-    declare: the displacement field is what a registration preset must produce, and the moved image is
-    that field applied to the moving -- derivable here (see :func:`_derive_moved`) rather than a second
-    thing every preset has to remember to write.
 
     Matched on the name rather than on a fixed filename: a displacement field may come out as an ITK
     image or as an OME-Zarr store, and a store is a DIRECTORY whose ``Path.stem`` is "DVF.ome" -- so a
@@ -96,8 +91,6 @@ def _find_output(root: Path, stem: str, required: bool = True) -> Path | None:
     """
     matches = sorted(root.rglob(f"{stem}.*"))
     if not matches:
-        if not required:
-            return None
         raise FileNotFoundError(f"Preset inference did not produce '{stem}' under {root}.")
     return matches[0]
 
@@ -214,10 +207,11 @@ def _derive_moved(moving_image: Path, dvf_path: Path, dest_dir: Path, field: sit
     so deriving it belongs to the orchestrator rather than being a second output every preset has to
     remember to declare.
 
-    FORMAT IN, SAME FORMAT OUT. Both ends go through the dispatch above, so an OME-Zarr moving yields
-    an OME-Zarr moved and an ITK one an ITK file; the resample never decides the format. Reading the
-    moving with ``sitk.ReadImage`` instead -- what this replaces -- cannot open a store at all, which
-    is why the ensemble path could not be used with OME-Zarr inputs.
+    THE FORMAT FOLLOWS THE FIELD, not the moving. Measured: a preset fed ``.mha`` inputs writes its
+    field as ``.ome.zarr`` when that is what it declares, so the input's form says nothing about the
+    output's -- the field is the only thing the preset committed to, so the derived moved matches it.
+    The moving is read through the dataset layer either way; ``sitk.ReadImage``, what this replaces,
+    cannot open a store at all, which is why the ensemble path failed on OME-Zarr inputs.
 
     Resampled through SimpleITK for the reason konfai's own ``ResampleTransform`` gives: the stored
     displacement is in world (x, y, z) units, and adding it onto a (z, y, x) voxel grid by hand
@@ -280,8 +274,8 @@ class ImpactRegKonfAIApp:
         quiet: bool,
         tta: int = 0,
         config_overrides: list[str] | None = None,
-    ) -> tuple[Path, Path]:
-        """Run one preset app on the fixed/moving pair (+ optional masks); return its (moved, displacement) paths.
+    ) -> Path:
+        """Run one preset app on the fixed/moving pair (+ optional masks); return its displacement field.
 
         Each preset runs through the ``konfai-apps`` CLI in its own subprocess: konfai keeps
         process-global state (its ``Config`` singleton, the ``KONFAI_*`` environment), so several preset
@@ -319,9 +313,12 @@ class ImpactRegKonfAIApp:
         if self._force_update:
             command.append("--force_update")
         subprocess.run(command, check=True)  # nosec B603
-        # The model emits both the moved image and the displacement field on the fixed grid; reusing them
-        # (rather than re-resampling here) keeps the single-preset path free of any extra image read/write.
-        return _find_output(out, "Moved", required=False), _find_output(out, "DVF")
+        # THE PRESET'S CONTRACT IS THE FIELD, AND ONLY THE FIELD. A registration app produces a
+        # displacement field on the fixed grid, in whatever format it declares; anything else that can
+        # be computed from it -- the moved image above all -- is this layer's job. Looking for a Moved
+        # here would make every preset carry an output it does not owe, and a tiled one blend it across
+        # every patch seam for a caller that has the field.
+        return _find_output(out, "DVF")
 
     def register(
         self,
@@ -360,9 +357,9 @@ class ImpactRegKonfAIApp:
                 fixed_mask = fixed_masks[index] if index < len(fixed_masks) else None
                 moving_mask = moving_masks[index] if index < len(moving_masks) else None
 
-                moved_paths, dvf_paths = [], []
+                dvf_paths = []
                 for preset in presets:
-                    moved, dvf = self._infer_preset(
+                    dvf = self._infer_preset(
                         preset,
                         fixed_image,
                         moving_image,
@@ -377,20 +374,11 @@ class ImpactRegKonfAIApp:
                     )
                     if keep_dvf:
                         dvf = _copy_output(dvf, case_out / _ENSEMBLE_DIR, preset)
-                    moved_paths.append(moved)
                     dvf_paths.append(dvf)
 
                 if len(presets) == 1:
                     dvf_out = _copy_output(dvf_paths[0], case_out, "DVF")
-                    if moved_paths[0] is not None:
-                        # The model already produced the moved image on the fixed grid — reuse it
-                        # verbatim. No input re-read, no re-resample, and the input format is whatever
-                        # the model handled (OME-Zarr included).
-                        _copy_output(moved_paths[0], case_out, "Moved")
-                    else:
-                        # A preset that declares only a field is complete: the moved image is that
-                        # field applied to the moving, and producing it belongs here.
-                        _derive_moved(moving_image, dvf_out, case_out)
+                    _derive_moved(moving_image, dvf_out, case_out)
                 else:
                     # Ensemble: average the presets' displacement fields (all on the fixed grid) and warp the
                     # moving image once with that averaged field — the one output no single preset produced.

--- a/apps/impact_reg/impact_reg_konfai/impact_reg.py
+++ b/apps/impact_reg/impact_reg_konfai/impact_reg.py
@@ -388,6 +388,7 @@ class ImpactRegKonfAIApp:
                         gpu=gpu,
                         cpu=cpu,
                         quiet=quiet,
+                        tmp_dir=work,
                     )
 
                 # Segmentation: moving seg warped onto fixed vs fixed seg (Dice).
@@ -408,6 +409,7 @@ class ImpactRegKonfAIApp:
                         gpu=gpu,
                         cpu=cpu,
                         quiet=quiet,
+                        tmp_dir=work,
                     )
 
                 # Landmarks (TRE): the transform is defined on the fixed grid and maps fixed->moving, so the
@@ -428,6 +430,7 @@ class ImpactRegKonfAIApp:
                         gpu=gpu,
                         cpu=cpu,
                         quiet=quiet,
+                        tmp_dir=work,
                     )
             finally:
                 shutil.rmtree(work, ignore_errors=True)
@@ -470,7 +473,11 @@ class ImpactRegKonfAIApp:
             stack.SetDirection(direction.flatten())
             sitk.WriteImage(stack, str(work / "DVFs.mha"))
 
-            command = ["konfai-apps", "uncertainty", _app_id(preset), "-i", str(work / "DVFs.mha"), "-o", str(output)]
+            # Same workspace hand-off as _infer_preset: without it konfai-apps auto-creates one under
+            # TMPDIR and stages Uncertainties there before copying it into -o, which is the staging
+            # this option exists to place. `work` is ours and already sits wherever tmp_dir asked for.
+            command = ["konfai-apps", "uncertainty", _app_id(preset), "-i", str(work / "DVFs.mha"),
+                       "-o", str(output), "--tmp-dir", str(work)]
             if gpu:
                 command += ["--gpu", *(str(g) for g in gpu)]
             elif cpu is not None:

--- a/apps/impact_reg/tests/unit/test_displacement_field_io.py
+++ b/apps/impact_reg/tests/unit/test_displacement_field_io.py
@@ -35,6 +35,7 @@ from impact_reg_konfai.impact_reg import (  # noqa: E402
     _displacement_transform,
     _find_output,
     _output_path,
+    _read_image,
     _write_displacement_field,
 )
 from konfai.utils.errors import TransformError  # noqa: E402
@@ -215,3 +216,31 @@ def test_transform_reads_back_identically_from_either_form(tmp_path: Path, suffi
     reference = sitk.DisplacementFieldTransform(sitk.Image(original))
     for point in ((9.0, -1.0, 12.0), (7.5, -2.5, 11.0)):
         assert restored.TransformPoint(point) == pytest.approx(reference.TransformPoint(point))
+
+
+@pytest.mark.skipif(not _zarr_v3_available(), reason="writing an OME-Zarr store needs zarr 3")
+def test_read_image_opens_an_ome_zarr_store(tmp_path) -> None:
+    """An ordinary image reads back from a store, not only from an ITK file.
+
+    ``sitk.ReadImage`` cannot open a directory, so every place that re-read an input was silently
+    ITK-only. That is what made the ensemble path unusable with OME-Zarr inputs while the
+    single-preset path — which reuses the model's output and never re-reads — worked fine.
+    """
+    volume = np.arange(4 * 5 * 6, dtype=np.float32).reshape(4, 5, 6)
+    store = tmp_path / "moving.ome.zarr"
+    write_ome_zarr(store, volume[np.newaxis], spacing=(1.5, 2.0, 2.5), origin=(3.0, -1.0, 0.5))
+
+    image = _read_image(store)
+
+    assert image.GetSpacing() == pytest.approx((1.5, 2.0, 2.5))
+    assert image.GetOrigin() == pytest.approx((3.0, -1.0, 0.5))
+    np.testing.assert_allclose(sitk.GetArrayFromImage(image), volume)
+
+
+def test_read_image_still_opens_an_itk_file(tmp_path) -> None:
+    """The other half of the dispatch: a plain file goes straight through SimpleITK."""
+    volume = np.arange(2 * 3 * 4, dtype=np.float32).reshape(2, 3, 4)
+    path = tmp_path / "moving.mha"
+    sitk.WriteImage(sitk.GetImageFromArray(volume), str(path))
+
+    np.testing.assert_allclose(sitk.GetArrayFromImage(_read_image(path)), volume)

--- a/apps/impact_reg/tests/unit/test_orchestration.py
+++ b/apps/impact_reg/tests/unit/test_orchestration.py
@@ -148,3 +148,36 @@ def test_register_multi_preset_averages_and_warps_once(tmp_path: Path) -> None:
     # keep_dvf persists each preset's field for a later uncertainty pass
     assert (case / "Ensemble" / "A.mha").is_file() and (case / "Ensemble" / "B.mha").is_file()
     assert (case / "Moved.mha").is_file()
+
+
+def test_register_derives_moved_when_the_preset_emits_only_a_field(tmp_path: Path) -> None:
+    """A preset is complete with a displacement field alone: the moved image is derived here.
+
+    The field IS the registration; the moved image is that field applied to the moving. Requiring both
+    made every preset carry a second output whose content the orchestrator can produce itself — and
+    for the tiled presets, blend across every patch seam only to have it thrown away.
+    """
+    moving = tmp_path / "moving.mha"
+    sitk.WriteImage(sitk.GetImageFromArray(np.arange(8**3, dtype=np.float32).reshape(8, 8, 8)), str(moving))
+    fixed = tmp_path / "fixed.mha"
+    sitk.WriteImage(sitk.GetImageFromArray(np.zeros((8, 8, 8), dtype=np.float32)), str(fixed))
+
+    reference = sitk.ReadImage(str(moving))
+    app = reg.ImpactRegKonfAIApp()
+
+    def field_only(preset, fixed_image, mov_image, fixed_mask, moving_mask, work, *args, **kwargs):
+        out = Path(work) / preset
+        out.mkdir(parents=True, exist_ok=True)
+        _write_dvf(out / "DVF.mha", (2.0, 0.0, 0.0), reference)
+        return None, out / "DVF.mha"
+
+    app._infer_preset = field_only  # type: ignore[method-assign]
+    out = tmp_path / "Output"
+    app.register(["FireANTs_SyN"], [fixed], [moving], output=out)
+
+    case = out / "P000"
+    assert (case / "Moved.mha").is_file(), "the orchestrator did not derive the moved image"
+    # moved(p) = moving(p + d), and d is +2 along x on a unit grid: moving is z*64 + y*8 + x.
+    moved = sitk.GetArrayFromImage(sitk.ReadImage(str(case / "Moved.mha")))
+    np.testing.assert_allclose(moved[0, 0, 0], 2.0, atol=1e-6)
+    np.testing.assert_allclose(moved[1, 1, 0], 74.0, atol=1e-6)

--- a/apps/impact_reg/tests/unit/test_orchestration.py
+++ b/apps/impact_reg/tests/unit/test_orchestration.py
@@ -98,21 +98,19 @@ def test_average_displacement_is_the_voxelwise_mean_with_reference_geometry(tmp_
 
 
 def _stub_infer(app: reg.ImpactRegKonfAIApp, moving_image: Path, dvf_by_preset: dict[str, tuple]):
-    """Replace ``_infer_preset`` so it writes a Moved.mha + a constant DVF.mha (per preset) on the moving grid."""
+    """Replace ``_infer_preset`` so it writes a constant DVF.mha per preset on the moving grid."""
     reference = sitk.ReadImage(str(moving_image))
 
     def fake(preset, fixed_image, mov_image, fixed_mask, moving_mask, work, *args, **kwargs):
         out = Path(work) / preset
         out.mkdir(parents=True, exist_ok=True)
-        moved = sitk.Image(reference)
-        sitk.WriteImage(moved, str(out / "Moved.mha"))
         _write_dvf(out / "DVF.mha", dvf_by_preset[preset], reference)
-        return out / "Moved.mha", out / "DVF.mha"
+        return out / "DVF.mha"
 
     app._infer_preset = fake  # type: ignore[method-assign]
 
 
-def test_register_single_preset_reuses_model_outputs(tmp_path: Path) -> None:
+def test_register_single_preset_reuses_the_field_and_derives_the_moved(tmp_path: Path) -> None:
     moving = tmp_path / "moving.mha"
     sitk.WriteImage(sitk.GetImageFromArray(np.zeros((8, 8, 8), dtype=np.float32)), str(moving))
     fixed = tmp_path / "fixed.mha"
@@ -169,7 +167,7 @@ def test_register_derives_moved_when_the_preset_emits_only_a_field(tmp_path: Pat
         out = Path(work) / preset
         out.mkdir(parents=True, exist_ok=True)
         _write_dvf(out / "DVF.mha", (2.0, 0.0, 0.0), reference)
-        return None, out / "DVF.mha"
+        return out / "DVF.mha"
 
     app._infer_preset = field_only  # type: ignore[method-assign]
     out = tmp_path / "Output"

--- a/apps/impact_reg/tests/unit/test_tmp_dir_forwarding.py
+++ b/apps/impact_reg/tests/unit/test_tmp_dir_forwarding.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The workspace the orchestrator was given must reach the nested konfai-apps commands.
+
+``--tmp-dir`` exists so a caller whose system temporary directory is the wrong medium can place the
+volume-sized staging itself. That only holds if EVERY nested invocation is told about it: a command
+left without one auto-creates its own workspace under TMPDIR and stages there, which is precisely
+the traffic the option was added to move. These tests pin the forwarding for each nested command, so
+a new one cannot be added without it.
+"""
+
+from pathlib import Path
+
+import pytest
+
+sitk = pytest.importorskip("SimpleITK")
+
+from impact_reg_konfai.impact_reg import ImpactRegKonfAIApp  # noqa: E402
+
+
+def _tmp_dir_value(command: list[str]) -> str:
+    """The value ``--tmp-dir`` carries in a captured command line (fails the test when absent)."""
+    assert "--tmp-dir" in command, f"nested command carries no --tmp-dir: {command}"
+    return command[command.index("--tmp-dir") + 1]
+
+
+def test_infer_preset_forwards_the_workspace(tmp_path: Path, monkeypatch, write_preset_output) -> None:
+    """``konfai-apps infer`` is told to work in the directory the orchestrator staged for it.
+
+    Pointed at ``-o``, so konfai-apps writes the prediction straight there instead of staging it in a
+    throwaway workspace and copying it in.
+    """
+    captured: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        captured.append(list(command))
+        # Stand in for the preset run: konfai-apps would leave its outputs under -o.
+        write_preset_output(Path(command[command.index("-o") + 1]))
+        return None
+
+    monkeypatch.setattr("impact_reg_konfai.impact_reg.subprocess.run", fake_run)
+
+    work = tmp_path / "work"
+    work.mkdir()
+    app = ImpactRegKonfAIApp()
+    app._infer_preset("FireANTs_SyN", tmp_path / "f.mha", tmp_path / "m.mha", None, None, work, [], None, True)
+
+    assert len(captured) == 1
+    assert _tmp_dir_value(captured[0]) == str(work / "FireANTs_SyN")
+
+
+def test_uncertainty_forwards_the_workspace(tmp_path: Path, monkeypatch, write_preset_output) -> None:
+    """``konfai-apps uncertainty`` stages inside the caller's tmp_dir, not under the system TMPDIR."""
+    captured: list[list[str]] = []
+    monkeypatch.setattr(
+        "impact_reg_konfai.impact_reg.subprocess.run",
+        lambda command, **kwargs: captured.append(list(command)),
+    )
+
+    _, first = write_preset_output(tmp_path / "a")
+    _, second = write_preset_output(tmp_path / "b")
+    staging = tmp_path / "staging"
+
+    ImpactRegKonfAIApp().uncertainty(
+        preset="FireANTs_SyN",
+        dvfs=[first, second],
+        output=tmp_path / "out",
+        quiet=True,
+        tmp_dir=staging,
+    )
+
+    assert len(captured) == 1
+    # The workspace is the private directory _work_dir made INSIDE the caller's tmp_dir -- never the
+    # caller's own directory, which the command must leave standing.
+    forwarded = Path(_tmp_dir_value(captured[0]))
+    assert forwarded.parent == staging
+    assert forwarded != staging


### PR DESCRIPTION
Rebased onto #92 `feat/resample-unified` and trimmed to its own theme; the follow-up work now lives in stacked PRs (see the stack list below).

The orchestrator gains a working directory like the other apps, forwards it to every nested konfai-apps command, and a preset may declare only its displacement field — the moved image is derived from it. All reads and writes go through KonfAI's `Dataset`, not a two-format branch.

- `5907865` feat(impact-reg): give the CLI its working directory, as the other apps have
- `f6b2684` fix(impact-reg): forward the workspace to every nested konfai-apps command
- `a511cbc` feat(impact-reg): let a preset declare only its field, and derive the moved image
- `f647c56` refactor(impact-reg): read and write through Dataset, not a two-format branch
- `c090453` refactor(impact-reg): the preset owes a field, and nothing else

Stacked on `feat/resample-unified`.
