### PR TITLE
fix(impact-reg): count produced cases, expand eval inputs, fields-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,10 @@ written replaces it.
   gets its own field, moved image and transform. Previously the cases were counted from the command-line
   arguments while konfai-apps counted them from the expanded units, so a directory input produced N
   results and only the first was collected, silently
+- **impact-reg**: `register --fields-only` writes the displacement fields and stops there. The moved
+  image and `Transform.h5` are both derived from the field, at the cost of a full-size resample and a
+  full-size rewrite, so a caller that composes the field with its own and derives its own moved — the
+  ExaSPIM tiled refinement does exactly that — no longer pays for two outputs it deletes
 - **impact-reg**: a registration preset now owes exactly one output, its displacement field, in whatever
   format it declares — `register` derives the moved image from it instead of expecting a second output.
   A preset can drop `MovedImage` entirely, which for a tiled one also drops blending a full-size moved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,7 +152,7 @@ written replaces it.
   a caller whose system temp directory is a tmpfs can now stage volume-sized intermediates on real disk
   instead of overriding `TMPDIR` from outside; the same change also writes the moved image and the
   displacement field once per run instead of twice
-- **impact-reg**: `register` accepts a whole dataset per input, not only one volume — a directory is
+- **impact-reg**: `register` and `eval` accept a whole dataset per input, not only one volume — a directory is
   expanded into one case per volume it holds, exactly as `konfai-apps infer` already does, and every case
   gets its own field, moved image and transform. Previously the cases were counted from the command-line
   arguments while konfai-apps counted them from the expanded units, so a directory input produced N

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,11 @@ written replaces it.
   a caller whose system temp directory is a tmpfs can now stage volume-sized intermediates on real disk
   instead of overriding `TMPDIR` from outside; the same change also writes the moved image and the
   displacement field once per run instead of twice
+- **impact-reg**: `register` accepts a whole dataset per input, not only one volume — a directory is
+  expanded into one case per volume it holds, exactly as `konfai-apps infer` already does, and every case
+  gets its own field, moved image and transform. Previously the cases were counted from the command-line
+  arguments while konfai-apps counted them from the expanded units, so a directory input produced N
+  results and only the first was collected, silently
 - **impact-reg**: a registration preset now owes exactly one output, its displacement field, in whatever
   format it declares — `register` derives the moved image from it instead of expecting a second output.
   A preset can drop `MovedImage` entirely, which for a tiled one also drops blending a full-size moved

--- a/apps/impact_reg/impact_reg_konfai/cli.py
+++ b/apps/impact_reg/impact_reg_konfai/cli.py
@@ -126,6 +126,14 @@ def main() -> None:
         help="Tune a preset parameter, forwarded to 'konfai-apps infer --set' (applies to every preset), "
         "e.g. --set iterations=300 (repeatable).",
     )
+    reg.add_argument(
+        "--fields-only",
+        "--fields_only",
+        dest="fields_only",
+        action="store_true",
+        help="Write the displacement fields only: skip the moved image and Transform.h5, both derived "
+        "from the field. For a caller that composes the field itself and would delete them.",
+    )
     _add_device(reg)
     _add_tmp_dir(reg)
 
@@ -209,6 +217,7 @@ def main() -> None:
             keep_dvf=args.uncertainty,
             config_overrides=args.config_overrides,
             tmp_dir=args.tmp_dir,
+            fields_only=args.fields_only,
         )
 
     elif args.command == "eval":

--- a/apps/impact_reg/impact_reg_konfai/impact_reg.py
+++ b/apps/impact_reg/impact_reg_konfai/impact_reg.py
@@ -38,7 +38,6 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Any
 
 import numpy as np
 import SimpleITK as sitk
@@ -52,6 +51,10 @@ from konfai_apps.app_repository import get_available_apps_on_hf_repo
 IMPACT_REG_KONFAI_REPO = os.environ.get("KONFAI_IMPACTREG_REPO", "VBoussot/ImpactReg")
 
 _ENSEMBLE_DIR = "Ensemble"
+
+# Writing needs a format named -- nothing is on disk yet to detect one from. Only the store spellings
+# need translating; every other suffix is already the token Dataset normalises (".mha" -> "mha").
+_FORMATS = {".ome.zarr": "omezarr", ".zarr": "omezarr"}
 
 
 def _app_id(preset: str) -> str:
@@ -190,44 +193,44 @@ def _write_displacement_field(field: sitk.Image, dest: Path) -> None:
         sitk.WriteImage(field, str(dest))
 
 
-def _dataset_entry(path: Path) -> tuple[Any, str, str]:
-    """Address one file or store as a konfai ``Dataset`` entry: ``(dataset, group, name)``.
+def _read_image(path: Path, work: Path) -> sitk.Image:
+    """A volume, read through ``Dataset`` — after building the dataset it needs.
 
-    Dataset is the layer that already knows every format konfai supports -- h5, DICOM, OME-Zarr, and
-    every ITK extension through SitkFile, which probes them itself. Going through it is what makes
-    this orchestrator format-agnostic without owning a dispatch of its own: a hand-written
-    ``if path.is_dir()`` knows exactly the two formats whoever wrote it thought of.
+    A dataset is a root of CASES holding GROUPS. A path on the command line is neither, so it is linked
+    into that layout first, exactly as konfai-apps stages its own inputs. Pretending instead that the
+    parent directory is a root and the file a group -- what this used to do -- makes detection probe one
+    level too deep inside a store, and is simply wrong for a single-store backend like h5, where the
+    file IS the dataset rather than an entry in one.
 
