### PR TITLE
feat(transform): the chain runs on the rank's device when GPUs are requested

### DIFF
--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -1414,6 +1414,7 @@ class DatasetManager:
         self._rewrite_saves = False
         # The per-rank budget the sweeps size their slabs against (None = the fixed _SWEEP_SLAB_ROWS).
         self._sweep_budget_bytes: float | None = None
+        self._chain_device: torch.device | None = None
         self._disk_statistics: dict[tuple[Dataset, str, str, tuple[int, ...] | None], dict[str, float]] = {}
         # Save caches already swept by THIS run, keyed by (store, group, entry): under --overwrite the
         # existence probe answers "not written", and without this ledger every copy of an Expand chain
@@ -1543,6 +1544,8 @@ class DatasetManager:
             data, _ = self.dataset.read_data(self.group_src, self.name)
 
         data = torch.from_numpy(data)
+        if self._chain_device is not None:
+            data = data.to(self._chain_device)
 
         if len(pre_transform):
             data = self._apply_chain(data, pre_transform[i:], self.cache_attributes[0], self.name)
@@ -1565,7 +1568,7 @@ class DatasetManager:
             tensor = transform_function(self.name, tensor, attribute)
             if isinstance(transform_function, Save):
                 dataset, group_dest = save_destination(transform_function, self.dataset, self.group_dest)
-                dataset.write(group_dest, entry, tensor.numpy(), attribute)
+                dataset.write(group_dest, entry, tensor.cpu().numpy(), attribute)
         return tensor
 
     def _load_augmentation(self, data_augmentations_list: list[DataAugmentationsList]) -> None:
@@ -2167,6 +2170,7 @@ class DatasetManager:
         fallback_budget_bytes: float | None = None,
         allow_fallback: bool = True,
         prefer_whole: bool = False,
+        device: "torch.device | None" = None,
     ) -> bool:
         """Write this case's chain to disk by the cheapest path that can, and say which one it took.
 
@@ -2190,6 +2194,10 @@ class DatasetManager:
         """
         self._set_rewrite(rewrite)
         self.set_memory_budget(fallback_budget_bytes)
+        # Opt-in only, and only here: this same machinery loads training cases inside DataLoader
+        # workers, where a CUDA default would be wrong. The transformer's rank is the one caller
+        # that knows its device.
+        self._chain_device = device if device is not None and device.type != "cpu" else None
         # A chain with an Expand materializes a COPY, whose draw must be part of the plan; without
         # one it materializes the case itself, and augmentations have nothing to do with writing.
         apply_augmentations = self._expand is not None and a > 0
@@ -2354,6 +2362,7 @@ class DatasetManager:
         rewrite: bool = False,
         fallback_budget_bytes: float | None = None,
         allow_fallback: bool = True,
