### PR TITLE
perf(runtime): give each rank a bounded CPU thread share

### DIFF
--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -657,6 +657,21 @@ class Log(MinimalLog):
         self.file.flush()
 
 
+def record(message: str) -> Path | None:
+    """Keep ``message`` in the run's log without printing it, and answer where it went.
+
+    For detail that belongs beside the run but not on a console every other workflow keeps to a
+    progress bar (the TRANSFORM plan). Answers None when no ``Log`` is installed, which is every
+    context that has no run directory to keep it in.
+    """
+    sink = sys.stdout
+    if not isinstance(sink, Log):
+        return None
+    sink.file.write(message if message.endswith("\n") else message + "\n")
+    sink.file.flush()
+    return Path(sink.file.name)
+
+
 class TensorBoard:
     """Lifecycle helper that optionally starts a TensorBoard side process."""
 
@@ -981,15 +996,26 @@ def execute_distributed_object(
                 os.environ[key] = value
 
 
+_cpu_budget_applied = False
+
+
 def apply_cpu_thread_budget() -> None:
     """Give each rank a bounded share of the node's cores instead of torch's every-core default.
 
     Past memory-bus saturation more intraop threads only add barrier contention; on a hybrid
     24-core CPU the 498^3 separable gather measures 0.7 s at 12 threads and 67 s at 24. An
     explicit ``OMP_NUM_THREADS`` keeps authority (torch already honors it at init).
+
+    Applied once per process, and never on macOS: torch documents ``set_num_threads`` as to be
+    called before any parallel work, and the Python API runs several workflows in one process.
+    On macOS the call intermittently crashes libomp with SIGSEGV once any parallel region ran,
+    whichever call is the first; the saturation this bounds was measured on many-core Linux
+    nodes, so macOS keeps torch's default.
     """
-    if os.environ.get("OMP_NUM_THREADS"):
+    global _cpu_budget_applied
+    if sys.platform == "darwin" or _cpu_budget_applied or os.environ.get("OMP_NUM_THREADS"):
         return
+    _cpu_budget_applied = True
     local_ranks = max(1, int(os.environ.get("KONFAI_LOCAL_RANKS") or 1))
     torch.set_num_threads(max(1, min((os.cpu_count() or 1) // local_ranks, 12)))
 

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -772,6 +772,7 @@ class DistributedObject(ABC):
         global_rank, local_rank = setup_gpu(world_size, rank)
         if global_rank is None or local_rank is None:
             return
+        apply_cpu_thread_budget()
         with Log(self.name, global_rank):
             if torch.cuda.is_available() and _PYNVML_AVAILABLE:
                 pynvml.nvmlInit()
@@ -978,6 +979,19 @@ def execute_distributed_object(
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = value
+
+
+def apply_cpu_thread_budget() -> None:
+    """Give each rank a bounded share of the node's cores instead of torch's every-core default.
+
+    Past memory-bus saturation more intraop threads only add barrier contention; on a hybrid
+    24-core CPU the 498^3 separable gather measures 0.7 s at 12 threads and 67 s at 24. An
+    explicit ``OMP_NUM_THREADS`` keeps authority (torch already honors it at init).
+    """
+    if os.environ.get("OMP_NUM_THREADS"):
+        return
+    local_ranks = max(1, int(os.environ.get("KONFAI_LOCAL_RANKS") or 1))
+    torch.set_num_threads(max(1, min((os.cpu_count() or 1) // local_ranks, 12)))
 
 
 def setup_gpu(world_size: int, rank: int | None = None) -> tuple[int | None, int | None]:

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -534,3 +534,34 @@ def test_the_inline_path_is_the_default(monkeypatch) -> None:
 
     assert ran_here == [0]
     assert spawned == []
+
+
+def _budget_applied(monkeypatch, cores: int, ranks: str | None, omp: str | None) -> list[int]:
+    calls: list[int] = []
+    monkeypatch.setattr(rt.os, "cpu_count", lambda: cores)
+    monkeypatch.setattr(rt.torch, "set_num_threads", calls.append)
+    for key, value in (("KONFAI_LOCAL_RANKS", ranks), ("OMP_NUM_THREADS", omp)):
+        monkeypatch.delenv(key, raising=False)
+        if value is not None:
+            monkeypatch.setenv(key, value)
+    rt.apply_cpu_thread_budget()
+    return calls
+
+
+def test_cpu_thread_budget_caps_torchs_every_core_default(monkeypatch) -> None:
+    """torch defaults to one intraop thread per core; past bus saturation that only adds barrier
+    contention (measured 0.7 s at 12 threads vs 67 s at 24 for the same gather)."""
+    assert _budget_applied(monkeypatch, cores=24, ranks=None, omp=None) == [12]
+
+
+def test_cpu_thread_budget_splits_the_node_between_ranks(monkeypatch) -> None:
+    assert _budget_applied(monkeypatch, cores=24, ranks="4", omp=None) == [6]
+
+
+def test_cpu_thread_budget_never_rounds_to_zero(monkeypatch) -> None:
+    assert _budget_applied(monkeypatch, cores=2, ranks="4", omp=None) == [1]
+
+
+def test_an_explicit_omp_setting_keeps_authority(monkeypatch) -> None:
+    """torch honors OMP_NUM_THREADS at init; the budget must not override the user's choice."""
+    assert _budget_applied(monkeypatch, cores=24, ranks="4", omp="20") == []

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -468,6 +468,29 @@ def test_interleaved_bars_each_keep_their_final_state(monkeypatch):
     assert "Train: 49/50" in lines and "Val: 49/50" in lines
 
 
+def test_record_keeps_detail_in_the_log_without_printing_it(tmp_path, monkeypatch):
+    """The run's log is where a run is read after the fact, so detail too long for a console belongs
+    there (the TRANSFORM plan). Without a Log installed there is no run directory to keep it in, and
+    recording is a no-op rather than a print that would land on the console it exists to spare."""
+    monkeypatch.setattr(sys, "stdout", _FileLikeMirror())
+    monkeypatch.setattr(sys, "stderr", sys.stdout)
+    monkeypatch.setenv("KONFAI_VERBOSE", "True")
+    monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
+    monkeypatch.setenv("KONFAI_STATE", "TRAIN")
+    monkeypatch.setenv("KONFAI_STATISTICS_DIRECTORY", str(tmp_path))
+    mirror = sys.stdout
+
+    rt.record("nothing is installed: this goes nowhere")
+    with rt.Log("RUN", 0) as log:
+        rt.record("line one\nline two")
+        log.write("printed\n")
+
+    assert "goes nowhere" not in mirror.written
+    assert "line one" not in mirror.written, "recorded detail must not reach the console"
+    assert "printed" in mirror.written
+    assert (tmp_path / "RUN" / "log_0.txt").read_text() == "line one\nline two\nprinted\n"
+
+
 # ---------------------------------------------------------------------------
 # A single rank runs in this process; more than one still spawns
 # ---------------------------------------------------------------------------
@@ -536,8 +559,10 @@ def test_the_inline_path_is_the_default(monkeypatch) -> None:
     assert spawned == []
 
 
-def _budget_applied(monkeypatch, cores: int, ranks: str | None, omp: str | None) -> list[int]:
+def _budget_applied(monkeypatch, cores: int, ranks: str | None, omp: str | None, platform: str = "linux") -> list[int]:
     calls: list[int] = []
+    monkeypatch.setattr(rt, "_cpu_budget_applied", False)
+    monkeypatch.setattr(rt.sys, "platform", platform)
     monkeypatch.setattr(rt.os, "cpu_count", lambda: cores)
     monkeypatch.setattr(rt.torch, "set_num_threads", calls.append)
     for key, value in (("KONFAI_LOCAL_RANKS", ranks), ("OMP_NUM_THREADS", omp)):
@@ -565,3 +590,17 @@ def test_cpu_thread_budget_never_rounds_to_zero(monkeypatch) -> None:
 def test_an_explicit_omp_setting_keeps_authority(monkeypatch) -> None:
     """torch honors OMP_NUM_THREADS at init; the budget must not override the user's choice."""
     assert _budget_applied(monkeypatch, cores=24, ranks="4", omp="20") == []
+
+
+def test_cpu_thread_budget_is_applied_once_per_process(monkeypatch) -> None:
+    """set_num_threads is documented as pre-parallel-work only, and the Python API runs several
+    workflows in one process: a second application mid-process can crash the OpenMP runtime."""
+    calls = _budget_applied(monkeypatch, cores=24, ranks=None, omp=None)
+    rt.apply_cpu_thread_budget()
+    assert calls == [12]
+
+
+def test_cpu_thread_budget_skips_macos(monkeypatch) -> None:
+    """On macOS set_num_threads intermittently crashes libomp once any parallel region ran (CI
+    SIGSEGV, whichever workflow called it first); the default stays."""
+    assert _budget_applied(monkeypatch, cores=24, ranks=None, omp=None, platform="darwin") == []


### PR DESCRIPTION
torch defaults to one intraop thread per logical core. On a hybrid 24-core CPU (8P+16E) the 498^3 separable gather measures 0.7 s at 12 threads and 67 s at 24: past memory-bus saturation, extra threads only add barrier contention. A 75-case TRANSFORM (resample + clip) ran 40 s/case on the default and ~5 s/case once capped.

Each rank now gets an equal share of the node's cores, capped at 12, applied at rank start. An explicit OMP_NUM_THREADS keeps authority: torch reads it at init and the budget then does nothing.

4 unit tests; lint, mypy and the runtime suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime recording for writing detailed messages to the active run log while keeping console output unchanged.
  * Recording safely does nothing when no active run log is available.

* **Performance**
  * Improved CPU thread allocation during runtime setup for more consistent performance across distributed workloads.
  * Balances available CPU resources across local processes with a bounded thread limit.
  * Preserves explicitly configured thread settings and excludes macOS.

* **Tests**
  * Added coverage for runtime recording and CPU thread allocation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->