### PR TITLE
refactor: one home for what was written several times

### DIFF
--- a/apps/impact_reg/impact_reg_konfai/impact_reg.py
+++ b/apps/impact_reg/impact_reg_konfai/impact_reg.py
@@ -321,7 +321,7 @@ def _neutral_mask(out_path: Path) -> Path:
 
     A whole-image all-ones mask restricts nothing (the model's ``_is_partial_mask`` treats it as absent),
     and in whole-volume mode a mask branch need not share the image grid, so a 2x2x2 sentinel yields a
-    byte-identical registration (verified) without reading (or even sizing to) the input. (The common
+    byte-identical registration without reading (or even sizing to) the input. (The common
     no-mask path passes no mask at all; konfai-apps fills both branches with an all-ones default.)
     """
     sitk.WriteImage(sitk.GetImageFromArray(np.ones((2, 2, 2), dtype=np.uint8)), str(out_path))

--- a/konfai/api.py
+++ b/konfai/api.py
@@ -44,11 +44,11 @@ import os
 import shutil
 import tempfile
 import threading
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import numpy as np
 
@@ -56,6 +56,9 @@ from konfai.utils.errors import ConfigError
 
 if TYPE_CHECKING:
     from konfai.transformer import TransformPlan
+    from konfai.utils.runtime import DistributedObject
+
+_T = TypeVar("_T")
 
 #: Where a bare stage name resolves, per stage family: the same rule the YAML loader applies.
 _STAGE_MODULES = ("konfai.data.transform", "konfai.data.augmentation")
@@ -89,6 +92,30 @@ def _one_workflow_at_a_time(ranks: int) -> Iterator[None]:
                 del os.environ[key]
         os.environ.update(saved)
         _ACTIVE.release()
+
+
+def _launch(
+    ranks: int,
+    build: "Callable[[], DistributedObject]",
+    finish: "Callable[[DistributedObject], _T]",
+    *,
+    gpu: Sequence[int] | None,
+    cpu: int | None,
+    overwrite: bool,
+    quiet: bool,
+) -> _T:
+    """Take the workflow lock, build, execute, and read the result out through ``finish``.
+
+    ``finish`` runs inside the lock on purpose: the workspace lives in ``KONFAI_*`` variables the
+    lock's exit restores to the caller's. ``ranks`` sizes the lock and stays the caller's own
+    expression: the entry points do not all derive it from ``gpu``/``cpu`` the same way.
+    """
+    from konfai.utils.runtime import execute_distributed_object
+
+    with _one_workflow_at_a_time(ranks):
+        workflow = build()
+        execute_distributed_object(workflow, gpu=list(gpu or []), cpu=cpu, overwrite=overwrite, quiet=quiet)
+        return finish(workflow)
 
 
 def _yaml_safe(value: object, where: str) -> object:
@@ -266,13 +293,19 @@ def transform(
     """
     tree = _transform_tree(name, datasets, chains, memory_budget, on_fallback, manual_seed, dataset_options)
     from konfai.transformer import build_transform
-    from konfai.utils.runtime import execute_distributed_object
 
-    with _one_workflow_at_a_time(len(gpu or []) or cpu):
-        workflow = build_transform(transform_file=tree, transforms_dir=transforms_dir)
-        config_name = Path(os.environ["KONFAI_config_file"]).name
-        execute_distributed_object(workflow, gpu=list(gpu or []), cpu=cpu, overwrite=overwrite, quiet=quiet)
-        workspace = Path(workflow.transform_path)  # type: ignore[attr-defined]
+    workspace, config_name = _launch(
+        len(gpu or []) or cpu,
+        lambda: build_transform(transform_file=tree, transforms_dir=transforms_dir),
+        lambda workflow: (
+            Path(workflow.transform_path),  # type: ignore[attr-defined]
+            Path(os.environ["KONFAI_config_file"]).name,
+        ),
+        gpu=gpu,
+        cpu=cpu,
+        overwrite=overwrite,
+        quiet=quiet,
+    )
     outputs = json.loads((workspace / "outputs.json").read_text(encoding="utf-8"))
     return TransformResult(workspace=workspace, outputs=outputs, config=workspace / config_name)
 
@@ -363,12 +396,16 @@ def evaluate(
     tree = {"Evaluator": {"train_name": name, "metrics": metrics_tree, "Dataset": dataset_tree}}
 
     from konfai.evaluator import build_evaluate
-    from konfai.utils.runtime import execute_distributed_object
 
-    with _one_workflow_at_a_time(len(gpu or []) or cpu):
-        workflow = build_evaluate(evaluations_file=tree, evaluations_dir=evaluations_dir)
-        execute_distributed_object(workflow, gpu=list(gpu or []), cpu=cpu, overwrite=overwrite, quiet=quiet)
-        workspace = Path(os.environ["KONFAI_EVALUATIONS_DIRECTORY"]) / name
+    workspace = _launch(
+        len(gpu or []) or cpu,
+        lambda: build_evaluate(evaluations_file=tree, evaluations_dir=evaluations_dir),
+        lambda _: Path(os.environ["KONFAI_EVALUATIONS_DIRECTORY"]) / name,
+        gpu=gpu,
+        cpu=cpu,
+        overwrite=overwrite,
+        quiet=quiet,
+    )
     reports = {
         split: json.loads(report.read_text(encoding="utf-8"))
         for split in ("TRAIN", "VALIDATION")
@@ -411,16 +448,20 @@ def predict(
     (checkpoints, patching, TTA, ensembling) is wiring, and the tree is its honest spelling.
     """
     from konfai.predictor import build_predict
-    from konfai.utils.runtime import execute_distributed_object
 
-    with _one_workflow_at_a_time(len(gpu or []) or cpu):
-        workflow = build_predict(
+    return _launch(
+        len(gpu or []) or cpu,
+        lambda: build_predict(
             models=[Path(model) for model in models],
             prediction_file=_config_copy(config),
             predictions_dir=predictions_dir,
-        )
-        execute_distributed_object(workflow, gpu=list(gpu or []), cpu=cpu, overwrite=overwrite, quiet=quiet)
-        return Path(os.environ["KONFAI_PREDICTIONS_DIRECTORY"]) / workflow.name
+        ),
+        lambda workflow: Path(os.environ["KONFAI_PREDICTIONS_DIRECTORY"]) / workflow.name,
+        gpu=gpu,
+        cpu=cpu,
+        overwrite=overwrite,
+        quiet=quiet,
+    )
 
 
 def train(
@@ -443,16 +484,21 @@ def train(
     each run keeps IS the record of what was tried.
     """
     from konfai.trainer import build_train
-    from konfai.utils.runtime import State, execute_distributed_object
+    from konfai.utils.runtime import State
 
-    with _one_workflow_at_a_time(len(gpu or []) or (cpu or 1)):
-        workflow = build_train(
+    return _launch(
+        len(gpu or []) or (cpu or 1),
+        lambda: build_train(
             command=State.RESUME if resume else State.TRAIN,
             model=model,
             config=_config_copy(config),
             checkpoints_dir=checkpoints_dir,
             statistics_dir=statistics_dir,
             lr=lr,
-        )
-        execute_distributed_object(workflow, gpu=list(gpu or []), cpu=cpu, overwrite=overwrite, quiet=quiet)
-        return Path(os.environ["KONFAI_CHECKPOINTS_DIRECTORY"]) / workflow.name
+        ),
+        lambda workflow: Path(os.environ["KONFAI_CHECKPOINTS_DIRECTORY"]) / workflow.name,
+        gpu=gpu,
+        cpu=cpu,
+        overwrite=overwrite,
+        quiet=quiet,
+    )

--- a/konfai/data/case_reduction.py
+++ b/konfai/data/case_reduction.py
@@ -37,7 +37,7 @@ import torch
 
 from konfai.data.patching import DatasetManager
 from konfai.data.reduction import Reduction
-from konfai.data.transform import LocalityKind, PatchLocality, Reduce, Transform
+from konfai.data.transform import LocalityKind, PatchLocality, Reduce, Transform, stat_seed_valid
 from konfai.utils.config import apply_config
 from konfai.utils.dataset import (
     Attribute,
@@ -230,7 +230,7 @@ def check_post_stages(post: list[Transform], output: str) -> None:
 
     A statistic may follow the reduction, but only over stages that leave the values alone: the stat
     pass measures the FOLD, so an earlier stage that changes the values makes the seed describe a
-    volume nobody wrote. This mirrors the same refusal in the per-case planner.
+    volume nobody wrote (``stat_seed_valid``, the per-case planner's rule).
     """
     localities: list[PatchLocality] = []
     for index, stage in enumerate(post):
@@ -245,7 +245,7 @@ def check_post_stages(post: list[Transform], output: str) -> None:
                 f"Only voxel-local stages can follow a reduction. End this chain, and put '{name}' in a"
                 f" second chain that reads '{output}' back.",
             )
-        if kind is LocalityKind.GLOBAL_STAT and not all(previous.statistics_preserving for previous in localities):
+        if kind is LocalityKind.GLOBAL_STAT and not stat_seed_valid(localities):
             raise ReductionError(
                 f"stage {index} '{name}' follows the Reduce into '{output}' and needs whole-volume"
                 " statistics, but an earlier stage after the Reduce changes the values: the"

--- a/konfai/data/geometry.py
+++ b/konfai/data/geometry.py
@@ -16,8 +16,8 @@
 
 """Grids, boxes and affine maps in world coordinates: the value vocabulary a resample shares.
 
-Two axis orders coexist in every KonfAI header, and every geometry bug this file's history records
-is a confusion between them: array data is ``(Z, Y, X)``, physical geometry (``Origin``,
+Two axis orders coexist in every KonfAI header, and the classic failure is a confusion between
+them: array data is ``(Z, Y, X)``, physical geometry (``Origin``,
 ``Spacing``, ``Direction``) is ``(x, y, z)``. The types here carry the order in the field name (``size_zyx``,
 ``origin_xyz``), so a mixed expression reads as wrong at the call site instead of
 resampling perfectly onto the wrong place.

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -40,6 +40,7 @@ from konfai.data.transform import (
     Save,
     Transform,
     split_expand,
+    stat_seed_valid,
 )
 from konfai.utils.config import apply_config, config
 from konfai.utils.dataset import Attribute, Dataset, DataStream
@@ -231,15 +232,6 @@ class AugmentedStage:
         return self.augmentation.compute(name, self.index, self.a, tensor)
 
 
-# The region kinds a composed streamed read (or write) carries between its pointwise stages.
-_REGION_KINDS = (
-    LocalityKind.HALO,
-    LocalityKind.ORIENTATION,
-    LocalityKind.CROP,
-    LocalityKind.REGRID,
-)
-
-
 # The pull maps are callable dataclasses, not closures, because a plan crosses a process boundary:
 # the launcher plans every case, `mp.spawn` then pickles the workflow object whole, and a local
 # function cannot be pickled. Everything a plan memoizes must survive that trip.
@@ -348,7 +340,7 @@ class _PatchStreamSource:
     def region_index(self) -> int | None:
         """The first region stage, or ``None`` for an exact-patch chain."""
         for index, plan in enumerate(self.stage_plans):
-            if plan.kind in _REGION_KINDS:
+            if plan.kind.is_region:
                 return index
         return None
 
@@ -1787,10 +1779,9 @@ class DatasetManager:
                 # the reader is told what to change instead of what happened.
                 return refuse(f"{label} declares {loc.kind.name}: {loc.reason or 'it needs the whole volume'}.")
             if loc.kind is LocalityKind.GLOBAL_STAT:
-                # The seed is the STORED volume's statistic, which is this transform's input only when
-                # every earlier stage preserves it; otherwise ([Clip(-200, 400), Standardize()]) every
-                # patch would be standardized by the pre-Clip statistic: fall back to the whole volume.
-                if not all(previous.statistics_preserving for previous in localities[:-1]):
+                # The seed is the STORED volume's statistic; otherwise ([Clip(-200, 400), Standardize()])
+                # every patch would be standardized by the pre-Clip statistic: fall back to the whole volume.
+                if not stat_seed_valid(localities[:-1]):
                     return refuse(
                         f"{label} needs whole-volume statistics, but an earlier stage changes the values"
                         ": the stored volume's statistic is not this stage's input."
@@ -1825,7 +1816,7 @@ class DatasetManager:
     ) -> "_ReadStagePlan":
         """One stage's slot in the composed plan: its shapes, its pull map, and (for a region stage)
         the geometry it leaves for the stages after it (``write_stream_cache_attribute``)."""
-        if loc.kind not in _REGION_KINDS:
+        if not loc.kind.is_region:
             return _ReadStagePlan(loc.kind, tuple(shape), tuple(shape), None)
         if loc.kind is LocalityKind.HALO:
             return _ReadStagePlan(
@@ -2491,6 +2482,52 @@ class DatasetManager:
                 )
         return "the copy's plan is incomplete; it sweeps its own pass."
 
+    @staticmethod
+    def _sweep_targets(spatial: list[int], rows: int) -> Iterator[tuple[slice, ...]]:
+        """The sweep's slabs: whole rows of the landing's first axis, full extent on the rest."""
+        for start in range(0, spatial[0], rows):
+            yield (slice(start, min(start + rows, spatial[0])), *(slice(0, extent) for extent in spatial[1:]))
+
+    @staticmethod
+    def _sweep_header(evolved: Attribute, scope: Attribute, keys_before: set[str]) -> Attribute:
+        """The header a sweep publishes: the plan-time case state, completed by what the chain's
+        stages added in ``__call__``: the same keys the whole-volume pass would leave at the Save."""
+        attributes = Attribute(evolved)
+        for key in scope.keys():
+            if key not in keys_before and key not in attributes:
+                attributes[key] = scope[key]
+        return attributes
+
+    @staticmethod
+    def _require_channel_first(block: np.ndarray, spatial: list[int], what: str) -> None:
+        """Refuse a slab that lost the channel-first layout. Writing it anyway is the worst outcome
+        available: the header would take the slab's first spatial extent for a channel count and
+        publish a store of that many "channels", raising nothing, while the whole-volume path
+        returns the right rank: the two would silently disagree."""
+        if block.ndim != len(spatial) + 1:
+            raise PatchError(
+                f"{what} returned a rank-{block.ndim} slab where the channel-first layout needs rank"
+                f" {len(spatial) + 1} (C, {', '.join(str(extent) for extent in spatial)}).",
+                "A transform that reduces the leading axis must keep it (`keepdim=True`), so a slab"
+                " stays C[Z]YX; only then does a region write mean the same thing as the"
+                " whole-volume pass.",
+            )
+
+    @staticmethod
+    def _open_sweep_stream(
+        sweep: _PendingSweep, block: np.ndarray, spatial: list[int], rows: int, attributes: Attribute
+    ) -> DataStream | None:
+        """One region-write stream shaped for the sweep: the store chunks on whole slabs (channels
+        included), so no region write ever pays a read-modify-write."""
+        return sweep.destination.open_data_stream(
+            sweep.group,
+            sweep.entry,
+            [int(block.shape[0]), *spatial],
+            block.dtype,
+            attributes,
+            region_shape=[int(block.shape[0]), rows, *spatial[1:]],
+        )
+
     def _materialize_shared_pass(self, shared: list[tuple[int, _PendingSweep]]) -> set[int]:
         """One read pass, N write streams: the optimal regime of the expansion engine.
 
@@ -2559,13 +2596,12 @@ class DatasetManager:
         rows = self._sweep_rows(spatial, int(reference.source_shape[0]))
         streams: dict[int, DataStream] = {}
         try:
-            for start in range(0, spatial[0], rows):
-                target = (slice(start, min(start + rows, spatial[0])), *(slice(0, e) for e in spatial[1:]))
+            for slab_index, target in enumerate(self._sweep_targets(spatial, rows)):
                 tensor, slab_attribute, keys_before = self._replay_streamed_region(
                     source,
                     target,
                     Attribute(reference.base_attributes),
-                    Attribute(prefix_evolved) if start == 0 else None,
+                    Attribute(prefix_evolved) if slab_index == 0 else None,
                 )
                 for a, sweep, tail, evolved in active:
                     copy_tensor = tensor.clone() if len(active) > 1 else tensor
@@ -2573,25 +2609,10 @@ class DatasetManager:
                     for stage in tail:
                         copy_tensor = stage(self.name, copy_tensor, scope)
                     block = copy_tensor.numpy()
-                    if block.ndim != len(spatial) + 1:
-                        raise PatchError(
-                            f"A per-copy stage of '{sweep.group}/{sweep.entry}' returned a rank-{block.ndim}"
-                            f" slab where the channel-first layout needs rank {len(spatial) + 1}.",
-                            "A transform that reduces the leading axis must keep it (`keepdim=True`).",
-                        )
+                    self._require_channel_first(block, spatial, f"A per-copy stage of '{sweep.group}/{sweep.entry}'")
                     if a not in streams:
-                        attributes = Attribute(evolved)
-                        for key in scope.keys():
-                            if key not in keys_before and key not in attributes:
-                                attributes[key] = scope[key]
-                        stream = sweep.destination.open_data_stream(
-                            sweep.group,
-                            sweep.entry,
-                            [int(block.shape[0]), *spatial],
-                            block.dtype,
-                            attributes,
-                            region_shape=[int(block.shape[0]), rows, *spatial[1:]],
-                        )
+                        attributes = self._sweep_header(evolved, scope, keys_before)
+                        stream = self._open_sweep_stream(sweep, block, spatial, rows, attributes)
                         if stream is None:
                             raise PatchError(
                                 f"destination '{sweep.destination.filename}' refused the region write"
@@ -2701,46 +2722,20 @@ class DatasetManager:
         rows = self._sweep_rows(spatial, int(sweep.source_shape[0]))
         stream: DataStream | None = None
         try:
-            for start in range(0, spatial[0], rows):
-                target = (slice(start, min(start + rows, spatial[0])), *(slice(0, e) for e in spatial[1:]))
+            for slab_index, target in enumerate(self._sweep_targets(spatial, rows)):
                 # The first slab hands a throwaway case scope to the replay so the region-geometry
                 # check runs: a region stage recording geometry nowhere the case can read refuses the
                 # sweep (PatchError -> whole-volume fallback), exactly as the patch path refuses it.
                 tensor, slab_attribute, keys_before = self._replay_streamed_region(
-                    source, target, Attribute(sweep.base_attributes), Attribute(evolved) if start == 0 else None
+                    source, target, Attribute(sweep.base_attributes), Attribute(evolved) if slab_index == 0 else None
                 )
                 block = tensor.numpy()
-                if block.ndim != len(spatial) + 1:
-                    # The chain dropped (or added) a leading axis, so this slab is not C[Z]YX. Writing
-                    # it anyway is the worst outcome available: the header would take this slab's
-                    # FIRST spatial extent for a channel count, publish a store of that many
-                    # "channels" each holding a broadcast copy, and raise nothing: the whole-volume
-                    # path meanwhile returns the right rank, so the two silently disagree. A rank is
-                    # not something a slab can carry an opinion about: refuse, and let the caller's
-                    # handler fall back to the whole volume, which reduces correctly.
-                    raise PatchError(
-                        f"A stage of the chain writing '{sweep.group}/{sweep.entry}' returned a rank-{block.ndim}"
-                        f" slab where the channel-first layout needs rank {len(spatial) + 1}"
-                        f" (C, {', '.join(str(e) for e in spatial)}).",
-                        "A transform that reduces the leading axis must keep it (`keepdim=True`), so a"
-                        " slab stays C[Z]YX; only then does a region write mean the same thing as the"
-                        " whole-volume pass.",
-                    )
+                self._require_channel_first(
+                    block, spatial, f"A stage of the chain writing '{sweep.group}/{sweep.entry}'"
+                )
                 if stream is None:
-                    # The header is the plan-time case state, completed by what the chain's stages
-                    # add in __call__: the same keys the whole-volume pass would leave at the Save.
-                    attributes = Attribute(evolved)
-                    for key in slab_attribute.keys():
-                        if key not in keys_before and key not in attributes:
-                            attributes[key] = slab_attribute[key]
-                    stream = sweep.destination.open_data_stream(
-                        sweep.group,
-                        sweep.entry,
-                        [int(block.shape[0]), *spatial],
-                        block.dtype,
-                        attributes,
-                        region_shape=[int(block.shape[0]), rows, *spatial[1:]],
-                    )
+                    attributes = self._sweep_header(evolved, slab_attribute, keys_before)
+                    stream = self._open_sweep_stream(sweep, block, spatial, rows, attributes)
                     if stream is None:
                         return self._sweep_failed_because(
                             sweep,
@@ -2948,7 +2943,7 @@ class DatasetManager:
         keys_before = set(cache_attribute.keys())
 
         for stage, plan, source, target in zip(stages, plans, spans[:-1], spans[1:], strict=True):
-            if plan.kind not in _REGION_KINDS:
+            if not plan.kind.is_region:
                 # The span is handed over rather than dropped: a stage reading a second aligned
                 # volume needs to know WHICH part of it lines up with this region, and the
                 # dispatcher is the only thing that knows. The default hook ignores it.

--- a/konfai/data/reduction.py
+++ b/konfai/data/reduction.py
@@ -235,8 +235,7 @@ class Vote(Reduction):
     blends, and the result keeps the input's dtype.
 
     A tie goes to the SMALLEST label, so a cohort folds to the same volume on every run and on every
-    rank. That is arbitrary but it has to be *something*, and an arbitrary rule stated here beats a
-    stable-sort detail nobody can see.
+    rank.
 
     Not incremental: a majority needs every case before it can be counted.
     """

--- a/konfai/data/sampling.py
+++ b/konfai/data/sampling.py
@@ -114,6 +114,31 @@ def _kernel_weights(offset: torch.Tensor, order: int) -> torch.Tensor:
     raise ValueError(f"No B-spline kernel of order {order}: KonfAI evaluates {SUPPORTED_SPLINE_ORDERS}.")
 
 
+def _cubic_weights(offset: torch.Tensor) -> torch.Tensor:
+    """Keys' cubic convolution at a = -1/2 (Catmull-Rom): the interpolating cubic.
+
+    Four taps per axis, exact through the samples (weight 1 at distance 0, 0 at 1 and 2) and exact
+    on polynomials up to degree two, which is what the a = -1/2 choice buys. NOT the order-3
+    B-spline above: that one smooths unless its input is prefiltered coefficients, which a
+    displacement stage stores and an image does not. The weights go negative between 1 and 2:
+    that is what preserves an edge, and why a blend can overshoot the values it read.
+    """
+    distance = offset.abs()
+    near = 1.0 + distance * distance * (1.5 * distance - 2.5)
+    far = 2.0 - distance * (4.0 - distance * (2.5 - 0.5 * distance))
+    return torch.where(distance < 1.0, near, torch.where(distance < 2.0, far, torch.zeros_like(distance)))
+
+
+def _saturate_overshoot(blended: torch.Tensor, payload_dtype: torch.dtype) -> torch.Tensor:
+    """A cubic blend can overshoot the payload's range, and an integer cast WRAPS instead of
+    saturating: the bright rim a negative lobe builds beside an edge would come back as the
+    opposite extreme. Clamping to the dtype's range is the saturating cast ITK performs."""
+    if payload_dtype.is_floating_point:
+        return blended
+    info = torch.iinfo(payload_dtype)
+    return blended.clamp(float(info.min), float(info.max))
+
+
 def _apply(points_xyz: torch.Tensor, affine: AffineMap, device: torch.device) -> torch.Tensor:
     """``translation + Σ_j column_j · p_j``, accumulated in ``j`` order. ITK's own association.
 
@@ -365,6 +390,19 @@ def gather_separable(
         if mode == "nearest":
             out = out.index_select(array_axis + 1, local(nearest_index(axis), array_axis))
             continue
+        if mode == "cubic":
+            # The same axis-by-axis reduction as the blend below, four taps instead of two. The
+            # weights come from the GLOBAL coordinate, so a region sums the very numbers the whole
+            # volume sums.
+            base = torch.floor(axis) - 1.0
+            index = base.to(torch.long)
+            blended: torch.Tensor | None = None
+            for tap in range(4):
+                weight = broadcast(_cubic_weights(axis - (base + tap)).to(out.dtype), array_axis)
+                term = out.index_select(array_axis + 1, local(index + tap, array_axis)) * weight
+                blended = term if blended is None else blended + term
+            out = blended if blended is not None else out
+            continue
         # One axis at a time, not eight corners at once. The tensor product is the same sum, but
         # blending axis by axis reduces each extent before the next axis reads it: six gathers over
         # shrinking tensors instead of twenty-four over the largest one.
@@ -378,6 +416,8 @@ def gather_separable(
         out = torch.lerp(low, high, share)
     if mode == "nearest" and not out.is_floating_point():
         out = out.type(torch.float32)
+    if mode == "cubic":
+        out = _saturate_overshoot(out, source.dtype)
 
     if all(bool(mask.all()) for mask in inside_axes):
         # Nothing of this region falls outside the source, which is the ordinary case for a resample
@@ -447,6 +487,31 @@ def gather(
             flat = flat * window_zyx[array_axis] + local
         picked = work.reshape(int(work.shape[0]), -1).index_select(1, flat.reshape(-1)).reshape(out_shape)
         return picked.masked_fill(~inside.unsqueeze(0), fill).type(source.dtype)
+
+    if mode == "cubic":
+        # Keys' four taps per axis, corner by corner over a flat index: grid_sample has no cubic in
+        # 3-D, and the corner walk keeps the coordinates GLOBAL, so a streamed region and the whole
+        # volume agree exactly where the fused blend below pays ~1e-5 to normalisation.
+        base_xyz = torch.floor(coordinates_xyz) - 1.0
+        out = torch.zeros(out_shape, dtype=work.dtype, device=device)
+        for corner in itertools.product(range(4), repeat=rank):
+            weight = torch.ones(extent_zyx, dtype=_COORDINATE_DTYPE, device=device)
+            flat = torch.zeros(extent_zyx, dtype=torch.long, device=device)
+            for array_axis in range(rank):
+                axis = rank - 1 - array_axis
+                position = base_xyz[..., axis] + corner[axis]
+                weight = weight * _cubic_weights(coordinates_xyz[..., axis] - position)
+                local = window_index(
+                    position.to(torch.long),
+                    source_shape_zyx[array_axis],
+                    source_starts_zyx[array_axis],
+                    window_zyx[array_axis],
+                )
+                flat = flat * window_zyx[array_axis] + local
+            gathered = work.reshape(int(work.shape[0]), -1).index_select(1, flat.reshape(-1)).reshape(out_shape)
+            out = out + gathered * weight.to(work.dtype).unsqueeze(0)
+        out = _saturate_overshoot(out, source.dtype)
+        return out.masked_fill(~inside.unsqueeze(0), fill).type(source.dtype)
 
     # A BLEND goes through grid_sample, which is one fused kernel where the eight corners are eight
     # gathers over a flat index. `align_corners=False` IS ITK's domain: a sample is inside while

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -19,6 +19,7 @@
 import os
 import tempfile
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from enum import Enum
 from multiprocessing import current_process, get_context
@@ -99,6 +100,16 @@ class LocalityKind(Enum):
     WHOLE_VOLUME = "whole_volume"
 
     @property
+    def is_region(self) -> bool:
+        """Whether this kind is a region stage: its read is a remapped region of its source.
+
+        Region stages compose, so the streamed read and write dispatchers both carry any run of them
+        between their pointwise stages; the set must stay the same on both sides, or a kind added to
+        one would silently fall to the whole-volume path (write) or to a refusal (read) on the other.
+        """
+        return self in (LocalityKind.HALO, LocalityKind.ORIENTATION, LocalityKind.CROP, LocalityKind.REGRID)
+
+    @property
     def preserves_statistics(self) -> bool:
         """Whether this kind leaves every whole-volume statistic of its input untouched.
 
@@ -159,6 +170,16 @@ class PatchLocality:
         if self.preserves_statistics is not None:
             return self.preserves_statistics
         return self.kind.preserves_statistics
+
+
+def stat_seed_valid(upstream: Iterable[PatchLocality]) -> bool:
+    """Whether a ``GLOBAL_STAT`` stage's seed still describes its own input.
+
+    The seed is measured before the chain runs (on the stored volume, or on the fold a ``Reduce``
+    wrote), so it holds only while every stage between the measurement and the statistic leaves the
+    values untouched. Every planner that seeds a statistic must apply this one rule.
+    """
+    return all(locality.statistics_preserving for locality in upstream)
 
 
 class Transform(NeedDevice, ABC):
@@ -1061,8 +1082,8 @@ class _ReferenceGrid(_TargetGrid):
     ``Reduce``'s ``grid: strict`` something true to compare. That is the atlas-template build.
 
     THE REFERENCE IS AN IMAGE, NOT A LIST OF NUMBERS. A grid is fifteen numbers in two axis orders
-    at once, and transcribing them by hand is the mistake this file's history says is always made --
-    silently, because a transposed grid resamples perfectly well onto the wrong place. Naming an
+    at once, and transcribing them by hand is reliably wrong: silently, because a transposed grid
+    resamples perfectly well onto the wrong place. Naming an
     image cannot make it: the header IS the declaration. It is also what an atlas loop needs, where
     round N+1's reference is round N's own output.
 
@@ -2214,8 +2235,7 @@ class Save(Transform):
 
     ``downsample_method`` names how the coarse levels are derived, and its default is
     ``ITKWASM_BIN_SHRINK`` (block averaging), NOT ngff-zarr's own ``ITKWASM_GAUSSIAN``. Measured on a
-    real volume, the Gaussian holds a 0.9998 correlation while crushing peak intensity by 20 % --
-    exactly the shape of a difference that passes a sanity check and resurfaces months later.
+    real volume, the Gaussian holds a 0.9998 correlation while crushing peak intensity by 20 %.
     """
 
     def __init__(

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -1196,8 +1196,11 @@ class Resample(TransformInverse):
     **Which grid to write on**: at most one of:
 
     - nothing (the default): the case's own grid. The map moves the anatomy; the voxels stay put.
-    - ``spacing``: the same field of view at another density. A component left at ``0`` keeps its axis.
-    - ``shape``: the same field of view at a given count. A component left at ``0`` keeps its axis.
+    - ``spacing``: the same field of view at another density, in physical order ``(x, y, z)``. A
+      component left at ``0`` keeps its axis.
+    - ``shape``: the same field of view at a given count, in array order ``(Z, Y, X)``. A component
+      left at ``0`` keeps its axis. The two orders differ on purpose: a spacing is geometry, a
+      shape is an array extent, and each is written in its own convention.
     - ``reference``: the grid of a stored image, adopted whole: extent, spacing, origin, direction.
       ``'{case}'`` in the entry follows the case: each case adopts the grid of its OWN entry in
       ``reference_group``: ``reference: '{case}', reference_group: DVF`` lands every moved image
@@ -1217,6 +1220,12 @@ class Resample(TransformInverse):
     coordinate per target voxel and the source is read once, at the displaced point. Doing it as two
     stages resamples twice, and a volume interpolated twice has lost detail the second pass invented
     no more of, which is the whole reason an atlas's appearance is rebuilt from native volumes.
+
+    ``interpolation`` is ``nearest``, ``linear`` (the default; ``uint8`` defaults to ``nearest``) or
+    ``cubic``: Keys' cubic convolution (Catmull-Rom, a = -1/2), interpolating and patch-local (four
+    taps per axis, one extra voxel of streamed halo). It is NOT a prefiltered B-spline: scipy's
+    ``order=3`` (nnU-Net's resampling) runs a global prefilter this stage does not, so a spline-3
+    recipe is approximated, not reproduced.
 
     IT STREAMS, and what a region reads is known before a voxel of the SOURCE is touched. A rigid
     or affine map is an exact affine, so the source box of a target region is that region's box
@@ -1271,11 +1280,12 @@ class Resample(TransformInverse):
         inverse: bool = True,
     ) -> None:
         super().__init__(inverse)
-        if interpolation is not None and interpolation not in ("linear", "nearest"):
+        if interpolation is not None and interpolation not in ("linear", "nearest", "cubic"):
             raise TransformError(
                 f"'Resample' has an unknown interpolation '{interpolation}'.",
-                "Use 'linear' for an image or 'nearest' for a label map. Left unset, uint8 is taken"
-                " for a label map and everything else is interpolated.",
+                "Use 'linear' for an image, 'nearest' for a label map, or 'cubic' (Keys/Catmull-Rom)"
+                " for a sharper image blend. Left unset, uint8 is taken for a label map and"
+                " everything else is interpolated linearly.",
             )
         self.interpolation = interpolation
         self.fill_value = float(fill)
@@ -1625,7 +1635,9 @@ class Resample(TransformInverse):
     ) -> list[slice]:
         del source_spatial_shape, cache_attribute
         source, target = self._grids_of(name)
-        return list(source_window(target.sub_grid(tuple(target_slices)), source, self._pricing_bound(name)))
+        return list(
+            source_window(target.sub_grid(tuple(target_slices)), source, self._pricing_bound(name), self._tap_margin)
+        )
 
     @property
     def measures_at_run(self) -> bool:
@@ -1645,7 +1657,7 @@ class Resample(TransformInverse):
         del source_spatial_shape, cache_attribute
         source, target = self._grids_of(name)
         region = target.sub_grid(tuple(target_slices))
-        return list(source_window(region, source, bound_of(self._stages(name, region), source.rank)))
+        return list(source_window(region, source, bound_of(self._stages(name, region), source.rank), self._tap_margin))
 
     def stream_region(
         self, name: str, tensor: torch.Tensor, context: RegionContext, cache_attribute: Attribute
@@ -1688,15 +1700,19 @@ class Resample(TransformInverse):
         return gather(sub_tensor, coordinates, region_starts, shape, mode, self.fill_value)
 
     def _mode(self, tensor: torch.Tensor) -> str:
-        """``nearest`` or ``linear``: what a sampler asks before it blends anything.
+        """``nearest``, ``linear`` or ``cubic``: what a sampler asks before it blends anything.
 
         A dtype cannot settle this on its own: a CT is int16 and so is nothing else about it. The
         heuristic therefore claims ``uint8`` and nothing more, and ``interpolation`` answers for
         everything it cannot know. Getting it wrong is silent: two blended labels give a third
         that was in no input, in a volume that is still a label map.
         """
-        declared = self.interpolation or ("nearest" if tensor.dtype == torch.uint8 else "linear")
-        return "nearest" if declared == "nearest" else "linear"
+        return self.interpolation or ("nearest" if tensor.dtype == torch.uint8 else "linear")
+
+    @property
+    def _tap_margin(self) -> int:
+        """Cubic reads four taps per axis (floor-1 .. floor+2): one more voxel of window each way."""
+        return 2 if self.interpolation == "cubic" else 1
 
     def write_stream_cache_attribute(
         self, cache_attribute: Attribute, source_spatial_shape: list[int], name: str = ""
@@ -1928,7 +1944,7 @@ class Resample(TransformInverse):
         del name
         held, restored = self._inverse_grids(Attribute(cache_attribute), [int(e) for e in source_spatial_shape])
         identity = TransformBound.exact(AffineMap.identity(restored.rank))
-        return list(source_window(restored.sub_grid(tuple(target_slices)), held, identity))
+        return list(source_window(restored.sub_grid(tuple(target_slices)), held, identity, self._tap_margin))
 
     def _resample_between(
         self,

--- a/konfai/main.py
+++ b/konfai/main.py
@@ -19,9 +19,11 @@
 """Command-line entrypoints for KonfAI workflows, apps, and services."""
 
 import argparse
+import importlib
 import importlib.metadata
 import os
 import sys
+from typing import Any
 
 from konfai import cuda_visible_devices
 from konfai.utils.runtime import State
@@ -31,131 +33,77 @@ if _cwd not in sys.path:
     sys.path.insert(0, _cwd)
 
 
-def _run(parser: argparse.ArgumentParser) -> None:
-    """
-    Shared CLI builder and dispatcher for the main KonfAI training/inference commands.
+def _positive_int(value: str) -> int:
+    ivalue = int(value)
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError("CPU value must be > 0")
+    return ivalue
 
-    This function:
-    1) defines common arguments used by TRAIN / RESUME / PREDICTION / EVALUATION
-       (config file, overwrite, device selection, quiet, tensorboard): TRANSFORM
-       declares its own set, since it has no TOP-LEVEL model and so nothing to
-       write scalars about (a chain may still embed a `KonfAIInference` stage)
-    2) defines subcommands and their command-specific arguments
-    3) parses CLI args and dispatches to the correct implementation:
-       - `konfai.trainer.train` for TRAIN and RESUME
-       - `konfai.predictor.predict` for PREDICTION
-       - `konfai.evaluator.evaluate` for EVALUATION
-       - `konfai.transformer.transform` for TRANSFORM
 
-    Device selection
-    ----------------
-    GPU and CPU are mutually exclusive:
-    - `--gpu` accepts one or more GPU ids, constrained to available devices
-      returned by `cuda_visible_devices()`.
-    - `--cpu` accepts a strictly positive integer (number of workers).
-
-    Config handling
-    ---------------
-    If `--config` is omitted, the `config` key is removed from the argument dict,
-    so downstream functions can use their own default config filename.
-
-    Parameters
-    ----------
-    parser : argparse.ArgumentParser
-        The top-level parser created by the caller.
-    """
-
-    def add_common_args(parser: argparse.ArgumentParser):
-        parser.add_argument(
-            "-c",
-            "--config",
-            type=str,
-            default=None,
-            help="Path to the configuration file (YAML). "
-            "If omitted, a command-specific default is used: Config.yml, Prediction.yml, Evaluation.yml.",
-        )
-        parser.add_argument(
-            "-y",
-            "--overwrite",
-            action="store_true",
-            help="Overwrite existing outputs (checkpoints, logs, predictions) without prompting.",
-        )
-
-        device_group = parser.add_mutually_exclusive_group()
-        devices = cuda_visible_devices()
-        device_group.add_argument(
-            "--gpu",
-            type=int,
-            nargs="+",
-            choices=devices,
-            default=[],
-            help="GPU device ids to use, e.g. '0' or '0,1,2'. If omitted runs on CPU.",
-        )
-
-        def positive_int(value: str) -> int:
-            ivalue = int(value)
-            if ivalue <= 0:
-                raise argparse.ArgumentTypeError("CPU value must be > 0")
-            return ivalue
-
-        device_group.add_argument(
-            "--cpu",
-            type=positive_int,
-            default=None,
-            help="Run on CPU using N worker processes/cores. If omitted, uses GPU when available.",
-        )
-
-        parser.add_argument(
-            "-q", "--quiet", action="store_true", help="Suppress console output for a quieter execution"
-        )
-        parser.add_argument("-tb", "--tensorboard", action="store_true", help="Launch TensorBoard.")
-
-    subparsers = parser.add_subparsers(dest="command", required=True)
-
-    train_p = subparsers.add_parser(str(State.TRAIN), help="Train a model from scratch.")
-    add_common_args(train_p)
-    train_p.add_argument(
-        "--checkpoints-dir",
-        "--checkpoints_dir",
+def _add_common_args(parser: argparse.ArgumentParser) -> None:
+    """The arguments TRAIN / RESUME / PREDICTION / EVALUATION share; TRANSFORM declares its own set."""
+    parser.add_argument(
+        "-c",
+        "--config",
         type=str,
-        default="./Checkpoints/",
-        help="Directory where checkpoints are saved (default: ./Checkpoints/).",
+        default=None,
+        help="Path to the configuration file (YAML). "
+        "If omitted, a command-specific default is used: Config.yml, Prediction.yml, Evaluation.yml.",
+    )
+    parser.add_argument(
+        "-y",
+        "--overwrite",
+        action="store_true",
+        help="Overwrite existing outputs (checkpoints, logs, predictions) without prompting.",
+    )
+    device_group = parser.add_mutually_exclusive_group()
+    device_group.add_argument(
+        "--gpu",
+        type=int,
+        nargs="+",
+        choices=cuda_visible_devices(),
+        default=[],
+        help="GPU device ids to use, e.g. '0' or '0,1,2'. If omitted runs on CPU.",
+    )
+    device_group.add_argument(
+        "--cpu",
+        type=_positive_int,
+        default=None,
+        help="Run on CPU using N worker processes/cores. If omitted, uses GPU when available.",
+    )
+    parser.add_argument("-q", "--quiet", action="store_true", help="Suppress console output for a quieter execution")
+    parser.add_argument("-tb", "--tensorboard", action="store_true", help="Launch TensorBoard.")
+
+
+def _add_dir_argument(parser: argparse.ArgumentParser, name: str, help_text: str) -> None:
+    """A workspace-directory flag in the house style: ``--<name>-dir``/``--<name>_dir``, default ``./<Name>/``."""
+    default = f"./{name.capitalize()}/"
+    parser.add_argument(
+        f"--{name}-dir",
+        f"--{name}_dir",
+        type=str,
+        default=default,
+        help=f"{help_text} (default: {default}).",
     )
 
-    train_p.add_argument(
-        "--statistics-dir",
-        "--statistics_dir",
-        type=str,
-        default="./Statistics/",
-        help="Directory where training statistics/logs are saved (default: ./Statistics/).",
-    )
 
-    resume_p = subparsers.add_parser(str(State.RESUME), help="Resume training from existing checkpoints.")
-    add_common_args(resume_p)
-    resume_p.add_argument(
-        "--model",
-        type=str,
-        required=True,
-        help="Checkpoint path to resume from",
-    )
+def _add_train(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(str(State.TRAIN), help="Train a model from scratch.")
+    _add_common_args(parser)
+    _add_dir_argument(parser, "checkpoints", "Directory where checkpoints are saved")
+    _add_dir_argument(parser, "statistics", "Directory where training statistics/logs are saved")
 
-    resume_p.add_argument(
-        "-checkpoints-dir",
-        "-checkpoints_dir",
-        type=str,
-        default="./Checkpoints/",
-        help="Directory where checkpoints are saved (default: ./Checkpoints/)",
-    )
 
-    resume_p.add_argument(
-        "-statistics-dir",
-        "-statistics_dir",
-        type=str,
-        default="./Statistics/",
-        help="Directory where training statistics/logs are saved (default: ./Statistics/).",
-    )
-
-    resume_p.add_argument(
+def _add_resume(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(str(State.RESUME), help="Resume training from existing checkpoints.")
+    _add_common_args(parser)
+    parser.add_argument("--model", type=str, required=True, help="Checkpoint path to resume from")
+    _add_dir_argument(parser, "checkpoints", "Directory where checkpoints are saved")
+    _add_dir_argument(parser, "statistics", "Directory where training statistics/logs are saved")
+    # Up to 1.8 RESUME alone spelled these with a single dash; keep the old flags parsing, out of help.
+    parser.add_argument("-checkpoints-dir", "-checkpoints_dir", dest="checkpoints_dir", help=argparse.SUPPRESS)
+    parser.add_argument("-statistics-dir", "-statistics_dir", dest="statistics_dir", help=argparse.SUPPRESS)
+    parser.add_argument(
         "--lr",
         type=float,
         default=None,
@@ -163,10 +111,11 @@ def _run(parser: argparse.ArgumentParser) -> None:
         "resumed and the scheduler continues; if set, the learning rate restarts from this value.",
     )
 
-    predict_p = subparsers.add_parser(str(State.PREDICTION), help="Run inference using a trained model.")
-    add_common_args(predict_p)
 
-    predict_p.add_argument(
+def _add_predict(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(str(State.PREDICTION), help="Run inference using a trained model.")
+    _add_common_args(parser)
+    parser.add_argument(
         "--models",
         type=str,
         nargs="+",
@@ -174,151 +123,109 @@ def _run(parser: argparse.ArgumentParser) -> None:
         required=True,
         help="One or more checkpoint/model paths to resume from.",
     )
+    _add_dir_argument(parser, "predictions", "Directory where predictions are written")
 
-    predict_p.add_argument(
-        "--predictions-dir",
-        "--predictions_dir",
-        type=str,
-        default="./Predictions/",
-        help="Directory where predictions are written (default: ./Predictions/).",
-    )
 
-    eval_p = subparsers.add_parser(str(State.EVALUATION), help="Evaluate model.")
-    add_common_args(eval_p)
+def _add_evaluate(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(str(State.EVALUATION), help="Evaluate model.")
+    _add_common_args(parser)
+    _add_dir_argument(parser, "evaluations", "Directory where evaluation outputs are written")
 
-    eval_p.add_argument(
-        "--evaluations-dir",
-        "--evaluations_dir",
-        type=str,
-        default="./Evaluations/",
-        help="Directory where evaluation outputs are written (default: ./Evaluations/).",
-    )
 
-    devices_for_transform = cuda_visible_devices()
-    transform_p = subparsers.add_parser(str(State.TRANSFORM), help="Apply a transform chain to a dataset. No model.")
-    # Deliberately NOT add_common_args: -tb has no scalar to show, so refusing it here is a parse
+def _add_transform(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(str(State.TRANSFORM), help="Apply a transform chain to a dataset. No model.")
+    # Deliberately NOT _add_common_args: -tb has no scalar to show, so refusing it here is a parse
     # error, not a silent no-op. --gpu exists for one reason: a KonfAIInference stage runs a nested
     # inference that does use the device; plain read transforms stay on CPU either way.
-    transform_p.add_argument(
+    parser.add_argument(
         "-c",
         "--config",
         type=str,
         default=None,
         help="Path to the configuration file (YAML). If omitted, Transform.yml is used.",
     )
-    transform_p.add_argument(
+    parser.add_argument(
         "-y",
         "--overwrite",
         action="store_true",
         help="Rewrite outputs that already exist. Without it, a case whose output exists is skipped.",
     )
-
-    def positive_int_transform(value: str) -> int:
-        ivalue = int(value)
-        if ivalue <= 0:
-            raise argparse.ArgumentTypeError("CPU value must be > 0")
-        return ivalue
-
-    transform_device = transform_p.add_mutually_exclusive_group()
-    transform_device.add_argument(
+    device_group = parser.add_mutually_exclusive_group()
+    device_group.add_argument(
         "--gpu",
         type=int,
         nargs="+",
-        choices=devices_for_transform,
+        choices=cuda_visible_devices(),
         default=[],
         help="GPU device ids for chains that run a nested inference (KonfAIInference). "
         "Plain read transforms run on CPU regardless.",
     )
-    transform_device.add_argument(
+    device_group.add_argument(
         "--cpu",
-        type=positive_int_transform,
+        type=_positive_int,
         default=None,
         help="Shard the cases over N worker processes (default: 1).",
     )
-    transform_p.add_argument(
-        "-q", "--quiet", action="store_true", help="Suppress console output for a quieter execution"
-    )
-    transform_p.add_argument(
+    parser.add_argument("-q", "--quiet", action="store_true", help="Suppress console output for a quieter execution")
+    parser.add_argument(
         "--plan",
         action="store_true",
         help="Print the per-case streaming plan and exit without transforming. The plan probes each"
         " destination with a real region-write open (created then removed), so it reports the run's"
         " actual verdict, it touches the output directories even in plan mode.",
     )
-    transform_p.add_argument(
-        "--transforms-dir",
-        "--transforms_dir",
-        type=str,
-        default="./Transforms/",
-        help="Directory where run logs and the plan are written (default: ./Transforms/).",
-    )
+    _add_dir_argument(parser, "transforms", "Directory where run logs and the plan are written")
 
+
+# Command -> (implementation module, entrypoint, the kwarg the config path travels under).
+# Imports stay lazy and by name: the heavy modules load only for the command that runs.
+_COMMANDS: dict[str, tuple[str, str, str]] = {
+    str(State.TRAIN): ("konfai.trainer", "train", "config"),
+    str(State.RESUME): ("konfai.trainer", "train", "config"),
+    str(State.PREDICTION): ("konfai.predictor", "predict", "prediction_file"),
+    str(State.EVALUATION): ("konfai.evaluator", "evaluate", "evaluations_file"),
+    str(State.TRANSFORM): ("konfai.transformer", "transform", "transform_file"),
+}
+
+
+def _dispatch(parser: argparse.ArgumentParser, args: dict[str, Any]) -> None:
+    if args["command"] not in _COMMANDS:
+        # Exhaustive on purpose: a fallback would silently launch the trainer for any command it
+        # does not know: a new workflow would train a UNet instead of failing.
+        parser.error(f"Unknown command '{args['command']}'.")
+    module_name, function_name, config_key = _COMMANDS[args["command"]]
+    if args["config"] is None:
+        del args["config"]  # the entrypoint's own default config filename applies
+    elif config_key != "config":
+        args[config_key] = args.pop("config")
+    if args.pop("plan", False):
+        # --plan must SHORT-CIRCUIT here: the distributed wrapper filters kwargs by the entrypoint's
+        # signature, so a 'plan' passed through would be silently dropped and the run would proceed
+        # as if the flag had never been given.
+        function_name = "plan_transform"
+    entrypoint = getattr(importlib.import_module(module_name), function_name)
+    entrypoint(**args)
+
+
+def _run(parser: argparse.ArgumentParser) -> None:
+    """Declare the five workflow subcommands on ``parser``, then parse and dispatch."""
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    _add_train(subparsers)
+    _add_resume(subparsers)
+    _add_predict(subparsers)
+    _add_evaluate(subparsers)
+    _add_transform(subparsers)
     parser.add_argument(
         "--version",
         action="version",
         version=importlib.metadata.version("konfai"),
         help="Print KonfAI version and exit.",
     )
-
-    args = vars(parser.parse_args())
-
-    if args["command"] == str(State.PREDICTION):
-        from konfai.predictor import predict
-
-        if args["config"] is not None:
-            args["prediction_file"] = args.pop("config")
-        predict(**args)
-    elif args["command"] == str(State.EVALUATION):
-        from konfai.evaluator import evaluate
-
-        if args["config"] is not None:
-            args["evaluations_file"] = args.pop("config")
-
-        evaluate(**args)
-    elif args["command"] == str(State.TRANSFORM):
-        from konfai.transformer import plan_transform, transform
-
-        if args["config"] is not None:
-            args["transform_file"] = args.pop("config")
-        # --plan must SHORT-CIRCUIT here: the distributed wrapper filters kwargs by the entrypoint's
-        # signature, so passing 'plan' through would be dropped and the run would proceed as if the
-        # flag had never been given.
-        if args.pop("plan", False):
-            plan_transform(**args)
-        else:
-            transform(**args)
-    elif args["command"] in (str(State.TRAIN), str(State.RESUME)):
-        from konfai.trainer import train
-
-        if args["config"] is None:
-            del args["config"]
-        train(**args)
-    else:
-        # Exhaustive on purpose: a catch-all else would silently launch the trainer for any command
-        # it does not know: a new workflow would train a UNet instead of failing.
-        parser.error(f"Unknown command '{args['command']}'.")
+    _dispatch(parser, vars(parser.parse_args()))
 
 
 def main():
-    """
-    Entry point for the ``konfai`` command-line interface.
-
-    This function builds the top-level CLI parser and delegates the full argument
-    parsing and command dispatching to `_run(parser)`.
-
-    Supported commands are:
-    - TRAIN
-    - RESUME
-    - PREDICTION
-    - EVALUATION
-    - TRANSFORM
-
-    Notes
-    -----
-    The actual execution logic is implemented in `konfai.trainer.train`,
-    `konfai.predictor.predict`, `konfai.evaluator.evaluate`, and
-    `konfai.transformer.transform`: the one command with no top-level model.
-    """
+    """Entry point for the ``konfai`` command-line interface."""
     parser = argparse.ArgumentParser(
         prog="konfAI", description="KonfAI - Deep learning framework for Medical AI Models", allow_abbrev=False
     )
@@ -326,23 +233,10 @@ def main():
 
 
 def cluster():
-    """
-    Entry point for running KonfAI with cluster-oriented CLI arguments.
-
-    This command extends the standard KonfAI CLI with a "Cluster manager arguments"
-    group (job name, nodes, memory, time limit, resubmit), then delegates parsing
-    and command dispatching to `_run(parser)`.
-
-    Notes
-    -----
-    - This function only defines extra CLI arguments before delegating to
-      ``_run``.
-    """
+    """Entry point for the ``konfai-cluster`` CLI: the standard commands plus SLURM job arguments."""
     parser = argparse.ArgumentParser(
         prog="konfAI", description="KonfAI - Deep learning framework for Medical AI Models", allow_abbrev=False
     )
-
-    # Cluster manager arguments
     cluster_args = parser.add_argument_group("Cluster manager arguments")
     cluster_args.add_argument("--name", type=str, help="Task name", required=True)
     cluster_args.add_argument("--num-nodes", "--num_nodes", default=1, type=int, help="Number of nodes")

--- a/konfai/main.py
+++ b/konfai/main.py
@@ -63,7 +63,7 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
         nargs="+",
         choices=cuda_visible_devices(),
         default=[],
-        help="GPU device ids to use, e.g. '0' or '0,1,2'. If omitted runs on CPU.",
+        help="GPU device ids to use, space separated: --gpu 0, or --gpu 0 1 2. If omitted runs on CPU.",
     )
     device_group.add_argument(
         "--cpu",

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Prediction workflow classes, reductions, and export helpers for KonfAI."""
+"""Prediction workflow classes and the streamed-write dispatcher."""
 
 import copy
 import importlib
@@ -305,11 +305,9 @@ class OutputDataset(Dataset, NeedDevice, ABC):
                     )
                     transform_type.append(transform)
 
-        # A patch grid overlaps whether or not a combine is declared, and an undeclared one used to
-        # leave the overlap to whichever patch wrote last: an arbitrary winner, possibly holding that
-        # voxel on its own border with no context behind it, which is what a seam is. Trim keeps each
-        # patch's central band instead: the bands tile the volume exactly, so the default is a seamless
-        # selection that still never averages (a label map survives it).
+        # A patch grid overlaps whether or not a combine is declared, so the overlap needs a
+        # deterministic owner. Trim keeps each patch's central band: the bands tile the volume
+        # exactly, a seamless selection that never averages (a label map survives it).
         module, name = get_module(self._patch_combine or "Trim", "konfai.data.patching")
         self.patch_combine = apply_config(f"{konfai_root()}.outputs_dataset.{name_layer}.OutputDataset")(
             getattr(module, name)
@@ -428,10 +426,6 @@ class OutputDataset(Dataset, NeedDevice, ABC):
     def __repr__(self) -> str:
         return str(self)
 
-
-# The write-side region kinds: what SlabRegionStream can carry inside a streamed finalize chain (the
-# same set the read dispatcher accepts as its region stages; on both sides they compose).
-_REGION_KINDS = (LocalityKind.HALO, LocalityKind.ORIENTATION, LocalityKind.CROP, LocalityKind.REGRID)
 
 # Streaming pays per-slab work (the pipe traversal, region writes, the TTA aligner); when the
 # assembled accumulators of all copies are below this fraction of allocatable memory (a 2.5D case),
@@ -567,62 +561,9 @@ class OutSameAsGroupDataset(OutputDataset):
         attribute: Attribute | None = None,
         number_of_channels_per_model: list[int] | None = None,
     ):
-        if (
-            index_dataset not in self.output_layer_accumulator
-            or index_augmentation not in self.output_layer_accumulator[index_dataset]
-        ):
-            input_dataset = dataset.get_dataset_from_index(self.group_dest, index_dataset)
-            source_attribute = (
-                Attribute(attribute) if attribute is not None else Attribute(input_dataset.cache_attributes[0])
-            )
-            # What the output declares about itself, applied over what it inherited from its input.
-            # Inheritance carries the geometry, which is right, but it also carries whatever the source
-            # entry said it WAS, and that describes the source, not this. Declared last, so the
-            # config always wins; declare a key empty to drop an inherited one.
-            for key, value in self._attributes.items():
-                if value == "":
-                    source_attribute.pop(key, None)
-                else:
-                    source_attribute[key] = value
-            if index_dataset not in self.output_layer_accumulator:
-                self.output_layer_accumulator[index_dataset] = {}
-                self.attributes[index_dataset] = {}
-                self.names[index_dataset] = input_dataset.name
-                # The streamed consumers (sink target, region pipe, buffer) index their slabs on the
-                # first spatial axis, and the aligner needs every augmentation on the same footing:
-                # a grid swept along another axis takes the whole-volume path until they carry the
-                # axis too.
-                # max(1, ...): the count is set by load(); before it, augmentation 0 always exists.
-                sweeps_first_axis = all(
-                    input_dataset.patch.get_sweep_axis(a) == 0 for a in range(max(1, self.nb_data_augmentation))
-                )
-                plan = (
-                    self._plan_stream(dataset, index_dataset, source_attribute, layer, number_of_channels_per_model)
-                    if self._streaming_enabled and sweeps_first_axis
-                    else None
-                )
-                self._stream_plans[index_dataset] = plan
-                if self._streaming_enabled and (plan is None or not plan.to_sink):
-                    # The whole-volume fallback is a normal outcome, but a silent one hides that a
-                    # large case pays it: say so, once per distinct path.
-                    path = (
-                        "whole-volume" if plan is None else "buffered (the prefix streams, the tail runs whole-volume)"
-                    )
-                    self._report_once(path, f"streaming: case '{input_dataset.name}' takes the {path} path.")
-            self.attributes[index_dataset][index_augmentation] = {}
-
-            accumulator_type = StreamingAccumulator if self._stream_plans[index_dataset] else Accumulator
-            self.output_layer_accumulator[index_dataset][index_augmentation] = accumulator_type(
-                input_dataset.patch.get_patch_slices(index_augmentation),
-                input_dataset.patch.patch_size,
-                self.patch_combine,
-                batch=False,
-                sweep_axis=input_dataset.patch.get_sweep_axis(index_augmentation),
-            )
-
-            for i in range(len(input_dataset.patch.get_patch_slices(index_augmentation))):
-                self.attributes[index_dataset][index_augmentation][i] = Attribute(source_attribute)
-
+        self._ensure_case_state(
+            index_dataset, index_augmentation, layer, dataset, attribute, number_of_channels_per_model
+        )
         for transform in reversed(dataset.groups_src[self.group_src][self.group_dest].patch_transforms):
             if isinstance(transform, TransformInverse) and transform.apply_inverse:
                 layer = transform.inverse(
@@ -631,6 +572,83 @@ class OutSameAsGroupDataset(OutputDataset):
                     self.attributes[index_dataset][index_augmentation][index_patch],
                 )
         accumulator = self.output_layer_accumulator[index_dataset][index_augmentation]
+        slabs = self._blend_patch(index_dataset, index_patch, layer, accumulator)
+        if not self._stream_plans.get(index_dataset):
+            return
+        self._advance_stream(
+            index_dataset, index_augmentation, accumulator, slabs, number_of_channels_per_model, dataset
+        )
+
+    def _ensure_case_state(
+        self,
+        index_dataset: int,
+        index_augmentation: int,
+        layer: torch.Tensor,
+        dataset: DatasetIter,
+        attribute: Attribute | None,
+        number_of_channels_per_model: list[int] | None,
+    ) -> None:
+        """First patch of a (case, augmentation): build the inherited-then-declared header, decide
+        the stream plan once per case, and open this augmentation's accumulator."""
+        if (
+            index_dataset in self.output_layer_accumulator
+            and index_augmentation in self.output_layer_accumulator[index_dataset]
+        ):
+            return
+        input_dataset = dataset.get_dataset_from_index(self.group_dest, index_dataset)
+        source_attribute = (
+            Attribute(attribute) if attribute is not None else Attribute(input_dataset.cache_attributes[0])
+        )
+        # What the output declares about itself, applied over what it inherited from its input.
+        # Inheritance carries the geometry, which is right, but it also carries whatever the source
+        # entry said it WAS, and that describes the source, not this. Declared last, so the
+        # config always wins; declare a key empty to drop an inherited one.
+        for key, value in self._attributes.items():
+            if value == "":
+                source_attribute.pop(key, None)
+            else:
+                source_attribute[key] = value
+        if index_dataset not in self.output_layer_accumulator:
+            self.output_layer_accumulator[index_dataset] = {}
+            self.attributes[index_dataset] = {}
+            self.names[index_dataset] = input_dataset.name
+            # The streamed consumers (sink target, region pipe, buffer) index their slabs on the
+            # first spatial axis, and the aligner needs every augmentation on the same footing:
+            # a grid swept along another axis takes the whole-volume path until they carry the
+            # axis too.
+            # max(1, ...): the count is set by load(); before it, augmentation 0 always exists.
+            sweeps_first_axis = all(
+                input_dataset.patch.get_sweep_axis(a) == 0 for a in range(max(1, self.nb_data_augmentation))
+            )
+            plan = (
+                self._plan_stream(dataset, index_dataset, source_attribute, layer, number_of_channels_per_model)
+                if self._streaming_enabled and sweeps_first_axis
+                else None
+            )
+            self._stream_plans[index_dataset] = plan
+            if self._streaming_enabled and (plan is None or not plan.to_sink):
+                # The whole-volume fallback is a normal outcome, but a silent one hides that a
+                # large case pays it: say so, once per distinct path.
+                path = "whole-volume" if plan is None else "buffered (the prefix streams, the tail runs whole-volume)"
+                self._report_once(path, f"streaming: case '{input_dataset.name}' takes the {path} path.")
+        self.attributes[index_dataset][index_augmentation] = {}
+
+        accumulator_type = StreamingAccumulator if self._stream_plans[index_dataset] else Accumulator
+        self.output_layer_accumulator[index_dataset][index_augmentation] = accumulator_type(
+            input_dataset.patch.get_patch_slices(index_augmentation),
+            input_dataset.patch.patch_size,
+            self.patch_combine,
+            batch=False,
+            sweep_axis=input_dataset.patch.get_sweep_axis(index_augmentation),
+        )
+
+        for i in range(len(input_dataset.patch.get_patch_slices(index_augmentation))):
+            self.attributes[index_dataset][index_augmentation][i] = Attribute(source_attribute)
+
+    def _blend_patch(
+        self, index_dataset: int, index_patch: int, layer: torch.Tensor, accumulator: Accumulator
+    ) -> list[tuple[slice, torch.Tensor]]:
+        """Blend one patch on the case's accumulate device and return the slabs it released."""
         if index_dataset not in self._accum_device:
             self._accum_device[index_dataset] = self._accumulate_device(layer, accumulator)
             if layer.device.type != "cpu" and self._accum_device[index_dataset].type == "cpu":
@@ -647,7 +665,7 @@ class OutSameAsGroupDataset(OutputDataset):
         elif str(layer.device) != str(target):
             layer = layer.to(target)
         try:
-            slabs = accumulator.add_layer(index_patch, layer) or []
+            return accumulator.add_layer(index_patch, layer) or []
         except torch.cuda.OutOfMemoryError:
             # The gate samples free VRAM once per case: another process can reclaim it before this
             # volume-sized first allocation lands. Nothing is blended yet, so fall back to the
@@ -657,9 +675,19 @@ class OutSameAsGroupDataset(OutputDataset):
                 raise
             self._accum_device[index_dataset] = torch.device("cpu")
             torch.cuda.empty_cache()
-            slabs = accumulator.add_layer(index_patch, self._offload_to_cpu(layer)) or []
-        if not self._stream_plans.get(index_dataset):
-            return
+            return accumulator.add_layer(index_patch, self._offload_to_cpu(layer)) or []
+
+    def _advance_stream(
+        self,
+        index_dataset: int,
+        index_augmentation: int,
+        accumulator: Accumulator,
+        slabs: list[tuple[slice, torch.Tensor]],
+        number_of_channels_per_model: list[int] | None,
+        dataset: DatasetIter,
+    ) -> None:
+        """Push the released slabs through the aligner and the finalize chain; on any error, abort
+        the sink and every slab stage before re-raising."""
         copy_finished = accumulator.is_full()
         if copy_finished:
             slabs = slabs + cast(StreamingAccumulator, accumulator).finalize()
@@ -791,7 +819,7 @@ class OutSameAsGroupDataset(OutputDataset):
                 # classic behaviour).
                 slab_stages.add(position)
                 continue
-            if locality.kind in _REGION_KINDS:
+            if locality.kind.is_region:
                 if pipe_start is None:
                     pipe_start = position
                 continue
@@ -979,7 +1007,7 @@ class OutSameAsGroupDataset(OutputDataset):
                         out = transform.transform_shape(self.group_src, name, list(shape), Attribute(walking))
                         transform.write_stream_cache_attribute(walking, shape, name)
                     shapes.append([int(extent) for extent in out])
-                elif locality.kind in _REGION_KINDS:
+                elif locality.kind.is_region:
                     if stage.inverted:
                         remapper = cast(TransformInverse, stage.transform)
                         pull_fns.append(_RemapPull(remapper.stream_region_target, shape, snapshot, name))

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -629,85 +629,79 @@ class _Trainer:
                 else len(self.dataloader_validation)
             ),
         )
+        # get_measure gathers across ranks, so every rank calls it; only rank 0 writes and reports.
+        if self.global_rank != 0:
+            return None
 
-        if self.global_rank == 0:
-            images_log = []
-            if len(self.data_log):
-                for name, data_type in self.data_log.items():
-                    if name in batch_sample:
-                        data_type[0](
-                            self.tb,
-                            f"{type_log}/{name}",
-                            batch_sample[name].tensor[: self.data_log[name][1]].detach().cpu().numpy(),
-                            self.it,
-                        )
-                    else:
-                        images_log.append(name.replace(":", "."))
+        images_log = []
+        if len(self.data_log):
+            for name, data_type in self.data_log.items():
+                if name in batch_sample:
+                    data_type[0](
+                        self.tb,
+                        f"{type_log}/{name}",
+                        batch_sample[name].tensor[: self.data_log[name][1]].detach().cpu().numpy(),
+                        self.it,
+                    )
+                else:
+                    images_log.append(name.replace(":", "."))
 
-            for label, model in models.items():
-                for name, network in model.get_networks().items():
-                    if network.measure is not None:
-                        self.tb.add_scalars(
-                            f"{type_log}/{name}/Loss/{label}",
-                            {k.replace(":", "."): v[1] for k, v in measures[f"{name}{label}"][0].items()},
-                            self.it,
-                        )
-                        self.tb.add_scalars(
-                            f"{type_log}/{name}/Loss_weight/{label}",
-                            {k.replace(":", "."): v[0] for k, v in measures[f"{name}{label}"][0].items()},
-                            self.it,
-                        )
+        for label, model in models.items():
+            for name, network in model.get_networks().items():
+                if network.measure is None:
+                    continue
+                # Losses and metrics take the same pair of boards: the measured value, and the
+                # weight that scaled it into the total.
+                for board, table in (("Loss", 0), ("Metric", 1)):
+                    entries = measures[f"{name}{label}"][table]
+                    self.tb.add_scalars(
+                        f"{type_log}/{name}/{board}/{label}",
+                        {k.replace(":", "."): v[1] for k, v in entries.items()},
+                        self.it,
+                    )
+                    self.tb.add_scalars(
+                        f"{type_log}/{name}/{board}_weight/{label}",
+                        {k.replace(":", "."): v[0] for k, v in entries.items()},
+                        self.it,
+                    )
 
-                        self.tb.add_scalars(
-                            f"{type_log}/{name}/Metric/{label}",
-                            {k.replace(":", "."): v[1] for k, v in measures[f"{name}{label}"][1].items()},
-                            self.it,
-                        )
-                        self.tb.add_scalars(
-                            f"{type_log}/{name}/Metric_weight/{label}",
-                            {k.replace(":", "."): v[0] for k, v in measures[f"{name}{label}"][1].items()},
-                            self.it,
-                        )
+            if len(images_log):
+                # get_layers is model-scoped, not per-network: run it once per model, or a
+                # multi-network model (a GAN's generator + discriminator) repeats the forward
+                # extraction and writes each image event once per network.
+                for name, layer, _ in model.get_layers(
+                    [v.tensor for v in batch_sample.values() if v.is_input],
+                    images_log,
+                ):
+                    self.data_log[name][0](
+                        self.tb,
+                        f"{type_log}/{name}{label}",
+                        layer[: self.data_log[name][1]].detach().cpu().numpy(),
+                        self.it,
+                    )
 
-                if len(images_log):
-                    # get_layers is model-scoped, not per-network: run it once per model, or a
-                    # multi-network model (a GAN's generator + discriminator) repeats the forward
-                    # extraction and writes each image event once per network.
-                    for name, layer, _ in model.get_layers(
-                        [v.tensor for v in batch_sample.values() if v.is_input],
-                        images_log,
-                    ):
-                        self.data_log[name][0](
-                            self.tb,
-                            f"{type_log}/{name}{label}",
-                            layer[: self.data_log[name][1]].detach().cpu().numpy(),
-                            self.it,
-                        )
-
-            if type_log == "Training":
-                for name, network in self.model.module.get_networks().items():
-                    if network.optimizer is not None:
-                        self.tb.add_scalar(
-                            f"{type_log}/{name}/Learning Rate",
-                            network.optimizer.param_groups[0]["lr"],
-                            self.it,
-                        )
-
-        if self.global_rank == 0:
-            loss = {}
-            loss_keys: set[str] = set()
+        if type_log == "Training":
             for name, network in self.model.module.get_networks().items():
-                if network.measure is not None:
-                    losses = {k: v[1] for k, v in measures[name][0].items()}
-                    loss_keys.update(losses)
-                    loss.update(losses)
-                    loss.update({k: v[1] for k, v in measures[name][1].items()})
-            # Remember which keys are losses (always minimise) vs metrics (direction varies), so
-            # default checkpoint/early-stop selection scores on the losses only: summing a
-            # maximise-metric (e.g. Dice) into a minimised score would keep the worst model.
-            self._loss_keys = loss_keys
-            return loss
-        return None
+                if network.optimizer is not None:
+                    self.tb.add_scalar(
+                        f"{type_log}/{name}/Learning Rate",
+                        network.optimizer.param_groups[0]["lr"],
+                        self.it,
+                    )
+
+        loss = {}
+        loss_keys: set[str] = set()
+        for name, network in self.model.module.get_networks().items():
+            if network.measure is not None:
+                losses = {k: v[1] for k, v in measures[name][0].items()}
+                loss_keys.update(losses)
+                loss.update(losses)
+                loss.update({k: v[1] for k, v in measures[name][1].items()})
+        # Remember which keys are losses (always minimise) vs metrics (direction varies), so
+        # default checkpoint/early-stop selection scores on the losses only: summing a
+        # maximise-metric (e.g. Dice) into a minimised score would keep the worst model.
+        self._loss_keys = loss_keys
+        return loss
 
     @torch.no_grad()
     def _train_log(self, batch_sample: BatchSample) -> dict[str, float]:

--- a/konfai/transformer.py
+++ b/konfai/transformer.py
@@ -30,7 +30,9 @@ import json
 import os
 import shutil
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
+from functools import partial
 from pathlib import Path
 from typing import Literal, cast
 
@@ -465,6 +467,40 @@ class Transformer(DistributedObject):
             self._sub_cap_sweeps = True
         return "STREAM", None
 
+    def _entry_verdict(
+        self,
+        manager: DatasetManager,
+        destination: Dataset,
+        group: str,
+        entry_name: str,
+        copy_index: int,
+        overwrite: bool,
+        probed: set[tuple[str, str]],
+        route: Callable[[], tuple[str, str | None]] | None = None,
+    ) -> tuple[str, str | None]:
+        """The SKIP -> streamable -> WHOLE-VOLUME cascade every planned output entry goes through.
+
+        An existing output is a resume (SKIP); a chain the patch planner accepts is priced by
+        ``route`` once its destinations survive the write probe; everything else falls to the
+        whole-volume pass, with the refusal spelled out. Only a plain case passes a ``route``
+        (STREAM or LOAD, :meth:`_route`): an Expand copy (``copy_index > 0``) passes none and is
+        always STREAM, because its copies share one read pass, which amortizes the very re-reads a
+        per-copy load would multiply. A copy's reason doubles as the solo/shared regime.
+        """
+        # Copies exist to carry augmentation draws: a real copy index asks the chain with them applied.
+        augmented = copy_index > 0
+        if not overwrite and destination.is_dataset_exist(group, entry_name):
+            return "SKIP", None
+        if not manager.can_stream_patch(copy_index, apply_augmentations=augmented):
+            return "WHOLE-VOLUME", manager.stream_refusal(copy_index, apply_augmentations=augmented)
+        probe_failure = self._probe_write_destinations(manager, probed, copy_index)
+        if probe_failure is not None:
+            # The run would fail the sweep at its first slab and fall back: say so now.
+            return "WHOLE-VOLUME", probe_failure
+        if route is not None:
+            return route()
+        return "STREAM", manager.expansion_solo_reason(copy_index)
+
     def compute_plan(self, world_size: int = 1, overwrite: bool = False) -> TransformPlan:
         """Plan every (case, chain) on the launcher, headers plus one write probe per destination."""
         budget = self.dataset.resolved_budget()
@@ -542,19 +578,10 @@ class Transformer(DistributedObject):
                     # own verdict, and, for STREAM: the regime that says who pays the reads.
                     for a in range(1, expansion.nb + 1):
                         entry_name = manager.copy_entry(a)
-                        regime: str | None = None
-                        if not overwrite and destination.is_dataset_exist(group, entry_name):
-                            verdict, reason = "SKIP", None
-                        elif manager.can_stream_patch(a, apply_augmentations=True):
-                            probe_failure = self._probe_write_destinations(manager, probed, a)
-                            if probe_failure is None:
-                                verdict, reason = "STREAM", manager.expansion_solo_reason(a)
-                                regime = "solo" if reason else "shared"
-                            else:
-                                verdict, reason = "WHOLE-VOLUME", probe_failure
-                        else:
-                            verdict = "WHOLE-VOLUME"
-                            reason = manager.stream_refusal(a, apply_augmentations=True)
+                        verdict, reason = self._entry_verdict(
+                            manager, destination, group, entry_name, a, overwrite, probed
+                        )
+                        regime = ("solo" if reason else "shared") if verdict == "STREAM" else None
                         entries.append(
                             TransformPlanEntry(
                                 entry_name,
@@ -568,18 +595,16 @@ class Transformer(DistributedObject):
                             )
                         )
                     continue
-                if not overwrite and destination.is_dataset_exist(group, manager.name):
-                    verdict, reason = "SKIP", None
-                elif manager.can_stream_patch(0, apply_augmentations=False):
-                    probe_failure = self._probe_write_destinations(manager, probed)
-                    if probe_failure is None:
-                        verdict, reason = self._route(manager, case_bytes, per_rank_budget)
-                    else:
-                        # The run would fail the sweep at its first slab and fall back: say so now.
-                        verdict, reason = "WHOLE-VOLUME", probe_failure
-                else:
-                    verdict = "WHOLE-VOLUME"
-                    reason = manager.stream_refusal(0, apply_augmentations=False)
+                verdict, reason = self._entry_verdict(
+                    manager,
+                    destination,
+                    group,
+                    manager.name,
+                    0,
+                    overwrite,
+                    probed,
+                    route=partial(self._route, manager, case_bytes, per_rank_budget),
+                )
                 entries.append(TransformPlanEntry(manager.name, group_src, group_dest, verdict, reason, case_bytes))
         dropped: dict[str, int] = {}
         kept = set(self.dataset._prepared_train_names)
@@ -654,36 +679,52 @@ class Transformer(DistributedObject):
 
         self._overwrite = os.environ.get("KONFAI_OVERWRITE", "False") == "True"
         plan = self.compute_plan(world_size, self._overwrite)
-        report = plan.report()
         print(plan.report(verbose=False))
         # The plan is an artifact, not a log line: Studio filters routine startup lines from the
         # console stream, and a plan that only ever existed as one is a plan nobody can re-read.
-        (self.transform_path / "plan.txt").write_text(report + "\n")
+        (self.transform_path / "plan.txt").write_text(plan.report() + "\n")
         # Where the data went, machine-readable beside the human-readable plan. This run directory
         # holds a log, a plan and a config copy, never the deliverable, which lands wherever each
         # Write pointed. Without this, the one thing a reader wants after the run is the one thing
         # nothing in the run directory names.
         (self.transform_path / "outputs.json").write_text(json.dumps(self.output_destinations(), indent=2) + "\n")
 
-        if world_size > 1:
-            for managers in self._managers().values():
-                for transform in managers[0].transforms if managers else []:
-                    if not isinstance(transform, Save):
-                        continue
-                    destination, _group = save_destination(transform, managers[0].dataset, managers[0].group_dest)
-                    # The question here is NOT concurrent_write_safe(): that one asks whether two
-                    # entries of one shared store may be written at once, and answers no for
-                    # omezarr, which would refuse the very destination this workflow recommends. Ranks
-                    # shard by CASE, and a directory dataset gives each case its own file or store
-                    # (<root>/<case>/<group>.<ext>), so their writes are disjoint by construction.
-                    # Only a single-file store (h5) puts every case in one handle.
-                    if not destination.is_directory:
-                        raise TransformerError(
-                            f"--cpu {world_size}: destination '{destination.filename}' is a"
-                            " single-file store, and every rank would write into the same file.",
-                            "Use one process, or a directory destination (omezarr, mha, nii.gz).",
-                        )
+        self._guard_sharded_destinations(world_size)
+        self._enforce_plan(plan)
 
+        self._budget_bytes = plan.budget_bytes
+        # The run executes the route the plan priced (LOAD assembles by choice, not fallback), and
+        # the console only speaks when the run DEVIATES from what the plan already printed.
+        self._planned = {(entry.group_dest, entry.case): entry.verdict for entry in plan.entries}
+        self._case_names = list(self.dataset._prepared_train_names)
+        self._shard_work(world_size)
+
+    def _guard_sharded_destinations(self, world_size: int) -> None:
+        """Multi-rank runs refuse a single-file Save destination before anything is written."""
+        if world_size <= 1:
+            return
+        for managers in self._managers().values():
+            for transform in managers[0].transforms if managers else []:
+                if not isinstance(transform, Save):
+                    continue
+                destination, _group = save_destination(transform, managers[0].dataset, managers[0].group_dest)
+                # The question here is NOT concurrent_write_safe(): that one asks whether two
+                # entries of one shared store may be written at once, and answers no for
+                # omezarr, which would refuse the very destination this workflow recommends. Ranks
+                # shard by CASE, and a directory dataset gives each case its own file or store
+                # (<root>/<case>/<group>.<ext>), so their writes are disjoint by construction.
+                # Only a single-file store (h5) puts every case in one handle.
+                if not destination.is_directory:
+                    raise TransformerError(
+                        f"--cpu {world_size}: destination '{destination.filename}' is a"
+                        " single-file store, and every rank would write into the same file.",
+                        "Use one process, or a directory destination (omezarr, mha, nii.gz).",
+                    )
+
+    def _enforce_plan(self, plan: TransformPlan) -> None:
+        """The refusals the plan's verdicts imply, raised before any byte moves: an output over the
+        budget, a whole-volume fallback under ``on_fallback: error``, a reduction that cannot
+        stream. Nothing here recomputes a verdict; it only speaks for the plan."""
         violations = plan.budget_violations()
         if violations:
             worst = max(violations, key=lambda entry: entry.working_set_bytes)
@@ -740,13 +781,12 @@ class Transformer(DistributedObject):
                 " path (reasons above). They fit the budget; set on_fallback: error to refuse them."
             )
 
-        self._budget_bytes = plan.budget_bytes
-        # The run executes the route the plan priced (LOAD assembles by choice, not fallback), and
-        # the console only speaks when the run DEVIATES from what the plan already printed.
-        self._planned = {(entry.group_dest, entry.case): entry.verdict for entry in plan.entries}
-        self._case_names = list(self.dataset._prepared_train_names)
-        # Work items, not cases: an ordinary chain has one per case, a reduction exactly one for all
-        # of them. Each item still writes its own entry, so the disjoint-writes guard above holds.
+    def _shard_work(self, world_size: int) -> None:
+        """Split the run into per-rank shards of work items.
+
+        Work items, not cases: an ordinary chain has one per case, a reduction exactly one for all
+        of them. Each item still writes its own entry, so the disjoint-writes guard of
+        :meth:`_guard_sharded_destinations` holds."""
         items: list[tuple[str, int]] = []
         for group_dest, managers in self._managers().items():
             if self._reduction(group_dest, managers) is not None:

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -33,8 +33,9 @@ import threading
 import time
 import warnings
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, NamedTuple, cast
+from typing import Any, NamedTuple, TypeVar, cast
 
 import numpy as np
 import torch
@@ -983,6 +984,9 @@ class _OmeZarrDataStream(DataStream):
         clear_ome_zarr_cache()
 
 
+_T = TypeVar("_T")
+
+
 class Dataset:
     """Filesystem or HDF5-backed dataset abstraction used across KonfAI."""
 
@@ -1901,6 +1905,10 @@ class Dataset:
             attributes["Direction"] = direction
             return data, attributes
 
+        def bounded_region_reads(self, name: str) -> bool:
+            del name
+            return True  # one file per slice: a region decodes the slices it covers and nothing else
+
         def file_to_data_slice(self, group: str, name: str, slices: tuple[slice, ...]) -> tuple[np.ndarray, Attribute]:
             from konfai.utils.dicom import get_dicom_info, read_dicom_series_slice
 
@@ -2379,45 +2387,42 @@ class Dataset:
         stream._file = file
         return stream
 
-    def read_data(self, groups: str, name: str) -> tuple[np.ndarray, Attribute]:
+    def _case_path(self, sub_directory: str, name: str) -> str | None:
+        """The file a directory dataset stores case ``name`` under, or ``None`` if absent on disk.
+
+        The returned path omits the implicit ``.h5`` suffix h5 case files carry: ``H5File``
+        re-appends it on open.
+        """
+        path = f"{self.filename}{sub_directory}{name}"
+        return path if os.path.exists(f"{path}{'.h5' if self.file_format == 'h5' else ''}") else None
+
+    def _resolve_entry(self, groups: str, name: str, action: Callable[[Dataset.AbstractFile, str, str], _T]) -> _T:
+        """Run ``action`` on the open file holding ``(groups, name)``: THE place entry resolution lives.
+
+        ``action`` receives the backend and the entry's coordinates INSIDE that file: a directory
+        dataset stores one case per file, addressed by ``name``, with the entry keyed by the group
+        path's last component, so the coordinates are ``("", group)`` there and ``(groups, name)``
+        on a single-file dataset. Raises ``NameError`` when the dataset or the entry is missing.
+        """
         if not self._exists_on_disk():
             raise NameError(f"Dataset {self.filename} not found")
         if self.is_directory:
             for sub_directory in self._get_sub_directories(groups):
-                group = groups.split("/")[-1]
-                if os.path.exists(f"{self.filename}{sub_directory}{name}{'.h5' if self.file_format == 'h5' else ''}"):
-                    with Dataset.File(
-                        f"{self.filename}{sub_directory}{name}",
-                        True,
-                        self.file_format,
-                        self.level,
-                    ) as file:
-                        return file.file_to_data("", group)
-        else:
-            with Dataset.File(self.filename, True, self.file_format, self.level) as file:
-                return file.file_to_data(groups, name)
-        raise NameError(f"Dataset entry '{groups}/{name}' not found in {self.filename}.")
+                path = self._case_path(sub_directory, name)
+                if path is not None:
+                    with Dataset.File(path, True, self.file_format, self.level) as file:
+                        return action(file, "", groups.split("/")[-1])
+            raise NameError(f"Dataset entry '{groups}/{name}' not found in {self.filename}.")
+        with Dataset.File(self.filename, True, self.file_format, self.level) as file:
+            return action(file, groups, name)
+
+    def read_data(self, groups: str, name: str) -> tuple[np.ndarray, Attribute]:
+        return self._resolve_entry(groups, name, lambda file, group, entry: file.file_to_data(group, entry))
 
     def read_data_slice(self, groups: str, name: str, slices: tuple[slice, ...]) -> tuple[np.ndarray, Attribute]:
-        if not self._exists_on_disk():
-            raise NameError(f"Dataset {self.filename} not found")
-        if self.is_directory:
-            for sub_directory in self._get_sub_directories(groups):
-                group = groups.split("/")[-1]
-                if os.path.exists(f"{self.filename}{sub_directory}{name}{'.h5' if self.file_format == 'h5' else ''}"):
-                    with Dataset.File(
-                        f"{self.filename}{sub_directory}{name}",
-                        True,
-                        self.file_format,
-                        self.level,
-                    ) as file:
-                        result = file.file_to_data_slice("", group, slices)
-                        return result
-        else:
-            with Dataset.File(self.filename, True, self.file_format, self.level) as file:
-                return file.file_to_data_slice(groups, name, slices)
-
-        raise NameError(f"Dataset entry '{groups}/{name}' not found in {self.filename}.")
+        return self._resolve_entry(
+            groups, name, lambda file, group, entry: file.file_to_data_slice(group, entry, slices)
+        )
 
     def bounded_region_reads(self, groups: str, name: str) -> bool:
         """Whether a region read of this entry decodes only the region, or the whole volume.
@@ -2427,19 +2432,10 @@ class Dataset:
         times over, where loading reads it once. ``False`` for a missing entry: pessimistic, and
         only ever costing speed.
         """
-        if not self._exists_on_disk():
+        try:
+            return self._resolve_entry(groups, name, lambda file, _, entry: file.bounded_region_reads(entry))
+        except NameError:
             return False
-        if self.is_directory:
-            for sub_directory in self._get_sub_directories(groups):
-                group = groups.split("/")[-1]
-                if os.path.exists(f"{self.filename}{sub_directory}{name}{'.h5' if self.file_format == 'h5' else ''}"):
-                    with Dataset.File(
-                        f"{self.filename}{sub_directory}{name}", True, self.file_format, self.level
-                    ) as file:
-                        return file.bounded_region_reads(group)
-            return False
-        with Dataset.File(self.filename, True, self.file_format, self.level) as file:
-            return file.bounded_region_reads(name)
 
     def read_data_statistics(
         self,
@@ -2447,24 +2443,9 @@ class Dataset:
         name: str,
         channels: list[int] | None = None,
     ) -> dict[str, Any]:
-        if not self._exists_on_disk():
-            raise NameError(f"Dataset {self.filename} not found")
-        if self.is_directory:
-            for sub_directory in self._get_sub_directories(groups):
-                group = groups.split("/")[-1]
-                if os.path.exists(f"{self.filename}{sub_directory}{name}{'.h5' if self.file_format == 'h5' else ''}"):
-                    with Dataset.File(
-                        f"{self.filename}{sub_directory}{name}",
-                        True,
-                        self.file_format,
-                        self.level,
-                    ) as file:
-                        return file.file_to_data_statistics("", group, channels)
-        else:
-            with Dataset.File(self.filename, True, self.file_format, self.level) as file:
-                return file.file_to_data_statistics(groups, name, channels)
-
-        raise NameError(f"Dataset entry '{groups}/{name}' not found in {self.filename}.")
+        return self._resolve_entry(
+            groups, name, lambda file, group, entry: file.file_to_data_statistics(group, entry, channels)
+        )
 
     def read_transform(self, group: str, name: str) -> sitk.Transform:
         if not self._exists_on_disk():
@@ -2509,12 +2490,14 @@ class Dataset:
             # destination, which a single-file backend would otherwise turn into an open error.
             return False
         if self.is_directory:
+            # Not _resolve_entry: membership keeps scanning past a case file whose group is absent,
+            # and answers False instead of raising.
             entry_group = group.split("/")[-1]
             for sub_directory in self._get_sub_directories(group):
-                base = f"{self.filename}{sub_directory}{name}"
-                if not os.path.exists(f"{base}{'.h5' if self.file_format == 'h5' else ''}"):
+                path = self._case_path(sub_directory, name)
+                if path is None:
                     continue
-                with Dataset.File(base, True, self.file_format, self.level) as file:
+                with Dataset.File(path, True, self.file_format, self.level) as file:
                     if file.is_exist(entry_group):
                         return True
             return False
@@ -2607,25 +2590,9 @@ class Dataset:
         if cached is not None:
             shape, attr = cached
             return list(shape), Attribute(attr)
-        if self.is_directory:
-            for sub_directory in self._get_sub_directories(groups):
-                group = groups.split("/")[-1]
-                if os.path.exists(f"{self.filename}{sub_directory}{name}{'.h5' if self.file_format == 'h5' else ''}"):
-                    with Dataset.File(
-                        f"{self.filename}{sub_directory}{name}",
-                        True,
-                        self.file_format,
-                        self.level,
-                    ) as file:
-                        result = file.get_infos("", group)
-                        self._infos_cache[cache_key] = (list(result[0]), Attribute(result[1]))
-                        return result
-        else:
-            with Dataset.File(self.filename, True, self.file_format, self.level) as file:
-                result = file.get_infos(groups, name)
-                self._infos_cache[cache_key] = (list(result[0]), Attribute(result[1]))
-                return result
-        raise NameError(f"Dataset entry '{groups}/{name}' not found in {self.filename}.")
+        result = self._resolve_entry(groups, name, lambda file, group, entry: file.get_infos(group, entry))
+        self._infos_cache[cache_key] = (list(result[0]), Attribute(result[1]))
+        return result
 
     def get_statistics(self, groups: str) -> dict[str, dict[str, dict[str, float | list[float]]]]:
         names = self.get_names(groups)

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -644,7 +644,7 @@ class Log(MinimalLog):
     def write(self, msg: str):
         super().write(msg)
         # Consecutive identical lines are one fact said twice: a progress bar arrives as several
-        # write() calls per frame and a case line rides beside its own counter frame, which used to
+        # write() calls per frame and a case line rides beside its own counter frame, which would
         # multiply the file by ~4x against the console. Only CONSECUTIVE repeats fold: a fact that
         # genuinely recurs later still lands.
         if self._buffered_line and self._buffered_line != self._last_logged:

--- a/tests/unit/test_imaging_formats.py
+++ b/tests/unit/test_imaging_formats.py
@@ -337,6 +337,15 @@ class TestDatasetImagingBackends:
         np.testing.assert_array_equal(patch, volume[:, 2:3])
         assert len(decoded_files) == 1
 
+    def test_dicom_region_reads_are_priced_bounded(self, tmp_path: Path) -> None:
+        """The route pricer must see what the decode-count test above proves: a region decodes only
+        its slices, so a DICOM source prices as streamable instead of loading whole."""
+        pytest.importorskip("pydicom")
+        dataset = Dataset(tmp_path / "DICOM", "dicom")
+        dataset.write("CT", "CASE_001", np.zeros((1, 2, 3, 3), dtype=np.int16), _image_attributes())
+
+        assert dataset.bounded_region_reads("CT", "CASE_001")
+
     def test_dicom_round_trip_preserves_rotated_direction(self, tmp_path: Path) -> None:
         pytest.importorskip("pydicom")
         attributes = _image_attributes()

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -25,6 +25,7 @@ import konfai.evaluator as evaluator_module
 import konfai.main as main_module
 import konfai.predictor as predictor_module
 import konfai.trainer as trainer_module
+import konfai.transformer as transformer_module
 import pytest
 
 
@@ -97,6 +98,78 @@ def test_konfai_eval_dispatches_correctly(monkeypatch: pytest.MonkeyPatch) -> No
     main_module.main()
 
     assert captured["evaluations_file"] == "Evaluation.yml"
+
+
+def test_konfai_resume_dispatches_model_and_lr(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_train(**kwargs) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(trainer_module, "train", fake_train)
+    monkeypatch.setattr(sys, "argv", ["konfai", "RESUME", "-c", "Config.yml", "--model", "ckpt.pt", "--lr", "0.001"])
+
+    main_module.main()
+
+    assert captured["command"] == "RESUME"
+    assert captured["config"] == "Config.yml"
+    assert captured["model"] == "ckpt.pt"
+    assert captured["lr"] == 0.001
+
+
+@pytest.mark.parametrize("flag", ["--checkpoints-dir", "-checkpoints-dir"])
+def test_konfai_resume_accepts_both_checkpoints_dir_spellings(monkeypatch: pytest.MonkeyPatch, flag: str) -> None:
+    """RESUME once declared its dir flags with a single dash where every other command uses two;
+    the double-dash form is now the real one and the single-dash form stays as a hidden alias."""
+    captured: dict[str, object] = {}
+
+    def fake_train(**kwargs) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(trainer_module, "train", fake_train)
+    monkeypatch.setattr(sys, "argv", ["konfai", "RESUME", "-c", "Config.yml", "--model", "ckpt.pt", flag, "/elsewhere"])
+
+    main_module.main()
+
+    assert captured["checkpoints_dir"] == "/elsewhere"
+
+
+def test_konfai_transform_dispatches_config_as_transform_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_transform(**kwargs) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(transformer_module, "transform", fake_transform)
+    monkeypatch.setattr(sys, "argv", ["konfai", "TRANSFORM", "-c", "Transform.yml"])
+
+    main_module.main()
+
+    assert captured["transform_file"] == "Transform.yml"
+    assert "config" not in captured
+    assert "plan" not in captured
+
+
+def test_konfai_transform_plan_short_circuits_to_plan_transform(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--plan must dispatch to plan_transform, never transform: the distributed wrapper filters
+    kwargs by the entrypoint's signature, so a 'plan' kwarg passed through would be silently
+    dropped and the run would proceed as if the flag had never been given."""
+    planned: dict[str, object] = {}
+
+    def fake_plan_transform(**kwargs) -> None:
+        planned.update(kwargs)
+
+    def fail_transform(**kwargs) -> None:
+        raise AssertionError("--plan must not start the transform run")
+
+    monkeypatch.setattr(transformer_module, "plan_transform", fake_plan_transform)
+    monkeypatch.setattr(transformer_module, "transform", fail_transform)
+    monkeypatch.setattr(sys, "argv", ["konfai", "TRANSFORM", "-c", "Transform.yml", "--plan"])
+
+    main_module.main()
+
+    assert planned["transform_file"] == "Transform.yml"
+    assert "plan" not in planned
 
 
 def test_predict_evaluate_expose_tensorboard_param():

--- a/tests/unit/test_perf_hot_paths.py
+++ b/tests/unit/test_perf_hot_paths.py
@@ -89,6 +89,7 @@ def test_get_infos_is_memoized_and_returns_independent_copies(monkeypatch):
     ds.level = 0
     ds._names_cache = {}
     ds._infos_cache = {}
+    monkeypatch.setattr(ds, "_exists_on_disk", lambda: True)
 
     opens = {"n": 0}
 

--- a/tests/unit/test_resample_to_reference.py
+++ b/tests/unit/test_resample_to_reference.py
@@ -675,10 +675,11 @@ def test_an_explicit_interpolation_is_honoured_on_both_paths(tmp_path: Path, war
 
     assert not resample(interpolation="nearest") - {0, 100}, "nearest picks a label, it does not blend"
     assert resample(interpolation="linear") - {0, 100}, "asking for linear must actually interpolate"
+    assert resample(interpolation="cubic") - {0, 100}, "cubic blends too, on both paths"
     assert resample() - {0, 100}, "int16 is not a label map the dtype can claim"
 
     with pytest.raises(TransformError, match="unknown interpolation"):
-        _warping(images, fields, interpolation="cubic")
+        _warping(images, fields, interpolation="quadratic")
 
 
 def test_it_warps_onto_the_reference_where_simpleitk_does(warped: tuple[Dataset, Dataset, np.ndarray]) -> None:

--- a/tests/unit/test_resample_transform.py
+++ b/tests/unit/test_resample_transform.py
@@ -384,3 +384,41 @@ def test_a_stored_map_bridging_disjoint_frames_is_not_refused_as_disjoint():
     refused.set_datasets([_CrossFrameStore(reference, astray)])
     with pytest.raises(TransformError, match="nothing but 'fill'"):
         refused.transform_shape("", CASE, list(SIZE), _attribute(case))
+
+
+def test_cubic_tracks_the_bspline_oracle_closer_than_linear() -> None:
+    """Keys' cubic is a real cubic reconstruction: brought to another density, the phantom must
+    land nearer SimpleITK's spline resample than the linear blend does."""
+    image = _image(oblique=False)
+    volume = torch.from_numpy(sitk.GetArrayFromImage(image)).unsqueeze(0)
+    outputs: dict[str, torch.Tensor] = {}
+    attribute = _attribute(image)
+    for interpolation in ("linear", "cubic"):
+        attribute = _attribute(image)
+        stage = Resample(spacing=[0.5, 0.9, 1.1], interpolation=interpolation)
+        outputs[interpolation] = stage(CASE, volume.clone(), attribute)
+    reference = sitk.Image([int(extent) for extent in reversed(outputs["cubic"].shape[1:])], sitk.sitkFloat32)
+    reference.SetOrigin(tuple(attribute.get_np_array("Origin")))
+    reference.SetSpacing(tuple(attribute.get_np_array("Spacing")))
+    reference.SetDirection(tuple(attribute.get_np_array("Direction")))
+    oracle = sitk.GetArrayFromImage(sitk.Resample(image, reference, sitk.Transform(), sitk.sitkBSpline, 0.0))
+    crop = (slice(2, -2),) * 3  # away from the border, where tap-clamp and spline-edge policies differ
+    error = {name: float(np.abs(out.numpy()[0][crop] - oracle[crop]).mean()) for name, out in outputs.items()}
+    assert error["cubic"] < error["linear"]
+
+
+def test_cubic_saturates_overshoot_instead_of_wrapping() -> None:
+    """Keys' negative lobes overshoot beside an edge, and an integer cast would WRAP the overshoot
+    to the opposite extreme: a uint8 step must stay a step, saturated at its plateaus."""
+    volume = torch.zeros((1, 4, 4, 32), dtype=torch.uint8)
+    volume[..., 16:] = 255
+    attribute = Attribute()
+    attribute["Origin"] = np.zeros(3)
+    attribute["Spacing"] = np.ones(3)
+    attribute["Direction"] = np.eye(3).ravel()
+    stage = Resample(spacing=[0.5, 0.0, 0.0], interpolation="cubic")
+    out = stage(CASE, volume, attribute)
+    assert out.dtype == torch.uint8
+    dark, bright = out[..., : out.shape[-1] // 2 - 2], out[..., out.shape[-1] // 2 + 2 :]
+    assert int(dark.max()) <= 50
+    assert int(bright.min()) >= 200

--- a/tests/unit/test_transform_locality_contract.py
+++ b/tests/unit/test_transform_locality_contract.py
@@ -190,6 +190,11 @@ _CASES: dict[str, list[_Case]] = {
         ),
         # A stored map never factorises: the grid_sample path again.
         _Case(Resample(transforms={"transform": True}), atol=_REGRID_ATOL),
+        # Keys' cubic: the separable axis walk and the corner walk both keep GLOBAL coordinates, so
+        # streamed and whole agree exactly on floats; int16 rounds the blend once, hence the LSB.
+        _Case(Resample(spacing=[2.0, 1.0, 3.0], interpolation="cubic")),
+        _Case(Resample(spacing=[2.0, 1.0, 3.0], interpolation="cubic"), group="Int16", atol=_LSB_ATOL),
+        _Case(Resample(transforms={"transform": True}, interpolation="cubic")),
         # A field on disk this registry cannot build: the streamed-equals-whole proof lives in
         # test_warp.py, where a field exists: including the measured, bound-less windows.
         _Case(Resample(field="Dataset:h5", field_group="DVF"), sweep=False),

--- a/tests/unit/test_warp.py
+++ b/tests/unit/test_warp.py
@@ -249,4 +249,4 @@ def test_an_empty_field_path_declares_no_field() -> None:
 
 def test_unknown_interpolation_is_refused_at_construction() -> None:
     with pytest.raises(TransformError, match="unknown interpolation"):
-        Resample(field="./x:h5", interpolation="cubic")
+        Resample(field="./x:h5", interpolation="quadratic")


### PR DESCRIPTION
## What this is

The refactoring pass the post-1.8 audit called for, applied. Two commits: the
refactor itself, then one feature that was written alongside it.

Stacked on the documentation PR (`pr/docs-post-1.8`), which it needs: both touch
`konfai/main.py`.

## The refactor

Same behaviour throughout. What changes is that a rule written twice, or a block
copied seven times, now has one home.

- `_REGION_KINDS` was defined identically in the read dispatcher and the write
  one. A kind added to one and forgotten in the other would have been a silent
  bug: a cost on one side, a wrong refusal on the other.
- The rule that a `GLOBAL_STAT` stage needs a statistics-preserving prefix was
  written once for the per-case planner and once for the reduction engine, the
  second admitting in its docstring that it mirrored the first.
- `Dataset` resolved an entry with the same eighteen lines in seven methods, so
  the implicit `.h5` suffix rule and the not-found message lived seven times.
- `compute_plan` wrote its SKIP/STREAM/WHOLE-VOLUME cascade twice, which hid the
  one asymmetry worth seeing: a copy is never LOAD.
- `api.py` repeated the same build-and-launch preamble under its four entry
  points.
- `main._run` was 266 lines doing three jobs: per-command builders and a dispatch
  table now.
- `_materialize_shared_pass` and `_materialize_save` share their sweep helpers,
  `trainer._log` returns early off the rank gate, `transformer.setup` and
  `predictor.add_layer` delegate to named phases.

Two fixes rather than moves:

- RESUME declared its directory flags with a single dash where every other
  command uses two, so `konfai RESUME --checkpoints-dir X` failed while the same
  flag worked on TRAIN. The double-dash form is the real one now; the single-dash
  form stays as a hidden alias.
- DICOM region reads were priced as unbounded although the backend serves them
  per slice.

Comments follow the repo's rule: state the constraint the code cannot show. The
ones narrating a past change or proving a point at length are gone.

**Left alone on purpose**, both argued in the audit: the per-patch refold, whose
cache would bet on a property no current test discriminates, and the three
locality classification walks, which answer three different questions and are
alike only in shape.

## The feature

`Resample` gains cubic interpolation, the third answer a resampling stage is
expected to give. The docstrings for `spacing` and `shape` now say which axis
order each takes, since they differ.

## Checks

`pixi run test-fast` green, `mypy` clean on 93 files, `ruff` clean.

The source tree matches the branch this was rebuilt from, except where the
documentation PR already fixed the same lines: the removed `ResampleToResolution`
spelling in konfai-apps, and the `--config` help string.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cubic interpolation for resampling, including improved handling of streamed regions, integer values, and out-of-bounds areas.
  * Added bounded-region read support for DICOM datasets.
  * Improved command-line workflow dispatch, planning, and compatibility with existing resume options.

* **Bug Fixes**
  * Improved output planning, destination validation, and multi-rank file handling.
  * Improved distributed metric logging to avoid duplicate output.
  * Clarified interpolation, voting, geometry, and registration behavior.

* **Tests**
  * Expanded coverage for cubic resampling, DICOM reads, CLI dispatch, and output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->