-    A dataset addresses ``{root}/{name}/{group}.{ext}``. An orchestrator input is a bare path, so the
-    case is empty: the parent directory is the root and the stem is the entry. The extension only
-    seeds the format token -- Dataset normalises it (``.ome.zarr`` / ``.zarr`` -> ``omezarr``) and
-    re-detects a directory store from disk regardless of what the token said.
+    Built properly, no format is named: konfai has a case to probe and detects the backend itself, which
+    is why this reads an ITK file, an OME-Zarr store or anything else konfai supports without a branch
+    here enumerating them.
     """
     from konfai.utils.dataset import Dataset
 
-    suffixes = "".join(path.suffixes)
-    stem = path.name[: len(path.name) - len(suffixes)] if suffixes else path.name
-    file_format = "omezarr" if suffixes.lower().endswith((".ome.zarr", ".zarr")) else suffixes.lstrip(".")
-    return Dataset(path.parent, file_format or "mha"), stem, ""
+    root = Path(tempfile.mkdtemp(prefix="entry_", dir=str(work)))
+    case = root / "P000"
+    case.mkdir()
+    (case / f"Entry{''.join(path.suffixes)}").symlink_to(path.resolve())
+    return Dataset(root, "").read_image("Entry", "P000")
 
 
-def _read_image(path: Path) -> sitk.Image:
-    """An image, in whatever format it is stored — read through konfai's Dataset."""
-    dataset, group, name = _dataset_entry(path)
-    return dataset.read_image(group, name)
+def _write_case_entry(image: sitk.Image, case_out: Path, group: str, file_format: str) -> None:
+    """Write one group of one case, through ``Dataset``.
 
-
-def _write_image(image: sitk.Image, dest: Path) -> None:
-    """Write an image in the form ``dest`` names — through the same layer that read it.
-
-    So the format out is the format in, for every format konfai writes, and not only for the two an
-    ``if`` here would have enumerated.
+    THIS side really is a dataset, and always was: ``<output>/<case>/<group>.<ext>`` is a root of cases
+    holding groups, which is why konfai can read it back without being told a format. So the write goes
+    through the layer that owns that layout instead of composing the path by hand -- and writing, unlike
+    reading, does need a format named, because there is nothing on disk yet to detect one from.
     """
-    dataset, group, name = _dataset_entry(dest)
-    dataset.write(group, name, image)
+    from konfai.utils.dataset import Dataset
+
+    Dataset(case_out.parent, file_format).write(group, case_out.name, image)
 
 
-def _derive_moved(moving_image: Path, dvf_path: Path, dest_dir: Path, field: sitk.Image | None = None) -> Path:
+def _derive_moved(
+    moving_image: Path, dvf_path: Path, dest_dir: Path, work: Path, field: sitk.Image | None = None
+) -> Path:
     """The moved image, resampled from the moving through the displacement field.
 
     A preset that emits only a field is complete: the moved image IS that field applied to the moving,