+        device: "torch.device | None" = None,
     ) -> dict[int, str]:
         """Write the :class:`Expand` copies of this case by the cheapest regime each can take.
 
@@ -2373,6 +2382,7 @@ class DatasetManager:
             )
         self._set_rewrite(rewrite)
         self.set_memory_budget(fallback_budget_bytes)
+        self._chain_device = device if device is not None and device.type != "cpu" else None
         verdicts: dict[int, str] = {}
         if not copies:
             return verdicts
@@ -2608,7 +2618,7 @@ class DatasetManager:
                     scope = Attribute(slab_attribute)
                     for stage in tail:
                         copy_tensor = stage(self.name, copy_tensor, scope)
-                    block = copy_tensor.numpy()
+                    block = copy_tensor.cpu().numpy()
                     self._require_channel_first(block, spatial, f"A per-copy stage of '{sweep.group}/{sweep.entry}'")
                     if a not in streams:
                         attributes = self._sweep_header(evolved, scope, keys_before)
@@ -2729,7 +2739,7 @@ class DatasetManager:
                 tensor, slab_attribute, keys_before = self._replay_streamed_region(
                     source, target, Attribute(sweep.base_attributes), Attribute(evolved) if slab_index == 0 else None
                 )
-                block = tensor.numpy()
+                block = tensor.cpu().numpy()
                 self._require_channel_first(
                     block, spatial, f"A stage of the chain writing '{sweep.group}/{sweep.entry}'"
                 )
@@ -2937,6 +2947,8 @@ class DatasetManager:
         data_slices = tuple([slice(None)] * n_prefix + spans[0])
         data, attributes = stream_source.dataset.read_data_slice(stream_source.group, stream_source.entry, data_slices)
         tensor = torch.from_numpy(data)
+        if self._chain_device is not None:
+            tensor = tensor.to(self._chain_device)
 
         cache_attribute.update(attributes)
         cache_attribute["StatisticsSeeded"] = 1.0  # same contract as the pointwise route above

--- a/konfai/transformer.py
+++ b/konfai/transformer.py
@@ -61,6 +61,7 @@ from konfai.utils.runtime import (
     State,
     _materialized_config,
     configure_workflow_environment,
+    get_device,
     run_distributed_app,
 )
 from konfai.utils.utils import get_module
@@ -801,7 +802,12 @@ class Transformer(DistributedObject):
     def run_process(self, world_size: int, global_rank: int, local_rank: int, dataloaders):
         """Materialize this rank's cases. The plan already said what will happen: the console gets
         the deviations from it, the live counter, and one final line that says how it went."""
-        del world_size, local_rank, dataloaders
+        del world_size, dataloaders
+        # The one caller that knows its device: cuda:<rank> when the launch requested GPUs (the
+        # runtime narrowed CUDA_VISIBLE_DEVICES to them), CPU otherwise. The chain then runs where
+        # the rank runs; regions still land on the host for every write.
+        device = get_device(local_rank)
+        chain_device = torch.device(f"cuda:{device}") if isinstance(device, int) else device
         started = time.monotonic()
         managers = self._managers()
         shard = self._shards[global_rank]
@@ -850,6 +856,7 @@ class Transformer(DistributedObject):
                             rewrite=self._overwrite,
                             fallback_budget_bytes=self._budget_bytes,
                             allow_fallback=allow_fallback,
+                            device=chain_device,
                         )
                         shared = sum(1 for regime in regimes.values() if regime == "stream-shared")
                         own = sum(1 for regime in regimes.values() if regime == "stream")
@@ -871,6 +878,7 @@ class Transformer(DistributedObject):
                             fallback_budget_bytes=self._budget_bytes,
                             allow_fallback=allow_fallback,
                             prefer_whole=planned == "LOAD",
+                            device=chain_device,
                         )
                         verdict = "STREAM" if streamed else ("LOAD" if planned == "LOAD" else "WHOLE-VOLUME")
                         counts[verdict] += 1

--- a/tests/unit/test_patching.py
+++ b/tests/unit/test_patching.py
@@ -754,3 +754,39 @@ def test_two_groups_share_one_construction_draw(streaming_dataset_stub) -> None:
             for group in ("CT", "SEG")
         )
         assert image_manager.shapes == label_manager.shapes, f"seed {seed}"
+
+
+def test_chain_device_is_opt_in_and_cpu_is_a_no_op(streaming_dataset_stub) -> None:
+    """This same machinery loads training cases inside DataLoader workers: only an explicit
+    non-CPU device handed to materialize() may ever move the chain."""
+    volume = np.zeros((1, 4, 6, 8), dtype=np.float32)
+    manager = DatasetManager(
+        index=0,
+        group_src="CT",
+        group_dest="CT",
+        name="CASE_000",
+        dataset=cast(Dataset, streaming_dataset_stub(volume)),
+        patch=None,
+        transforms=[],
+        data_augmentations_list=[],
+    )
+    assert manager._chain_device is None
+    manager.materialize(rewrite=True, device=torch.device("cpu"))
+    assert manager._chain_device is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
+def test_chain_device_records_the_requested_cuda_device(streaming_dataset_stub) -> None:
+    volume = np.zeros((1, 4, 6, 8), dtype=np.float32)
+    manager = DatasetManager(
+        index=0,
+        group_src="CT",
+        group_dest="CT",
+        name="CASE_000",
+        dataset=cast(Dataset, streaming_dataset_stub(volume)),
+        patch=None,
+        transforms=[],
+        data_augmentations_list=[],
+    )
+    manager.materialize(rewrite=True, device=torch.device("cuda", 0))
+    assert manager._chain_device == torch.device("cuda", 0)


### PR DESCRIPTION
The TRANSFORM workflow accepted a gpu list and then ran every stage on CPU: the whole-volume load and the streamed replay both build their tensor with torch.from_numpy and never move it.

materialize()/materialize_copies() now take an opt-in device, set only by the transformer's rank via get_device(local_rank). This same machinery loads training cases inside DataLoader workers, where a CUDA default would be wrong, so None stays the default everywhere else. Slabs and assembled volumes come back to the host for every write.

A CPU run and a GPU run of the same case write identical bytes (measured on real data, max abs diff 0). 265 unit tests green across patching, transform and the streamed dispatchers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting the processing device when materializing datasets and copies.
  * Data processing can now run on supported accelerators, such as CUDA-enabled devices, for improved performance.
  * Results are automatically returned in a standard CPU-compatible format for saving and further use.
* **Bug Fixes**
  * Improved device handling during dataset loading, region reads, and chained processing.
  * Added coverage to ensure CPU and accelerator selections behave consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->