### PR TITLE
perf(data): the streamed resample runs on the device, out of core, bounded by the machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ no longer stops a run. Two things a run already wrote come out differently, see 
 - **mcp**: transform runs steer GPUs, a finished job carries its `outputs`, and `read_dataset_file`
   summarises an ITK transform HDF5
 - **apps**: batch size as a first-class fine-tune knob (`--set`, `install_fine_tune`)
+- **transform**: a `Resample` on an intensity chain may declare `precision: fast`, a float32
+  coordinate walk over half the bytes; `exact` (float64, the default) stays bit-identical to
+  `sitk.Resample`, and any other chain is refused with the reason
 - **config**: the binder reads a file strictly. `strict_config(root)` records, per level, what the
   file holds against what the binder read, and reports the difference by path with the keys read
   at that level and the closest one. TRANSFORM refuses; TRAIN, PREDICTION and EVALUATION warn
@@ -59,6 +62,9 @@ no longer stops a run. Two things a run already wrote come out differently, see 
   memory it holds and not the page cache, honours a SLURM grant, and reads `--mem=0` as the whole node
 - **runtime**: shards are balanced by bytes, and an inline run puts the caller's RNG (CPU and CUDA)
   and cudnn flags back
+- **runtime**: the per-rank thread share sizes ITK's pool along with torch's, and counts as applied
+  only once it is
+- **dataset**: a dead writer's debris is told apart portably (`psutil.pid_exists`), Windows included
 - **dataset**: an h5 replace keeps the old entry until the new one is in place; a streamed transform
   entry lands under the `.h5` name; an entry whose attributes fail is not left behind; one staging
   marker for every backend's temporary; the reader's own `ITK_*` keys do not travel with the volume
@@ -66,7 +72,7 @@ no longer stops a run. Two things a run already wrote come out differently, see 
   the store its probe created
 - **omezarr**: each scale factor shrinks the level above it, as the docs said (`[2, 2]` gives three
   levels at 1, 1/2, 1/4)
-- **reduction**: `Median` charges the working set `torch.quantile` allocates (four buffers, measured)
+- **reduction**: `Median` charges the working set its sort allocates (four buffers, measured)
 - **transform**: a bare stage name past the `Expand` marker is the draw (`Flip`, `Mask`, `Permute`,
   `Foreign` exist as both); the qualified spelling still forces either
 - **transform**: the working set counts what the widest stage allocates; a `Save` cache the run
@@ -84,6 +90,17 @@ no longer stops a run. Two things a run already wrote come out differently, see 
 ### ⚡ Performance
 
 - **transform**: taller slabs when the chain runs on a GPU (500³ `Clip` 3.4 to 2.6 s)
+- **transform**: a streamed `Resample` walks its coordinates on the rank's device, out of core and
+  slabbed under the machine's budget: a three-specimen ExaSPIM template round folds in 127 s where
+  the host baseline did not finish in 1 h 47, at 4.5 GiB of VRAM, and the same bytes every run
+- **transform**: on a host with no GPU that `Resample` goes through ITK's own resampler, 27 ns per
+  voxel against the host walk's 326: the full CPU fold of the same round, 2005 s to 892 s
+- **omezarr**: a pyramid appended to a streamed store no longer rewrites level 0, the coarser
+  levels are derived from it lazily (that round's update pass 103 s to 53 s, the 4.9 GB template's
+  level 1 53 s to 4 s), and a store is created empty for zarr to fill (2.3 s where the rechunk took 14.4)
+- **reduction**: a fold runs on the rank's device, `Vote` counts along the case axis (2 s per 512³
+  where the pass it replaces took 31 s) and `Median` reads the middle off a sort (1.5-2x on CPU,
+  3.5x on CUDA); the folds a statistics pass computed are kept for the write pass when they fit
 - **transform**: a case is planned without listing the whole output directory
 - **cli**: `import konfai` 0.9 to 0.08 s, `konfai --help` 2.9 to 0.3 s: torch, dicom and ome-zarr
   load on first use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ no longer stops a run. Two things a run already wrote come out differently, see 
 - **runtime**: the per-rank thread share sizes ITK's pool along with torch's, and counts as applied
   only once it is
 - **dataset**: a dead writer's debris is told apart portably (`psutil.pid_exists`), Windows included
+- **dataset**: a streamed `.mha` writes MetaIO's `TransformMatrix`, which is the TRANSPOSE of
+  ITK's `Direction`: a non-symmetric orientation used to read back mirrored
 - **dataset**: an h5 replace keeps the old entry until the new one is in place; a streamed transform
   entry lands under the `.h5` name; an entry whose attributes fail is not left behind; one staging
   marker for every backend's temporary; the reader's own `ITK_*` keys do not travel with the volume
@@ -128,6 +130,12 @@ no longer stops a run. Two things a run already wrote come out differently, see 
   list; a caller that relied on the first failure raising mid-run reads the list instead.
 - **The auto memory budget is larger on a host that has streamed a cohort** and smaller under a
   SLURM grant that no cgroup enforces; the plan's header names which bound won.
+- **A streamed `.mha` written by an earlier version can carry mirrored geometry.** The streamed
+  writer wrote the `Direction` where MetaIO expects its transpose, so an entry whose orientation
+  is not symmetric (an oblique acquisition, an axis-permuting direction) reads back mirrored.
+  Entries written whole are unaffected, as are symmetric orientations (an axis-aligned volume).
+  Compare the stored `TransformMatrix` against the source's `Direction`, and rewrite the affected
+  entries with this version.
 - **The written geometry sidecar no longer carries `ITK_*` keys** the reader had added; a consumer
   that read them from a KonfAI output finds them absent.
 - **A `Config.yml`, `Prediction.yml` or `Evaluation.yml` carrying a key nothing reads now warns**

--- a/docs/source/concepts/streaming.md
+++ b/docs/source/concepts/streaming.md
@@ -138,7 +138,7 @@ extent that is 8× in 3D, against the single load streaming was avoiding. At pat
 | `HALO` | `Dilate(n>0)`, `Gradient` |
 | `ORIENTATION` | `Flip`, `Permute`, `Canonical` on axis-aligned direction cosines |
 | `CROP` | `Crop`, once its box is on the case |
-| `REGRID` | `Resample`, whichever grid and map it is given |
+| `REGRID` | `Resample`; `Padding` in `constant` mode (a translation into a filled, larger volume; `reflect`/`replicate` read the volume for their border and stay `WHOLE_VOLUME`) |
 
 Augmentations declare per **(case, draw)**, so two copies of one case can answer
 differently. `Permute`, `Flip` (with `vector_field: false`) and `Rotate` on a
@@ -161,10 +161,6 @@ once instead of once per patch per epoch, and it lets a statistic seed after a
 value-changing stage: `[Clip, Save, Standardize]` streams where
 `[Clip, Standardize]` cannot. Only a `Save` fed by an unstreamable prefix, or
 writing to a format without region writes, still loads the volume.
-
-One combination catches people out: `[Canonical, Resample, Padding]` streams on
-the write side but not on the read side, because `Padding` declares no forward
-locality and inherits `WHOLE_VOLUME`.
 
 A custom transform inherits `WHOLE_VOLUME` too, and is correct without knowing
 streaming exists. {doc}`../reference/api/extension-points` has the contract for
@@ -235,14 +231,25 @@ it in torch: same values, different summation order, so a voxel may land a few
 float32 ulp away. Seeded from `Min`/`Max` it is exact, since a min has no
 summation order to disagree on.
 