@@ -252,12 +255,13 @@ def _derive_moved(moving_image: Path, dvf_path: Path, dest_dir: Path, field: sit
     size, origin = field.GetSize(), field.GetOrigin()
     spacing, direction = field.GetSpacing(), field.GetDirection()
     transform = sitk.DisplacementFieldTransform(field)
-    moving = _read_image(moving_image)
+    moving = _read_image(moving_image, work)
     moved = sitk.Resample(
         moving, size, transform, sitk.sitkLinear, origin, spacing, direction, 0.0, moving.GetPixelID()
     )
-    dest = _output_path(dest_dir, "Moved", "".join(dvf_path.suffixes))
-    _write_image(moved, dest)
+    suffixes = "".join(dvf_path.suffixes)
+    dest = _output_path(dest_dir, "Moved", suffixes)
+    _write_case_entry(moved, dest_dir, "Moved", _FORMATS.get(suffixes.lower(), suffixes.lstrip(".")))
     return dest
 
 
@@ -441,7 +445,7 @@ class ImpactRegKonfAIApp:
 
                 if len(presets) == 1:
                     dvf_out = _copy_output(dvf_paths[0], case_out, "DVF")
-                    _derive_moved(moving_image, dvf_out, case_out)
+                    _derive_moved(moving_image, dvf_out, case_out, work)
                 else:
                     # Ensemble: average the presets' displacement fields (all on the fixed grid) and warp the
                     # moving image once with that averaged field — the one output no single preset produced.
@@ -451,7 +455,9 @@ class ImpactRegKonfAIApp:
                     # Through the same derivation as the single-preset path, which reads the moving in
                     # either form: the sitk.ReadImage this replaces cannot open a store at all, so an
                     # ensemble of OME-Zarr inputs failed here and nowhere else.
-                    _derive_moved(moving_image, dvf_out, case_out, field=sitk.Cast(avg_dvf, sitk.sitkVectorFloat64))
+                    _derive_moved(
+                        moving_image, dvf_out, case_out, work, field=sitk.Cast(avg_dvf, sitk.sitkVectorFloat64)
+                    )
 
                 # Transform.h5 (consumed by `evaluate` and SlicerImpactReg): the fixed-grid displacement
                 # field as a SimpleITK transform.
@@ -516,10 +522,10 @@ class ImpactRegKonfAIApp:
             try:
                 # Image: moving resampled onto the fixed grid vs fixed (MAE). Mask is optional.
                 if index < len(fixed_images) and index < len(moving_images):
-                    fixed = _read_image(fixed_images[index])
+                    fixed = _read_image(fixed_images[index], work)
                     moved = work / "moved_image.nii.gz"
                     sitk.WriteImage(
-                        sitk.Resample(_read_image(moving_images[index]), fixed, transform), str(moved)
+                        sitk.Resample(_read_image(moving_images[index], work), fixed, transform), str(moved)
                     )
                     app.evaluate(
                         inputs=[[fixed_images[index]]],
@@ -535,11 +541,11 @@ class ImpactRegKonfAIApp:
 
                 # Segmentation: moving seg warped onto fixed vs fixed seg (Dice).
                 if index < len(gt_fixed_seg) and index < len(gt_moving_seg):
-                    fixed_seg = _read_image(gt_fixed_seg[index])
+                    fixed_seg = _read_image(gt_fixed_seg[index], work)
                     moved_seg = work / "moved_seg.nii.gz"
                     sitk.WriteImage(
                         sitk.Resample(
-                            _read_image(gt_moving_seg[index]), fixed_seg, transform, sitk.sitkNearestNeighbor
+                            _read_image(gt_moving_seg[index], work), fixed_seg, transform, sitk.sitkNearestNeighbor
                         ),
                         str(moved_seg),
                     )

--- a/apps/impact_reg/impact_reg_konfai/impact_reg.py
+++ b/apps/impact_reg/impact_reg_konfai/impact_reg.py
@@ -82,17 +82,23 @@ def get_available_presets(force_update: bool = False) -> list[str]:
     return list(get_available_apps_on_hf_repo(IMPACT_REG_KONFAI_REPO, force_update))
 
 
-def _find_output(root: Path, stem: str) -> Path:
-    """Locate the single output named ``stem`` under ``root``, whatever form the preset wrote it in.
+def _find_outputs(root: Path, stem: str) -> dict[str, Path]:
+    """Every output named ``stem`` under ``root``, keyed by the CASE it belongs to.
 
     Matched on the name rather than on a fixed filename: a displacement field may come out as an ITK
     image or as an OME-Zarr store, and a store is a DIRECTORY whose ``Path.stem`` is "DVF.ome" -- so a
     fixed "DVF.mha" finds nothing and the run dies with the output sitting in the directory it listed.
+
+    A MAPPING, NOT THE FIRST MATCH. konfai-apps writes one dataset per output group --
+    ``<run>/<group>/<case>/<group>.<ext>`` -- and one run produces as many cases as the inputs expanded
+    to, which is not the number of paths on the command line: a directory is walked so each volume in
+    it becomes its own case. Taking ``matches[0]`` therefore kept P000 and dropped every case after it,
+    silently, with the results sitting on disk. The case is the entry's parent directory.
     """
     matches = sorted(root.rglob(f"{stem}.*"))
     if not matches:
         raise FileNotFoundError(f"Preset inference did not produce '{stem}' under {root}.")
-    return matches[0]
+    return {match.parent.name: match for match in matches}
 
 
 def _output_path(dest_dir: Path, stem: str, suffixes: str) -> Path:
@@ -105,6 +111,15 @@ def _output_path(dest_dir: Path, stem: str, suffixes: str) -> Path:
     for stale in [p for p in dest_dir.iterdir() if p.name.startswith(f"{stem}.")]:
         shutil.rmtree(stale) if stale.is_dir() else stale.unlink()
     return dest_dir / (stem + suffixes)
+
+
+def _neutral_masks(work: Path, side: str, count: int) -> list[Path]:
+    """``count`` all-ones sentinels, one per case, standing in for a mask group the caller left out.
+
+    Input groups pair by POSITION, so a group that is present at all must carry as many units as the
+    others: one sentinel would pair with the first case and leave the rest unmasked on that side.
+    """
+    return [_neutral_mask(work / f"{side}Mask_{index:03d}.mha") for index in range(count)]
 
 
 def _work_dir(tmp_dir: Path | None, prefix: str) -> Path:
@@ -264,31 +279,40 @@ class ImpactRegKonfAIApp:
     def _infer_preset(
         self,
         preset: str,
-        fixed_image: Path,
-        moving_image: Path,
-        fixed_mask: Path | None,
-        moving_mask: Path | None,
+        fixed_images: list[Path],
+        moving_images: list[Path],
+        fixed_masks: list[Path],
+        moving_masks: list[Path],
+        n_cases: int,
         work: Path,
         gpu: list[int],
         cpu: int | None,
         quiet: bool,
         tta: int = 0,
         config_overrides: list[str] | None = None,
-    ) -> Path:
-        """Run one preset app on the fixed/moving pair (+ optional masks); return its displacement field.
+    ) -> dict[str, Path]:
+        """Run one preset app on every case at once; return its displacement field per case.
 
-        Each preset runs through the ``konfai-apps`` CLI in its own subprocess: konfai keeps
-        process-global state (its ``Config`` singleton, the ``KONFAI_*`` environment), so several preset
-        inferences in one process would clash. The ``-i`` inputs map positionally to the app's input groups.
+        ONE RUN, NOT ONE PER CASE. Each ``-i`` is an input GROUP, and konfai-apps expands each group's
+        paths into units -- a file is one, a store or DICOM series is one, a plain directory is walked
+        so each volume in it becomes one -- then pairs the groups by position into ``Dataset/P{i:03d}``.
+        So the whole cohort goes in a single invocation and the model is loaded once, rather than once
+        per case.
+
+        Each preset still runs in its own subprocess: konfai keeps process-global state (its ``Config``
+        singleton, the ``KONFAI_*`` environment), so several preset inferences in one process would clash.
+
         Masks are optional: konfai-apps fills any we omit with an all-ones default, so with no mask we pass
         only fixed+moving. Because the mapping is positional, a lone moving mask still needs the fixed-mask
-        slot present, so send the pair (defaulting the absent one to an all-ones sentinel) once either is given.
+        slot present -- filled with one all-ones sentinel per case so the groups keep pairing.
         """
         out = work / preset
-        command = ["konfai-apps", "infer", _app_id(preset), "-i", str(fixed_image), "-i", str(moving_image)]
-        if fixed_mask is not None or moving_mask is not None:
-            command += ["-i", str(fixed_mask or _neutral_mask(work / "FixedMask.mha"))]
-            command += ["-i", str(moving_mask or _neutral_mask(work / "MovingMask.mha"))]
+        command = ["konfai-apps", "infer", _app_id(preset)]
+        command += ["-i", *(str(path) for path in fixed_images)]
+        command += ["-i", *(str(path) for path in moving_images)]
+        if fixed_masks or moving_masks:
+            command += ["-i", *(str(path) for path in fixed_masks or _neutral_masks(work, "Fixed", n_cases))]
+            command += ["-i", *(str(path) for path in moving_masks or _neutral_masks(work, "Moving", n_cases))]
         command += ["-o", str(out)]
         # Hand konfai-apps a workspace we own, which is what every other app CLI does by exposing
         # --tmp-dir. Without it konfai-apps auto-creates one under TMPDIR, writes the prediction to
@@ -318,7 +342,7 @@ class ImpactRegKonfAIApp:
         # be computed from it -- the moved image above all -- is this layer's job. Looking for a Moved
         # here would make every preset carry an output it does not owe, and a tiled one blend it across
         # every patch seam for a caller that has the field.
-        return _find_output(out, "DVF")
+        return _find_outputs(out, "DVF")
 
     def register(
         self,
@@ -336,42 +360,69 @@ class ImpactRegKonfAIApp:
         config_overrides: list[str] | None = None,
         tmp_dir: Path | None = None,
     ) -> None:
-        """Register each fixed/moving pair with the selected presets and ensemble their DVFs.
+        """Register every case with the selected presets and ensemble their DVFs.
+
+        A case is whatever konfai-apps makes of the inputs: one image per group gives one case, and a
+        directory per group gives one case per volume inside it, paired by position. So the caller may
+        pass single volumes or whole datasets, exactly as ``konfai-apps infer`` accepts them.
 
         Masks are optional and restrict the metric region; when omitted a whole-image mask is auto-filled,
         so every preset app always receives the four inputs (fixed, moving, fixed mask, moving mask) it declares.
 
         ``tmp_dir`` names where the intermediates are staged; see :func:`_work_dir`.
         """
-        for index, (fixed_image, moving_image) in enumerate(zip(fixed_images, moving_images, strict=True)):
-            case_out = output / f"P{index:03d}"
-            case_out.mkdir(parents=True, exist_ok=True)
-            # The per-preset displacement fields are large; only persist them (under Ensemble/) when the
-            # caller asks, so `uncertainty` can measure the ensemble spread afterwards.
-            if keep_dvf:
-                (case_out / _ENSEMBLE_DIR).mkdir(parents=True, exist_ok=True)
-            work = _work_dir(tmp_dir, "impact_reg_")
-            try:
-                # Masks are optional (they restrict the metric region); pass only those the caller gave and
-                # let konfai-apps fill the rest with an all-ones default — no input read on the no-mask path.
-                fixed_mask = fixed_masks[index] if index < len(fixed_masks) else None
-                moving_mask = moving_masks[index] if index < len(moving_masks) else None
+        # The cases are konfai-apps' to define, not ours to count. It expands each input GROUP into
+        # units -- a file, a store, a DICOM series, or every volume inside a plain directory -- and pairs
+        # the groups by position. Asking it for the moving group's units is what tells this layer which
+        # volume belongs to which case, in the same order it will use, so a dataset in and a single pair
+        # in go down one path.
+        moving_units = [source for source, _ in KonfAIApp._list_input_units(list(moving_images))]
+
+        work = _work_dir(tmp_dir, "impact_reg_")
+        try:
+            fields_by_preset = {
+                preset: self._infer_preset(
+                    preset,
+                    list(fixed_images),
+                    list(moving_images),
+                    list(fixed_masks),
+                    list(moving_masks),
+                    len(moving_units),
+                    work,
+                    gpu,
+                    cpu,
+                    quiet,
+                    tta,
+                    config_overrides,
+                )
+                for preset in presets
+            }
+            cases = sorted(fields_by_preset[presets[0]])
+            for preset, fields in fields_by_preset.items():
+                if sorted(fields) != cases:
+                    raise RuntimeError(
+                        f"preset '{preset}' produced cases {sorted(fields)} where '{presets[0]}' produced "
+                        f"{cases}; an ensemble can only be averaged case by case."
+                    )
+            if len(cases) != len(moving_units):
+                raise RuntimeError(
+                    f"the presets produced {len(cases)} case(s) for {len(moving_units)} moving unit(s); "
+                    "the moved image is derived per case and needs the two to line up."
+                )
+
+            for case, moving_image in zip(cases, moving_units, strict=True):
+                # konfai-apps already named the cases; reusing its names keeps the two layers' notion of
+                # a case identical instead of renumbering from the command line and hoping they agree.
+                case_out = output / case
+                case_out.mkdir(parents=True, exist_ok=True)
+                # The per-preset displacement fields are large; only persist them (under Ensemble/) when the
+                # caller asks, so `uncertainty` can measure the ensemble spread afterwards.
+                if keep_dvf:
+                    (case_out / _ENSEMBLE_DIR).mkdir(parents=True, exist_ok=True)
 
                 dvf_paths = []
                 for preset in presets:
-                    dvf = self._infer_preset(
-                        preset,
-                        fixed_image,
-                        moving_image,
-                        fixed_mask,
-                        moving_mask,
-                        work,
-                        gpu,
-                        cpu,
-                        quiet,
-                        tta,
-                        config_overrides,
-                    )
+                    dvf = fields_by_preset[preset][case]
                     if keep_dvf:
                         dvf = _copy_output(dvf, case_out / _ENSEMBLE_DIR, preset)
                     dvf_paths.append(dvf)
@@ -393,8 +444,8 @@ class ImpactRegKonfAIApp:
                 # Transform.h5 (consumed by `evaluate` and SlicerImpactReg): the fixed-grid displacement
                 # field as a SimpleITK transform.
                 sitk.WriteTransform(_displacement_transform(dvf_out), str(case_out / "Transform.h5"))
-            finally:
-                shutil.rmtree(work, ignore_errors=True)
+        finally:
+            shutil.rmtree(work, ignore_errors=True)
 
     def _average_displacement(self, dvf_paths: list[Path]) -> sitk.Image:
         """Average several presets' displacement fields (all on the same fixed grid) into one field.

--- a/apps/impact_reg/impact_reg_konfai/impact_reg.py
+++ b/apps/impact_reg/impact_reg_konfai/impact_reg.py
@@ -113,6 +113,18 @@ def _output_path(dest_dir: Path, stem: str, suffixes: str) -> Path:
     return dest_dir / (stem + suffixes)
 
 
+def _units(paths: list[Path]) -> list[Path]:
+    """What an input group expands to, in konfai-apps' own order.
+
+    A file, an OME-Zarr store or a DICOM series is one unit; a plain directory is walked so every
+    supported file inside becomes one, sorted so groups pair consistently. Asking konfai-apps rather
+    than counting the command line is what keeps this layer's notion of a case identical to the one the
+    ``Dataset/P{i:03d}`` staging is built with -- counting arguments instead is how a directory input
+    came to register N volumes and report one.
+    """
+    return [source for source, _ in KonfAIApp._list_input_units(list(paths))] if paths else []
+
+
 def _neutral_masks(work: Path, side: str, count: int) -> list[Path]:
     """``count`` all-ones sentinels, one per case, standing in for a mask group the caller left out.
 
@@ -376,7 +388,7 @@ class ImpactRegKonfAIApp:
         # the groups by position. Asking it for the moving group's units is what tells this layer which
         # volume belongs to which case, in the same order it will use, so a dataset in and a single pair
         # in go down one path.
-        moving_units = [source for source, _ in KonfAIApp._list_input_units(list(moving_images))]
+        moving_units = _units(moving_images)
 
         work = _work_dir(tmp_dir, "impact_reg_")
         try:
@@ -487,6 +499,14 @@ class ImpactRegKonfAIApp:
         already registered and only resampled onto the fixed grid (identity).
         """
         app = KonfAIApp(_app_id(preset), self._download, self._force_update)
+        # Every group is expanded the same way ``register`` expands its inputs, so a directory of
+        # volumes evaluates case by case instead of collapsing to its first entry. Transforms and
+        # landmark files expand too: .h5, .fcsv and .itk.txt are all supported extensions.
+        fixed_images, moving_images = _units(fixed_images), _units(moving_images)
+        gt_fixed_seg, gt_moving_seg = _units(gt_fixed_seg), _units(gt_moving_seg)
+        gt_fixed_fid, gt_moving_fid = _units(gt_fixed_fid), _units(gt_moving_fid)
+        transforms = _units(transforms)
+        mask = _units(mask) if mask else mask
         n_cases = max(len(fixed_images), len(gt_fixed_seg), len(gt_fixed_fid))
         for index in range(n_cases):
             transform_path = transforms[index] if index < len(transforms) else None

--- a/apps/impact_reg/impact_reg_konfai/impact_reg.py
+++ b/apps/impact_reg/impact_reg_konfai/impact_reg.py
@@ -375,6 +375,7 @@ class ImpactRegKonfAIApp:
         keep_dvf: bool = False,
         config_overrides: list[str] | None = None,
         tmp_dir: Path | None = None,
+        fields_only: bool = False,
     ) -> None:
         """Register every case with the selected presets and ensemble their DVFs.
 
@@ -386,6 +387,12 @@ class ImpactRegKonfAIApp:
         so every preset app always receives the four inputs (fixed, moving, fixed mask, moving mask) it declares.
 
         ``tmp_dir`` names where the intermediates are staged; see :func:`_work_dir`.
+
+        ``fields_only`` writes the displacement fields and stops there. The moved image and
+        ``Transform.h5`` are both derived FROM the field, at the cost of a full-size resample and a
+        full-size rewrite -- worth it for a caller that wants a registration to look at, waste for one
+        that composes the field with another and derives its own. A caller that reads only the fields
+        should be able to say so rather than pay for outputs it deletes.
         """
         # The cases are konfai-apps' to define, not ours to count. It expands each input GROUP into
         # units -- a file, a store, a DICOM series, or every volume inside a plain directory -- and pairs
@@ -445,23 +452,27 @@ class ImpactRegKonfAIApp:
 
                 if len(presets) == 1:
                     dvf_out = _copy_output(dvf_paths[0], case_out, "DVF")
-                    _derive_moved(moving_image, dvf_out, case_out, work)
+                    if not fields_only:
+                        _derive_moved(moving_image, dvf_out, case_out, work)
                 else:
                     # Ensemble: average the presets' displacement fields (all on the fixed grid) and warp the
                     # moving image once with that averaged field — the one output no single preset produced.
                     avg_dvf = self._average_displacement(dvf_paths)
                     dvf_out = _output_path(case_out, "DVF", "".join(dvf_paths[0].suffixes))
                     _write_displacement_field(avg_dvf, dvf_out)
-                    # Through the same derivation as the single-preset path, which reads the moving in
-                    # either form: the sitk.ReadImage this replaces cannot open a store at all, so an
-                    # ensemble of OME-Zarr inputs failed here and nowhere else.
-                    _derive_moved(
-                        moving_image, dvf_out, case_out, work, field=sitk.Cast(avg_dvf, sitk.sitkVectorFloat64)
-                    )
+                    if not fields_only:
+                        # Through the same derivation as the single-preset path, which reads the moving
+                        # in either form: the sitk.ReadImage this replaces cannot open a store at all,
+                        # so an ensemble of OME-Zarr inputs failed here and nowhere else.
+                        _derive_moved(
+                            moving_image, dvf_out, case_out, work, field=sitk.Cast(avg_dvf, sitk.sitkVectorFloat64)
+                        )
 