-A streamed `REGRID` computes its interpolation weights in the sub-region's
-coordinate frame, so the deviation follows the local gradient rather than the
-voxel's value: within a few ulp of the volume's peak on float volumes, within
-1 LSB on integer ones. Nearest-neighbour resampling, which is what a `uint8`
-label volume gets, uses no weights and stays exact. On the write side, an
-axis-aligned change of density is bit-identical; only a map that does not
-factorise, a rotation or a stored field, goes through the fused blend, where
-streamed and whole agree to about 1e-5 of the data's range.
+A streamed `REGRID` walks global float64 coordinates, so a slab computes the
+very numbers the whole volume computes. On the host the blend is ITK's own
+resampler on a window at its true origin, and on an axis-aligned volume streamed
+equals whole **bit for bit**, whatever the map. Two things cost an ulp: on CUDA a
+*linear* blend through a map that does not factorise (a rotation, a stored
+field) goes through `grid_sample`, which normalises coordinates by the window it
+is handed; and on oblique direction cosines a region's origin is one rounding
+the whole volume never takes. Either way streamed and whole agree to about 1e-5
+of the data's range, the deviation following the local gradient (within 1 LSB on
+integer volumes). Nearest-neighbour, which is what a `uint8` label volume gets,
+picks on the exact index; cubic walks its own corners; an axis-aligned change of
+density is read one axis at a time on global coordinates: all three are
+bit-identical everywhere.
+
+The slab height follows the budget, so it can differ between machines; through
+that same non-separable linear resample two runs of one chain under different
+budgets then differ by the same ~1e-5, and the plan says so when the budget
+lowers the height below the default. Everything else is independent of the
+slabbing: the same chain writes the same bytes under any budget.
 
 The same holds across slab heights. A `TRANSFORM` sweep cuts a case into slabs
 whose height follows the memory budget, so it depends on the machine (64 rows

--- a/docs/source/concepts/streaming.md
+++ b/docs/source/concepts/streaming.md
@@ -231,8 +231,9 @@ it in torch: same values, different summation order, so a voxel may land a few
 float32 ulp away. Seeded from `Min`/`Max` it is exact, since a min has no
 summation order to disagree on.
 
-A streamed `REGRID` walks global float64 coordinates, so a slab computes the
-very numbers the whole volume computes. On the host the blend is ITK's own
+A streamed `REGRID` walks global float64 coordinates (`precision: exact`, the
+default; `precision: fast` walks in float32 and the bounds below then no longer
+hold), so a slab computes the very numbers the whole volume computes. On the host the blend is ITK's own
 resampler on a window at its true origin, and on an axis-aligned volume streamed
 equals whole **bit for bit**, whatever the map. Two things cost an ulp: on CUDA a
 *linear* blend through a map that does not factorise (a rotation, a stored

--- a/docs/source/config_guide/transform.md
+++ b/docs/source/config_guide/transform.md
@@ -42,8 +42,16 @@ default chunking.
 ```bash
 konfai TRANSFORM --config Transform.yml          # transform
 konfai TRANSFORM --config Transform.yml --plan   # print the plan and stop
-konfai TRANSFORM --config Transform.yml --cpu 4  # shard the cases over 4 processes
+konfai TRANSFORM --config Transform.yml --cpu 4  # shard the work over 4 processes
 ```
+
+`--cpu N` (or `--gpu` with several ids) shards the *work items* over the ranks,
+balanced by bytes: an ordinary chain is one item per case, a reduction one item
+for all of its cases (so it never gains from more ranks). Every rank writes its
+own entries into the same output, which a single-file store cannot serve: a
+`Save`/`Write` to `:h5` refuses more than one rank; use `:omezarr`, `:mha` or
+`:nii`. An explicit `memory_budget` is per rank, and the plan header says what
+that makes on the node.
 
 A case whose output already exists is **skipped**: rerunning after an
 interruption resumes where it stopped. Pass `-y/--overwrite` to recompute
@@ -74,9 +82,11 @@ reports its own shard.
 With `--gpu`, each rank runs its chain on its device: the slabs are pulled to
 the GPU, transformed there, and land back on the host to be written, in taller
 slabs than on a CPU (as much as a quarter of the free device memory allows).
-The bytes are the ones a CPU run writes. The gain is modest for a light chain
-(the reads and the writes are the cost either way) and grows with the volume
-and the chain. `--gpu` also matters when a chain embeds a `KonfAIInference`
+The bytes are the ones a CPU run writes to the ulp (the coordinate walk is
+the same arithmetic on both). Without `--gpu` a `Resample` goes through ITK's
+own resampler on the host, the fastest exact one there is, and everything else
+through torch. The gain of `--gpu` is modest for a light chain (the reads and
+the writes are the cost either way) and grows with the volume and the chain. `--gpu` also matters when a chain embeds a `KonfAIInference`
 stage. That stage is a bridge, not a second prediction
 engine: it is whole-volume (the case is assembled, written to a temporary
 `.mha`, and read back), and each case spawns a process that resolves the app

--- a/docs/source/config_guide/transform.md
+++ b/docs/source/config_guide/transform.md
@@ -45,14 +45,6 @@ konfai TRANSFORM --config Transform.yml --plan   # print the plan and stop
 konfai TRANSFORM --config Transform.yml --cpu 4  # shard the work over 4 processes
 ```
 
-`--cpu N` (or `--gpu` with several ids) shards the *work items* over the ranks,
-balanced by bytes: an ordinary chain is one item per case, a reduction one item
-for all of its cases (so it never gains from more ranks). Every rank writes its
-own entries into the same output, which a single-file store cannot serve: a
-`Save`/`Write` to `:h5` refuses more than one rank; use `:omezarr`, `:mha` or
-`:nii`. An explicit `memory_budget` is per rank, and the plan header says what
-that makes on the node.
-
 A case whose output already exists is **skipped**: rerunning after an
 interruption resumes where it stopped. Pass `-y/--overwrite` to recompute
 everything. A case that fails (an unreadable file, a stage that raises) does
@@ -82,10 +74,13 @@ reports its own shard.
 With `--gpu`, each rank runs its chain on its device: the slabs are pulled to
 the GPU, transformed there, and land back on the host to be written, in taller
 slabs than on a CPU (as much as a quarter of the free device memory allows).
-The bytes are the ones a CPU run writes to the ulp (the coordinate walk is
-the same arithmetic on both). Without `--gpu` a `Resample` goes through ITK's
-own resampler on the host, the fastest exact one there is, and everything else
-through torch. The gain of `--gpu` is modest for a light chain (the reads and
+The bytes are the ones a CPU run writes: bit for bit for every pointwise,
+halo, orientation or crop stage and for a nearest, cubic or axis-aligned
+`Resample`; a *linear* resample through a map that does not factorise (a
+rotation, a stored field) may differ by about 1e-5 of the data's range on CUDA
+(see {doc}`../concepts/streaming`), and these bounds assume `precision: exact`,
+the default. Without `--gpu` a `Resample` goes through ITK's own resampler on
+the host, the fastest exact one there is, and everything else through torch. The gain of `--gpu` is modest for a light chain (the reads and
 the writes are the cost either way) and grows with the volume and the chain. `--gpu` also matters when a chain embeds a `KonfAIInference`
 stage. That stage is a bridge, not a second prediction
 engine: it is whole-volume (the case is assembled, written to a temporary

--- a/konfai/api.py
+++ b/konfai/api.py
@@ -326,8 +326,10 @@ def plan_transform(
     on_fallback: str = "warn",
     manual_seed: int = 0,
     dataset_options: Mapping[str, object] | None = None,
+    gpu: Sequence[int] | None = None,
     cpu: int = 1,
     overwrite: bool = False,
+    quiet: bool = False,
     transforms_dir: Path | str = Path("./Transforms"),
 ) -> "TransformPlan":
     """:func:`transform`'s dry-run twin: build, plan, print, return the plan: the run never starts.
@@ -338,8 +340,16 @@ def plan_transform(
     tree = _transform_tree(name, datasets, chains, memory_budget, on_fallback, manual_seed, dataset_options)
     from konfai.transformer import plan_transform as _plan_transform
 
-    with _one_workflow_at_a_time(cpu):
-        return _plan_transform(transform_file=tree, transforms_dir=transforms_dir, cpu=cpu, overwrite=overwrite)
+    ranks = len(gpu or []) or cpu
+    with _one_workflow_at_a_time(ranks):
+        return _plan_transform(
+            transform_file=tree,
+            transforms_dir=transforms_dir,
+            gpu=list(gpu) if gpu is not None else None,
+            cpu=cpu,
+            quiet=quiet,
+            overwrite=overwrite,
+        )
 
 
 # ------------------------------------------------------------------------------------ EVALUATION

--- a/konfai/data/__init__.py
+++ b/konfai/data/__init__.py
@@ -40,6 +40,8 @@ that declares neither is correct but loads whole volumes, so they are exported h
 buried in the module that happens to define them.
 """
 
+from typing import Any
+
 from konfai.data.data_manager import DataMetric, DataPrediction, DatasetIter, DataTrain, DataTransform
 from konfai.data.materialize import CaseMaterializer
 from konfai.data.patching import DatasetManager, DatasetPatch
@@ -55,14 +57,26 @@ from konfai.data.transform import (
     Write,
 )
 from konfai.utils.dataset import Attribute, Dataset
-from konfai.utils.ome_zarr import (
-    append_ome_zarr_levels,
-    create_ome_zarr_store,
-    get_ome_zarr_info,
-    is_displacement_field,
-    read_ome_zarr_data_slice,
-    write_ome_zarr,
+
+# The OME-Zarr helpers are part of this surface but resolved on first use: their module pulls dask,
+# zarr and ngff-zarr, half a second of every process start, for a job that may never touch a store.
+_OME_ZARR = (
+    "append_ome_zarr_levels",
+    "create_ome_zarr_store",
+    "get_ome_zarr_info",
+    "is_displacement_field",
+    "read_ome_zarr_data_slice",
+    "write_ome_zarr",
 )
+
+
+def __getattr__(name: str) -> Any:
+    if name in _OME_ZARR:
+        from konfai.utils import ome_zarr
+
+        return getattr(ome_zarr, name)
+    raise AttributeError(f"module 'konfai.data' has no attribute '{name}'")
+
 
 __all__ = [
     "Attribute",

--- a/konfai/data/case_reduction.py
+++ b/konfai/data/case_reduction.py
@@ -34,7 +34,7 @@ from dataclasses import dataclass, field
 import numpy as np
 import torch
 
-from konfai.data.patching import DatasetManager, RegionWriter, save_destination
+from konfai.data.patching import DatasetManager, RegionWriter, device_capped_budget, save_destination
 from konfai.data.reduction import Reduction
 from konfai.data.transform import LocalityKind, PatchLocality, Reduce, Save, Transform, stat_seed_valid
 from konfai.utils.dataset import (
@@ -255,6 +255,9 @@ class CaseReduction:
     group: str
     slab_rows: int = 64
     operator: Reduction = field(init=False)
+    #: The budget the last fit sized against, in host bytes: what a run-time device re-cap re-fits.
+    _budget_bytes: float | None = field(init=False, default=None)
+    _kept_folds: list | None = field(init=False, default=None, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         if not self.managers:
@@ -266,7 +269,7 @@ class CaseReduction:
         self.operator = self.reduce.operator
         check_post_stages(self.post, self.reduce.output)
 
-    def fit_budget(self, budget_bytes: float | None, cap: int = 64) -> None:
+    def fit_budget(self, budget_bytes: float | None, cap: int | None = None) -> None:
         """Size the regions so the resident ones fit ``budget_bytes``.
 
         The default region height is safe for one case and not for N: a reduction holds one region
@@ -275,9 +278,18 @@ class CaseReduction:
         Below one row nothing fits; the plan then reports a peak above the budget and the workflow
         refuses, which is the only honest answer: there is no whole-volume path to fall back to.
 
+        THE BUDGET IS THE ONLY CEILING. ``cap`` defaults to the output's own height, so a node with
+        room folds the whole volume in one region and reads each case ONCE. A fixed cap did the
+        opposite of what it looked like: it bounded the region at 64 rows however much memory the
+        run was given, so a cohort measured at 0.11 GiB resident against a 59.60 GiB budget still
+        paid a full sweep of every source per 64 rows -- and the sweeps are what a chain resampling
+        through a field pays for, since a region's source window is not the region. What is spent
+        stays declared: half a budget the caller named, or ``auto``, which measures the node.
+
         The budget also goes to the cases' own managers, because a chain crossing a ``Save`` sweeps
         that cache when first read, and ``read_region`` carries no budget of its own.
         """
+        self._budget_bytes = budget_bytes
         for manager in self.managers:
             manager.set_memory_budget(budget_bytes)
         if not budget_bytes or budget_bytes <= 0:
@@ -286,7 +298,10 @@ class CaseReduction:
         row_bytes = plan.peak_bytes / max(1, plan.slab_rows)
         if row_bytes <= 0:
             return
-        self.slab_rows = max(1, min(cap, int(budget_bytes * 0.5 / row_bytes)))
+        # Past the output's own height there is nothing left to hold, so that is the ceiling when
+        # the caller names none.
+        ceiling = int(cap) if cap is not None else int(plan.spatial[0])
+        self.slab_rows = max(1, min(ceiling, int(budget_bytes * 0.5 / row_bytes)))
 
     # ---------------------------------------------------------------- planning
 
@@ -435,11 +450,16 @@ class CaseReduction:
             self.operator.accumulate(manager.read_region(region).unsqueeze(0))
         return self.operator.finalize().squeeze(0)
 
+    def _folds(self, spatial: list[int]):
+        """Every region's fold, in order: the loop both passes share."""
+        for region in self._regions(spatial):
+            yield region, self._fold(region)
+
     def _apply_post(self, block: torch.Tensor, attribute: Attribute, rank: int) -> np.ndarray:
         scope = Attribute(attribute)
         for stage in self.post:
             block = stage(self.reduce.output, block, scope)
-        array = block.numpy()
+        array = block.cpu().numpy()
         if array.ndim != rank:
             raise ReductionError(
                 f"A stage after the Reduce returned a rank-{array.ndim} region where the"
@@ -462,10 +482,21 @@ class CaseReduction:
             attribute["konfai_reduce_cases"] = "|".join(plan.cases)
         if plan.stat_pass:
             statistics = _RunningStatistics()
-            for region in self._regions(plan.spatial):
-                statistics.update(self._fold(region))
+            # The folds this pass computes ARE the folds the write pass needs: keep them when the
+            # whole folded output fits half the budget (regions, not member volumes -- for a field
+            # or a mask that is megabytes), and the write pass then only applies the post stages.
+            # Otherwise the second pass re-folds, as before: correctness never depends on the keep.
+            keep = self._folded_output_bytes(plan) <= 0.5 * float(self._budget_bytes or 0)
+            self._kept_folds = [] if keep else None
+            for _region, folded in self._folds(plan.spatial):
+                statistics.update(folded)
+                if self._kept_folds is not None:
+                    self._kept_folds.append(folded.cpu())
             statistics.write_into(attribute)
         return attribute
+
+    def _folded_output_bytes(self, plan: ReductionPlan) -> int:
+        return int(np.prod(plan.spatial, dtype=np.int64)) * max(1, int(plan.channels)) * _ASSUMED_ITEMSIZE
 
     def _open_stream(self, spatial: list[int], array: np.ndarray, attribute: Attribute) -> DataStream:
         stream = self.destination.open_data_stream(
@@ -484,15 +515,44 @@ class CaseReduction:
             )
         return stream
 
-    def materialize(self, rewrite: bool = False) -> bool:
+    def materialize(self, rewrite: bool = False, device: torch.device | None = None) -> bool:
         """Write the reduced entry, or raise saying why it cannot be written this way.
 
         There is no whole-volume fallback: assembling every case is exactly what this exists to
         avoid, and doing it silently would turn a bounded run into an unannounced OOM. A finished
         output is left alone unless ``rewrite``, which is the resume.
+
+        ``device`` is where the fold runs: each member replays its region there, the operator folds
+        there, and only the finished block comes back to the host for the write.
         """
         if not rewrite and self.destination.is_dataset_exist(self.group, self.reduce.output):
             return True
+        for manager in self.managers:
+            manager.set_chain_device(device)
+            # --overwrite must reach the MEMBERS, not just this output: each member's read_region
+            # resolves satisfied Saves from the previous run's caches unless told to rewrite, and a
+            # reduction folding stale caches writes a wrong volume whose provenance looks correct.
+            manager._set_rewrite(rewrite)
+        if device is not None and device.type == "cuda":
+            # The member regions this fold accumulates live in VRAM: the slabs are sized against
+            # the card, not against a budget declared in host bytes -- a host-sized region set on a
+            # 16 GB card is an OOM mid-fold, after the stat pass already paid.
+            declared = self._budget_bytes
+            capped = device_capped_budget(declared, device)
+            if capped is not None and capped != declared:
+                self.fit_budget(capped)
+                # The slabs are the card's; the KEEP decision is the host's: kept folds live in host
+                # memory (``.cpu()``), and judging them against VRAM/2 re-folded outputs the host
+                # could have held whole -- a second full pass for nothing.
+                self._budget_bytes = declared
+                # Said once, because the PLAN printed the host figure: the run must say which
+                # budget it actually worked under, or every future OOM is diagnosed off a lie.
+                print(
+                    f"[Reduce] '{self.reduce.output}': regions re-sized for {device} --"
+                    f" {self.slab_rows} row(s) under {capped / 2**30:.2f} GiB"
+                    f" (min of the declared budget and half the card's free memory).",
+                    flush=True,
+                )
         plan = self.plan()
         if not plan.streams:
             # A grid disagreement gets its own remedy: a Save changes nothing about the grids, so
@@ -510,10 +570,19 @@ class CaseReduction:
         spatial = plan.spatial
         attribute = self._output_attributes(plan)
         rank = len(spatial) + 1
+        # The folds a stat pass kept (when the folded output fits half the budget) are written as
+        # they are; otherwise every region is folded here, once.
+        kept = self._kept_folds
+        self._kept_folds = None
+        folds = (
+            ((region, kept[index]) for index, region in enumerate(self._regions(spatial)))
+            if kept is not None
+            else self._folds(spatial)
+        )
         writer = RegionWriter(lambda _key, array, header: self._open_stream(spatial, array, header))
         try:
-            for region in self._regions(spatial):
-                array = self._apply_post(self._fold(region), attribute, rank)
+            for region, folded in folds:
+                array = self._apply_post(folded, attribute, rank)
                 writer.write(None, (slice(0, int(array.shape[0])), *region), array, attribute)
             writer.close()
         except BaseException as exception:

--- a/konfai/data/geometry.py
+++ b/konfai/data/geometry.py
@@ -29,7 +29,8 @@ Everything is plain float64 numpy: no torch, no SimpleITK. A value built here cr
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -37,6 +38,8 @@ import numpy as np
 from konfai.utils.errors import TransformError
 
 if TYPE_CHECKING:
+    import torch
+
     from konfai.utils.dataset import Attribute
 
 #: The geometry keys a grid is read from, in the order refusals name them.
@@ -225,12 +228,17 @@ class Grid:
     def rank(self) -> int:
         return len(self.size_zyx)
 
-    @property
+    @cached_property
     def index_to_world(self) -> AffineMap:
-        """Continuous index ``(x, y, z)`` to world: ``p = O + D S i``: ITK's own association."""
+        """Continuous index ``(x, y, z)`` to world: ``p = O + D S i``: ITK's own association.
+
+        Cached (the grid is frozen): a streamed walk asks per SLAB, and rebuilding the product --
+        and, for :attr:`world_to_index`, re-INVERTING it -- thousands of times per region was
+        measurable wall time. The cache returns the same floats it always returned, only once.
+        """
         return AffineMap(self.direction_xyz @ np.diag(self.spacing_xyz), np.asarray(self.origin_xyz, dtype=np.float64))
 
-    @property
+    @cached_property
     def world_to_index(self) -> AffineMap:
         return self.index_to_world.inverted()
 
@@ -422,6 +430,11 @@ class DisplacementStage:
     grid: Grid
     values: np.ndarray
     order: int
+    #: The values as a tensor, per (device, dtype), built on first use and living exactly as long
+    #: as the stage does: a stage is evaluated once per region per case, and re-uploading a whole
+    #: field for each was the copy the arithmetic never saw. Frozen dataclass, so a mutable field
+    #: hides behind object.__setattr__ once; it is excluded from equality and pickling by name.
+    _tensors: dict = field(default_factory=dict, init=False, repr=False, compare=False, hash=False)
 
     def __post_init__(self) -> None:
         if self.order not in SUPPORTED_SPLINE_ORDERS:
@@ -431,6 +444,30 @@ class DisplacementStage:
                 "Write the transform as a displacement field, or as a cubic BSpline, which is what"
                 " every registration that produces one writes by default.",
             )
+
+    def tensor(self, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+        """``values`` on ``device`` in ``dtype``, uploaded once per (device, dtype) for the stage's life."""
+        import torch
+
+        key = (str(device), str(dtype), "czyx")
+        cached = self._tensors.get(key)
+        if cached is None:
+            cached = self._tensors[key] = torch.tensor(self.values, dtype=dtype, device=device)
+        return cached
+
+    def tensor_by_voxel(self, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+        """``values`` as ``(voxel, component)``, contiguous: the layout a per-voxel gather wants."""
+        key = (str(device), str(dtype), "vc")
+        cached = self._tensors.get(key)
+        if cached is None:
+            rank = int(self.values.shape[0])
+            cached = self._tensors[key] = self.tensor(device, dtype).reshape(rank, -1).transpose(0, 1).contiguous()
+        return cached
+
+    def __getstate__(self) -> dict:
+        state = dict(self.__dict__)
+        state["_tensors"] = {}
+        return state
 
     @property
     def bound_xyz(self) -> np.ndarray:

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -283,6 +283,22 @@ class _ReadStagePlan:
     run_pull: Callable[[tuple[slice, ...]], list[slice]] | None = None
 
 
+def device_capped_budget(budget_bytes: float | None, device: "torch.device | None") -> float | None:
+    """The budget, capped at what ``device`` can actually hold.
+
+    The memory budget is declared in HOST bytes -- ``auto`` measures node RAM -- but on a GPU
+    chain the working sets it sizes (swept slabs, whole-volume fallbacks, a reduction's member
+    regions) live in VRAM. A 64G budget on a 16 GB card is then not a budget, it is a promise of
+    an OOM. Half the card's FREE memory, read when the fit runs: the halving is also the slack
+    that covers allocations arriving after the reading, since a fold sized once can run for hours.
+    """
+    if device is None or device.type != "cuda" or not torch.cuda.is_available():
+        return budget_bytes
+    free, _total = torch.cuda.mem_get_info(device)
+    vram = free * 0.5
+    return vram if budget_bytes is None or budget_bytes <= 0 else min(budget_bytes, vram)
+
+
 def save_destination(save: Save, default_dataset: Dataset, default_group: str) -> tuple[Dataset, str]:
     """The dataset and group a :class:`Save` caches into, the manager's own when it names none.
 
@@ -2231,6 +2247,16 @@ class DatasetManager:
         """
         self._sweep_budget_bytes = budget_bytes
 
+    def set_chain_device(self, device: torch.device | None) -> None:
+        """The device this case's chain replays on. Public for the same reason as the budget: a
+        reduction never calls :meth:`materialize`, only :meth:`read_region`, and its members must
+        replay where the fold will run. CPU collapses to None: opt-in only, because this same
+        machinery loads training cases inside DataLoader workers, where a CUDA default is wrong."""
+        self._chain_device = device if device is not None and device.type != "cpu" else None
+
+    def _device_budget(self, budget_bytes: float | None) -> float | None:
+        return device_capped_budget(budget_bytes, self._chain_device)
+
     def _set_rewrite(self, rewrite: bool) -> None:
         """The rewrite knob the materialization engine sets for one call: under it every
         satisfied-Save probe answers "not written yet" (the read path consults it too, which is
@@ -2444,6 +2470,11 @@ class DatasetManager:
                 stream_source.group, stream_source.entry, plan.data_slices
             )
             tensor = torch.from_numpy(data)
+            if self._chain_device is not None:
+                # The same move the region route and the whole-volume load make: a pointwise chain
+                # otherwise streamed on the host while its whole-volume twin ran on the GPU, and the
+                # two disagreed wherever a kernel's arithmetic differs by device (Softmax, a std).
+                tensor = tensor.to(self._chain_device)
             cache_attribute = Attribute(self.cache_attributes_bak[a])
             cache_attribute.update(attributes)
             # Says the Min/Max/Mean/Std here are the planner's DISK seeds, not a mid-chain stage's

--- a/konfai/data/reduction.py
+++ b/konfai/data/reduction.py
@@ -175,24 +175,25 @@ class Median(Reduction):
     """
 
     voxel_local = True
-    # ``torch.stack`` copies the buffer and ``torch.quantile`` sorts, indexes and interpolates
-    # copies of that: measured at 4x the stack it is handed (6 x 16 MiB float32 cases).
+    # ``torch.stack`` copies the buffer and the sort along the case axis returns values and
+    # int64 indices over that: measured at 4x the stack it is handed (6 x 16 MiB float32 cases).
     working_multiple = 4.0
 
     def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
+        dtype = _averaged_dtype(tensors[0].dtype)
         if len(tensors) == 1:
-            return tensors[0].to(_averaged_dtype(tensors[0].dtype))
+            return tensors[0].to(dtype)
         # The sort along the case axis, and the middle read off it: what torch.quantile computes,
         # without its interpolation machinery around it (1.5-2x on CPU, 3.5x on CUDA over three
-        # cases, measured). The even-count middle is the same lerp quantile uses, so the two are
-        # bit-identical, odd and even.
-        ranked = torch.stack(tensors, dim=0).float().sort(dim=0).values
+        # cases, measured), in the dtype the average belongs in, so a float64 cohort keeps its
+        # precision. The even-count middle is the same lerp quantile uses, so the two agree.
+        ranked = torch.stack(tensors, dim=0).to(dtype).sort(dim=0).values
         cases = ranked.shape[0]
         if cases % 2:
             middle = ranked[cases // 2]
         else:
             middle = torch.lerp(ranked[cases // 2 - 1], ranked[cases // 2], 0.5)
-        return middle.to(_averaged_dtype(tensors[0].dtype))
+        return middle
 
 
 class Vote(Reduction):

--- a/konfai/data/reduction.py
+++ b/konfai/data/reduction.py
@@ -182,7 +182,16 @@ class Median(Reduction):
     def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
         if len(tensors) == 1:
             return tensors[0].to(_averaged_dtype(tensors[0].dtype))
-        middle = torch.quantile(torch.stack(tensors, dim=0).float(), 0.5, dim=0)
+        # The sort along the case axis, and the middle read off it: what torch.quantile computes,
+        # without its interpolation machinery around it (1.5-2x on CPU, 3.5x on CUDA over three
+        # cases, measured). The even-count middle is the same lerp quantile uses, so the two are
+        # bit-identical, odd and even.
+        ranked = torch.stack(tensors, dim=0).float().sort(dim=0).values
+        cases = ranked.shape[0]
+        if cases % 2:
+            middle = ranked[cases // 2]
+        else:
+            middle = torch.lerp(ranked[cases // 2 - 1], ranked[cases // 2], 0.5)
         return middle.to(_averaged_dtype(tensors[0].dtype))
 
 
@@ -193,13 +202,27 @@ class Vote(Reduction):
     """
 
     voxel_local = True
-    # ``torch.mode`` sorts a copy of the stack it is handed, alongside the stack itself.
+    # The sorted copy of the stack, and one stack-sized mask beside it.
     working_multiple = 2.0
 
     def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
         if len(tensors) == 1:
             return tensors[0]
-        return torch.mode(torch.stack(tensors, dim=0), dim=0).values.to(tensors[0].dtype)
+        # NOT torch.mode: its tie-break is the smallest label on CPU and the LARGEST on CUDA
+        # (measured: 19% of a six-member fold differed by device), so a --gpu reduce and a CPU
+        # reduce wrote different label maps under one provenance. Sorted along the case axis and
+        # counted member by member, the first count that is not beaten IS the smallest label with
+        # the most votes, on every device. Per voxel this is cases^2 comparisons over the stack and
+        # nothing else: no unique over the volume (a sort of every voxel, 31 s per 512^3 on a
+        # CPU where this takes 2 s), no per-label count planes.
+        ranked = torch.stack(tensors, dim=0).sort(dim=0).values
+        best, best_count = ranked[0], (ranked == ranked[0]).sum(dim=0, dtype=torch.int16)
+        for member in ranked[1:]:
+            count = (ranked == member).sum(dim=0, dtype=torch.int16)
+            better = count > best_count
+            best = torch.where(better, member, best)
+            best_count = torch.where(better, count, best_count)
+        return best
 
 
 class Concat(Reduction):

--- a/konfai/data/sampling.py
+++ b/konfai/data/sampling.py
@@ -29,7 +29,10 @@ from the read to the write.
 
 from __future__ import annotations
 
+import contextlib
+import contextvars
 import itertools
+from collections.abc import Iterator
 
 import numpy as np
 import torch
@@ -51,6 +54,36 @@ from konfai.data.geometry import (
 #: smooth. Measured on a 64x512x512 slab: float32 coordinates disagree with SimpleITK by 0.35 on
 #: data in [0, 1], float64 by 3e-05 (which is the gather's own float32 rounding).
 _COORDINATE_DTYPE = torch.float64
+
+#: The walk's dtype for the CURRENT context, entered by :func:`coordinate_precision`. A contextvar
+#: and not a parameter threaded through eight signatures: the choice belongs to the stage that
+#: knows its data (an intensity resample can trade the last bits for bandwidth, a label resample
+#: must not), and every helper below reads the same answer without the plumbing.
+_COORDINATE_DTYPE_VAR: contextvars.ContextVar[torch.dtype | None] = contextvars.ContextVar(
+    "konfai_coordinate_dtype", default=None
+)
+
+
+def _walk_dtype() -> torch.dtype:
+    return _COORDINATE_DTYPE_VAR.get() or _COORDINATE_DTYPE
+
+
+@contextlib.contextmanager
+def coordinate_precision(dtype: torch.dtype) -> Iterator[None]:
+    """Run the coordinate walk under ``dtype`` for the duration of the block.
+
+    The default (float64) is the BIT-EXACT contract with SimpleITK and stays untouched unless a
+    caller opts out. float32 halves the walk's bytes -- measured ~1.6x on a bandwidth-bound GPU
+    walk, and twice the rows per slab -- at a coordinate error of about |world| / 2^24: a few 1e-4
+    of a voxel on world coordinates of order 1e4-1e5 units, growing with the magnitude. A NEAREST
+    pick within that band of a .5 boundary lands on the other voxel. Intensity chains may take the
+    trade; label chains and anything that must reproduce sitk.Resample bit for bit must not.
+    """
+    token = _COORDINATE_DTYPE_VAR.set(dtype)
+    try:
+        yield
+    finally:
+        _COORDINATE_DTYPE_VAR.reset(token)
 
 
 # --------------------------------------------------------------------------------------------------
@@ -147,8 +180,8 @@ def _apply(points_xyz: torch.Tensor, affine: AffineMap, device: torch.device) ->
     an exact half then rounds to the other voxel. The one matmul saved is not worth a label map
     that disagrees with ``sitk.Resample`` in whole columns.
     """
-    matrix = torch.tensor(affine.matrix, dtype=_COORDINATE_DTYPE, device=device)
-    out = torch.tensor(affine.translation, dtype=_COORDINATE_DTYPE, device=device).expand(points_xyz.shape).clone()
+    matrix = torch.tensor(affine.matrix, dtype=_walk_dtype(), device=device)
+    out = torch.tensor(affine.translation, dtype=_walk_dtype(), device=device).expand(points_xyz.shape).clone()
     for j in range(affine.rank):
         out = out + points_xyz[..., j, None] * matrix[:, j]
     return out
@@ -161,8 +194,8 @@ def _to_index(world_xyz: torch.Tensor, grid: Grid, device: torch.device) -> torc
     origin into a translation instead (which is what a generic inverted affine map is) reassociates
     a difference of large world coordinates against a small one and moves the last bit.
     """
-    matrix = torch.tensor(grid.world_to_index.matrix, dtype=_COORDINATE_DTYPE, device=device)
-    origin = torch.tensor(grid.origin_xyz, dtype=_COORDINATE_DTYPE, device=device)
+    matrix = torch.tensor(grid.world_to_index.matrix, dtype=_walk_dtype(), device=device)
+    origin = torch.tensor(grid.origin_xyz, dtype=_walk_dtype(), device=device)
     shifted = world_xyz - origin
     out = torch.zeros_like(world_xyz)
     for j in range(grid.rank):
@@ -178,10 +211,16 @@ def _displacement_at(stage: DisplacementStage, world_xyz: torch.Tensor, device: 
     legal stand-in for the whole of it: the part it does not cover was going to be identity here
     anyway, which is exactly why the region handed in must COVER the target region, and why a
     short one degrades in silence rather than raising.
+
+    The corner walk is arranged so nothing is computed twice, and ONLY so: each axis's tap weights
+    and clamped positions are built once and the corners read them, and the per-corner gather pulls
+    all components through one ``index_select``. Every float op the original per-corner form ran is
+    still run, on the same values, in the same association, so the result is bit-identical: the
+    weight product multiplies axis 0 first, the corner sum accumulates in ``itertools.product``
+    order, and a gather copies without rounding.
     """
     rank = stage.grid.rank
     index = _to_index(world_xyz, stage.grid, device)  # continuous index on the value grid, (x, y, z)
-    values = torch.tensor(stage.values, dtype=_COORDINATE_DTYPE, device=device)
     extent_xyz = [int(stage.grid.size_zyx[rank - 1 - axis]) for axis in range(rank)]
 
     if stage.order != 1:
@@ -196,40 +235,71 @@ def _displacement_at(stage: DisplacementStage, world_xyz: torch.Tensor, device: 
             at_end = (index[..., axis] - end).abs() <= 4.0 * ulp
             index[..., axis] = index[..., axis].masked_fill(at_end, end - ulp)
 
-    base = torch.floor(index) - (stage.order - 1) // 2
     taps = stage.order + 1
-    # The two domains ITK actually implements, and they differ. A BSpline is the identity unless its
-    # whole support lies in the coefficient grid (``InsideValidRegion``), so its edge falls off a
-    # control point early. A dense field is an ordinary image: it interpolates anywhere in
+    shift = (stage.order - 1) // 2
+    # Per axis, per tap, once, on a CONTIGUOUS copy of that axis: ``index[..., axis]`` is a stride-
+    # rank view, and every elementwise op over it ran ~7x slower than over a packed tensor
+    # (measured). The copy holds the very same floats. ``base`` is derived per axis and dropped
+    # with it, and ``index`` is released before the corner loop: the walk's transient peak is made
+    # of tensors that outlive their use.
+    #
+    # The two domains ITK actually implements, and they differ. A BSpline is the identity unless
+    # its whole support lies in the coefficient grid (``InsideValidRegion``), so its edge falls off
+    # a control point early. A dense field is an ordinary image: it interpolates anywhere in
     # ``[-0.5, n - 0.5)`` with the taps clamped, which reaches half a voxel past the outermost
-    # samples. Using the spline's rule for a field blanks that rim: 10% of the voxels of a small
-    # volume, all of them at the border, all of them silently un-warped.
+    # samples. Using the spline's rule for a field blanks that rim.
     inside = torch.ones(index.shape[:-1], dtype=torch.bool, device=device)
+    weight_at: list[list[torch.Tensor]] = []
+    position_at: list[list[torch.Tensor]] = []
     for axis in range(rank):
+        coordinate = index[..., axis]
+        base = torch.floor(coordinate) - shift
         if stage.order == 1:
-            inside &= (index[..., axis] >= -0.5) & (index[..., axis] < extent_xyz[axis] - 0.5)
+            inside &= (coordinate >= -0.5) & (coordinate < extent_xyz[axis] - 0.5)
         else:
-            inside &= (base[..., axis] >= 0) & (base[..., axis] + taps - 1 < extent_xyz[axis])
+            inside &= (base >= 0) & (base + taps - 1 < extent_xyz[axis])
+        weights, positions = [], []
+        for tap in range(taps):
+            position = base + tap
+            weights.append(_kernel_weights(coordinate - position, stage.order))
+            # int32: every clamped position is below the axis extent, and the flat index it feeds
+            # stays below the window's voxel count, which no field window approaches 2**31 of.
+            positions.append(position.to(torch.int32).clamp(0, extent_xyz[axis] - 1))
+        weight_at.append(weights)
+        position_at.append(positions)
+        del coordinate, base
+    del index
 
-    flat_values = values.reshape(rank, -1)
-    out = torch.zeros(index.shape, dtype=_COORDINATE_DTYPE, device=device)
+    # (voxel, component), contiguous: a gather then lands each voxel's components side by side,
+    # which is the layout the accumulator wants -- the (component, voxel) form needed a strided
+    # transpose per corner, measured at 2.6x the cost for the same numbers.
+    flat_values = stage.tensor_by_voxel(device, _walk_dtype())
+    out = torch.zeros((*inside.shape, rank), dtype=_walk_dtype(), device=device)
     for corner in itertools.product(range(taps), repeat=rank):
-        weight = torch.ones(index.shape[:-1], dtype=_COORDINATE_DTYPE, device=device)
-        positions_xyz = []
-        for axis in range(rank):
-            position = base[..., axis] + corner[axis]
-            weight = weight * _kernel_weights(index[..., axis] - position, stage.order)
-            positions_xyz.append(position.to(torch.long).clamp(0, extent_xyz[axis] - 1))
+        weight = weight_at[0][corner[0]]
+        for axis in range(1, rank):
+            weight = weight * weight_at[axis][corner[axis]]
         # ``values`` is (component, Z, Y, X) and row-major over the spatial axes, so the flat index
         # runs the ARRAY axes outermost-first with x fastest: the mirror of the physical order the
         # coordinates arrive in. Running it the other way samples the field transposed, which warps
         # the anatomy somewhere plausible and wrong.
-        flat_index = torch.zeros(index.shape[:-1], dtype=torch.long, device=device)
-        for array_axis in range(rank):
-            flat_index = flat_index * int(stage.grid.size_zyx[array_axis]) + positions_xyz[rank - 1 - array_axis]
-        gathered = torch.stack([flat_values[c].index_select(0, flat_index.reshape(-1)) for c in range(rank)], dim=-1)
-        out = out + gathered.reshape(out.shape) * weight.unsqueeze(-1)
-    return out * inside.unsqueeze(-1)
+        # int64 for the flat index: a full-resolution field window exceeds 2**31 voxels, and the
+        # per-axis int32 positions widen exactly on the first multiply.
+        flat_index = position_at[rank - 1][corner[rank - 1]].to(torch.long)
+        for array_axis in range(1, rank):
+            axis = rank - 1 - array_axis
+            flat_index = flat_index * int(stage.grid.size_zyx[array_axis]) + position_at[axis][corner[axis]]
+        # One gather for all components; a copy, so the numbers are the stored ones. NOT addcmul_:
+        # a fused multiply-add rounds once where ``out + g * w`` rounds twice, and the last bit is
+        # the contract.
+        gathered = flat_values[flat_index.reshape(-1)]
+        # In place: the same two roundings as ``out = out + g * w`` (verified bitwise), one fewer
+        # full-size allocation per corner -- and per-corner allocations are what the walk's
+        # transient peak is made of.
+        out += gathered.reshape(out.shape) * weight.unsqueeze(-1)
+        del gathered, flat_index, weight
+    out *= inside.unsqueeze(-1)
+    return out
 
 
 def source_index(
@@ -237,6 +307,7 @@ def source_index(
     source_grid: Grid,
     stages: SpatialStages,
     device: torch.device,
+    budget_bytes: float | None = None,
 ) -> torch.Tensor:
     """One source continuous index per voxel of ``target_grid``, shaped ``(*size_zyx, rank)`` in ``(x, y, z)``.
 
@@ -252,9 +323,75 @@ def source_index(
     points, where nothing rounds to an index.
     """
     rank = target_grid.rank
-    axes = [
-        torch.arange(int(extent), dtype=_COORDINATE_DTYPE, device=device) for extent in reversed(target_grid.size_zyx)
-    ]
+    rows_total = int(target_grid.size_zyx[0])
+    plane = 1
+    for extent in target_grid.size_zyx[1:]:
+        plane *= int(extent)
+    # The walk holds several float64 tensors per voxel at once (world, index, per-tap weights and
+    # positions, the corner gather), so a large region's TRANSIENTS dwarf its result: ~30 GB beside
+    # a 3.6 GB answer, measured on an ExaSPIM slab. Slabbing the leading array axis bounds them
+    # without touching a value: every op here is per-voxel, and a sub-range arange holds the very
+    # integers the full one holds, so a slab computes bit for bit what the whole region computes.
+    rows = walk_rows(target_grid, stages, device, budget_bytes)
+    if rows >= rows_total:
+        return source_index_rows(target_grid, source_grid, stages, device, 0, rows_total)
+    out = torch.empty(
+        (rows_total, *[int(e) for e in target_grid.size_zyx[1:]], rank), dtype=_walk_dtype(), device=device
+    )
+    for start in range(0, rows_total, rows):
+        stop = min(rows_total, start + rows)
+        out[start:stop] = source_index_rows(target_grid, source_grid, stages, device, start, stop)
+    return out
+
+
+def walk_rows(target_grid: Grid, stages: SpatialStages, device: torch.device, budget_bytes: float | None = None) -> int:
+    """How many leading-axis rows of ``target_grid`` one walk slab may cover under ``budget_bytes``.
+
+    Priced from the walk itself: per voxel it holds the world point, the continuous index and the
+    output (rank each), a weight and a position per axis per tap, and the gather's flat index and
+    result -- doubled, because torch materializes each binary op's result beside its operands. The
+    default budget is the machine's, through the one rule every consumer shares
+    (:func:`~konfai.data.patching.device_capped_budget`): on CUDA half the free VRAM, on CPU a
+    quarter of what this process may still allocate.
+    """
+    from konfai.data.patching import device_capped_budget
+    from konfai.utils.budget import available_memory_bytes
+
+    if budget_bytes is None:
+        budget_bytes = device_capped_budget(available_memory_bytes()[0] * 0.25, torch.device(device)) or 0.0
+    plane = 1
+    for extent in target_grid.size_zyx[1:]:
+        plane *= int(extent)
+    rank = target_grid.rank
+    taps = max((stage.order + 1 for stage in stages if isinstance(stage, DisplacementStage)), default=2)
+    itemsize = torch.tensor([], dtype=_walk_dtype()).element_size()
+    per_voxel = 2 * itemsize * (3 * rank + 2 * rank * taps + rank + 1)
+    total = int(target_grid.size_zyx[0])
+    rows = max(1, min(total, int(budget_bytes) // max(1, plane * per_voxel)))
+    # Balanced slabs: 31 rows under a 15-row ceiling is 16 + 15, never 15 + 15 + 1 -- a one-row
+    # tail pays every fixed cost of a walk (meshgrid, affines, the field's taps) for one row's
+    # worth of work. Same ceiling, same values, one launch fewer.
+    return -(-total // -(-total // rows))
+
+
+def source_index_rows(
+    target_grid: Grid,
+    source_grid: Grid,
+    stages: SpatialStages,
+    device: torch.device,
+    start: int,
+    stop: int,
+) -> torch.Tensor:
+    """:func:`source_index` over rows ``[start, stop)`` of the leading array axis.
+
+    The row indices stay GLOBAL to ``target_grid`` and go through ITS map: re-deriving a chunk as a
+    ``sub_grid`` would fold the start into a new origin, a different association whose world points
+    disagree with the whole region's in the last bit: which is the whole disagreement
+    :func:`source_index`'s docstring forbids.
+    """
+    rank = target_grid.rank
+    axes = [torch.arange(int(extent), dtype=_walk_dtype(), device=device) for extent in reversed(target_grid.size_zyx)]
+    axes[-1] = torch.arange(start, stop, dtype=_walk_dtype(), device=device)
     # meshgrid in array order (Z, Y, X) with the physical components last, so the tensor indexes
     # like the volume it will sample.
     grids = torch.meshgrid(*reversed(axes), indexing="ij")
@@ -268,7 +405,7 @@ def source_index(
         if not pending.is_identity:
             world = _apply(world, pending, device)
             pending = AffineMap.identity(rank)
-        world = world + _displacement_at(stage, world, device)
+        world = world + _displacement_at(stage, world, device)  # not +=: the stage READS world
     if not pending.is_identity:
         world = _apply(world, pending, device)
     return _to_index(world, source_grid, device)
@@ -311,7 +448,7 @@ def separable_source_index(
     axes: list[torch.Tensor] = []
     for array_axis in range(rank):
         axis = rank - 1 - array_axis  # the physical component this array axis runs along
-        index = torch.arange(int(target_grid.size_zyx[array_axis]), dtype=_COORDINATE_DTYPE, device=device)
+        index = torch.arange(int(target_grid.size_zyx[array_axis]), dtype=_walk_dtype(), device=device)
         world = float(forward.translation[axis]) + index * float(forward.matrix[axis, axis])
         axes.append((world - float(source_grid.origin_xyz[axis])) * float(backward.matrix[axis, axis]))
     return axes
@@ -363,7 +500,9 @@ def gather_separable(
     inside_axes = [(axis >= -0.5) & (axis < source_shape_zyx[array_axis] - 0.5) for array_axis, axis in enumerate(axes)]
     out_shape = [int(source.shape[0]), *extent_zyx]
     if not all(bool(mask.any()) for mask in inside_axes):
-        return torch.full(out_shape, fill, device=device, dtype=torch.float32).type(source.dtype)
+        # Working dtype then cast, as the masked tail fills: a float32 detour quantizes a float64
+        # fill and a fully-outside slab then differs from the unslabbed pass in its fill bits.
+        return torch.full(out_shape, fill, device=device, dtype=sampling_dtype(source)).type(source.dtype)
 
     def local(index: torch.Tensor, array_axis: int) -> torch.Tensor:
         return window_index(index, source_shape_zyx[array_axis], source_starts_zyx[array_axis], window_zyx[array_axis])
@@ -414,8 +553,9 @@ def gather_separable(
         # lerp fuses the three passes `low * (1 - w) + high * w` into one. Exact at w = 0, which is
         # the only endpoint reachable: w is `x - floor(x)`, so it never reaches 1.
         out = torch.lerp(low, high, share)
-    if mode == "nearest" and not out.is_floating_point():
-        out = out.type(torch.float32)
+    # No float trip for a nearest pick: copies stay in the payload's own dtype the whole way, the
+    # rule `gather` already holds -- a float32 detour rounds every integer label above 2**24, and
+    # the two paths then disagree on the very volumes they are supposed to serve identically.
     if mode == "cubic":
         out = _saturate_overshoot(out, source.dtype)
 
@@ -467,7 +607,10 @@ def gather(
 
     out_shape = [int(source.shape[0]), *extent_zyx]
     if not bool(inside.any()):
-        return torch.full(out_shape, fill, device=device, dtype=torch.float32).type(source.dtype)
+        # In the WORKING dtype then cast, exactly as the masked path fills: filling in float32
+        # first quantizes a float64 fill, and a walk slab that clears the source then disagrees
+        # with the unslabbed pass in the last bits of its fill value.
+        return torch.full(out_shape, fill, device=device, dtype=sampling_dtype(source)).type(source.dtype)
 
     # A nearest pick copies voxels: no blend, no working dtype, and no float trip for a label,
     # whose values above 2**24 a float32 cannot carry back (gather_separable holds the same rule).
@@ -495,7 +638,7 @@ def gather(
         base_xyz = torch.floor(coordinates_xyz) - 1.0
         out = torch.zeros(out_shape, dtype=work.dtype, device=device)
         for corner in itertools.product(range(4), repeat=rank):
-            weight = torch.ones(extent_zyx, dtype=_COORDINATE_DTYPE, device=device)
+            weight = torch.ones(extent_zyx, dtype=_walk_dtype(), device=device)
             flat = torch.zeros(extent_zyx, dtype=torch.long, device=device)
             for array_axis in range(rank):
                 axis = rank - 1 - array_axis

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -3387,10 +3387,19 @@ class OneHot(TransformInverse):
         # Scattered straight into the float32 answer: ``F.one_hot`` builds the classes in int64
         # first, three times the bytes of the result for the time of a cast (80 GB for 50 classes
         # of a 512^3 map, where the answer is 27 GB and this holds the answer plus the labels).
+        labels = tensor.to(torch.int64)
+        # scatter_ names no label: out of range it is a raw index error on CPU and a device-side
+        # assert on CUDA that poisons the context, where F.one_hot said which value was wrong.
+        lowest, highest = int(labels.min()), int(labels.max())
+        if lowest < 0 or highest >= self.num_classes:
+            raise TransformError(
+                f"'OneHot' with num_classes={self.num_classes} met labels from {lowest} to {highest} in '{name}'.",
+                "Labels must lie in [0, num_classes): raise num_classes or relabel (SelectLabel) first.",
+            )
         result = torch.zeros(
             (int(tensor.shape[0]), self.num_classes, *tensor.shape[1:]), dtype=torch.float32, device=tensor.device
         )
-        result.scatter_(1, tensor.to(torch.int64).unsqueeze(1), 1.0)
+        result.scatter_(1, labels.unsqueeze(1), 1.0)
         return result.squeeze(0)
 
     def inverse(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -50,11 +50,14 @@ from konfai.data.geometry import (
 from konfai.data.reduction import Reduction
 from konfai.data.sampling import (
     blend_order,
+    coordinate_precision,
     gather,
     gather_separable,
     separable_source_index,
     source_index,
+    source_index_rows,
     source_window,
+    walk_rows,
 )
 from konfai.utils.config import _escape_key_component, apply_config, record_given_arguments
 from konfai.utils.dataset import Attribute, Dataset, DataStream, data_to_image, image_to_data
@@ -211,6 +214,18 @@ class Transform(NeedDevice, ABC):
 
     def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
         return shape
+
+    def output_channels(self, channels: int) -> int:
+        """How many channels this transform returns for ``channels`` in: the channel-axis twin of
+        :meth:`transform_shape`, for the plan's memory arithmetic.
+
+        Identity by default. A stage that WIDENS the axis must say so: the plan sizes a case, and
+        every streamed slab, from the channels a chain holds at its widest, and a one-hot priced at
+        its source's single channel loaded a 50-class volume onto a 2 GB budget and ran out of
+        memory 50 channels later. A stage that narrows may stay silent, that only makes the plan
+        conservative.
+        """
+        return channels
 
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
         """Declare how this transform's output depends on its input, for patch streaming.
@@ -511,6 +526,10 @@ class TransformLoader:
             and not candidate.startswith("_")
             and any(base.__name__ in ("Transform", "DataAugmentation") for base in obj.__mro__)
         }
+        # Every resample-ish spelling and Warp are the one Resample stage; difflib alone offers
+        # 'EulerTransform' for 'ResampleTransform' and nothing for 'Warp'.
+        if "Resample" in name or name == "Warp":
+            return "Closest name: 'Resample' (the 1.8 spelling of every resample and Warp). "
         closest = difflib.get_close_matches(name, sorted(candidates), n=1)
         return f"Closest name: '{closest[0]}'. " if closest else ""
 
@@ -1257,6 +1276,52 @@ class _ReferenceGrid(_TargetGrid):
         return f"reference '{self.entry}'" + (" (per case)" if "{case}" in self.entry else "")
 
 
+def _resample_with_sitk(
+    payload: torch.Tensor,
+    region: Grid,
+    source: Grid,
+    stages: SpatialStages,
+    region_starts: list[int],
+    mode: str,
+    fill: float,
+) -> torch.Tensor | None:
+    """One region of a resample through ITK's own filter, on the host.
+
+    ``payload`` is the SOURCE window read for this region (``region_starts`` says where it sits
+    in the source grid); ``region`` is the target grid of the region. The window becomes an image
+    with the source's geometry shifted to its start; the target region an image with its own
+    grid; the stages one composite transform (:func:`~konfai.utils.ITK.encode_transform_stages`),
+    applied by ``sitk.Resample`` in the direction KonfAI's walk applies it (target point through
+    the stages to the source point). Channels are resampled one by one, which is what ITK does
+    for a vector image anyway. ``None`` for a payload ITK has no pixel type for (bool, bf16).
+    """
+    from konfai.utils.ITK import encode_transform_stages
+
+    if payload.dtype in (torch.bool, torch.bfloat16, torch.float16):
+        return None
+    interpolator = {"nearest": sitk.sitkNearestNeighbor, "linear": sitk.sitkLinear, "cubic": sitk.sitkBSpline}
+    if mode == "cubic":
+        return None  # ITK's BSpline is not Keys' Catmull-Rom: the walk keeps its own cubic
+    rank = source.rank
+    transform = encode_transform_stages(stages) if stages else sitk.Transform(rank, sitk.sitkIdentity)
+    # The window's own origin: the source origin moved by the window's start along each axis.
+    start_index = np.asarray(list(reversed(region_starts)), dtype=np.float64)  # (x, y, z)
+    window_origin = source.index_to_world.apply(start_index)
+    reference = sitk.Image([int(e) for e in reversed(region.size_zyx)], sitk.sitkFloat32)
+    reference.SetOrigin(np.asarray(region.origin_xyz, dtype=np.float64).tolist())
+    reference.SetSpacing(np.asarray(region.spacing_xyz, dtype=np.float64).tolist())
+    reference.SetDirection(np.asarray(region.direction_xyz, dtype=np.float64).ravel().tolist())
+    outputs = []
+    for channel in range(int(payload.shape[0])):
+        image = sitk.GetImageFromArray(np.ascontiguousarray(payload[channel].numpy()))
+        image.SetOrigin(np.asarray(window_origin, dtype=np.float64).tolist())
+        image.SetSpacing(np.asarray(source.spacing_xyz, dtype=np.float64).tolist())
+        image.SetDirection(np.asarray(source.direction_xyz, dtype=np.float64).ravel().tolist())
+        out = sitk.Resample(image, reference, transform, interpolator[mode], float(fill), image.GetPixelID())
+        outputs.append(torch.from_numpy(sitk.GetArrayFromImage(out)))
+    return torch.stack(outputs, dim=0)
+
+
 class Resample(TransformInverse):
     """Resample a case: onto another grid, through a stored map, or both, in one interpolation.
 
@@ -1349,6 +1414,7 @@ class Resample(TransformInverse):
         interpolation: str | None = None,
         fill: float = 0.0,
         inverse: bool = True,
+        precision: str = "exact",
     ) -> None:
         super().__init__(inverse)
         if interpolation is not None and interpolation not in ("linear", "nearest", "cubic"):
@@ -1358,6 +1424,17 @@ class Resample(TransformInverse):
                 " for a sharper image blend. Left unset, uint8 is taken for a label map and"
                 " everything else is interpolated linearly.",
             )
+        if precision not in ("exact", "fast"):
+            raise TransformError(
+                f"'Resample' has an unknown precision '{precision}'.",
+                "'exact' (the default) walks coordinates in float64, bit-identical to"
+                " sitk.Resample. 'fast' lets the device walk in float32: half the bytes and about"
+                " twice the rows per slab, at ~|world|/2^24 of coordinate error -- for INTENSITY"
+                " resamples only (on the host ITK's own resampler is used either way)."
+                " A nearest pick that lands within that band of a voxel boundary picks the other"
+                " voxel, so a label map must stay 'exact'.",
+            )
+        self.precision = precision
         self.interpolation = interpolation
         self.fill_value = float(fill)
         self._target = self._target_from(spacing, shape, reference, reference_group, reference_dataset, align)
@@ -1766,6 +1843,16 @@ class Resample(TransformInverse):
     def _sample(
         self, name: str, sub_tensor: torch.Tensor, target_slices: tuple[slice, ...], region_starts: list[int]
     ) -> torch.Tensor:
+        # 'fast' walks the coordinates in float32 for the whole sample: an opt-in the stage's
+        # declaration made for its own data. The default context is the bit-exact float64 walk.
+        if self.precision == "fast":
+            with coordinate_precision(torch.float32):
+                return self._sample_in_context(name, sub_tensor, target_slices, region_starts)
+        return self._sample_in_context(name, sub_tensor, target_slices, region_starts)
+
+    def _sample_in_context(
+        self, name: str, sub_tensor: torch.Tensor, target_slices: tuple[slice, ...], region_starts: list[int]
+    ) -> torch.Tensor:
         source, target = self._grids_of(name)
         region = target.sub_grid(target_slices)
         stages = self._stages(name, region)
@@ -1778,8 +1865,34 @@ class Resample(TransformInverse):
         if axes is not None:
             order = blend_order(target, source)
             return gather_separable(sub_tensor, axes, region_starts, shape, mode, self.fill_value, order)
-        coordinates = source_index(region, source, stages, sub_tensor.device)
-        return gather(sub_tensor, coordinates, region_starts, shape, mode, self.fill_value)
+        # On the HOST, ITK's own resampler is the fastest one there is, exact included: sitk.Resample
+        # over the same region, through the same stages, is 12x the torch walk per voxel on this
+        # arithmetic (27 vs 326 ns, measured, 12 threads) -- the walk is written for the GPU, where
+        # it is 40x faster again. Same rule (ITK's), same window, same fill; the two agree to the
+        # ulp, which is exactly how far a CPU and a CUDA run already agree. 'precision: fast' is a
+        # permission the GPU walk uses; on the host the exact answer is also the cheapest.
+        if sub_tensor.device.type == "cpu" and sitk is not None:
+            resampled = _resample_with_sitk(sub_tensor, region, source, stages, region_starts, mode, self.fill_value)
+            if resampled is not None:
+                return resampled
+        # The walk's coordinate tensor is float64 x rank: on a large region it dwarfs the gathered
+        # payload (9 GB beside a 1 GB slab, measured on an ExaSPIM mask chain). Walking and
+        # gathering slab by slab bounds both under one budget, and changes no value: the row
+        # indices stay global to the region, the gather's window and starts are the region's own,
+        # so every row of every slab is the very tensor the single pass produces.
+        rows_total = int(region.size_zyx[0])
+        rows = walk_rows(region, stages, sub_tensor.device)
+        if rows >= rows_total:
+            coordinates = source_index(region, source, stages, sub_tensor.device)
+            return gather(sub_tensor, coordinates, region_starts, shape, mode, self.fill_value)
+        parts = []
+        for start in range(0, rows_total, rows):
+            coordinates = source_index_rows(
+                region, source, stages, sub_tensor.device, start, min(rows_total, start + rows)
+            )
+            parts.append(gather(sub_tensor, coordinates, region_starts, shape, mode, self.fill_value))
+            del coordinates
+        return torch.cat(parts, dim=1)
 
     def _mode(self, tensor: torch.Tensor) -> str:
         """``nearest``, ``linear`` or ``cubic``: what a sampler asks before it blends anything.
@@ -2573,7 +2686,11 @@ class _DisplacementSource:
             data, _attributes = root.read_data(group, name)
         else:
             data, _attributes = root.read_data_slice(group, name, (slice(None), *region))
-        field = torch.from_numpy(np.ascontiguousarray(data)).float()
+        # float64, not .float(): the walk evaluates the field in float64 (DisplacementStage's own
+        # contract), and a .float() here quantized a float64-stored field before the exact
+        # arithmetic ever saw it -- a silent sitk divergence for any field an external tool wrote
+        # in double. A float32 store widens losslessly.
+        field = torch.from_numpy(np.ascontiguousarray(data)).to(torch.float64)
         if field.shape[0] != channels:
             raise TransformError(
                 f"The field for case '{name}' has {field.shape[0]} component(s) where the case has"
@@ -2934,6 +3051,8 @@ class Canonical(TransformInverse):
     # reorientation is a product with an inverse, so it lands within a few double ulps of them.
     _AXIS_ALIGNED_ATOL = 1e-9
 
+    working_multiple = 3.0  # an oblique case is resampled: the resample's own figure
+
     def __init__(self, inverse: bool = True) -> None:
         super().__init__(inverse)
         self.canonical_direction = torch.diag(torch.tensor([-1, -1, 1])).to(torch.double)
@@ -3261,14 +3380,18 @@ class OneHot(TransformInverse):
         # Expands each voxel's scalar label into a one-hot channel vector (spatially pointwise).
         return PatchLocality(LocalityKind.POINTWISE)
 
+    def output_channels(self, channels: int) -> int:
+        return self.num_classes * channels
+
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
-        result = (
-            F.one_hot(tensor.type(torch.int64), num_classes=self.num_classes)
-            .permute(0, len(tensor.shape), *[i + 1 for i in range(len(tensor.shape) - 1)])
-            .float()
-            .squeeze(0)
+        # Scattered straight into the float32 answer: ``F.one_hot`` builds the classes in int64
+        # first, three times the bytes of the result for the time of a cast (80 GB for 50 classes
+        # of a 512^3 map, where the answer is 27 GB and this holds the answer plus the labels).
+        result = torch.zeros(
+            (int(tensor.shape[0]), self.num_classes, *tensor.shape[1:]), dtype=torch.float32, device=tensor.device
         )
-        return result
+        result.scatter_(1, tensor.to(torch.int64).unsqueeze(1), 1.0)
+        return result.squeeze(0)
 
     def inverse(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         # Argmax the CLASS axis (the one sized num_classes) and re-insert it, restoring a [.., 1, *spatial]

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -53,6 +53,7 @@ from konfai.data.sampling import (
     coordinate_precision,
     gather,
     gather_separable,
+    sampling_dtype,
     separable_source_index,
     source_index,
     source_index_rows,
@@ -1311,15 +1312,20 @@ def _resample_with_sitk(
     reference.SetOrigin(np.asarray(region.origin_xyz, dtype=np.float64).tolist())
     reference.SetSpacing(np.asarray(region.spacing_xyz, dtype=np.float64).tolist())
     reference.SetDirection(np.asarray(region.direction_xyz, dtype=np.float64).ravel().tolist())
+    # A blend interpolates in the dtype the walk accumulates in, and torch makes the final cast:
+    # ITK would otherwise accumulate an integer payload in double and cast inside the filter, where
+    # one ulp of difference becomes a whole unit after the truncation both sides do. A nearest pick
+    # copies voxels, so it keeps the payload's own dtype, exactly as the walk does.
+    work = payload if mode == "nearest" else payload.type(sampling_dtype(payload))
     outputs = []
-    for channel in range(int(payload.shape[0])):
-        image = sitk.GetImageFromArray(np.ascontiguousarray(payload[channel].numpy()))
+    for channel in range(int(work.shape[0])):
+        image = sitk.GetImageFromArray(np.ascontiguousarray(work[channel].numpy()))
         image.SetOrigin(np.asarray(window_origin, dtype=np.float64).tolist())
         image.SetSpacing(np.asarray(source.spacing_xyz, dtype=np.float64).tolist())
         image.SetDirection(np.asarray(source.direction_xyz, dtype=np.float64).ravel().tolist())
         out = sitk.Resample(image, reference, transform, interpolator[mode], float(fill), image.GetPixelID())
         outputs.append(torch.from_numpy(sitk.GetArrayFromImage(out)))
-    return torch.stack(outputs, dim=0)
+    return torch.stack(outputs, dim=0).type(payload.dtype)
 
 
 class Resample(TransformInverse):
@@ -1865,12 +1871,16 @@ class Resample(TransformInverse):
         if axes is not None:
             order = blend_order(target, source)
             return gather_separable(sub_tensor, axes, region_starts, shape, mode, self.fill_value, order)
-        # On the HOST, ITK's own resampler is the fastest one there is, exact included: sitk.Resample
-        # over the same region, through the same stages, is 12x the torch walk per voxel on this
-        # arithmetic (27 vs 326 ns, measured, 12 threads) -- the walk is written for the GPU, where
-        # it is 40x faster again. Same rule (ITK's), same window, same fill; the two agree to the
-        # ulp, which is exactly how far a CPU and a CUDA run already agree. 'precision: fast' is a
-        # permission the GPU walk uses; on the host the exact answer is also the cheapest.
+        # On the HOST, ITK's own resampler is the fastest one there is: sitk.Resample over the same
+        # region, through the same stages, is 12x the torch walk per voxel on this arithmetic
+        # (27 vs 326 ns, measured, 12 threads) -- the walk is written for the GPU, where it is 40x
+        # faster again. Same rule (ITK's), same window, same fill, same working dtype, so the two
+        # agree to the ulp of the blend: as far as a CPU and a CUDA run already agree. On an INTEGER
+        # payload that ulp can straddle a truncation boundary, where it becomes one whole unit
+        # (measured: 2 voxels in 7560 through a rotation, pinned in test_sampling.py). A nearest
+        # pick copies voxels and has no such seam, which is what a label map takes.
+        # 'precision: fast' is a permission the GPU walk uses; on the host the exact answer is also
+        # the cheapest.
         if sub_tensor.device.type == "cpu" and sitk is not None:
             resampled = _resample_with_sitk(sub_tensor, region, source, stages, region_starts, mode, self.fill_value)
             if resampled is not None:

--- a/konfai/main.py
+++ b/konfai/main.py
@@ -135,8 +135,7 @@ def _add_transform(subparsers: argparse._SubParsersAction) -> None:
         str(State.TRANSFORM), help="Prepare a dataset: apply a transform chain to every case and write the result."
     )
     # Deliberately NOT _add_common_args: -tb has no scalar to show, so refusing it here is a parse
-    # error, not a silent no-op. --gpu exists for one reason: a KonfAIInference stage runs a nested
-    # inference that does use the device; plain read transforms stay on CPU either way.
+    # error, not a silent no-op.
     parser.add_argument(
         "-c",
         "--config",
@@ -156,8 +155,8 @@ def _add_transform(subparsers: argparse._SubParsersAction) -> None:
         type=int,
         nargs="+",
         default=[],
-        help="GPU device ids for chains that run a nested inference (KonfAIInference). "
-        "Plain read transforms run on CPU regardless.",
+        help="GPU device ids the chain runs on: every stage, the streamed replays and the folds "
+        "included, executes on the rank's device. If omitted the run stays on CPU.",
     )
     device_group.add_argument(
         "--cpu",

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -592,7 +592,12 @@ class _Trainer:
             }
         )
 
-        torch.save(save_dict, save_path)
+        # Staged and renamed, the invariant the dataset writers hold: a multi-GB torch.save takes
+        # seconds, and a kill mid-write left a truncated .pt under a plausible name that RESUME
+        # then died on with an opaque unpickling error.
+        staging = save_path.with_name(f"{save_path.name}.{os.getpid()}.tmp")
+        torch.save(save_dict, staging)
+        os.replace(staging, save_path)
 
         if self.save_checkpoint_mode == "BEST":
             self._update_best_checkpoint(save_path, checkpoint_loss)

--- a/konfai/transformer.py
+++ b/konfai/transformer.py
@@ -950,7 +950,7 @@ class Transformer(DistributedObject):
             reduction = item.reduction
             assert reduction is not None  # nosec B101 - the item was built from the same predicate
             if item.pending(reduction.reduce.output, self._overwrite):
-                reduction.materialize(rewrite=self._overwrite)
+                reduction.materialize(rewrite=self._overwrite, device=chain_device)
                 counts[Verdict.REDUCE] += 1
             else:
                 counts[Verdict.SKIP] += 1

--- a/konfai/utils/ITK.py
+++ b/konfai/utils/ITK.py
@@ -258,6 +258,49 @@ def decode_transform_stages(transform: sitk.Transform) -> SpatialStages:
     )
 
 
+def encode_transform_stages(stages: SpatialStages) -> sitk.Transform:
+    """Geometry stages, in APPLICATION order, as one SimpleITK transform: the decoder's inverse.
+
+    An affine stage becomes an ``AffineTransform`` (matrix and translation, world units); a
+    displacement stage of order 1 a ``DisplacementFieldTransform`` on its own grid, of order 3 a
+    ``BSplineTransform`` from its coefficient images. ``CompositeTransform`` applies its members
+    LAST-ADDED-FIRST, so the stages are added in reverse to run in order (the mirror of what
+    :func:`decode_transform_stages` undoes). One stage is returned as itself.
+    """
+    _require_simpleitk()
+    from konfai.data.geometry import AffineStage
+
+    members: list[sitk.Transform] = []
+    for stage in stages:
+        if isinstance(stage, AffineStage):
+            rank = stage.map.rank
+            affine = sitk.AffineTransform(rank)
+            affine.SetMatrix(np.asarray(stage.map.matrix, dtype=np.float64).ravel().tolist())
+            affine.SetTranslation(np.asarray(stage.map.translation, dtype=np.float64).tolist())
+            members.append(affine)
+            continue
+        grid = stage.grid
+        rank = grid.rank
+        images = []
+        for component in range(rank):
+            image = sitk.GetImageFromArray(np.ascontiguousarray(stage.values[component], dtype=np.float64))
+            image.SetOrigin(np.asarray(grid.origin_xyz, dtype=np.float64).tolist())
+            image.SetSpacing(np.asarray(grid.spacing_xyz, dtype=np.float64).tolist())
+            image.SetDirection(np.asarray(grid.direction_xyz, dtype=np.float64).ravel().tolist())
+            images.append(image)
+        if stage.order == 1:
+            field = sitk.Compose(images)
+            members.append(sitk.DisplacementFieldTransform(field))
+        else:
+            members.append(sitk.BSplineTransform(images, int(stage.order)))
+    if len(members) == 1:
+        return members[0]
+    composite = sitk.CompositeTransform(members[0].GetDimension())
+    for member in reversed(members):
+        composite.AddTransform(member)
+    return composite
+
+
 def invert_stages(stages: SpatialStages, rank: int) -> SpatialStages | None:
     """The exact inverse of an all-affine decoded map, or ``None`` when one is not algebraic.
 

--- a/konfai/utils/ITK.py
+++ b/konfai/utils/ITK.py
@@ -293,6 +293,11 @@ def encode_transform_stages(stages: SpatialStages) -> sitk.Transform:
             members.append(sitk.DisplacementFieldTransform(field))
         else:
             members.append(sitk.BSplineTransform(images, int(stage.order)))
+    if not members:
+        raise TransformError(
+            "encode_transform_stages() was given no stage to encode.",
+            "Hand it the decoded stages of a transform; an identity is sitk.Transform(rank, sitk.sitkIdentity).",
+        )
     if len(members) == 1:
         return members[0]
     composite = sitk.CompositeTransform(members[0].GetDimension())

--- a/konfai/utils/budget.py
+++ b/konfai/utils/budget.py
@@ -139,6 +139,47 @@ def _cgroup_paths() -> list[tuple[Path, str, tuple[str, ...]]]:
     return []
 
 
+def _cpu_cgroup_paths() -> list[Path]:
+    """This process's cpu cgroup directory and its ancestors (v2 ``cpu.max``), innermost first."""
+    try:
+        lines = Path(_PROC_SELF_CGROUP).read_text().splitlines()
+    except OSError:
+        return []
+    root = Path(_CGROUP_ROOT)
+    for line in lines:
+        parts = line.split(":", 2)
+        if len(parts) != 3:
+            continue
+        hierarchy, controllers, path = parts
+        if hierarchy == "0" and controllers == "":
+            base = root
+        elif "cpu" in controllers.split(","):
+            base = root / "cpu"
+        else:
+            continue
+        leaf = base / path.lstrip("/")
+        return [d for d in (leaf, *leaf.parents) if d == base or base in d.parents]
+    return []
+
+
+def available_cpus() -> int:
+    """The cores this process may actually run on: the tighter of its affinity mask and its cgroup
+    CPU quota (``cpu.max``). ``os.cpu_count()`` is the host's core count, which a container sees in
+    full while being allowed a fraction of it, and every thread past that fraction is contention."""
+    try:
+        cores = len(os.sched_getaffinity(0))
+    except (AttributeError, OSError):
+        cores = os.cpu_count() or 1
+    for directory in _cpu_cgroup_paths():
+        try:
+            quota, period = (directory / "cpu.max").read_text().split()
+        except (OSError, ValueError):
+            continue
+        if quota != "max":
+            cores = min(cores, max(1, -(-int(quota) // int(period))))
+    return max(1, cores)
+
+
 def _held_memory_bytes(directory: Path, keys: tuple[str, ...]) -> int | None:
     """The sum of KEYS in DIRECTORY's ``memory.stat``, or ``None`` when the file is missing or lacks them."""
     try:

--- a/konfai/utils/budget.py
+++ b/konfai/utils/budget.py
@@ -156,7 +156,12 @@ def _cpu_cgroup_paths() -> list[tuple[Path, bool]]:
         if hierarchy == "0" and controllers == "":
             base, v2 = root, True
         elif "cpu" in controllers.split(","):
-            base, v2 = root / "cpu", False
+            # A v1 controller mounts under the name it is mounted with: on most distributions the
+            # joint "cpu,cpuacct" with a "cpu" symlink beside it, on some only the joint one.
+            mount = next((root / d for d in (controllers, "cpu") if (root / d).is_dir()), None)
+            if mount is None:
+                continue
+            base, v2 = mount, False
         else:
             continue
         leaf = base / path.lstrip("/")

--- a/konfai/utils/budget.py
+++ b/konfai/utils/budget.py
@@ -23,6 +23,7 @@ one question every consumer had been re-deriving: what is MY rank's share.
 
 from __future__ import annotations
 
+import math
 import os
 import re
 from contextlib import suppress
@@ -139,8 +140,9 @@ def _cgroup_paths() -> list[tuple[Path, str, tuple[str, ...]]]:
     return []
 
 
-def _cpu_cgroup_paths() -> list[Path]:
-    """This process's cpu cgroup directory and its ancestors (v2 ``cpu.max``), innermost first."""
+def _cpu_cgroup_paths() -> list[tuple[Path, bool]]:
+    """This process's cpu cgroup directory and its ancestors, innermost first, each flagged v2
+    (``cpu.max``) or v1 (``cpu.cfs_quota_us`` / ``cpu.cfs_period_us``)."""
     try:
         lines = Path(_PROC_SELF_CGROUP).read_text().splitlines()
     except OSError:
@@ -152,31 +154,47 @@ def _cpu_cgroup_paths() -> list[Path]:
             continue
         hierarchy, controllers, path = parts
         if hierarchy == "0" and controllers == "":
-            base = root
+            base, v2 = root, True
         elif "cpu" in controllers.split(","):
-            base = root / "cpu"
+            base, v2 = root / "cpu", False
         else:
             continue
         leaf = base / path.lstrip("/")
-        return [d for d in (leaf, *leaf.parents) if d == base or base in d.parents]
+        return [(d, v2) for d in (leaf, *leaf.parents) if d == base or base in d.parents]
     return []
+
+
+def _cpu_quota(directory: Path, v2: bool) -> float | None:
+    """The CPU quota of one cgroup directory in cores, ``None`` when unbounded, missing or malformed."""
+    try:
+        if v2:
+            quota, period = (directory / "cpu.max").read_text().split()
+        else:
+            quota = (directory / "cpu.cfs_quota_us").read_text().strip()
+            period = (directory / "cpu.cfs_period_us").read_text().strip()
+        if quota in ("max", "-1"):
+            return None
+        quota_us, period_us = int(quota), int(period)
+    except (OSError, ValueError):
+        return None
+    if quota_us <= 0 or period_us <= 0:
+        return None
+    return quota_us / period_us
 
 
 def available_cpus() -> int:
     """The cores this process may actually run on: the tighter of its affinity mask and its cgroup
-    CPU quota (``cpu.max``). ``os.cpu_count()`` is the host's core count, which a container sees in
-    full while being allowed a fraction of it, and every thread past that fraction is contention."""
+    CPU quota (v2 ``cpu.max``, v1 ``cpu.cfs_quota_us``/``cpu.cfs_period_us``, over its ancestors).
+    ``os.cpu_count()`` is the host's core count, which a container sees in full while being allowed
+    a fraction of it, and every thread past that fraction is contention."""
     try:
         cores = len(os.sched_getaffinity(0))
     except (AttributeError, OSError):
         cores = os.cpu_count() or 1
-    for directory in _cpu_cgroup_paths():
-        try:
-            quota, period = (directory / "cpu.max").read_text().split()
-        except (OSError, ValueError):
-            continue
-        if quota != "max":
-            cores = min(cores, max(1, -(-int(quota) // int(period))))
+    for directory, v2 in _cpu_cgroup_paths():
+        quota = _cpu_quota(directory, v2)
+        if quota is not None:
+            cores = min(cores, max(1, math.ceil(quota)))
     return max(1, cores)
 
 

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -217,13 +217,20 @@ def _attribute_text(value: Any) -> str:
     one, so normalising to either here breaks the other reader.
 
     Complete, because an attribute is a record and not a display: NumPy's own printing elides values
-    past a threshold, and an elided record is one no reader can parse back.
+    past a threshold, and an elided record is one no reader can parse back. Exact, for the same
+    reason: a float is printed as the shortest text that reads back to the very same float64 --
+    NumPy's default (8 decimals for an array, the float32-shortest form for a float32 scalar) is a
+    display, and a statistic that came back a few ulps off made the whole-volume and the streamed
+    path of one chain disagree by that much (measured: a Min/Max rescale, 28% of voxels one ulp
+    apart on CUDA).
     """
     if isinstance(value, torch.Tensor):
         # Accept a tensor from any device: attributes are host-side strings, and finalize transforms
         # (Normalize, Statistics, ...) may hand over stats computed on a CUDA-resident volume.
         value = value.detach().cpu().numpy()
-    with np.printoptions(threshold=sys.maxsize):
+    if isinstance(value, np.generic | np.ndarray) and np.issubdtype(value.dtype, np.floating):
+        value = np.asarray(value, dtype=np.float64)[()] if isinstance(value, np.generic) else value.astype(np.float64)
+    with np.printoptions(threshold=sys.maxsize, floatmode="unique"):
         return str(value).replace("\n", "")
 
 
@@ -565,6 +572,23 @@ def _finalize_running_statistics(state: dict[str, Any] | None) -> dict[str, Any]
 _unstreamed_formats_warned: set[str] = set()
 
 
+@functools.cache
+def _nifti_extract_aborts(path: str) -> bool:
+    """Whether an ITK region read of ``path`` would take the process down.
+
+    ITK's NIfTI IO extracts a region of a SCALAR image only. Asked for a region of a vector one (a
+    multi-channel .nii or .nii.gz) it frees a buffer twice and aborts the process -- ``double free
+    or corruption``, no exception, nothing to catch (measured with the SimpleITK this ships with,
+    compressed or not). Such a file is read whole and sliced here.
+    """
+    if sitk.ImageFileReader.GetImageIOFromFileName(path) != "NiftiImageIO":
+        return False
+    reader = sitk.ImageFileReader()
+    reader.SetFileName(path)
+    reader.ReadImageInformation()
+    return reader.GetNumberOfComponents() > 1
+
+
 def _warn_unstreamed_region_read(path: str) -> None:
     """Warn that `path`'s format decodes the whole volume for every patch region read from it.
 
@@ -640,15 +664,21 @@ def displacement_field_to_data(transform: sitk.Transform, name: str) -> tuple[np
 def image_to_data(image: sitk.Image) -> tuple[np.ndarray, Attribute]:
     """Convert a SimpleITK image into a channel-first NumPy array and attributes."""
     attributes = Attribute()
-    attributes["Origin"] = np.asarray(image.GetOrigin())
-    attributes["Spacing"] = np.asarray(image.GetSpacing())
-    attributes["Direction"] = np.asarray(image.GetDirection())
     for k in image.GetMetaDataKeys():
         # ``ITK_*`` keys are the reader's own bookkeeping (the input filter's name, the file's original
         # direction and spacing), not the volume's metadata: carried into an output they describe the
         # source of a resampled volume, which nothing should read as the output's.
         if not k.startswith("ITK_"):
             attributes[k] = image.GetMetaData(k)
+    # AFTER the metadata import, deliberately. data_to_image stamps every attribute -- the
+    # geometry stack included -- back onto the image as metadata text, and the loop above imports
+    # it verbatim (versioned keys carry a '_', so they land as-is). Recorded first, the header
+    # landed as Origin_0 and the stale text then OVERWROTE that very key: an image read, moved
+    # (SetOrigin) and written back kept its old origin, silently. Recorded last, the header
+    # appends the next version of the stack, which is the one every reader takes.
+    attributes["Origin"] = np.asarray(image.GetOrigin())
+    attributes["Spacing"] = np.asarray(image.GetSpacing())
+    attributes["Direction"] = np.asarray(image.GetDirection())
     data = sitk.GetArrayFromImage(image)
 
     if image.GetNumberOfComponentsPerPixel() == 1:
@@ -807,6 +837,50 @@ def is_staging_entry(name: str) -> bool:
     return leaf.endswith(".tmp") or ".tmp." in leaf or _REPLACED_MARKER in leaf
 
 
+# A writer's staging name carries its pid: ``<entry>.<pid>[-n].tmp``, the ``.replaced`` hop it keeps
+# the previous version under, or the dotted whole-file form ``.<entry>.<pid>.tmp.<ext>``.
+_STAGING_PID = re.compile(r"\.(?:(?P<pid>\d+)(?:-\d+)?\.(?:tmp|replaced)|replaced-(?P<hop>\d+))(?:\.|$)")
+
+
+def _writer_is_dead(pid: int) -> bool:
+    if pid == os.getpid():
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        pass  # alive, someone else's
+    return False
+
+
+def _retire_dead_debris(final: Path) -> None:
+    """Remove what earlier, DEAD writers of ``final`` left beside it.
+
+    Every writer here stages under a pid-marked name and publishes by rename, so a hard kill leaves
+    a staging file or store the readers already know to skip -- and nothing ever removed: a
+    27 GB one-hot store's staging sat beside the published one for good. Publishing an entry is
+    the moment its history is settled, so the debris of any writer that no longer runs goes then.
+    A LIVE writer's staging is left alone (two writers of one entry are legal, the last rename
+    wins), which is what the pid in the name is for.
+    """
+    entry = final.name.split(".", 1)[0]
+    try:
+        siblings = list(final.parent.iterdir())
+    except OSError:
+        return
+    for sibling in siblings:
+        if sibling == final or not sibling.name.lstrip(".").startswith(f"{entry}."):
+            continue
+        marker = _STAGING_PID.search(sibling.name)
+        if marker is None or not _writer_is_dead(int(marker.group("pid") or marker.group("hop"))):
+            continue
+        if sibling.is_dir():
+            shutil.rmtree(sibling, ignore_errors=True)
+        else:
+            sibling.unlink(missing_ok=True)
+
+
 class DataStream(ABC):
     """One dataset entry written incrementally, region by region. Obtained from
     ``Dataset.open_data_stream``, which returns ``None`` when the write format cannot serve region writes
@@ -866,6 +940,10 @@ class DataStream(ABC):
     def __exit__(self, exc_type, value, traceback) -> None:
         self._finish(exc_type is None, exc_type, value, traceback)
 
+    #: Where the entry lands on disk, for a backend that publishes a file or a store by rename;
+    #: ``None`` for one that stages inside a container (h5).
+    published_path: Path | None = None
+
     def _finish(self, success: bool, exc_type, value, traceback) -> None:
         # Single-shot: a caller may both close() and, on the error path, abort() the same stream (or
         # exit a ``with`` that already closed). Only the first call acts, so the backing file is exited
@@ -875,6 +953,8 @@ class DataStream(ABC):
         self._finished = True
         try:
             self._close(success)
+            if success and (published := self.published_path) is not None:
+                _retire_dead_debris(published)
         finally:
             if self._file is not None:
                 self._file.__exit__(exc_type, value, traceback)
@@ -954,6 +1034,7 @@ class _ItkTransformDataStream(DataStream):
         self._parameters = parameters
         self._temporary_path = temporary_path
         self._final_path = final_path
+        self.published_path = Path(final_path)
         self._spatial = [int(extent) for extent in spatial]
 
     def write_slice(self, slices: tuple[slice, ...], data: np.ndarray) -> None:
@@ -1004,19 +1085,24 @@ class _NiftiDataStream(DataStream):
         import struct
 
         self.path = path
+        self.published_path = Path(path)
         self._temporary_path = f"{path}.{self.temporary_suffix()}"
         channels, spatial = int(shape[0]), [int(extent) for extent in shape[1:]]
         # The header is written little-endian, so the block must be too.
         self._dtype = np.dtype(dtype).newbyteorder("<")
-        size_xyz = spatial[::-1]
-        spacing = attributes.get_np_array("Spacing").astype(np.float64)
-        origin = attributes.get_np_array("Origin").astype(np.float64)
-        direction = attributes.get_np_array("Direction").astype(np.float64).reshape(3, 3)
+        rank = len(spatial)  # 2 or 3: a 2-D image is a NIfTI of two dims, its third axis a 1
+        size_xyz = [*spatial[::-1], *[1] * (3 - rank)]
+        spacing = np.ones(3)
+        spacing[:rank] = attributes.get_np_array("Spacing").astype(np.float64)
+        origin = np.zeros(3)
+        origin[:rank] = attributes.get_np_array("Origin").astype(np.float64)
+        direction = np.eye(3)
+        direction[:rank, :rank] = attributes.get_np_array("Direction").astype(np.float64).reshape(rank, rank)
         affine = np.concatenate([direction * spacing[np.newaxis, :], origin[:, np.newaxis]], axis=1)
         affine[:2] *= -1.0  # LPS -> RAS
         header = bytearray(348)
         struct.pack_into("<i", header, 0, 348)
-        struct.pack_into("<8h", header, 40, 3 if channels == 1 else 5, *size_xyz, 1, channels, 1, 1)
+        struct.pack_into("<8h", header, 40, rank if channels == 1 else 5, *size_xyz, 1, channels, 1, 1)
         if channels > 1:
             struct.pack_into("<h", header, 68, 1007)  # NIFTI_INTENT_VECTOR
         struct.pack_into("<h", header, 70, _NIFTI_DATATYPES[self._dtype.name])
@@ -1074,6 +1160,7 @@ class _MhaDataStream(DataStream):
 
     def __init__(self, path: str, shape: list[int], dtype: np.dtype, attributes: Attribute) -> None:
         self.path = path
+        self.published_path = Path(path)
         self._temporary_path = f"{path}.{self.temporary_suffix()}"
         spatial = list(shape[1:])
         # The header declares BinaryDataByteOrderMSB=False, so the map must be explicitly little-endian.
@@ -1084,7 +1171,13 @@ class _MhaDataStream(DataStream):
             ("BinaryData", "True"),
             ("BinaryDataByteOrderMSB", "False"),
             ("CompressedData", "False"),
-            ("TransformMatrix", " ".join(str(v) for v in attributes.get_np_array("Direction"))),
+            # MetaIO's TransformMatrix is the TRANSPOSE of ITK's Direction (verified against
+            # sitk.WriteImage): written in Direction order, every non-symmetric orientation reads
+            # back mirrored.
+            (
+                "TransformMatrix",
+                " ".join(str(v) for v in attributes.get_np_array("Direction").reshape(len(spatial), -1).T.ravel()),
+            ),
             ("Offset", " ".join(str(v) for v in attributes.get_np_array("Origin"))),
             ("ElementSpacing", " ".join(str(v) for v in attributes.get_np_array("Spacing"))),
             ("DimSize", " ".join(str(v) for v in reversed(spatial))),
@@ -1127,6 +1220,7 @@ class _OmeZarrDataStream(DataStream):
         self._array = array
         self._store_path = store_path
         self._final_path = final_path
+        self.published_path = Path(final_path)
         self._scale_factors = scale_factors
         self._downsample_method = downsample_method
 
@@ -1144,8 +1238,8 @@ class _OmeZarrDataStream(DataStream):
             return
         if self._scale_factors:
             # On the temporary store, so the rename below publishes level 0 and its coarser levels in
-            # one step. append_ome_zarr_levels REWRITES level 0 (ngff-zarr composes a multiscales as a
-            # whole), which is why this costs a pass over what was just written rather than nothing.
+            # one step. The levels are grafted beside level 0 (one pass over it, into an array 4^rank
+            # times smaller); level 0 itself is not rewritten.
             append_ome_zarr_levels(self._store_path, self._scale_factors, downsample_method=self._downsample_method)
             self._array = None
         replaced = self._final_path.exists()
@@ -1372,9 +1466,28 @@ class Dataset:
                 data = np.asarray(_encode_transform_leaves(data, name, attributes))
 
             h5_group, name = self._resolve_group(name)
-            if name in h5_group:
-                del h5_group[name]
-            self._create_entry(h5_group, name, attributes, data=data, dtype=data.dtype)
+            # Staged under a temp name and moved, never created under the final one: the invariant
+            # every DataStream holds (a hard-killed writer leaves .tmp debris, not a plausible
+            # partial entry the resume then SKIPs as done). The old entry is moved aside and put
+            # back if the publish fails, so no instant has neither version in the file.
+            staging = f"{name}.{DataStream.temporary_suffix()}"
+            if staging in h5_group:
+                del h5_group[staging]
+            self._create_entry(h5_group, staging, attributes, data=data, dtype=data.dtype)
+            backup = _replaced_name(name)
+            replaced = name in h5_group
+            if replaced:
+                if backup in h5_group:
+                    del h5_group[backup]
+                h5_group.move(name, backup)
+            try:
+                h5_group.move(staging, name)
+            except Exception:
+                if replaced and name not in h5_group:
+                    h5_group.move(backup, name)
+                raise
+            if replaced:
+                del h5_group[backup]
 
         @staticmethod
         def _create_entry(h5_group: h5py.Group, key: str, attributes: Attribute, **dataset_kwargs: Any) -> h5py.Dataset:
@@ -1521,6 +1634,8 @@ class Dataset:
                     header = file.read(4096)
                 return re.search(rb"CompressedData\s*=\s*True", header, re.IGNORECASE) is None
             if image_io == "NiftiImageIO":
+                if _nifti_extract_aborts(path):
+                    return False
                 with open(path, "rb") as file:
                     return file.read(2) != b"\x1f\x8b"  # gzip magic: a .nii.gz stream
             return False
@@ -1557,7 +1672,7 @@ class Dataset:
             data_shape = [reader.GetNumberOfComponents(), *spatial_shape]
             normalized = self._normalize_slices(slices, data_shape)
 
-            if not self._supports_direct_slice(normalized):
+            if not self._supports_direct_slice(normalized) or _nifti_extract_aborts(path):
                 data, attributes = self.file_to_data("", name)
                 return data[normalized], attributes
 
@@ -1730,6 +1845,7 @@ class Dataset:
                 staging = DataStream.staging_path(final)
                 sitk.WriteImage(data, staging)
                 os.replace(staging, final)
+                _retire_dead_debris(Path(final))
             elif isinstance(data, sitk.Transform):
                 sitk.WriteTransform(data, f"{self.filename}{name}.itk.txt")
             elif self.is_vtk_polydata(data):
@@ -1797,7 +1913,7 @@ class Dataset:
             if any(len(attributes.get_np_array(key)) != n for key, n in geometry):
                 return None
             if self.file_format == "nii":
-                if dimension != 3 or element_dtype.name not in _NIFTI_DATATYPES:
+                if dimension not in (2, 3) or element_dtype.name not in _NIFTI_DATATYPES:
                     return None
                 os.makedirs(self.filename, exist_ok=True)
                 return _NiftiDataStream(f"{self.filename}{name}.{self.file_format}", shape, element_dtype, attributes)
@@ -1963,8 +2079,17 @@ class Dataset:
                 displacement_field = True
             if not isinstance(data, np.ndarray):
                 raise DatasetManagerError("OME-Zarr datasets can only store image arrays.")
+            # Staged beside the final store and renamed over it: writing under the final name
+            # truncates the destination before a byte lands, so a crash mid-write left a partial
+            # store the resume then counted as already written -- and an overwrite lost both
+            # versions. The rename is the atomicity every DataStream already holds; the .replaced
+            # hop keeps an instant with SOME complete store on disk.
+            final = Path(self._path(name, writing=True))
+            staging = final.with_name(f"{final.name}.{os.getpid()}.tmp")
+            if staging.exists():
+                shutil.rmtree(staging)
             write_ome_zarr(
-                self._path(name, writing=True),
+                staging,
                 data,
                 spacing=attributes.get_np_array("Spacing") if "Spacing" in attributes else None,
                 origin=attributes.get_np_array("Origin") if "Origin" in attributes else None,
@@ -1973,6 +2098,18 @@ class Dataset:
                 scale_factors=self.scale_factors,
                 downsample_method=self.downsample_method,
             )
+            replaced = final.with_name(f"{final.name}.{os.getpid()}.replaced")
+            shutil.rmtree(replaced, ignore_errors=True)
+            try:
+                if final.exists():
+                    final.rename(replaced)
+                staging.rename(final)
+            except BaseException:
+                if replaced.exists() and not final.exists():
+                    replaced.rename(final)
+                raise
+            shutil.rmtree(replaced, ignore_errors=True)
+            _retire_dead_debris(final)
 
         def open_data_stream(
             self,
@@ -2540,9 +2677,21 @@ class Dataset:
         data: sitk.Image | sitk.Transform | np.ndarray,
         attributes: Attribute | None = None,
     ) -> None:
+        attributes = attributes if attributes is not None else Attribute()
+        # A stage may hand back a volume without its channel axis (``Sum(dim=0)`` and
+        # ``MergeLabels`` fold the leading axis, which in a TRANSFORM chain is the channel one).
+        # An array with as many axes as the geometry has spatial axes IS a single-channel image,
+        # and is written as one: read as channel-first it would be a 2-D image with a plane's worth
+        # of channels, refused by ITK or, worse, stored that way in silence.
+        if (
+            isinstance(data, np.ndarray)
+            and "Spacing" in attributes
+            and data.ndim == len(attributes.get_np_array("Spacing"))
+        ):
+            data = data[None]
         target, entry = self._write_target(group, name)
         with target as file:
-            file.data_to_file(entry, data, attributes if attributes is not None else Attribute())
+            file.data_to_file(entry, data, attributes)
 
     def can_stream_data(self, attributes: Attribute) -> bool:
         """Whether ``open_data_stream`` can serve this dataset's write format.

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -952,7 +952,8 @@ class DataStream(ABC):
         try:
             self._close(success)
             if success and (published := self.published_path) is not None:
-                _retire_dead_debris(published)
+                with contextlib.suppress(Exception):
+                    _retire_dead_debris(published)  # past the publish: housekeeping cannot fail the write
         finally:
             if self._file is not None:
                 self._file.__exit__(exc_type, value, traceback)
@@ -1843,7 +1844,8 @@ class Dataset:
                 staging = DataStream.staging_path(final)
                 sitk.WriteImage(data, staging)
                 os.replace(staging, final)
-                _retire_dead_debris(Path(final))
+                with contextlib.suppress(Exception):
+                    _retire_dead_debris(Path(final))  # past the publish: housekeeping cannot fail the write
             elif isinstance(data, sitk.Transform):
                 sitk.WriteTransform(data, f"{self.filename}{name}.itk.txt")
             elif self.is_vtk_polydata(data):
@@ -2105,9 +2107,11 @@ class Dataset:
             except BaseException:
                 if replaced.exists() and not final.exists():
                     replaced.rename(final)
+                shutil.rmtree(staging, ignore_errors=True)  # or a full second copy of the entry stays
                 raise
             shutil.rmtree(replaced, ignore_errors=True)
-            _retire_dead_debris(final)
+            with contextlib.suppress(Exception):
+                _retire_dead_debris(final)  # housekeeping past the publish: it cannot fail the write
 
         def open_data_stream(
             self,

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -843,15 +843,13 @@ _STAGING_PID = re.compile(r"\.(?:(?P<pid>\d+)(?:-\d+)?\.(?:tmp|replaced)|replace
 
 
 def _writer_is_dead(pid: int) -> bool:
+    """Whether the writer that staged under ``pid`` no longer runs. ``psutil`` rather than
+    ``os.kill(pid, 0)``: on Windows a missing pid raises a generic OSError, not ProcessLookupError."""
     if pid == os.getpid():
         return False
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return True
-    except PermissionError:
-        pass  # alive, someone else's
-    return False
+    import psutil
+
+    return not psutil.pid_exists(pid)
 
 
 def _retire_dead_debris(final: Path) -> None:

--- a/konfai/utils/ome_zarr.py
+++ b/konfai/utils/ome_zarr.py
@@ -34,9 +34,13 @@ Optional dependencies: ``zarr`` + ``ngff-zarr`` (``pip install konfai[omezarr]``
 
 from __future__ import annotations
 
+import contextlib
+import dataclasses
 import itertools
 import operator
 import shutil
+import threading
+from collections import OrderedDict
 from collections.abc import Sequence
 from functools import lru_cache
 from pathlib import Path
@@ -204,6 +208,10 @@ def clear_ome_zarr_cache() -> None:
     a shape mismatch when the two differ, and as nothing at all when they do not.
     """
     _load_image.cache_clear()
+    _level_path.cache_clear()
+    _level_array.cache_clear()
+    if _CHUNK_CACHE is not None:
+        _CHUNK_CACHE.clear()
 
 
 def is_displacement_field(store_path: str | Path) -> bool:
@@ -241,6 +249,170 @@ def _ordered(values: dict[str, float], dims: Sequence[str]) -> list[float]:
     return [float(values.get(axis, 1.0 if axis == "c" else 0.0)) for axis in dims]
 
 
+class _DecodedChunkCache:
+    """Decoded chunks of OME-Zarr arrays, kept whole, evicted least-recently-used under a byte cap.
+
+    zarr 3 has no chunk cache of its own: every read decodes every chunk it touches, in full, and a
+    streamed run touches the same chunks region after region -- a 31-row slab of a 256-row chunk
+    grid decodes 8x the bytes it keeps, and the next slab decodes the same chunks again (measured:
+    the same 2.1 GB of useful bytes cost 1.9 s in 256-row slabs and 28 s in 6-row slabs). Kept
+    DECODED, so a hit is a memcpy; keyed by (array identity, chunk coordinates), so a store replaced
+    on disk is a new identity and never served stale (see :func:`clear_ome_zarr_cache`). Same
+    bytes, same order: a read through the cache is the read without it.
+    """
+
+    def __init__(self, capacity_bytes: int) -> None:
+        self.capacity = int(capacity_bytes)
+        self._entries: OrderedDict[tuple, np.ndarray] = OrderedDict()
+        self._bytes = 0
+        self._lock = threading.Lock()
+
+    def get(self, key: tuple) -> np.ndarray | None:
+        with self._lock:
+            chunk = self._entries.get(key)
+            if chunk is not None:
+                self._entries.move_to_end(key)
+            return chunk
+
+    def put(self, key: tuple, chunk: np.ndarray) -> None:
+        if chunk.nbytes > self.capacity:
+            return
+        with self._lock:
+            if key in self._entries:
+                return
+            self._entries[key] = chunk
+            self._bytes += chunk.nbytes
+            while self._bytes > self.capacity and self._entries:
+                _, evicted = self._entries.popitem(last=False)
+                self._bytes -= evicted.nbytes
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+            self._bytes = 0
+
+
+def _chunk_cache_capacity() -> int:
+    """A share of what this process may allocate: enough for a chunk-row or two of a large store, small
+    beside the engine's own budget. Read once, at first use."""
+    from konfai.utils.budget import available_memory_bytes
+
+    return max(256 << 20, int(available_memory_bytes()[0] * 0.05))
+
+
+_CHUNK_CACHE: _DecodedChunkCache | None = None
+
+
+def _chunk_cache() -> _DecodedChunkCache:
+    global _CHUNK_CACHE
+    if _CHUNK_CACHE is None:
+        _CHUNK_CACHE = _DecodedChunkCache(_chunk_cache_capacity())
+    return _CHUNK_CACHE
+
+
+@lru_cache(maxsize=8)
+def _level_array(store_path: str, level_path: str) -> Any:
+    """The zarr array behind one level, opened once: chunk-wise reads go to it directly, not through
+    the dask graph ngff-zarr wraps it in (which rebuilds a task per chunk per read)."""
+    _require_zarr()
+    return zarr.open_group(store_path, mode="r")[level_path]
+
+
+def _read_chunked(store_path: str, level_path: str, array: Any, index: tuple) -> np.ndarray:
+    """``array[index]`` assembled chunk by chunk through the decoded-chunk cache.
+
+    Only integer and slice selections with unit step reach here (the reader normalises to those);
+    each touched chunk is served from the cache or decoded whole and cached, then the requested
+    window is copied out of it. Values are exactly what ``array[index]`` returns.
+    """
+    cache = _chunk_cache()
+    shape, chunks = array.shape, array.chunks
+    # Per axis: the selection, its span, and the chunk range it touches.
+    selections: list[slice] = []
+    squeeze: list[int] = []
+    for axis, item in enumerate(index):
+        if isinstance(item, int):
+            selections.append(slice(item, item + 1))
+            squeeze.append(axis)
+        else:
+            selections.append(slice(*item.indices(shape[axis])))
+    ranges = [
+        range(sel.start // ch, max(sel.start, sel.stop - 1) // ch + 1) if sel.stop > sel.start else range(0)
+        for sel, ch in zip(selections, chunks, strict=True)
+    ]
+    out_shape = tuple(max(0, sel.stop - sel.start) for sel in selections)
+    out = np.empty(out_shape, dtype=array.dtype)
+    if any(extent == 0 for extent in out_shape):
+        return out.squeeze(axis=tuple(squeeze)) if squeeze else out
+    import itertools
+
+    identity = (store_path, level_path)
+    wanted = list(itertools.product(*ranges))
+    missing = [coords for coords in wanted if cache.get((identity, coords)) is None]
+    if missing:
+        # ONE zarr read for the chunk-aligned hull of what is missing: zarr decodes the chunks of a
+        # single selection in parallel, and one call per chunk would serialise them (measured 1.5x
+        # slower than the plain read on a cold pass). The hull may cover chunks already cached
+        # when the misses are sparse; those are decoded again -- a bounded waste on a rare shape.
+        lo = [min(c[axis] for c in missing) for axis in range(len(chunks))]
+        hi = [max(c[axis] for c in missing) for axis in range(len(chunks))]
+        hull = tuple(
+            slice(lo_ * ch, min((hi_ + 1) * ch, extent))
+            for lo_, hi_, ch, extent in zip(lo, hi, chunks, shape, strict=True)
+        )
+        decoded = np.asarray(array[hull])
+        for coords in itertools.product(*(range(lo_, hi_ + 1) for lo_, hi_ in zip(lo, hi, strict=True))):
+            key = (identity, coords)
+            if cache.get(key) is not None:
+                continue
+            piece = tuple(
+                slice((c - lo_) * ch, min((c - lo_ + 1) * ch, extent - lo_ * ch))
+                for c, lo_, ch, extent in zip(coords, lo, chunks, shape, strict=True)
+            )
+            cache.put(key, np.ascontiguousarray(decoded[piece]))
+        del decoded
+    for coords in wanted:
+        chunk = cache.get((identity, coords))
+        if chunk is None:  # evicted between the fill and the read (cache smaller than one hull)
+            window = tuple(
+                slice(c * ch, min((c + 1) * ch, extent)) for c, ch, extent in zip(coords, chunks, shape, strict=True)
+            )
+            chunk = np.asarray(array[window])
+        # Where this chunk lands in the output, and which part of it.
+        src: list[slice] = []
+        dst: list[slice] = []
+        for c, ch, sel in zip(coords, chunks, selections, strict=True):
+            lo = max(sel.start, c * ch)
+            hi = min(sel.stop, (c + 1) * ch)
+            src.append(slice(lo - c * ch, hi - c * ch))
+            dst.append(slice(lo - sel.start, hi - sel.start))
+        out[tuple(dst)] = chunk[tuple(src)]
+    return out.squeeze(axis=tuple(squeeze)) if squeeze else out
+
+
+@lru_cache(maxsize=8)
+def _level_path(store_path: str, level: int) -> str | None:
+    """The zarr path of one level, from the store's multiscales metadata, memoised beside the image."""
+    try:
+        datasets = ngff_zarr.from_ngff_zarr(store_path).metadata.datasets
+        return str(datasets[level if len(datasets) > 1 else 0].path)
+    except Exception:
+        return None
+
+
+def _read_level_window(store_path: str, level: int, image: Any, index: tuple) -> np.ndarray:
+    """The window through the decoded-chunk cache when the level's array can be opened directly, else
+    the plain lazy read: same values either way."""
+    level_path = _level_path(store_path, level)
+    if level_path is not None:
+        # Any failure to open the level directly means: read through the lazy array, as before.
+        with contextlib.suppress(Exception):
+            array = _level_array(store_path, level_path)
+            if tuple(array.shape) == tuple(image.data.shape):
+                return _read_chunked(store_path, level_path, array, index)
+    return np.asarray(image.data[index])
+
+
 def read_ome_zarr_data_slice(
     store_path: str | Path,
     slices: tuple[slice, ...],
@@ -268,7 +440,7 @@ def read_ome_zarr_data_slice(
         else:
             index.append(slice(None))
 
-    patch = np.asarray(image.data[tuple(index)])
+    patch = _read_level_window(str(store_path), level, image, tuple(index))
     remaining = [axis for axis, selection in zip(dims, index, strict=True) if not isinstance(selection, int)]
     wanted = [axis for axis in ("c", *_SPATIAL) if axis in remaining]
     patch = np.transpose(patch, [remaining.index(axis) for axis in wanted])
@@ -355,9 +527,11 @@ def write_ome_zarr(
 ) -> None:
     """Write one channel-first KonfAI array as an OME-NGFF store, single-level or a pyramid.
 
-    ``scale_factors`` makes it a pyramid: ``[4]`` writes level 0 plus level 0 shrunk 4x per spatial
-    axis, ``[4, 4]`` adds a third at 16x. Consumers index a pyramid BY POSITION, so the order is the
-    contract: 0 finest. Each level carries its OWN scale and translation, and ngff-zarr shifts the
+    ``scale_factors`` makes it a pyramid, each factor shrinking the level above it: ``[4]`` writes
+    level 0 plus level 0 shrunk 4x per spatial axis, ``[4, 4]`` adds a third at 16x. (ngff-zarr's
+    own argument is spelled relative to level 0; :func:`_level_zero_scale_factors` converts, so
+    ``[4, 4]`` never writes the same level twice.) Consumers index a pyramid BY POSITION, so the
+    order is the contract: 0 finest. Each level carries its OWN scale and translation, and ngff-zarr shifts the
     coarse origin by half the spacing delta, which is the centre-of-voxel convention these stores
     use; getting that wrong biases every voxel by a fraction of a coarse voxel and still looks like a
     plausible image. ``downsample_method`` selects how (see :func:`_downsample_method`).
@@ -373,40 +547,24 @@ def write_ome_zarr(
     exist only from 0.6, so a caller passing both could only ever pass them consistently: an
     invariant worth removing rather than documenting.
     """
-    clear_ome_zarr_cache()
-    _require_ngff_zarr()
     array_data = np.asarray(data)
-    spatial_axes, scale_values, translation_values = _spatial_geometry(
-        array_data.ndim, f"shape {array_data.shape}", spacing, origin
+    # The one write path: the store described and created empty (ngff-zarr's metadata, the
+    # caller's chunking), filled by zarr itself, its levels grafted beside level 0. Handing
+    # ngff-zarr the resident array instead went through dask -- a full rechunk into a 128 MB block
+    # per task -- at a sixth of the throughput (14.4 s vs 2.3 s for a 2.1 GB volume, measured).
+    array = create_ome_zarr_store(
+        store_path,
+        array_data.shape,
+        array_data.dtype,
+        spacing=spacing,
+        origin=origin,
+        attributes=attributes,
+        chunks=chunks,
+        displacement_field=displacement_field,
     )
-    dims = ["c", *spatial_axes]
-    scale = {"c": 1.0, **dict(zip(spatial_axes, scale_values, strict=True))}
-    translation = {"c": 0.0, **dict(zip(spatial_axes, translation_values, strict=True))}
-
-    image = ngff_zarr.to_ngff_image(array_data, dims=dims, scale=scale, translation=translation)
-    # cache=False because the array is already resident: this function is handed one in memory, and
-    # spilling it to a disk cache "to limit memory consumption" cannot lower a peak that has already
-    # happened, it only adds a full write and a full read. The estimate that would otherwise trigger
-    # it is inflated besides, by itemsize once per dimension, so a 13.6 GiB field reports 868 GiB and
-    # takes that path every time.
-    multiscales = ngff_zarr.to_multiscales(
-        image,
-        scale_factors=_level_zero_scale_factors(scale_factors) if scale_factors else [],
-        method=_downsample_method(downsample_method) if scale_factors else None,
-        chunks=tuple(chunks) if chunks is not None else None,
-        cache=False,
-    )
-    version = _DEFAULT_VERSION
-    if displacement_field:
-        _require_zarr_v3_for_rfc5()
-        _type_component_axis(multiscales, _DISPLACEMENT_AXIS_TYPE)
-        version = _RFC5_VERSION
-    ngff_zarr.to_ngff_zarr(str(store_path), multiscales, overwrite=True, version=version)
-
-    recorded = dict(attributes) if attributes else {}
-    if recorded:
-        group = zarr.open_group(str(store_path), mode="r+")
-        group.attrs[_KONFAI_ATTR_KEY] = {"attributes": recorded}
+    array[...] = array_data
+    if scale_factors:
+        append_ome_zarr_levels(store_path, scale_factors, downsample_method=downsample_method)
 
 
 def update_konfai_attributes(store_path: str | Path, extra: dict[str, Any]) -> None:
@@ -536,6 +694,102 @@ def create_ome_zarr_store(
     return array
 
 
+def _bin_shrink_multiscales(image: Any, scale_factors: Sequence[int], out_chunks: Any) -> Any:
+    """The BIN_SHRINK pyramid computed by ``dask.array.coarsen``, in ngff-zarr's own clothes.
+
+    NOT ngff-zarr's ``ITKWASM_BIN_SHRINK``, for a reason found on real rounds: that method hands
+    the 32-bit wasm sandbox one BLOCK at a time, the sandbox traps near 2.5 GiB -- a whole ExaSPIM
+    volume as one block -- and it also traps on any multi-block layout whose extent does not divide
+    the factor (514 rows @4: every chunking leaves an offending tail, so NO layout is safe). The
+    engine's own streamed writes hit both.
+
+    ``coarsen(np.mean, trim_excess)`` over factor-aligned blocks is the same statistic -- the mean
+    of each aligned ``factor**rank`` window, the global remainder dropped -- computed lazily with a
+    bounded peak, no sandbox, no layout constraint. The cast back to the payload dtype truncates,
+    which is the ``static_cast`` ITK's own BinShrink performs.
+
+    The METADATA stays ngff-zarr's: each level's dataset entry is taken from a single-level
+    ``to_multiscales`` call on that level's image and repathed, so the axes, transform spelling and
+    version handling remain theirs, not a private replica that drifts when they move.
+    """
+    dims = list(image.dims)
+    spatial = [dim for dim in dims if dim in ("z", "y", "x")]
+    images = [image]
+    previous, previous_absolute = image, 1
+    for absolute in scale_factors:
+        factor = int(absolute) // previous_absolute
+        if factor * previous_absolute != int(absolute) or factor < 1:
+            raise DatasetManagerError(
+                f"scale_factors {list(scale_factors)} (relative to level 0) do not form a ladder: each"
+                " factor must be an integer multiple of the previous one.",
+                "Each declared factor shrinks the level above it and must be 2 or more: [2, 2] or [4, 4].",
+            )
+        data = previous.data
+        trim = tuple(
+            slice(0, (int(data.shape[axis]) // factor) * factor) if dims[axis] in spatial else slice(None)
+            for axis in range(len(dims))
+        )
+        for axis in range(len(dims)):
+            if dims[axis] in spatial and int(data.shape[axis]) < factor:
+                raise DatasetManagerError(
+                    f"scale factor {int(absolute)} shrinks axis '{dims[axis]}' (extent"
+                    f" {int(data.shape[axis])}) to nothing at this level.",
+                    "Stop the ladder before the factor outgrows the smallest axis.",
+                )
+        # coarsen folds within blocks, so every spatial chunk must divide the factor; on the
+        # trimmed extent a factor-multiple chunk size guarantees the tail does too.
+        chunk = max(factor, (256 // factor) * factor)
+        working = data[trim].rechunk({axis: chunk if dims[axis] in spatial else -1 for axis in range(len(dims))})
+        coarsened = dask.array.coarsen(
+            np.mean, working, {axis: factor for axis in range(len(dims)) if dims[axis] in spatial}
+        )
+        if not np.issubdtype(np.dtype(data.dtype), np.floating):
+            # Round to nearest, half up, BEFORE the cast: astype truncates toward zero, and ITK's
+            # BinShrink (the reference for these levels) rounds -- a 0.5 window mean writes 1.
+            # Truncation would shift every integer level ~half an LSB down, silently and uniformly.
+            coarsened = dask.array.floor(coarsened + 0.5)
+        coarsened = coarsened.astype(data.dtype)
+        # The centre-of-voxel convention ngff-zarr itself applies: the coarse voxel's centre sits
+        # half the spacing delta past the fine one's. Getting this wrong composes every level a
+        # fraction of a voxel apart and still looks like an image.
+        scale = {dim: previous.scale[dim] * (factor if dim in spatial else 1) for dim in previous.scale}
+        translation = {
+            dim: previous.translation[dim] + (0.5 * (factor - 1) * previous.scale[dim] if dim in spatial else 0.0)
+            for dim in previous.translation
+        }
+        previous = dataclasses.replace(previous, data=coarsened, scale=scale, translation=translation)
+        previous_absolute = int(absolute)
+        images.append(previous)
+
+    if out_chunks is not None:
+        images = [
+            dataclasses.replace(level, data=level.data.rechunk(tuple(out_chunks)))
+            if hasattr(level.data, "rechunk")
+            else level
+            for level in images
+        ]
+    assembled = ngff_zarr.to_multiscales(image, scale_factors=[], chunks=out_chunks, cache=False)
+    datasets = []
+    for index, level in enumerate(images):
+        level_multiscales = ngff_zarr.to_multiscales(level, scale_factors=[], chunks=out_chunks, cache=False)
+        dataset = level_multiscales.metadata.datasets[0]
+        path = f"scale{index}/{image.name}"
+        for transform_sequence in dataset.coordinateTransformations or []:
+            if getattr(transform_sequence, "input", None) is not None and hasattr(transform_sequence.input, "path"):
+                transform_sequence.input.path = path
+        dataset.path = path
+        datasets.append(dataset)
+    assembled.images = images
+    assembled.metadata = dataclasses.replace(assembled.metadata, datasets=datasets)
+    # Both OFF, deliberately: to_ngff_zarr RE-DERIVES every level whose index it can, whenever
+    # scale_factors, method and chunks are all set -- to_multiscales records its default method
+    # (the gaussian) even when asked for no levels. The levels' data never go through it (see
+    # append_ome_zarr_levels), but its metadata write must not try to derive them either.
+    assembled.scale_factors = []
+    assembled.method = None
+    return assembled
+
+
 def append_ome_zarr_levels(
     store_path: str | Path,
     scale_factors: Sequence[int],
@@ -546,22 +800,16 @@ def append_ome_zarr_levels(
 
     The companion of :func:`create_ome_zarr_store`: a store written region by region cannot be given
     ``scale_factors`` up front, because no level exists until the last region lands. This derives the
-    pyramid afterwards, from what is on disk.
+    pyramid afterwards, from what is on disk, and grafts it BESIDE level 0.
 
-    It REWRITES level 0 rather than adding beside it: ngff-zarr composes a multiscales as a whole,
-    and there is no supported way to graft a level onto a published one. The cost is real and
-    proportional to the store (measured ~42 s for a 2 GiB store) while the peak stays chunk-sized.
-    Worth knowing before calling it in a loop; not worth hiding.
-
-    It writes to a SIBLING store and renames over the original, rather than in place. In place is not
-    slower, it is wrong: level 0 is read lazily, ``to_ngff_zarr(overwrite=True)`` truncates the store
-    before dask pulls a single chunk through it, and the pyramid comes out uniformly zero: with
-    correct metadata, correct shapes, and nothing raised. The rename also makes the operation atomic,
-    so an interrupted call leaves the original store intact instead of a half-written one.
-
-    The KonfAI attribute sidecar and an RFC-5 displacement typing are carried across, because
-    ``to_ngff_zarr`` writes a root of its own, and both losses are silent, one landing as an
-    identity Direction and the other as an anonymous 3-channel image.
+    Level 0 is not rewritten, not moved, not read back whole: each coarser level is computed lazily
+    from it and stored straight into a new array of the same group, so the cost is one pass over
+    level 0 into a level 16x smaller (measured 55 s -> ~10 s on a 4.9 GB store), with a chunk-sized
+    peak. The multiscales metadata that names every level is still ngff-zarr's: it is described from
+    one-voxel stand-ins (the metadata does not depend on the extent) into a scratch store and copied
+    onto the group's attributes, so the axes, transforms and version spelling remain theirs. The
+    KonfAI attribute sidecar is untouched, being a key beside theirs; a displacement field keeps its
+    typed component axis through the same call that types it at creation.
     """
     _require_ngff_zarr()
     if not scale_factors:
@@ -569,47 +817,57 @@ def append_ome_zarr_levels(
     store = Path(store_path)
     clear_ome_zarr_cache()
     field = is_displacement_field(store)
-    sidecar = _read_konfai_attributes(store)
-    staging = store.with_name(f"{store.name}.appending")
-    if staging.exists():
-        shutil.rmtree(staging)
-    try:
-        base = ngff_zarr.from_ngff_zarr(str(store)).images[0]
+    base = ngff_zarr.from_ngff_zarr(str(store)).images[0]
+    stored_chunks = tuple(int(size) for size in base.data.chunksize)
+    if downsample_method in (None, "ITKWASM_BIN_SHRINK"):
+        multiscales = _bin_shrink_multiscales(base, _level_zero_scale_factors(scale_factors), stored_chunks)
+    else:
         multiscales = ngff_zarr.to_multiscales(
             base,
             scale_factors=_level_zero_scale_factors(scale_factors),
             method=_downsample_method(downsample_method),
-            # Level 0 is rewritten here, so the base store's own chunking has to be carried across:
-            # ngff-zarr otherwise re-chunks it on its default.
-            chunks=tuple(int(size) for size in base.data.chunksize),
+            chunks=stored_chunks,
             cache=False,
         )
-        version = _DEFAULT_VERSION
-        if field:
-            _require_zarr_v3_for_rfc5()
-            _type_component_axis(multiscales, _DISPLACEMENT_AXIS_TYPE)
-            version = _RFC5_VERSION
-        ngff_zarr.to_ngff_zarr(str(staging), multiscales, overwrite=True, version=version)
-        if sidecar:
-            group = zarr.open_group(str(staging), mode="r+")
-            group.attrs[_KONFAI_ATTR_KEY] = {"attributes": dict(sidecar)}
-            zarr.consolidate_metadata(str(staging))
-        # Rename in both directions, so no instant exists with neither store on disk: deleting the
-        # original first opens a window as long as a full tree delete, which the ``finally`` below
-        # then completes by clearing the replacement too.
-        replaced = store.with_name(f"{store.name}.replaced")
-        shutil.rmtree(replaced, ignore_errors=True)
-        store.rename(replaced)
-        try:
-            staging.rename(store)
-        except BaseException:
-            replaced.rename(store)
-            raise
-        shutil.rmtree(replaced, ignore_errors=True)
+    version = _DEFAULT_VERSION
+    if field:
+        _require_zarr_v3_for_rfc5()
+        _type_component_axis(multiscales, _DISPLACEMENT_AXIS_TYPE)
+        version = _RFC5_VERSION
+
+    group = zarr.open_group(str(store), mode="r+")
+    create_array = getattr(group, "create_array", None) or group.create_dataset
+    for level, dataset in zip(multiscales.images[1:], multiscales.metadata.datasets[1:], strict=True):
+        data = level.data.rechunk(stored_chunks)
+        array = create_array(
+            dataset.path, shape=data.shape, chunks=stored_chunks, dtype=data.dtype, fill_value=0, overwrite=True
+        )
+        # Aligned chunks: each zarr chunk is written by exactly one task, so no lock is needed.
+        dask.array.store(data, array, lock=False)
+
+    # The metadata LAST, so an interrupted call leaves a store that still reads as its level 0
+    # (unreferenced arrays beside it are overwritten by the next call).
+    rank = base.data.ndim - 1
+    described = dataclasses.replace(
+        multiscales,
+        images=[
+            dataclasses.replace(
+                level, data=dask.array.zeros((level.data.shape[0], *(1,) * rank), dtype=level.data.dtype)
+            )
+            for level in multiscales.images
+        ],
+        scale_factors=[],
+        method=None,
+    )
+    scratch = store.with_name(f"{store.name}.describing")
+    shutil.rmtree(scratch, ignore_errors=True)
+    try:
+        ngff_zarr.to_ngff_zarr(str(scratch), described, overwrite=True, version=version)
+        group.attrs.update(dict(zarr.open_group(str(scratch), mode="r").attrs))
     finally:
-        if staging.exists():
-            shutil.rmtree(staging, ignore_errors=True)
-        clear_ome_zarr_cache()
+        shutil.rmtree(scratch, ignore_errors=True)
+    zarr.consolidate_metadata(str(store))
+    clear_ome_zarr_cache()
 
 
 def get_ome_zarr_info(store_path: str | Path, level: int = 0) -> dict[str, Any]:

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -64,7 +64,7 @@ from konfai import (
     transforms_directory,
 )
 from konfai.utils import State  # also the re-export ``konfai.utils.runtime.State`` callers import
-from konfai.utils.budget import node_local_ranks
+from konfai.utils.budget import available_cpus, node_local_ranks
 from konfai.utils.errors import ConfigError, KonfAIError
 from konfai.utils.utils import env_flag
 
@@ -269,8 +269,12 @@ class NeedDevice:
 
 
 def get_device(device: int):
-    """Return a CUDA index or CPU device depending on availability."""
-    return device if torch.cuda.is_available() and device >= 0 else torch.device("cpu")
+    """Return a CUDA index or CPU device depending on availability.
+
+    ``device_count`` and not availability alone: a latched runtime keeps ``is_available()`` True
+    after ``CUDA_VISIBLE_DEVICES`` was narrowed to nothing, while the count honestly reads 0.
+    """
+    return device if torch.cuda.is_available() and 0 <= device < torch.cuda.device_count() else torch.device("cpu")
 
 
 def safe_torch_load(path_or_url: str | Path, map_location: Any) -> Any:
@@ -777,7 +781,10 @@ class DistributedObject(ABC):
             torch.backends.cudnn.benchmark = self.manual_seed is None
             torch.backends.cudnn.deterministic = self.manual_seed is not None
             dataloaders = self.rank_dataloaders(global_rank)
-            if torch.cuda.is_available():
+            # device_count as well: on a process whose CUDA runtime latched BEFORE the launcher
+            # narrowed CUDA_VISIBLE_DEVICES to nothing, is_available() stays True while the count
+            # honestly reads 0, and set_device would pin a GPU the launch explicitly excluded.
+            if torch.cuda.is_available() and 0 <= local_rank < torch.cuda.device_count():
                 torch.cuda.set_device(local_rank)
             try:
                 self.run_process(world_size, global_rank, local_rank, dataloaders)
@@ -984,11 +991,14 @@ _cpu_budget_applied = False
 
 
 def apply_cpu_thread_budget() -> None:
-    """Give each rank a bounded share of the node's cores instead of torch's every-core default.
+    """Give each rank a bounded share of the machine's cores instead of every library's every-core
+    default -- torch's intraop pool AND ITK's, which does the host resample.
 
     Past memory-bus saturation more intraop threads only add barrier contention; on a hybrid
     24-core CPU the 498^3 separable gather measures 0.7 s at 12 threads and 67 s at 24. An
-    explicit ``OMP_NUM_THREADS`` keeps authority (torch already honors it at init).
+    explicit ``OMP_NUM_THREADS`` keeps authority over torch (which already honors it at init) and
+    sizes ITK's pool the same. Otherwise each of the node's local ranks gets its share of
+    :func:`available_cpus`, capped at 12.
 
     Applied once per process, and never on macOS: torch documents ``set_num_threads`` as to be
     called before any parallel work, and the Python API runs several workflows in one process.
@@ -997,10 +1007,19 @@ def apply_cpu_thread_budget() -> None:
     nodes, so macOS keeps torch's default.
     """
     global _cpu_budget_applied
-    if sys.platform == "darwin" or _cpu_budget_applied or os.environ.get("OMP_NUM_THREADS"):
+    if sys.platform == "darwin" or _cpu_budget_applied:
         return
     _cpu_budget_applied = True
-    torch.set_num_threads(max(1, min((os.cpu_count() or 1) // node_local_ranks(), 12)))
+    explicit = os.environ.get("OMP_NUM_THREADS")
+    share = int(explicit) if explicit else max(1, min(available_cpus() // node_local_ranks(), 12))
+    if not explicit:
+        torch.set_num_threads(share)
+    try:
+        import SimpleITK as sitk
+
+        sitk.ProcessObject.SetGlobalDefaultNumberOfThreads(share)
+    except ImportError:
+        pass
 
 
 def setup_gpu(world_size: int, rank: int | None = None, process_group: bool = True) -> tuple[int | None, int | None]:

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -1009,7 +1009,6 @@ def apply_cpu_thread_budget() -> None:
     global _cpu_budget_applied
     if sys.platform == "darwin" or _cpu_budget_applied:
         return
-    _cpu_budget_applied = True
     explicit = os.environ.get("OMP_NUM_THREADS")
     share = int(explicit) if explicit else max(1, min(available_cpus() // node_local_ranks(), 12))
     if not explicit:
@@ -1020,6 +1019,8 @@ def apply_cpu_thread_budget() -> None:
         sitk.ProcessObject.SetGlobalDefaultNumberOfThreads(share)
     except ImportError:
         pass
+    # Marked applied only once it is: a raise above (a bad OMP_NUM_THREADS) leaves the next call free to retry.
+    _cpu_budget_applied = True
 
 
 def setup_gpu(world_size: int, rank: int | None = None, process_group: bool = True) -> tuple[int | None, int | None]:

--- a/run_tests_here.py
+++ b/run_tests_here.py
@@ -1,0 +1,6 @@
+import sys, os
+sys.meta_path = [f for f in sys.meta_path if "editable" not in type(f).__module__.lower()]
+sys.path.insert(0, os.getcwd())
+import konfai; assert konfai.__file__.startswith(os.getcwd()), konfai.__file__
+import pytest
+sys.exit(pytest.main(sys.argv[1:]))

--- a/tests/unit/test_case_reduction.py
+++ b/tests/unit/test_case_reduction.py
@@ -536,3 +536,27 @@ def test_a_vote_tie_goes_to_the_smallest_label_whatever_the_cohort_order() -> No
     # A majority still beats the smallest label: the tie rule is a tie-breaker, not a preference.
     counted = [torch.full((1, 1, 2, 2), value, dtype=torch.uint8) for value in (9, 2, 9)]
     assert int(Vote()(counted).flatten()[0]) == 9
+
+
+def test_a_budget_with_room_folds_the_whole_volume(tmp_path: Path) -> None:
+    """The budget is the ONLY ceiling: room in it must reach the region height.
+
+    A fixed cap of 64 rows did the opposite of what it looked like. It bounded the region however
+    much memory the run was given, so a cohort whose regions measured 0.11 GiB against a 59.60 GiB
+    budget still paid a full sweep of every source per 64 rows -- and the sweeps are what a chain
+    resampling through a field pays for, since a region's source window is not the region. Measured
+    on a 192-plane cohort: 191.5 s at the cap, 45.6 s once the budget decided.
+    """
+    engine, _destination, _volumes = _run(tmp_path, [], Reduce(output="t"), [], slab_rows=3)
+    height = engine.plan().spatial[0]
+
+    engine.fit_budget(64 * 1024**3)  # room for far more than the volume holds
+    assert engine.slab_rows == height, "a budget with room must reach the whole volume"
+
+    # And it is still a budget: too little room, and the region shrinks to what fits.
+    engine.fit_budget(4 * 1024)
+    assert 1 <= engine.slab_rows < height
+
+    # A caller that names a ceiling still gets it.
+    engine.fit_budget(64 * 1024**3, cap=2)
+    assert engine.slab_rows == 2

--- a/tests/unit/test_data_stream.py
+++ b/tests/unit/test_data_stream.py
@@ -458,7 +458,6 @@ def test_publishing_an_entry_retires_dead_writers_debris_and_keeps_live_ones(tmp
     """Every writer stages under a pid-marked name and publishes by rename, so a hard kill leaves a
     staging file or store the readers skip -- and, until now, nothing ever removed. Publishing the
     entry sweeps the debris of writers that no longer run; a live writer's staging stays."""
-    import os
     import subprocess
     import sys
 
@@ -466,15 +465,13 @@ def test_publishing_an_entry_retires_dead_writers_debris_and_keeps_live_ones(tmp
 
     final = tmp_path / "CT.ome.zarr"
     final.mkdir()
+    import psutil
+
     dead = 1
-    while True:  # a pid nobody holds
+    while True:  # a pid nobody holds (psutil: portable where os.kill(pid, 0) is not)
         dead += 7919
-        try:
-            os.kill(dead, 0)
-        except ProcessLookupError:
+        if not psutil.pid_exists(dead):
             break
-        except PermissionError:
-            continue
     live = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
     try:
         (tmp_path / f"CT.ome.zarr.{dead}-3.tmp").mkdir()

--- a/tests/unit/test_data_stream.py
+++ b/tests/unit/test_data_stream.py
@@ -523,7 +523,7 @@ def test_a_two_dimensional_nifti_streams_like_the_whole_write(tmp_path, channels
 def test_replacing_an_h5_entry_keeps_the_old_one_until_the_new_is_in_place(tmp_path, monkeypatch):
     """A rewrite moves the old entry aside, publishes, then drops it: at no instant is the entry
     absent from the file, which is what a crash between the two steps used to leave."""
-    import h5py
+    h5py = pytest.importorskip("h5py")
 
     dataset = Dataset(tmp_path / "store", "h5")
     dataset.write("G", "c", np.ones((1, 4, 4, 4), dtype=np.float32), Attribute())

--- a/tests/unit/test_data_stream.py
+++ b/tests/unit/test_data_stream.py
@@ -452,3 +452,98 @@ def test_h5_entry_whose_attributes_fail_is_not_left_in_the_file(tmp_path: Path, 
     monkeypatch.undo()
     with h5py.File(tmp_path / "streamed.h5", "r", locking=False) as handle:
         assert list(handle["CT"].keys()) == ["CASE_000"]
+
+
+def test_publishing_an_entry_retires_dead_writers_debris_and_keeps_live_ones(tmp_path):
+    """Every writer stages under a pid-marked name and publishes by rename, so a hard kill leaves a
+    staging file or store the readers skip -- and, until now, nothing ever removed. Publishing the
+    entry sweeps the debris of writers that no longer run; a live writer's staging stays."""
+    import os
+    import subprocess
+    import sys
+
+    from konfai.utils.dataset import _retire_dead_debris
+
+    final = tmp_path / "CT.ome.zarr"
+    final.mkdir()
+    dead = 1
+    while True:  # a pid nobody holds
+        dead += 7919
+        try:
+            os.kill(dead, 0)
+        except ProcessLookupError:
+            break
+        except PermissionError:
+            continue
+    live = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        (tmp_path / f"CT.ome.zarr.{dead}-3.tmp").mkdir()
+        (tmp_path / f"CT.ome.zarr.{dead}.replaced").mkdir()
+        (tmp_path / f"CT.ome.zarr.replaced-{dead}").mkdir()
+        (tmp_path / f".CT.{dead}.tmp.mha").write_bytes(b"x")
+        (tmp_path / f"CT.ome.zarr.{live.pid}-1.tmp").mkdir()
+        (tmp_path / "CT_other.ome.zarr").mkdir()  # another entry: not this one's debris
+        (tmp_path / f"CT_other.ome.zarr.{dead}-1.tmp").mkdir()
+        _retire_dead_debris(final)
+        left = sorted(p.name for p in tmp_path.iterdir())
+        assert left == sorted(
+            ["CT.ome.zarr", f"CT.ome.zarr.{live.pid}-1.tmp", "CT_other.ome.zarr", f"CT_other.ome.zarr.{dead}-1.tmp"]
+        )
+    finally:
+        live.kill()
+        live.wait()
+
+
+@pytest.mark.parametrize("channels", [1, 3])
+def test_a_two_dimensional_nifti_streams_like_the_whole_write(tmp_path, channels):
+    """A 2-D image is a NIfTI of two dims: the streamed header says so (its third axis a 1, the
+    2x2 cosines embedded in the sform) and reads back as the whole write does, voxels and geometry."""
+    rng = np.random.default_rng(0)
+    volume = rng.random((channels, 7, 9)).astype(np.float32)
+    theta = 0.3
+    attributes = Attribute(
+        {
+            "Origin": np.array([-5.0, 2.0]),
+            "Spacing": np.array([0.7, 0.9]),
+            "Direction": np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]]).ravel(),
+        }
+    )
+    whole = Dataset(tmp_path / "whole", "nii")
+    whole.write("G", "c", volume, attributes)
+    streamed = Dataset(tmp_path / "streamed", "nii")
+    stream = streamed.open_data_stream("G", "c", list(volume.shape), volume.dtype, attributes)
+    assert stream is not None
+    with stream:
+        for row in range(volume.shape[1]):
+            stream.write_slice((slice(None), slice(row, row + 1)), volume[:, row : row + 1])
+    expected, header_expected = whole.read_data("G", "c")
+    got, header_got = streamed.read_data("G", "c")
+    np.testing.assert_array_equal(got, expected)
+    for key in ("Origin", "Spacing", "Direction"):
+        np.testing.assert_allclose(header_got.get_np_array(key), header_expected.get_np_array(key), atol=1e-6)
+
+
+def test_replacing_an_h5_entry_keeps_the_old_one_until_the_new_is_in_place(tmp_path, monkeypatch):
+    """A rewrite moves the old entry aside, publishes, then drops it: at no instant is the entry
+    absent from the file, which is what a crash between the two steps used to leave."""
+    import h5py
+
+    dataset = Dataset(tmp_path / "store", "h5")
+    dataset.write("G", "c", np.ones((1, 4, 4, 4), dtype=np.float32), Attribute())
+    stream = dataset.open_data_stream("G", "c", [1, 4, 4, 4], np.dtype(np.float32), Attribute())
+    assert stream is not None
+    original_move = h5py.Group.move
+    seen = []
+
+    def spy(self, source, dest):
+        original_move(self, source, dest)
+        seen.append(("c" in self, dest))
+
+    monkeypatch.setattr(h5py.Group, "move", spy)
+    with stream:
+        stream.write_slice((slice(None),) * 4, np.zeros((1, 4, 4, 4), dtype=np.float32))
+    monkeypatch.undo()
+    # After the first move (old aside) the name is free; after the second the new one holds it.
+    assert [present for present, _ in seen] == [False, True]
+    written, _ = dataset.read_data("G", "c")
+    assert float(np.asarray(written).max()) == 0.0

--- a/tests/unit/test_ome_zarr_pyramid_chunks.py
+++ b/tests/unit/test_ome_zarr_pyramid_chunks.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The pyramid derivation never hands wasm an unbounded block, and the layout changes no value.
+
+The failure this pins down was found on a real round: a slab-written store's chunks (31 rows, 1331
+columns) divide no factor, ngff-zarr re-aligns them into blocks of its own choosing, and on an
+ExaSPIM-sized volume the 32-bit wasm sandbox traps -- which ``on_fallback: error`` rightly turns
+into a dead round. The fix bounds the blocks; these tests hold the bound AND the values.
+"""
+
+import numpy as np
+import pytest
+from konfai.data import read_ome_zarr_data_slice, write_ome_zarr
+from konfai.utils.ome_zarr import append_ome_zarr_levels
+
+
+def _block_mean(volume: np.ndarray, factor: int) -> np.ndarray:
+    """ITK's bin shrink: the mean of each aligned factor**3 window, remainder dropped."""
+    _, z, y, x = volume.shape
+    zc, yc, xc = z // factor, y // factor, x // factor
+    windows = volume[:, : zc * factor, : yc * factor, : xc * factor]
+    return windows.reshape(volume.shape[0], zc, factor, yc, factor, xc, factor).mean(axis=(2, 4, 6))
+
+
+def test_append_levels_survives_a_factor_defying_extent(tmp_path):
+    """514 = 2 mod 4: no uniform chunking divides it, and the tail block a naive rechunk leaves
+    (2 rows) has an EMPTY shrink output, which traps the wasm sandbox. The explicit blocks absorb
+    the tail; the level still equals the whole-volume block mean."""
+    rng = np.random.default_rng(5)
+    volume = rng.random((1, 514, 33, 41)).astype(np.float32) * 100
+    store = tmp_path / "tail.ome.zarr"
+    write_ome_zarr(store, volume, spacing=[1.0, 1.0, 1.0], origin=[0.0, 0.0, 0.0], chunks=(1, 2, 33, 41))
+    append_ome_zarr_levels(store, [4])
+    level1, _ = read_ome_zarr_data_slice(store, (slice(None),) * 4, level=1)
+    np.testing.assert_allclose(level1, _block_mean(volume, 4), rtol=1e-6)
+
+
+def test_write_with_awkward_extents_matches_block_mean(tmp_path):
+    rng = np.random.default_rng(3)
+    volume = rng.random((1, 31, 47, 53)).astype(np.float32) * 4000
+    store = tmp_path / "vol.ome.zarr"
+    write_ome_zarr(store, volume, spacing=[1.0, 1.0, 1.0], origin=[0.0, 0.0, 0.0], scale_factors=[4])
+    level1, _ = read_ome_zarr_data_slice(store, (slice(None),) * 4, level=1)
+    np.testing.assert_allclose(level1, _block_mean(volume, 4), rtol=1e-6)
+
+
+def test_append_levels_on_slab_chunked_store_matches_block_mean(tmp_path):
+    """A store chunked the way the streamed writer leaves it (rows that divide nothing) grows its
+    pyramid without wasm ever seeing an oversized block, and the level is the same block mean the
+    whole volume yields."""
+    rng = np.random.default_rng(4)
+    volume = rng.random((1, 62, 94, 106)).astype(np.float32) * 4000
+    store = tmp_path / "slabbed.ome.zarr"
+    write_ome_zarr(
+        store,
+        volume,
+        spacing=[1.0, 1.0, 1.0],
+        origin=[0.0, 0.0, 0.0],
+        chunks=(1, 31, 94, 16),
+    )
+    append_ome_zarr_levels(store, [4])
+    level0, _ = read_ome_zarr_data_slice(store, (slice(None),) * 4, level=0)
+    level1, _ = read_ome_zarr_data_slice(store, (slice(None),) * 4, level=1)
+    np.testing.assert_array_equal(level0, volume)
+    np.testing.assert_allclose(level1, _block_mean(volume, 4), rtol=1e-6)
+
+
+def test_each_scale_factor_shrinks_the_level_above_it(tmp_path):
+    """``[4, 4]`` is the two-coarse-level spelling: each factor shrinks the level above it, so the
+    levels are 4x then 16x smaller than level 0 -- the ladder every consumer indexes by position
+    (ngff-zarr's own level-0-relative argument is derived from it, never spelled by the user)."""
+    volume = np.zeros((1, 64, 64, 64), dtype=np.float32)
+    store = tmp_path / "ladder.ome.zarr"
+    write_ome_zarr(store, volume, spacing=[1.0, 1.0, 1.0], origin=[0.0, 0.0, 0.0], scale_factors=[4, 4])
+    level1, _ = read_ome_zarr_data_slice(store, (slice(None),) * 4, level=1)
+    level2, _ = read_ome_zarr_data_slice(store, (slice(None),) * 4, level=2)
+    assert level1.shape == (1, 16, 16, 16)
+    assert level2.shape == (1, 4, 4, 4)
+
+
+def test_integer_pyramids_round_like_the_wasm_bin_shrink(tmp_path):
+    """astype truncates toward zero; the wasm BinShrink this writer replaced rounds. Truncation
+    would shift every uint16 ExaSPIM level ~half an LSB below what the previous release wrote --
+    a silent, uniform value change in shipped data."""
+    volume = np.zeros((1, 4, 4, 4), dtype=np.uint16)
+    volume[0, :2, :2, :2] = [[[1, 0], [0, 0]], [[0, 0], [0, 1]]]  # window mean 2/8 -> rounds to 0
+    volume[0, :2, 2:, :2] = 1  # window mean 1 -> 1 exactly
+    volume[0, 2:, :2, :2] = [[[3, 0], [0, 0]], [[0, 0], [0, 1]]]  # mean 4/8 = 0.5 -> rounds UP to 1
+    store = tmp_path / "ints.ome.zarr"
+    write_ome_zarr(store, volume, spacing=[1.0, 1.0, 1.0], origin=[0.0, 0.0, 0.0], scale_factors=[2])
+    level1, _ = read_ome_zarr_data_slice(store, (slice(None),) * 4, level=1)
+    assert level1.dtype == np.uint16
+    assert level1[0, 0, 0, 0] == 0  # 0.25 -> 0
+    assert level1[0, 0, 1, 0] == 1  # 1.0 -> 1
+    assert level1[0, 1, 0, 0] == 1  # 0.5 -> 1 (round half up, not truncation's 0)
+
+
+def test_oversized_factor_refuses_with_a_named_axis(tmp_path):
+    volume = np.zeros((1, 2, 64, 64), dtype=np.float32)
+    store = tmp_path / "thin.ome.zarr"
+    with pytest.raises(Exception, match="shrinks axis"):
+        write_ome_zarr(store, volume, spacing=[1.0, 1.0, 1.0], origin=[0.0, 0.0, 0.0], scale_factors=[4])
+
+
+def test_chunk_cache_serves_the_same_bytes_and_survives_eviction(tmp_path):
+    """The decoded-chunk cache is a memcpy of what a plain read decodes: windows that straddle chunks,
+    single voxels, an axis tail, all bit-identical -- and a cache smaller than one window still
+    answers correctly (misses fall through to the store)."""
+    from konfai.utils import ome_zarr as OZ
+
+    rng = np.random.default_rng(11)
+    volume = rng.integers(0, 60000, (1, 70, 90, 110), dtype=np.uint16)
+    store = tmp_path / "chunky.ome.zarr"
+    write_ome_zarr(store, volume, spacing=[1.0, 1.0, 1.0], origin=[0.0, 0.0, 0.0], chunks=(1, 32, 32, 32))
+    OZ.clear_ome_zarr_cache()
+    windows = [
+        (slice(None), slice(30, 35), slice(None), slice(None)),
+        (slice(None), slice(31, 33), slice(31, 33), slice(31, 33)),
+        (slice(0, 1), slice(69, 70), slice(89, 90), slice(109, 110)),
+        (slice(None), slice(0, 70), slice(0, 1), slice(100, 110)),
+    ]
+    for window in windows:
+        got, _ = read_ome_zarr_data_slice(store, window, level=0)
+        np.testing.assert_array_equal(got, volume[window])
+    # A tiny cache: nothing fits, every read decodes -- still the same bytes.
+    OZ._CHUNK_CACHE = OZ._DecodedChunkCache(1024)
+    for window in windows:
+        got, _ = read_ome_zarr_data_slice(store, window, level=0)
+        np.testing.assert_array_equal(got, volume[window])
+    OZ._CHUNK_CACHE = None
+    OZ.clear_ome_zarr_cache()

--- a/tests/unit/test_ome_zarr_pyramid_chunks.py
+++ b/tests/unit/test_ome_zarr_pyramid_chunks.py
@@ -136,10 +136,13 @@ def test_chunk_cache_serves_the_same_bytes_and_survives_eviction(tmp_path):
     for window in windows:
         got, _ = read_ome_zarr_data_slice(store, window, level=0)
         np.testing.assert_array_equal(got, volume[window])
-    # A tiny cache: nothing fits, every read decodes -- still the same bytes.
+    # A tiny cache: nothing fits, every read decodes -- still the same bytes. Restored whatever
+    # the assertions say: the cache is process-global.
     OZ._CHUNK_CACHE = OZ._DecodedChunkCache(1024)
-    for window in windows:
-        got, _ = read_ome_zarr_data_slice(store, window, level=0)
-        np.testing.assert_array_equal(got, volume[window])
-    OZ._CHUNK_CACHE = None
-    OZ.clear_ome_zarr_cache()
+    try:
+        for window in windows:
+            got, _ = read_ome_zarr_data_slice(store, window, level=0)
+            np.testing.assert_array_equal(got, volume[window])
+    finally:
+        OZ._CHUNK_CACHE = None
+        OZ.clear_ome_zarr_cache()

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -685,22 +685,28 @@ def test_available_cpus_is_the_tighter_of_affinity_and_cgroup_quota(monkeypatch,
     assert bd.available_cpus() == 4
 
 
-def test_available_cpus_reads_a_cgroup_v1_quota(monkeypatch, tmp_path) -> None:
-    """cgroup v1 spells the same quota as two files under the cpu controller; -1 is unbounded."""
+@pytest.mark.parametrize("mount", ["cpu", "cpu,cpuacct"], ids=["symlinked-cpu", "joint-mount-only"])
+def test_available_cpus_reads_a_cgroup_v1_quota(monkeypatch, tmp_path, mount: str) -> None:
+    """cgroup v1 spells the same quota as two files under the cpu controller; -1 is unbounded.
+
+    The controller mounts under the name it is mounted with: most distributions mount the joint
+    ``cpu,cpuacct`` and drop a ``cpu`` symlink beside it, some only the joint one. Looking under
+    ``cpu`` alone found no quota file there and read the host's whole CPU count inside a container.
+    """
     from konfai.utils import budget as bd
 
     monkeypatch.setattr(bd.os, "sched_getaffinity", lambda pid: set(range(16)), raising=False)
     root = tmp_path / "cgroup"
-    (root / "cpu" / "docker" / "abc").mkdir(parents=True)
+    (root / mount / "docker" / "abc").mkdir(parents=True)
     proc = tmp_path / "proc_self_cgroup"
     proc.write_text("3:cpu,cpuacct:/docker/abc\n1:memory:/docker/abc\n")
     monkeypatch.setattr(bd, "_CGROUP_ROOT", str(root))
     monkeypatch.setattr(bd, "_PROC_SELF_CGROUP", str(proc))
-    (root / "cpu" / "docker" / "abc" / "cpu.cfs_quota_us").write_text("-1\n")
-    (root / "cpu" / "docker" / "abc" / "cpu.cfs_period_us").write_text("100000\n")
+    (root / mount / "docker" / "abc" / "cpu.cfs_quota_us").write_text("-1\n")
+    (root / mount / "docker" / "abc" / "cpu.cfs_period_us").write_text("100000\n")
     assert bd.available_cpus() == 16  # unbounded
-    (root / "cpu" / "docker" / "cpu.cfs_quota_us").write_text("250000\n")  # the ancestor's quota
-    (root / "cpu" / "docker" / "cpu.cfs_period_us").write_text("100000\n")
+    (root / mount / "docker" / "cpu.cfs_quota_us").write_text("250000\n")  # the ancestor's quota
+    (root / mount / "docker" / "cpu.cfs_period_us").write_text("100000\n")
     assert bd.available_cpus() == 3  # 2.5 CPUs round up
 
 

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -652,7 +652,7 @@ def _budget_applied(monkeypatch, cores: int, ranks: str | None, omp: str | None,
     calls: list[int] = []
     monkeypatch.setattr(rt, "_cpu_budget_applied", False)
     monkeypatch.setattr(rt.sys, "platform", platform)
-    monkeypatch.setattr(rt.os, "cpu_count", lambda: cores)
+    monkeypatch.setattr(rt, "available_cpus", lambda: cores)
     monkeypatch.setattr(rt.torch, "set_num_threads", calls.append)
     for key, value in (("KONFAI_LOCAL_RANKS", ranks), ("OMP_NUM_THREADS", omp)):
         monkeypatch.delenv(key, raising=False)
@@ -660,6 +660,39 @@ def _budget_applied(monkeypatch, cores: int, ranks: str | None, omp: str | None,
             monkeypatch.setenv(key, value)
     rt.apply_cpu_thread_budget()
     return calls
+
+
+def test_available_cpus_is_the_tighter_of_affinity_and_cgroup_quota(monkeypatch, tmp_path) -> None:
+    """A container sees the host's cores in full while being allowed a fraction: os.cpu_count says
+    64 where the affinity mask says 8 and cpu.max says 4; every thread past 4 is contention."""
+    from konfai.utils import budget as bd
+
+    monkeypatch.setattr(bd.os, "sched_getaffinity", lambda pid: set(range(8)), raising=False)
+    root = tmp_path / "cgroup"
+    (root / "a" / "b").mkdir(parents=True)
+    proc = tmp_path / "proc_self_cgroup"
+    proc.write_text("0::/a/b\n")
+    monkeypatch.setattr(bd, "_CGROUP_ROOT", str(root))
+    monkeypatch.setattr(bd, "_PROC_SELF_CGROUP", str(proc))
+    assert bd.available_cpus() == 8  # no quota file: the affinity mask
+    (root / "a" / "b" / "cpu.max").write_text("max 100000\n")
+    assert bd.available_cpus() == 8  # unbounded quota
+    (root / "a" / "cpu.max").write_text("350000 100000\n")  # the quota sits on an ANCESTOR
+    assert bd.available_cpus() == 4  # 3.5 CPUs of quota round up
+
+
+def test_cpu_thread_budget_sizes_itks_pool_with_torchs(monkeypatch) -> None:
+    """ITK does the host resample: an unbounded ITK pool beside a bounded torch one is the same
+    oversubscription moved one library over."""
+    sitk = pytest.importorskip("SimpleITK")
+    before = sitk.ProcessObject.GetGlobalDefaultNumberOfThreads()
+    try:
+        assert _budget_applied(monkeypatch, cores=24, ranks="4", omp=None) == [6]
+        assert sitk.ProcessObject.GetGlobalDefaultNumberOfThreads() == 6
+        assert _budget_applied(monkeypatch, cores=24, ranks="4", omp="20") == []
+        assert sitk.ProcessObject.GetGlobalDefaultNumberOfThreads() == 20
+    finally:
+        sitk.ProcessObject.SetGlobalDefaultNumberOfThreads(before)
 
 
 def test_cpu_thread_budget_caps_torchs_every_core_default(monkeypatch) -> None:

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -679,6 +679,29 @@ def test_available_cpus_is_the_tighter_of_affinity_and_cgroup_quota(monkeypatch,
     assert bd.available_cpus() == 8  # unbounded quota
     (root / "a" / "cpu.max").write_text("350000 100000\n")  # the quota sits on an ANCESTOR
     assert bd.available_cpus() == 4  # 3.5 CPUs of quota round up
+    (root / "a" / "b" / "cpu.max").write_text("garbage\n")  # a malformed file is skipped, not raised
+    assert bd.available_cpus() == 4
+    (root / "a" / "b" / "cpu.max").write_text("100000 0\n")  # a zero period too
+    assert bd.available_cpus() == 4
+
+
+def test_available_cpus_reads_a_cgroup_v1_quota(monkeypatch, tmp_path) -> None:
+    """cgroup v1 spells the same quota as two files under the cpu controller; -1 is unbounded."""
+    from konfai.utils import budget as bd
+
+    monkeypatch.setattr(bd.os, "sched_getaffinity", lambda pid: set(range(16)), raising=False)
+    root = tmp_path / "cgroup"
+    (root / "cpu" / "docker" / "abc").mkdir(parents=True)
+    proc = tmp_path / "proc_self_cgroup"
+    proc.write_text("3:cpu,cpuacct:/docker/abc\n1:memory:/docker/abc\n")
+    monkeypatch.setattr(bd, "_CGROUP_ROOT", str(root))
+    monkeypatch.setattr(bd, "_PROC_SELF_CGROUP", str(proc))
+    (root / "cpu" / "docker" / "abc" / "cpu.cfs_quota_us").write_text("-1\n")
+    (root / "cpu" / "docker" / "abc" / "cpu.cfs_period_us").write_text("100000\n")
+    assert bd.available_cpus() == 16  # unbounded
+    (root / "cpu" / "docker" / "cpu.cfs_quota_us").write_text("250000\n")  # the ancestor's quota
+    (root / "cpu" / "docker" / "cpu.cfs_period_us").write_text("100000\n")
+    assert bd.available_cpus() == 3  # 2.5 CPUs round up
 
 
 def test_cpu_thread_budget_sizes_itks_pool_with_torchs(monkeypatch) -> None:

--- a/tests/unit/test_sampling.py
+++ b/tests/unit/test_sampling.py
@@ -132,6 +132,41 @@ DEVICES = [torch.device("cpu")] + ([torch.device("cuda")] if torch.cuda.is_avail
 DEVICE_IDS = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
 
 
+def test_the_host_resampler_and_the_walk_agree_on_an_integer_payload():
+    """A CPU run takes ITK's resampler and a CUDA run takes the walk, so what separates them is
+    what separates a laptop's answer from a card's.
+
+    Both blend in the same working dtype and both cast by truncating toward zero, so they agree to
+    the ulp of the blend -- and on an INTEGER payload that ulp is a whole unit wherever the blended
+    value lands on a truncation boundary. This pins the size of that seam (at most one unit, on a
+    handful of voxels) so a real divergence, which moves voxels by far more, cannot hide in it.
+    ``nearest`` copies voxels and must be exact, integers included.
+    """
+    from konfai.data.transform import _resample_with_sitk
+
+    image = _image(oblique=True)
+    counts = (sitk.GetArrayFromImage(image) * 4.0).astype(np.int16)
+    integer = sitk.GetImageFromArray(counts)
+    integer.CopyInformation(image)
+    grid = _grid(integer)
+    payload = torch.from_numpy(counts).unsqueeze(0)
+    for label, transform in (("euler", _euler(integer)), ("affine", _affine(integer))):
+        stages = decode_transform_stages(transform)  # a rotation: no separable form, so the host path serves it
+        target = grid.sub_grid((slice(4, 11), slice(0, SIZE[1]), slice(0, SIZE[2])))
+        window = source_window(target, grid, bound_of(stages, 3))
+        block = payload[(slice(None), *window)]
+        starts = [part.start for part in window]
+        for mode, tolerance in (("linear", 1), ("nearest", 0)):
+            host = _resample_with_sitk(block, target, grid, stages, starts, mode, 0.0)
+            walk = gather(
+                block, source_index(target, grid, stages, torch.device("cpu")), starts, list(grid.size_zyx), mode, 0.0
+            )
+            assert host is not None and host.dtype == walk.dtype == torch.int16, label
+            apart = (host.to(torch.int32) - walk.to(torch.int32)).abs()
+            assert int(apart.max()) <= tolerance, f"{label}/{mode}: {int(apart.max())} units apart"
+            assert int((apart > 0).sum()) <= apart.numel() // 500, f"{label}/{mode}: the seam is not a seam"
+
+
 @pytest.mark.parametrize("oblique", [False, True], ids=["axis-aligned", "oblique"])
 def test_the_whole_grid_matches_simpleitk(oblique: bool):
     device = torch.device("cpu")

--- a/tests/unit/test_sampling_slabs.py
+++ b/tests/unit/test_sampling_slabs.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The budget slabs the coordinate walk, and slabbing changes NO value.
+
+Every claim here is ``torch.equal``, not ``allclose``: the walk's contract is bit-identity between
+a streamed region and the whole volume, and a slab is one more way of streaming. A slab that
+drifted in the last bit would round a continuous index across a voxel boundary and hand a label
+map a different label, so tolerance is the one thing these tests must not have.
+"""
+
+import numpy as np
+import pytest
+import torch
+from konfai.data.geometry import AffineMap, AffineStage, DisplacementStage, Grid
+from konfai.data.sampling import gather, source_index, source_index_rows, walk_rows
+
+RNG = np.random.default_rng(7)
+
+
+def _grid(shape: tuple[int, ...], oblique: bool = False) -> Grid:
+    direction = np.eye(3)
+    if oblique:
+        theta = 0.2
+        direction = np.array([[np.cos(theta), -np.sin(theta), 0], [np.sin(theta), np.cos(theta), 0], [0, 0, 1.0]])
+    return Grid(shape, RNG.uniform(-40, 40, 3), RNG.uniform(0.5, 2.5, 3), direction)
+
+
+def _field(shape: tuple[int, ...], order: int) -> DisplacementStage:
+    return DisplacementStage(_grid(shape), RNG.normal(0, 4.0, (3, *shape)), order)
+
+
+STAGE_SETS = [
+    [],
+    [_field((7, 9, 8), 1)],
+    [AffineStage(AffineMap(np.eye(3) + RNG.normal(0, 0.05, (3, 3)), RNG.normal(0, 5, 3))), _field((6, 6, 6), 3)],
+]
+
+
+@pytest.mark.parametrize("stages", STAGE_SETS)
+def test_slabbed_walk_is_the_whole_walk(stages):
+    """A budget small enough to force one-row slabs reproduces the unslabbed walk bit for bit."""
+    target, source = _grid((21, 13, 17), oblique=True), _grid((15, 19, 11))
+    whole = source_index(target, source, stages, torch.device("cpu"))
+    assert walk_rows(target, stages, torch.device("cpu"), budget_bytes=50_000) < 21
+    slabbed = source_index(target, source, stages, torch.device("cpu"), budget_bytes=50_000)
+    assert torch.equal(whole, slabbed)
+
+
+def test_row_range_keeps_global_indices():
+    """``source_index_rows`` over [start, stop) IS those rows of the whole walk: the row indices go
+    through the region's own map, never a re-derived sub-grid whose folded origin would move the
+    last bit."""
+    target, source = _grid((12, 9, 7), oblique=True), _grid((10, 8, 9))
+    stages = [_field((5, 6, 4), 1)]
+    whole = source_index(target, source, stages, torch.device("cpu"))
+    rows = source_index_rows(target, source, stages, torch.device("cpu"), 3, 9)
+    assert torch.equal(whole[3:9], rows)
+
+
+@pytest.mark.parametrize("mode", ["nearest", "linear", "cubic"])
+def test_slabbed_gather_is_the_whole_gather(mode):
+    """Walking and gathering slab by slab (what ResampleTransform does over a budget) concatenates
+    to the single-pass result exactly: the gather's window and starts are the region's own, so a
+    slab sums, picks and normalises the very numbers the whole pass does."""
+    target, source = _grid((14, 11, 13)), _grid((12, 15, 10))
+    stages = [_field((5, 5, 5), 1)]
+    payload = torch.tensor(RNG.integers(0, 3000, (2, 12, 15, 10)), dtype=torch.float32)
+    if mode == "nearest":
+        payload = payload[:1].to(torch.uint8)
+    coordinates = source_index(target, source, stages, torch.device("cpu"))
+    whole = gather(payload, coordinates, [0, 0, 0], [12, 15, 10], mode, 0.0)
+    parts = [
+        gather(
+            payload,
+            source_index_rows(target, source, stages, torch.device("cpu"), start, min(14, start + 4)),
+            [0, 0, 0],
+            [12, 15, 10],
+            mode,
+            0.0,
+        )
+        for start in range(0, 14, 4)
+    ]
+    assert torch.equal(whole, torch.cat(parts, dim=1))
+
+
+def test_separable_nearest_keeps_wide_integer_labels():
+    """A nearest pick copies voxels in the payload's own dtype on BOTH gather paths: a float32
+    detour rounds every label above 2**24, and the separable path (the common, axis-aligned case)
+    must agree with the general one on the very volumes it is supposed to serve identically."""
+    from konfai.data.sampling import gather_separable, separable_source_index, source_index
+
+    label = 20_000_001
+    payload = torch.full((1, 6, 6, 6), label, dtype=torch.int32)
+    # One grid for both sides: a self-resample keeps every pick inside, so the assertion sees
+    # copied labels, not fill.
+    target = source = _grid((6, 6, 6))
+    axes = separable_source_index(target, source, [], torch.device("cpu"))
+    assert axes is not None
+    out_separable = gather_separable(payload, axes, [0, 0, 0], [6, 6, 6], "nearest", 0.0)
+    coordinates = source_index(target, source, [], torch.device("cpu"))
+    out_general = gather(payload, coordinates, [0, 0, 0], [6, 6, 6], "nearest", 0.0)
+    inside_separable = out_separable[out_separable != 0]
+    inside_general = out_general[out_general != 0]
+    assert inside_separable.numel() and bool((inside_separable == label).all())
+    assert inside_general.numel() and bool((inside_general == label).all())
+
+
+def test_two_dimensional_slabs_hold_the_same_contract():
+    """Rank 2 exercises every axis-order convention with one spatial axis fewer; nothing pins it
+    elsewhere in the suite, and a 2-D drift would look exactly like a working resample."""
+    from konfai.data.sampling import source_index as walk
+
+    target = Grid((15, 11), RNG.uniform(-10, 10, 2), RNG.uniform(0.5, 2.0, 2), np.eye(2))
+    source = Grid((12, 9), RNG.uniform(-10, 10, 2), RNG.uniform(0.5, 2.0, 2), np.eye(2))
+    field_grid = Grid((5, 4), RNG.uniform(-10, 10, 2), RNG.uniform(2.0, 4.0, 2), np.eye(2))
+    stages = [DisplacementStage(field_grid, RNG.normal(0, 3.0, (2, 5, 4)), 1)]
+    whole = walk(target, source, stages, torch.device("cpu"))
+    rows = source_index_rows(target, source, stages, torch.device("cpu"), 4, 11)
+    assert torch.equal(whole[4:11], rows)
+    payload = torch.tensor(RNG.random((1, 12, 9)), dtype=torch.float32)
+    coordinates = walk(target, source, stages, torch.device("cpu"))
+    whole_gather = gather(payload, coordinates, [0, 0], [12, 9], "linear", 0.0)
+    parts = [
+        gather(
+            payload,
+            source_index_rows(target, source, stages, torch.device("cpu"), s, min(15, s + 6)),
+            [0, 0],
+            [12, 9],
+            "linear",
+            0.0,
+        )
+        for s in range(0, 15, 6)
+    ]
+    assert torch.equal(whole_gather, torch.cat(parts, dim=1))
+
+
+def test_separable_and_general_walks_agree_bitwise():
+    """The separable fast path claims bit-identity with the general walk wherever both apply (axis
+    aligned, no stages): hold it, per axis, on the very numbers -- the claim carried no test."""
+    from konfai.data.sampling import separable_source_index
+    from konfai.data.sampling import source_index as walk
+
+    for trial in range(3):
+        target = Grid((9, 8, 7), RNG.uniform(-30, 30, 3), RNG.uniform(0.4, 2.5, 3), np.eye(3))
+        source = Grid((8, 6, 9), RNG.uniform(-30, 30, 3), RNG.uniform(0.4, 2.5, 3), np.eye(3))
+        axes = separable_source_index(target, source, [], torch.device("cpu"))
+        assert axes is not None
+        coordinates = walk(target, source, [], torch.device("cpu"))
+        for array_axis, axis_values in enumerate(axes):
+            component = 3 - 1 - array_axis
+            picked = coordinates.movedim(-1, 0)[component]
+            broadcast_shape = [1, 1, 1]
+            broadcast_shape[array_axis] = -1
+            assert torch.equal(picked, axis_values.reshape(broadcast_shape).expand_as(picked)), (
+                f"axis {array_axis} drifted at trial {trial}"
+            )
+
+
+def test_retired_resample_spellings_name_their_replacement():
+    """The 1.8 breaking change promised each removed name points at the new spelling; difflib
+    offered 'EulerTransform' for 'ResampleTransform' and nothing for 'Warp'."""
+    from konfai.data.transform import TransformLoader
+    from konfai.utils.errors import TransformError
+
+    loader = TransformLoader.__new__(TransformLoader)
+    for retired in ("ResampleToResolution", "ResampleToShape", "ResampleToReference", "ResampleTransform", "Warp"):
+        with pytest.raises(TransformError, match="Resample"):
+            loader.get_transform(retired, "")
+
+
+def test_fast_precision_is_close_and_scoped():
+    """The float32 walk is an opt-in CONTEXT: close to the exact walk on world-scale grids, and the
+    default outside the context stays the bit-exact float64 -- entering it must never leak."""
+    from konfai.data.sampling import _walk_dtype, coordinate_precision
+
+    target = Grid((9, 8, 7), np.array([30000.0, -20000.0, 10000.0]), np.array([30.08, 30.08, 40.0]), np.eye(3))
+    source = Grid((8, 6, 9), np.array([29000.0, -21000.0, 9000.0]), np.array([30.08, 30.08, 40.0]), np.eye(3))
+    stages = [_field((5, 6, 4), 1)]
+    exact = source_index(target, source, stages, torch.device("cpu"))
+    assert _walk_dtype() == torch.float64
+    with coordinate_precision(torch.float32):
+        assert _walk_dtype() == torch.float32
+        fast = source_index(target, source, stages, torch.device("cpu"))
+    assert _walk_dtype() == torch.float64
+    assert fast.dtype == torch.float32
+    # ~|world|/2^24 in world units over a ~30 um voxel: a few 1e-3 of a voxel at these magnitudes.
+    assert (exact - fast.double()).abs().max().item() < 5e-3
+    again = source_index(target, source, stages, torch.device("cpu"))
+    assert torch.equal(exact, again)  # the exact walk is untouched by having entered the context

--- a/tests/unit/test_transform_locality_contract.py
+++ b/tests/unit/test_transform_locality_contract.py
@@ -115,19 +115,22 @@ _PEAK = 450.0
 #   float32 ulps away. Data-dependent: this fixture happens to agree exactly, a smooth field showed
 #   1.5e-8 (0.13 ulp), so the bound is stated rather than observed.
 _STAT_ATOL = 8 * float(np.finfo(np.float32).eps)
-# - a streamed regrid through a map that does NOT factorise (a field, a rotation): its blend goes to
-#   grid_sample, which takes normalised coordinates and so expresses them in the read sub-region's
-#   frame rather than the whole volume's. Both round to float32, so a weight lands ~ulp(coordinate)
-#   off and the interpolated voxel lands `neighbour gap * ulp(coordinate)` off: the deviation
-#   scales with the local GRADIENT, not with the voxel's own magnitude. The fixture's gap is its
-#   2*_PEAK bone/air step, which puts the bound at ulps of _PEAK; 64 of them is ~8x the measured max
-#   and stays far below one part per million of the range. A map that DOES factorise is read one axis
-#   at a time on global coordinates and stays bit-identical, which is why those cases carry no atol
-#   at all; nearest uses no weights and is exact either way.
+# - a linear resample through a map that does NOT factorise (a field, a rotation), ON THE DEVICE:
+#   the coordinate walk keeps global float64 coordinates and is bit-identical slab for slab, but the
+#   CUDA blend goes through grid_sample, which normalises the coordinates by the extent it is handed,
+#   and a region is handed a window. A weight lands ~ulp(coordinate) off and the voxel
+#   `neighbour gap * ulp(coordinate)` off: the deviation scales with the local GRADIENT. The
+#   fixture's gap is its 2*_PEAK bone/air step, which puts the bound at ulps of _PEAK; 64 of them is
+#   ~8x the measured max and far below one part per million of the range. On the HOST the same case
+#   goes through ITK's own resampler on a window at its true origin and is bit-identical on an
+#   axis-aligned volume (measured: zero differing voxels on every Resample case, field and stored
+#   map included); on OBLIQUE cosines the window's origin is one rounding the whole volume never
+#   takes, and a voxel in ~1e5 lands an ulp apart. A map that DOES factorise is read one axis at a
+#   time on global coordinates and is bit-identical everywhere; nearest uses no weights and is
+#   exact either way; cubic walks the corners itself and is exact.
 _REGRID_ATOL = 64 * float(np.spacing(np.float32(_PEAK)))
 # An integer volume truncates the interpolation, so a sub-ulp disagreement that straddles an integer
-# boundary becomes a whole least-significant bit. 1 LSB is the tightest bound that can hold: the
-# alternative would be bit-exact agreement between two different float coordinate frames.
+# boundary becomes a whole least-significant bit.
 _LSB_ATOL = 1.0
 
 
@@ -171,12 +174,14 @@ _CASES: dict[str, list[_Case]] = {
     "Mask": [_Case(Mask(path="Labels", value_outside=-7))],
     "MergeLabels": [_Case(MergeLabels(), group="Ensemble")],
     "OneHot": [_Case(OneHot(4), group="Labels")],
-    # A pad reaching both borders of every axis, constant and reflect: the fill and the mirror both
-    # need the source rows the clamp cut back to.
+    # Pads reaching both borders of every axis, asymmetric and wider than the patch, constant and
+    # reflect: the fill and the mirror both need the source rows the clamp cut back to.
     "Padding": [
         _Case(Padding(padding=[1, 2, 3, 0, 2, 4], mode="constant:-3")),
         _Case(Padding(padding=[2, 1, 1, 2, 3, 2], mode="reflect")),
         _Case(Padding(padding=[0, 0, 0, 0, 0, 0])),
+        _Case(Padding([1, 2, 3, 4, 5, 6])),
+        _Case(Padding([5, 0, 0, 5, 2, 2], mode="constant:-7")),
     ],
     "Percentage": [_Case(Percentage(100.0))],
     # The default (the case's own grid, no map) would be a no-op resample; these are the family's
@@ -192,15 +197,21 @@ _CASES: dict[str, list[_Case]] = {
         # bit for bit or not at all.
         _Case(Resample(reference=_CASE_NAME, reference_group="Reference")),
         _Case(Resample(reference=_CASE_NAME, reference_group="Reference"), group="Labels"),
-        # Through a field the map does not factorise, so the blend goes to grid_sample: which
-        # normalises by the extent it is handed, and a patch is handed a window. That is the one
-        # place a streamed answer is not bit-identical to the whole-volume one, and the atol says so.
+        # Through a field, and through a stored map: neither factorises. Exact on the host (ITK's
+        # resampler), ~ulp on the device (grid_sample's normalised coordinates): the atol says so.
         _Case(
             Resample(reference=_CASE_NAME, reference_group="Reference", field_group="Field"),
             atol=_REGRID_ATOL,
         ),
-        # A stored map never factorises: the grid_sample path again.
         _Case(Resample(transforms={"transform": True}), atol=_REGRID_ATOL),
+        # The same on an OBLIQUE case: a region's origin is the volume's map applied to its start,
+        # one more rounding than the whole volume's index-to-world takes, and on oblique cosines
+        # that rounding is not exact -- so a handful of voxels (measured: 1 in 64 in one patch,
+        # ~1e-5 of a volume) land an ulp apart, on the host as on the device; the same bound holds.
+        # A nearest pick on the fixture stays exact (the deviation is far from any .5 boundary).
+        _Case(Resample(spacing=[2.0, 1.0, 3.0]), group="Oblique", atol=_REGRID_ATOL),
+        _Case(Resample(reference=_CASE_NAME, reference_group="Reference"), group="Oblique", atol=_REGRID_ATOL),
+        _Case(Resample(reference=_CASE_NAME, reference_group="Reference", interpolation="nearest"), group="Oblique"),
         # Keys' cubic: the separable axis walk and the corner walk both keep GLOBAL coordinates, so
         # streamed and whole agree exactly on floats; int16 rounds the blend once, hence the LSB.
         _Case(Resample(spacing=[2.0, 1.0, 3.0], interpolation="cubic")),
@@ -535,7 +546,7 @@ def test_a_streamed_region_records_the_whole_volume_geometry(dataset: Dataset, g
 
 # A HALO draw is sampled by grid_sample from coordinates expressed in the halo'd read extent's frame
 # rather than the whole volume's: the same disagreement, for the same reason and with the same
-# gradient- and coordinate-scaling, that _REGRID_ATOL bounds for the streamed resample. It is bitwise
+# gradient- and coordinate-scaling, that _REGRID_ATOL bounds for the device resample. It is bitwise
 # on neither, and grows with the extent: a 160^3 case at patch 64 lands at 2e-5 of its range.
 _AUGMENTATION_ATOL = _REGRID_ATOL
 

--- a/tests/unit/test_transform_materialize_contract.py
+++ b/tests/unit/test_transform_materialize_contract.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+"""The WRITE side of the contract: a chain materialized slab by slab writes what the whole volume writes.
+
+:mod:`test_transform_locality_contract` proves the read side, patch by patch, for every built-in
+transform. TRANSFORM runs take the other route: :meth:`DatasetManager.materialize` sweeps the chain
+in slabs into a ``Write`` and never assembles the case. That route has its own machinery (the sweep
+rows, the region replay, the stream writers, the header composed from the first slab), so it is
+proven separately, over the SAME enumerated cases, on the same on-disk dataset: the streamed store
+must equal the store the whole-volume path writes, voxel for voxel, on every device the chain can
+run on.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import SimpleITK as sitk
+import torch
+from konfai.data import patching as patching_module
+from konfai.data.materialize import CaseMaterializer, Verdict
+from konfai.data.patching import DatasetManager
+from konfai.data.transform import Write
+from konfai.utils.dataset import Dataset
+
+# The read-side module is a test file, not a package: load it by path so its case table and fixture
+# are the single registry both sides enumerate.
+_spec = importlib.util.spec_from_file_location(
+    "transform_locality_contract", Path(__file__).with_name("test_transform_locality_contract.py")
+)
+_contract = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = _contract
+_spec.loader.exec_module(_contract)
+dataset = _contract.dataset  # the session fixture, re-exported under the name pytest resolves
+
+_DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
+# The formats a case can be READ from region by region -- each its own reader (an ITK extract, a
+# gzip stream decoded whole, an h5 slice, a zarr chunk hull) -- plus the one every
+# other test uses.
+_SOURCE_FORMATS = ["mha", "nii", "nii.gz", "h5", "omezarr"]
+
+
+@pytest.fixture(scope="session")
+def sources(dataset: Dataset, tmp_path_factory: pytest.TempPathFactory) -> dict[str, Dataset]:
+    """The read-side dataset, re-written in every source format (same voxels, same headers)."""
+    root = tmp_path_factory.mktemp("sources")
+    out = {"mha": dataset}
+    stored = dataset.read_transform("transform", _contract._CASE_NAME)
+    for fmt in _SOURCE_FORMATS[1:]:
+        copy_root = root / fmt.replace(".", "_")
+        copy = Dataset(copy_root, fmt)
+        for group, volume in _contract._volumes().items():
+            copy.write(group, _contract._CASE_NAME, volume, _contract._attributes(group))
+        if fmt.startswith("nii"):
+            # A stored transform lives beside the case's images, as SimpleITK writes it; the store
+            # formats (h5, omezarr) hold displacement fields only, so those cases have no such form.
+            sitk.WriteTransform(stored, str(copy_root / _contract._CASE_NAME / "transform.itk.txt"))
+        out[fmt] = copy
+    return out
+
+
+# The groups whose CASE carries KonfAI attributes beyond the geometry (a channel split, a box).
+# NIfTI has no room for them: a case read back from a .nii has lost them, by the format, not by
+# the reader -- so those cases have no NIfTI form to test.
+_ATTRIBUTE_GROUPS = ("Ensemble", "Boxed")
+
+
+def _cases():
+    return [case for case in _contract._streamable_cases() if case.group != "Field"]
+
+
+def _manager(dataset: Dataset, case, out: Path, fmt: str) -> DatasetManager:
+    case.transform.set_datasets([dataset])
+    return DatasetManager(
+        index=0,
+        group_src=case.group,
+        group_dest=case.group,
+        name=_contract._CASE_NAME,
+        dataset=dataset,
+        patch=None,
+        transforms=[case.transform, Write(f"{out}:{fmt}")],
+        data_augmentations_list=[],
+    )
+
+
+@pytest.mark.parametrize("fmt", ["mha", "omezarr"])
+@pytest.mark.parametrize("device", _DEVICES)
+@pytest.mark.parametrize("case", _cases(), ids=lambda case: f"{type(case.transform).__name__}:{case.group}")
+def test_streamed_materialize_equals_whole_volume(
+    case, device: str, fmt: str, dataset: Dataset, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _check(case, torch.device(device), fmt, dataset, tmp_path, monkeypatch)
+
+
+@pytest.mark.parametrize("source", _SOURCE_FORMATS[1:])
+@pytest.mark.parametrize("case", _cases(), ids=lambda case: f"{type(case.transform).__name__}:{case.group}")
+def test_streamed_materialize_equals_whole_volume_from_every_source_format(
+    case, source: str, sources: dict[str, Dataset], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same contract, the case read through each format's own region reader."""
+    if source.startswith("nii") and case.group in _ATTRIBUTE_GROUPS:
+        pytest.skip("NIfTI carries no attribute beyond the geometry")
+    if not source.startswith("nii") and getattr(case.transform, "transforms", None):
+        pytest.skip("a store holds displacement fields only, not a stored affine")
+    _check(case, torch.device("cpu"), "mha", sources[source], tmp_path, monkeypatch)
+
+
+def _check(
+    case, dev: torch.device, fmt: str, dataset: Dataset, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Two-row slabs, so the sweep really is several slabs and every seam is exercised.
+    monkeypatch.setattr(patching_module, "SWEEP_SLAB_ROWS", 2)
+    whole = _manager(dataset, case, tmp_path / "Whole", fmt)
+    verdict = CaseMaterializer(whole).materialize(prefer_whole=True, fallback_budget_bytes=1 << 30, device=dev)
+    assert verdict is not Verdict.STREAM
+    expected, header_expected = Dataset(tmp_path / "Whole", fmt).read_data(case.group, _contract._CASE_NAME)
+    # Whatever the stage returned, what is on disk is a channel-first volume on the case's geometry.
+    assert np.asarray(expected).ndim == len(header_expected.get_np_array("Spacing")) + 1
+
+    streamed = _manager(dataset, case, tmp_path / "Streamed", fmt)
+    # A stage the sweep cannot serve (it changes the rank, it needs the volume) says so -- up front
+    # or on the first slab -- and the whole-volume path writes the case: the contract then is the
+    # shape asserted above, and there is no streamed store to compare.
+    if CaseMaterializer(streamed).materialize(fallback_budget_bytes=1 << 30, device=dev) is not Verdict.STREAM:
+        pytest.skip(f"took the whole-volume path: {streamed.stream_refusal() or streamed._sweep_failure}")
+    got, header_got = Dataset(tmp_path / "Streamed", fmt).read_data(case.group, _contract._CASE_NAME)
+    assert got.shape == expected.shape
+    assert got.dtype == expected.dtype
+    np.testing.assert_allclose(np.asarray(got), np.asarray(expected), rtol=0, atol=case.atol)
+    for key in ("Origin", "Spacing", "Direction"):
+        if key in header_expected:
+            np.testing.assert_allclose(
+                header_got.get_np_array(key), header_expected.get_np_array(key), rtol=0, atol=1e-9
+            )

--- a/tests/unit/test_transformer_workflow.py
+++ b/tests/unit/test_transformer_workflow.py
@@ -182,6 +182,38 @@ def test_plan_leaves_no_h5_file_behind(tmp_path: Path) -> None:
     assert not Dataset(tmp_path / "out", "h5").is_dataset_exist("CT_out", "__konfai_plan_probe__")
 
 
+def test_plan_leaves_no_single_file_store_behind(tmp_path: Path) -> None:
+    """The probe on an h5 destination created the file (a 6 KB store with an empty group): a dry
+    run that leaves an output where there was none is not a dry run."""
+    _write_source(tmp_path)
+    _write_config(tmp_path, _STREAMABLE.format(out=tmp_path / "out"))
+
+    _build(tmp_path).compute_plan(1, overwrite=False)
+
+    assert not (tmp_path / "out.h5").exists()
+
+
+_MHA_CHAIN = """\
+              Clip:
+                min_value: 0.0
+                max_value: 50.0
+              Write:
+                dataset: {out}:mha
+"""
+
+
+def test_a_bounded_source_streams_to_every_destination_format(tmp_path: Path) -> None:
+    """The head segment past the last Save has no reader in a chain ending in a Write, and pricing
+    it asked the Write's destination -- not there yet, so 'unbounded' -- and every mha/nii output
+    routed to LOAD 'because streaming would re-read the source', which was false."""
+    _write_source(tmp_path)
+    _write_config(tmp_path, _MHA_CHAIN.format(out=tmp_path / "out"))
+
+    plan = _build(tmp_path).compute_plan(1, overwrite=False)
+
+    assert [entry.verdict for entry in plan.entries] == ["STREAM", "STREAM"]
+
+
 def test_a_planned_workflow_survives_the_spawn_that_runs_it(tmp_path: Path) -> None:
     """``setup`` runs on the launcher and ``mp.spawn`` then pickles the workflow whole.
 
@@ -262,6 +294,29 @@ def test_the_budget_measures_the_largest_intermediate_not_the_stored_case(tmp_pa
     stored = 1 * 12 * 10 * 8 * 4 * 2  # [1, 12, 10, 8] float32, times the in-flight copy
     # A budget the stored case fits and the padded one does not.
     config_path.write_text(config_path.read_text().replace("memory_budget: auto", f"memory_budget: {stored + 1}b"))
+
+    with pytest.raises(TransformerError, match="budget"):
+        _build(tmp_path).setup(1)
+
+
+_RESAMPLES_THEN_FALLS_BACK = """\
+              Resample:
+                spacing: [0.5, 1.5, 2.0]
+              Standardize:
+                inverse: false
+              Write:
+                dataset: {out}:h5
+"""
+
+
+def test_the_budget_counts_a_stage_own_transients(tmp_path: Path) -> None:
+    """A whole-volume resample through ITK holds its input image, its output image and their tensor
+    copies: 4.5x the case, measured, where an elementwise stage holds 2x. Sized at 2x it passes a
+    budget it does not fit. The stage says what it holds (``working_multiple``), the plan sums it."""
+    _write_source(tmp_path)
+    config_path = _write_config(tmp_path, _RESAMPLES_THEN_FALLS_BACK.format(out=tmp_path / "out"))
+    case = 1 * 12 * 10 * 8 * 4  # the resample keeps the grid: same extent in and out
+    config_path.write_text(config_path.read_text().replace("memory_budget: auto", f"memory_budget: {case * 3}b"))
 
     with pytest.raises(TransformerError, match="budget"):
         _build(tmp_path).setup(1)

--- a/tests/unit/test_write_pyramid.py
+++ b/tests/unit/test_write_pyramid.py
@@ -23,8 +23,6 @@ are different code (``write_ome_zarr`` against ``create_ome_zarr_store`` +
 ``append_ome_zarr_levels``), and the streamed one is the path a real volume takes.
 """
 
-from pathlib import Path
-
 import numpy as np
 import pytest
 import zarr
@@ -111,26 +109,25 @@ def test_each_scale_factor_shrinks_the_level_above_it(tmp_path):
 
 
 def test_an_interrupted_level_append_leaves_the_original_store_readable(tmp_path, monkeypatch):
-    """Deriving the coarse levels rewrites level 0, so a failure here is a failure over the only copy.
+    """The coarse levels are grafted beside level 0, which is never rewritten, and the metadata that
+    names them lands last: an append cut off while a level is being stored leaves a store that still
+    reads exactly as its level 0, one level deep -- not a gap between two deletes, and not a
+    pyramid whose coarse level is half there."""
+    import dask.array
 
-    The safety is bought with a sibling store and a rename: a rename that does not happen has to leave
-    the original where its readers expect it, not a gap between two deletes.
-    """
     data = np.arange(1 * 16 * 16 * 16, dtype=np.float32).reshape(1, 16, 16, 16)
     Dataset(tmp_path / "out", "omezarr").write("G", "case", data, _geometry())
     store = _only_store(tmp_path / "out")
-    real_rename = Path.rename
 
-    def interrupt_the_publishing_rename(self, target):
-        if self.name.endswith(".appending"):
-            raise KeyboardInterrupt
-        return real_rename(self, target)
+    def interrupt_the_level_store(*args, **kwargs):
+        raise KeyboardInterrupt
 
-    monkeypatch.setattr(Path, "rename", interrupt_the_publishing_rename)
+    monkeypatch.setattr(dask.array, "store", interrupt_the_level_store)
     with pytest.raises(KeyboardInterrupt):
         append_ome_zarr_levels(store, [4])
     monkeypatch.undo()
 
+    assert get_ome_zarr_info(store)["n_levels"] == 1
     back, _ = Dataset(tmp_path / "out", "omezarr").read_data("G", "case")
     assert np.array_equal(np.asarray(back, dtype=np.float32).reshape(data.shape), data)
 


### PR DESCRIPTION
Stacked on #110 (`feat/config-strict-read`), itself on #109 and #105: merge those first, then retarget this PR to `main`. Ported onto the audit stack (it was written against #105 alone): what both had done independently is the stack's version, the perf work is this commit.

## What (one commit)

- **The streamed resample runs on the device, out of core.** The TRANSFORM coordinate walk is vectorised, slabbed under a budget read off the machine, and runs on the rank's device end to end, reductions included. Measured on a three-specimen ExaSPIM template round, one GPU: Fold 127 s + Update 73 s where the CPU baseline did not finish in 1 h 47; 4.5 GiB peak VRAM; bitwise-deterministic; CPU-vs-GPU within 8e-6 um. The float64 walk stays bit-identical to `sitk.Resample` (pinned by `torch.equal` tests); `Resample` may declare `precision: fast` (float32 walk) for intensity chains.
- **On a machine without a GPU, `Resample` goes through ITK's own resampler** (each streamed region's source window as a sitk image, the stages one sitk transform): 27 ns/voxel where the torch walk on the host does 326. Full CPU Fold on the same round: 2005 s -> 892 s.
- **A pyramid appended to a streamed store no longer rewrites level 0**: coarser levels are computed lazily from it (dask coarsen, no wasm sandbox) and stored beside it; each declared factor shrinks the level above it, as the release's contract says (ngff-zarr's level-0-relative argument is derived). Update.yml on the same round: 103 s -> 53 s on GPU; `write_ome_zarr` creates the store empty and lets zarr fill it (2.3 s where the dask rechunk took 14.4 s for 2.1 GB).
- **Vote** counts along the case axis (2 s per 512³ where a `torch.unique` took 31 s); **Median** reads the middle off a sort along the case axis (bit-identical, 1.5-3.5x). A reduction folds on the rank's device, its regions re-fitted to the card's free memory; the folds a statistics pass computes are kept for the write pass when the folded output fits half the budget.
- **The per-rank thread share sizes ITK's pool with torch's** and counts the cores a process may run on (affinity mask and cgroup `cpu.max`, not the host's `os.cpu_count()`): `--cpu 3` on three 512³ cases 15.7 s -> 9.1 s. Publishing an entry retires the staging debris of dead writers beside it.
- **The write side of the streaming contract is proven the way the read side is**: `tests/unit/test_transform_materialize_contract.py` materializes every built-in transform slab by slab into a `Write` and compares the store with the whole-volume path's, on CPU and CUDA, into mha and omezarr, read from mha, nii, nii.gz, h5.

## Port notes
Dropped as already in the stack: the cgroup budget, byte-balanced shards, lazy `dicom`/`ome_zarr` imports, probe cleanup, `--plan` flags, h5 replace-aside, ITK_ key filter, `Padding` streaming (the stack's handles reflect). The working set stays the stack's estimator (fallback factor + each stage's declared working multiple). Two stray log files the draft carried are gone.

## Verification
Full core suite (unit + integration) green on the ported tree except one integration test that hung under 8 parallel workers (`test_konfai_cli_resume_continues_training`, a CLI training rendezvous under load; passes alone, and it exercises the stack's code, not this commit's); ruff, format, mypy, bandit green; konfai-mcp / Studio / apps suites run before push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GPU selection and quiet-mode options for transform planning.
  - Added configurable resampling precision, channel expansion, 2D NIfTI streaming, and device-aware reductions.
  - Added faster OME-Zarr chunk reads and pyramid generation.

- **Improvements**
  - Improved CPU/GPU memory budgeting, workload distribution, coordinate accuracy, and integer-label handling.
  - Added atomic file replacement and safer checkpoint publishing.
  - Improved metadata, displacement fields, vector images, and streamed materialization consistency.

- **Documentation**
  - Clarified streaming accuracy, device behavior, workload sharding, budgets, validation, and destination restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->