-                # Transform.h5 (consumed by `evaluate` and SlicerImpactReg): the fixed-grid displacement
-                # field as a SimpleITK transform.
-                sitk.WriteTransform(_displacement_transform(dvf_out), str(case_out / "Transform.h5"))
+                if not fields_only:
+                    # Transform.h5 (consumed by `evaluate` and SlicerImpactReg): the fixed-grid
+                    # displacement field as a SimpleITK transform. Another full-size write of the same
+                    # voxels, which is why it goes with the moved image rather than being unconditional.
+                    sitk.WriteTransform(_displacement_transform(dvf_out), str(case_out / "Transform.h5"))
         finally:
             shutil.rmtree(work, ignore_errors=True)
 

--- a/apps/impact_reg/tests/unit/test_displacement_field_io.py
+++ b/apps/impact_reg/tests/unit/test_displacement_field_io.py
@@ -231,15 +231,18 @@ def test_transform_reads_back_identically_from_either_form(tmp_path: Path, suffi
 def test_read_image_opens_an_ome_zarr_store(tmp_path) -> None:
     """An ordinary image reads back from a store, not only from an ITK file.
 
-    ``sitk.ReadImage`` cannot open a directory, so every place that re-read an input was silently
-    ITK-only. That is what made the ensemble path unusable with OME-Zarr inputs while the
-    single-preset path — which reuses the model's output and never re-reads — worked fine.
+    Read through ``Dataset`` with no format named: the path is staged into a real case/group layout
+    first, so konfai detects the backend itself. ``sitk.ReadImage`` cannot open a directory, which is
+    what made the ensemble path unusable with OME-Zarr inputs while the single-preset path — which
+    reuses the model's output and never re-reads — worked fine.
     """
     volume = np.arange(4 * 5 * 6, dtype=np.float32).reshape(4, 5, 6)
     store = tmp_path / "moving.ome.zarr"
     write_ome_zarr(store, volume[np.newaxis], spacing=(1.5, 2.0, 2.5), origin=(3.0, -1.0, 0.5))
 
-    image = _read_image(store)
+    work = tmp_path / "work"
+    work.mkdir()
+    image = _read_image(store, work)
 
     assert image.GetSpacing() == pytest.approx((1.5, 2.0, 2.5))
     assert image.GetOrigin() == pytest.approx((3.0, -1.0, 0.5))
@@ -247,9 +250,11 @@ def test_read_image_opens_an_ome_zarr_store(tmp_path) -> None:
 
 
 def test_read_image_still_opens_an_itk_file(tmp_path) -> None:
-    """The other half of the dispatch: a plain file goes straight through SimpleITK."""
+    """The same call, on a plain ITK file: one reader, no branch on the form."""
     volume = np.arange(2 * 3 * 4, dtype=np.float32).reshape(2, 3, 4)
     path = tmp_path / "moving.mha"
     sitk.WriteImage(sitk.GetImageFromArray(volume), str(path))
 
-    np.testing.assert_allclose(sitk.GetArrayFromImage(_read_image(path)), volume)
+    work = tmp_path / "work"
+    work.mkdir()
+    np.testing.assert_allclose(sitk.GetArrayFromImage(_read_image(path, work)), volume)

--- a/apps/impact_reg/tests/unit/test_displacement_field_io.py
+++ b/apps/impact_reg/tests/unit/test_displacement_field_io.py
@@ -33,7 +33,7 @@ pytest.importorskip("ngff_zarr")
 from impact_reg_konfai.impact_reg import (  # noqa: E402
     _copy_output,
     _displacement_transform,
-    _find_output,
+    _find_outputs,
     _output_path,
     _read_image,
     _write_displacement_field,
@@ -71,18 +71,27 @@ def _write_store(dest: Path, field: "sitk.Image") -> Path:
 
 
 @pytest.mark.parametrize("suffix", [".mha", ".ome.zarr"])
-def test_find_output_locates_either_form(tmp_path: Path, suffix: str) -> None:
+def test_find_outputs_locates_either_form(tmp_path: Path, suffix: str) -> None:
     """Discovery is by name, not by filename: a store is a directory whose stem is 'DVF.ome'."""
     produced = tmp_path / "P000"
     produced.mkdir()
     _write_displacement_field(_field(), produced / f"DVF{suffix}")
 
-    assert _find_output(tmp_path, "DVF").name == f"DVF{suffix}"
+    assert _find_outputs(tmp_path, "DVF")["P000"].name == f"DVF{suffix}"
 
 
-def test_find_output_reports_the_name_it_looked_for(tmp_path: Path) -> None:
+def test_find_outputs_keys_every_case_the_run_produced(tmp_path: Path) -> None:
+    """One run yields one entry per case, so none is silently dropped."""
+    for case in ("P000", "P001", "P002"):
+        (tmp_path / case).mkdir()
+        _write_displacement_field(_field(), tmp_path / case / "DVF.mha")
+
+    assert sorted(_find_outputs(tmp_path, "DVF")) == ["P000", "P001", "P002"]
+
+
+def test_find_outputs_reports_the_name_it_looked_for(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError, match="DVF"):
-        _find_output(tmp_path, "DVF")
+        _find_outputs(tmp_path, "DVF")
 
 
 @pytest.mark.parametrize("suffix", [".mha", ".ome.zarr"])
@@ -180,7 +189,7 @@ def test_output_path_clears_the_stem_whatever_the_previous_form(tmp_path: Path) 
 
 def test_rerunning_in_the_other_form_leaves_one_output(tmp_path: Path) -> None:
     """Discovery is by stem, so a run that emits the other form must not leave the previous one
-    beside it -- ``_find_output`` returns the first match, and ``DVF.mha`` sorts before its store."""
+    beside it -- discovery is by stem, and ``DVF.mha`` sorts before its store."""
     source, destination = tmp_path / "src", tmp_path / "out"
     source.mkdir()
     destination.mkdir()
@@ -191,7 +200,7 @@ def test_rerunning_in_the_other_form_leaves_one_output(tmp_path: Path) -> None:
     _copy_output(source / "DVF.ome.zarr", destination, "DVF")
 
     assert [p.name for p in destination.iterdir()] == ["DVF.ome.zarr"]
-    assert _find_output(destination, "DVF").name == "DVF.ome.zarr"
+    assert _find_outputs(destination, "DVF")[destination.name].name == "DVF.ome.zarr"
 
 
 def test_store_written_by_the_orchestrator_is_a_declared_field(tmp_path: Path) -> None:

--- a/apps/impact_reg/tests/unit/test_orchestration.py
+++ b/apps/impact_reg/tests/unit/test_orchestration.py
@@ -53,9 +53,9 @@ def test_get_available_presets_keeps_only_registration_apps(tmp_path: Path, monk
     assert reg.get_available_presets() == ["FireANTs_SyN", "Generic_Rigid"]
 
 
-def test_find_output_raises_when_missing(tmp_path: Path) -> None:
+def test_find_outputs_raises_when_missing(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError, match=r"Moved\.mha"):
-        reg._find_output(tmp_path, "Moved.mha")
+        reg._find_outputs(tmp_path, "Moved.mha")
 
 
 # --------------------------------------------------------------------------- mask sentinel
@@ -101,11 +101,11 @@ def _stub_infer(app: reg.ImpactRegKonfAIApp, moving_image: Path, dvf_by_preset: 
     """Replace ``_infer_preset`` so it writes a constant DVF.mha per preset on the moving grid."""
     reference = sitk.ReadImage(str(moving_image))
 
-    def fake(preset, fixed_image, mov_image, fixed_mask, moving_mask, work, *args, **kwargs):
-        out = Path(work) / preset
+    def fake(preset, fixed, moving, fixed_masks, moving_masks, n_cases, work, *args, **kwargs):
+        out = Path(work) / preset / "P000"
         out.mkdir(parents=True, exist_ok=True)
         _write_dvf(out / "DVF.mha", dvf_by_preset[preset], reference)
-        return out / "DVF.mha"
+        return {"P000": out / "DVF.mha"}
 
     app._infer_preset = fake  # type: ignore[method-assign]
 
@@ -163,11 +163,11 @@ def test_register_derives_moved_when_the_preset_emits_only_a_field(tmp_path: Pat
     reference = sitk.ReadImage(str(moving))
     app = reg.ImpactRegKonfAIApp()
 
-    def field_only(preset, fixed_image, mov_image, fixed_mask, moving_mask, work, *args, **kwargs):
-        out = Path(work) / preset
+    def field_only(preset, fixed, moving, fixed_masks, moving_masks, n_cases, work, *args, **kwargs):
+        out = Path(work) / preset / "P000"
         out.mkdir(parents=True, exist_ok=True)
         _write_dvf(out / "DVF.mha", (2.0, 0.0, 0.0), reference)
-        return out / "DVF.mha"
+        return {"P000": out / "DVF.mha"}
 
     app._infer_preset = field_only  # type: ignore[method-assign]
     out = tmp_path / "Output"

--- a/apps/impact_reg/tests/unit/test_orchestration.py
+++ b/apps/impact_reg/tests/unit/test_orchestration.py
@@ -179,3 +179,26 @@ def test_register_derives_moved_when_the_preset_emits_only_a_field(tmp_path: Pat
     moved = sitk.GetArrayFromImage(sitk.ReadImage(str(case / "Moved.mha")))
     np.testing.assert_allclose(moved[0, 0, 0], 2.0, atol=1e-6)
     np.testing.assert_allclose(moved[1, 1, 0], 74.0, atol=1e-6)
+
+
+def test_register_fields_only_writes_nothing_derived(tmp_path: Path) -> None:
+    """A caller that composes the field itself pays for the field, and nothing else.
+
+    Both the moved image and Transform.h5 are derived FROM the field -- a full-size resample and a
+    full-size rewrite of the same voxels. The tiled refinement reads the field, composes it with its
+    global pass and derives its own moved, so producing them for it is pure waste.
+    """
+    moving = tmp_path / "moving.mha"
+    sitk.WriteImage(sitk.GetImageFromArray(np.zeros((8, 8, 8), dtype=np.float32)), str(moving))
+    fixed = tmp_path / "fixed.mha"
+    sitk.WriteImage(sitk.GetImageFromArray(np.zeros((8, 8, 8), dtype=np.float32)), str(fixed))
+
+    app = reg.ImpactRegKonfAIApp()
+    _stub_infer(app, moving, {"FireANTs_SyN": (2.0, 0.0, 0.0)})
+    out = tmp_path / "Output"
+    app.register(["FireANTs_SyN"], [fixed], [moving], output=out, fields_only=True)
+
+    case = out / "P000"
+    assert (case / "DVF.mha").is_file()
+    assert not (case / "Moved.mha").exists()
+    assert not (case / "Transform.h5").exists()

--- a/apps/impact_reg/tests/unit/test_tmp_dir_forwarding.py
+++ b/apps/impact_reg/tests/unit/test_tmp_dir_forwarding.py
@@ -48,8 +48,8 @@ def test_infer_preset_forwards_the_workspace(tmp_path: Path, monkeypatch, write_
 
     def fake_run(command, **kwargs):
         captured.append(list(command))
-        # Stand in for the preset run: konfai-apps would leave its outputs under -o.
-        write_preset_output(Path(command[command.index("-o") + 1]))
+        # Stand in for the preset run: konfai-apps leaves one case directory per unit under -o.
+        write_preset_output(Path(command[command.index("-o") + 1]) / "P000")
         return None
 
     monkeypatch.setattr("impact_reg_konfai.impact_reg.subprocess.run", fake_run)
@@ -57,7 +57,9 @@ def test_infer_preset_forwards_the_workspace(tmp_path: Path, monkeypatch, write_
     work = tmp_path / "work"
     work.mkdir()
     app = ImpactRegKonfAIApp()
-    app._infer_preset("FireANTs_SyN", tmp_path / "f.mha", tmp_path / "m.mha", None, None, work, [], None, True)
+    app._infer_preset(
+        "FireANTs_SyN", [tmp_path / "f.mha"], [tmp_path / "m.mha"], [], [], 1, work, [], None, True
+    )
 
     assert len(captured) == 1
     assert _tmp_dir_value(captured[0]) == str(work / "FireANTs_SyN")


### PR DESCRIPTION
Correctness pass over the orchestrator's plumbing: case counting comes from what konfai-apps actually produced, evaluation inputs expand the same way register's do, reads build the `Dataset` they need, and a caller can ask for the fields and nothing else.

- `6bf61bd` fix(impact-reg): count the cases konfai-apps produced, not the arguments given
- `668ca09` fix(impact-reg): expand eval's inputs the way register's are
- `e8b18e5` refactor(impact-reg): read through Dataset by building the dataset it needs
- `ef702f6` feat(impact-reg): let a caller ask for the fields and nothing else

Stacked on #91.
