### PR TITLE
feat(mcp): support stateless streamable HTTP deployments

### DIFF
--- a/docs/source/usage/mcp.md
+++ b/docs/source/usage/mcp.md
@@ -102,6 +102,40 @@ KONFAI_MCP_WORKSPACES_ROOT = "/path/to/workspaces"
 KONFAI_MCP_APP_CATALOG = "/path/to/my_apps.json"   # optional: your own app sources
 ```
 
+### Remote and stateless deployments
+
+Beyond stdio, the server speaks the MCP *streamable HTTP* transport
+(specification revision 2025-03-26, which replaced the deprecated HTTP+SSE
+transport). Sessions are optional in that revision: with `--stateless-http`
+the server never issues an `Mcp-Session-Id` header, every request is
+self-contained, and replicas can run behind a load balancer or on serverless
+platforms without session affinity. `--json-response` additionally returns
+plain `application/json` bodies instead of opening a Server-Sent Events
+stream per request, which suits proxies that buffer streaming responses.
+
+```bash
+# Stateful streamable HTTP (default): sessions pinned to this process
+konfai-mcp --transport streamable-http --host 0.0.0.0 --port 8123 --bearer-token "$TOKEN"
+
+# Stateless streamable HTTP: safe behind a load balancer, no session affinity
+konfai-mcp --transport streamable-http --stateless-http --json-response \
+    --host 0.0.0.0 --port 8123 --bearer-token "$TOKEN"
+```
+
+Both flags can also be set through the environment
+(`KONFAI_MCP_STATELESS_HTTP=1`, `KONFAI_MCP_JSON_RESPONSE=1`). They apply
+only to `streamable-http`; stdio is inherently per-process and the
+deprecated SSE transport requires sessions.
+
+```{warning}
+Stateless mode removes MCP *protocol* session state, not KonfAI's own
+experiment state. Experiment workspaces live on disk under
+`KONFAI_MCP_WORKSPACES_ROOT` and survive across requests and restarts, but
+the in-memory job registry is per-process: when scaling to multiple
+replicas, point them at a shared workspaces root and route job-monitoring
+calls consistently, or run a single replica for job-heavy workflows.
+```
+
 ## Tool surface at a glance
 
 | Stage | Tools |

--- a/konfai-mcp/konfai_mcp/__init__.py
+++ b/konfai-mcp/konfai_mcp/__init__.py
@@ -25,6 +25,13 @@ from typing import Any
 
 _TRANSPORT_CHOICES = ("stdio", "sse", "streamable-http")
 
+_ENV_FLAG_TRUE = {"1", "true", "yes", "on"}
+
+
+def _env_flag(name: str) -> bool:
+    """Interpret an environment variable as a boolean flag."""
+    return os.environ.get(name, "").strip().lower() in _ENV_FLAG_TRUE
+
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run the KonfAI MCP server.")
@@ -72,6 +79,25 @@ def _build_parser() -> argparse.ArgumentParser:
         default=os.environ.get("KONFAI_MCP_BEARER_TOKEN"),
         help="Optional bearer token required for SSE or streamable HTTP transports.",
     )
+    parser.add_argument(
+        "--stateless-http",
+        action="store_true",
+        default=_env_flag("KONFAI_MCP_STATELESS_HTTP"),
+        help=(
+            "Serve streamable HTTP without MCP session state: no Mcp-Session-Id header is issued and every "
+            "request is self-contained, so replicas can sit behind a load balancer or serverless platform "
+            "without session affinity. Streamable HTTP only."
+        ),
+    )
+    parser.add_argument(
+        "--json-response",
+        action="store_true",
+        default=_env_flag("KONFAI_MCP_JSON_RESPONSE"),
+        help=(
+            "Return plain application/json bodies instead of opening a Server-Sent Events stream per request; "
+            "pairs well with --stateless-http behind buffering proxies. Streamable HTTP only."
+        ),
+    )
     return parser
 
 
@@ -86,6 +112,10 @@ def _apply_cli_environment(args: argparse.Namespace) -> None:
         "KONFAI_MCP_PATH": args.path,
         "KONFAI_MCP_LOG_LEVEL": args.log_level,
         "KONFAI_MCP_BEARER_TOKEN": args.bearer_token,
+        # Only propagate truthy flags: a plain `False` means "not requested", and clobbering the
+        # variable with "False" would surprise anyone who exported it before launching.
+        "KONFAI_MCP_STATELESS_HTTP": "1" if args.stateless_http else None,
+        "KONFAI_MCP_JSON_RESPONSE": "1" if args.json_response else None,
     }
     for key, value in updates.items():
         if value is None:
@@ -104,6 +134,11 @@ def main(argv: Sequence[str] | None = None) -> None:
             f"KONFAI_MCP_TRANSPORT={args.transport!r} is not a valid transport; "
             f"choose from {', '.join(_TRANSPORT_CHOICES)}."
         )
+    if (args.stateless_http or args.json_response) and args.transport != "streamable-http":
+        parser.error(
+            "--stateless-http and --json-response only apply to the 'streamable-http' transport "
+            "(stdio is inherently per-process and the deprecated SSE transport requires sessions)."
+        )
     _apply_cli_environment(args)
 
     from .server import main as server_main
@@ -115,6 +150,8 @@ def main(argv: Sequence[str] | None = None) -> None:
         path=args.path,
         log_level=args.log_level,
         bearer_token=args.bearer_token,
+        stateless_http=args.stateless_http,
+        json_response=args.json_response,
     )
 
 

--- a/konfai-mcp/konfai_mcp/server.py
+++ b/konfai-mcp/konfai_mcp/server.py
@@ -42,6 +42,7 @@ except ImportError as exc:  # pragma: no cover - depends on optional install
         "KonfAI MCP requires 'fastmcp'. Install the MCP server with: pip install -e ./konfai-mcp"
     ) from exc
 
+from . import _env_flag
 from .capabilities import describe_config_schema as _describe_config_schema
 from .capabilities import describe_konfai_capabilities as _describe_konfai_capabilities
 from .catalog import COMPONENT_KINDS
@@ -683,6 +684,10 @@ def server_info() -> dict[str, Any]:
         "name": "KonfAI MCP",
         "konfai_version": KONFAI_VERSION,
         "transport": transport,
+        "transport_options": {
+            "stateless_http": _env_flag("KONFAI_MCP_STATELESS_HTTP"),
+            "json_response": _env_flag("KONFAI_MCP_JSON_RESPONSE"),
+        },
         "workspace_root": str(WORKSPACES_ROOT),
         "current_session": WORKSPACE_LAYOUT.current_session,
         "session_root": str(WORKSPACE_LAYOUT.workspace_dir()),
@@ -3367,7 +3372,22 @@ def main(
     path: str | None = None,
     log_level: str | None = None,
     bearer_token: str | None = None,
+    stateless_http: bool | None = None,
+    json_response: bool | None = None,
 ) -> None:
+    # MCP specification revision 2025-03-26 made HTTP sessions optional: a streamable HTTP
+    # server MAY skip issuing an Mcp-Session-Id header, in which case every request is
+    # self-contained and replicas need no session affinity. FastMCP exposes this as
+    # stateless_http (and json_response for plain JSON bodies instead of per-request SSE).
+    if stateless_http is None:
+        stateless_http = _env_flag("KONFAI_MCP_STATELESS_HTTP")
+    if json_response is None:
+        json_response = _env_flag("KONFAI_MCP_JSON_RESPONSE")
+    if (stateless_http or json_response) and transport != "streamable-http":
+        raise ValueError(
+            "stateless_http and json_response only apply to the 'streamable-http' transport "
+            "(stdio is inherently per-process and the deprecated SSE transport requires sessions)."
+        )
     _configure_transport_auth(
         transport,
         host=host,
@@ -3387,6 +3407,9 @@ def main(
             transport_kwargs["path"] = path
         if log_level is not None:
             transport_kwargs["log_level"] = log_level
+        if transport == "streamable-http":
+            transport_kwargs["stateless_http"] = stateless_http
+            transport_kwargs["json_response"] = json_response
     # MCP stdio transports must keep stdout protocol-clean for the client.
     mcp.run(transport, show_banner=False, **transport_kwargs)
 

--- a/konfai-mcp/pyproject.toml
+++ b/konfai-mcp/pyproject.toml
@@ -23,7 +23,9 @@ authors = [
 dependencies = [
   "konfai>1.7.0",
   "konfai-apps>1.7.0",
-  "fastmcp",
+  # >= 2.10.2 for stateless streamable HTTP (stateless_http/json_response run
+  # kwargs and the FASTMCP_STATELESS_HTTP setting) per MCP spec rev 2025-03-26.
+  "fastmcp>=2.10.2",
   "ruamel.yaml",
   "numpy"
 ]

--- a/konfai-mcp/tests/test_mcp_server_cli.py
+++ b/konfai-mcp/tests/test_mcp_server_cli.py
@@ -43,6 +43,8 @@ def test_cli_sets_environment_and_forwards_transport(monkeypatch) -> None:
     monkeypatch.delenv("KONFAI_MCP_WORKSPACES_ROOT", raising=False)
     monkeypatch.delenv("KONFAI_MCP_PORT", raising=False)
     monkeypatch.delenv("KONFAI_MCP_BEARER_TOKEN", raising=False)
+    monkeypatch.delenv("KONFAI_MCP_STATELESS_HTTP", raising=False)
+    monkeypatch.delenv("KONFAI_MCP_JSON_RESPONSE", raising=False)
 
     previous = {
         key: os.environ.get(key)
@@ -85,6 +87,8 @@ def test_cli_sets_environment_and_forwards_transport(monkeypatch) -> None:
             "path": "/mcp",
             "log_level": "warning",
             "bearer_token": "dev-token",
+            "stateless_http": False,
+            "json_response": False,
         }
         assert os.environ["KONFAI_MCP_TRANSPORT"] == "sse"
         assert os.environ["KONFAI_MCP_SESSION"] == "challenge round 1"
@@ -109,3 +113,45 @@ def test_parser_default_accepts_valid_transport_env(monkeypatch: pytest.MonkeyPa
     monkeypatch.setenv("KONFAI_MCP_TRANSPORT", "streamable-http")
     args = konfai_mcp._build_parser().parse_args([])
     assert args.transport == "streamable-http"
+
+
+def test_cli_forwards_stateless_http_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_server_main(**kwargs):
+        captured.update(kwargs)
+
+    fake_server = ModuleType("konfai_mcp.server")
+    fake_server.main = fake_server_main  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "konfai_mcp.server", fake_server)
+
+    for key in ("KONFAI_MCP_TRANSPORT", "KONFAI_MCP_STATELESS_HTTP", "KONFAI_MCP_JSON_RESPONSE"):
+        monkeypatch.delenv(key, raising=False)
+
+    konfai_mcp.main(["--transport", "streamable-http", "--stateless-http", "--json-response"])
+
+    assert captured["transport"] == "streamable-http"
+    assert captured["stateless_http"] is True
+    assert captured["json_response"] is True
+    assert os.environ["KONFAI_MCP_STATELESS_HTTP"] == "1"
+    assert os.environ["KONFAI_MCP_JSON_RESPONSE"] == "1"
+    monkeypatch.delenv("KONFAI_MCP_STATELESS_HTTP", raising=False)
+    monkeypatch.delenv("KONFAI_MCP_JSON_RESPONSE", raising=False)
+
+
+def test_parser_reads_stateless_http_from_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KONFAI_MCP_STATELESS_HTTP", "true")
+    monkeypatch.delenv("KONFAI_MCP_JSON_RESPONSE", raising=False)
+    args = konfai_mcp._build_parser().parse_args([])
+    assert args.stateless_http is True
+    assert args.json_response is False
+
+
+@pytest.mark.parametrize("transport", ["stdio", "sse"])
+def test_cli_rejects_stateless_http_on_session_transports(
+    monkeypatch: pytest.MonkeyPatch, transport: str
+) -> None:
+    monkeypatch.delenv("KONFAI_MCP_TRANSPORT", raising=False)
+    monkeypatch.delenv("KONFAI_MCP_STATELESS_HTTP", raising=False)
+    with pytest.raises(SystemExit):
+        konfai_mcp.main(["--transport", transport, "--stateless-http"])


### PR DESCRIPTION
MCP specification revision 2025-03-26 replaced the HTTP+SSE transport with Streamable HTTP and made protocol sessions optional: a server MAY assign an Mcp-Session-Id header at initialization, and one that does not treats every request as self-contained, so replicas can run behind a load balancer or on serverless platforms without session affinity. FastMCP exposes this as the stateless_http run option (and json_response for plain JSON bodies instead of per-request SSE streams), available since fastmcp 2.10.2.

- Add --stateless-http and --json-response CLI flags with KONFAI_MCP_STATELESS_HTTP / KONFAI_MCP_JSON_RESPONSE environment fallbacks, forwarded to FastMCP.run() for the streamable-http transport.
- Reject the flags on stdio (inherently per-process) and the deprecated SSE transport (requires sessions; fastmcp raises on sse + stateless), failing fast at the CLI and in server.main().
- Report the active transport options in the server://info resource.
- Raise the fastmcp floor to 2.10.2 for stateless_http support.
- Document remote and stateless deployments, including the caveat that MCP protocol statelessness does not shard KonfAI's in-memory job registry across replicas: experiment workspaces persist on disk under KONFAI_MCP_WORKSPACES_ROOT, but multi-replica setups should share a workspaces root and route job-monitoring calls consistently.

Tools do not use sampling or elicitation, so no tool behavior changes in stateless mode.

<!--
Thanks for contributing to KonfAI!
PR titles must follow Conventional Commits, e.g.:
  feat(utils): add OME-Zarr resolution selection
  fix(data): correct degree-to-radian rotation
Types: feat | fix | perf | refactor | docs | test | build | ci | chore
-->

## Description

<!-- What does this PR change, and why? Keep it focused on one logical change. -->

## Related issues

<!-- e.g. "Closes #123", "Refs #456". Delete if none. -->

## Type of change

- [x] `feat`: new feature
- [ ] `fix`: bug fix
- [ ] `perf`: performance improvement
- [ ] `refactor`: no behaviour change
- [ ] `docs`: documentation only
- [ ] `test`: tests only
- [ ] `build` / `ci` / `chore`: tooling, deps, CI
- [ ] Breaking change (describe the migration below)

## How has this been tested?

<!-- Commands run and what you observed. -->

```bash
pixi run check
```

## Checklist

- [x] PR title and commits follow **Conventional Commits**
- [ ] `pixi run check` passes (ruff lint + format + tests)
- [ ] `pixi run --environment dev python -m pytest konfai-apps/tests` passes *(if `konfai-apps/` changed)*
- [ ] Tests added/updated for the change
- [ ] Docs updated *(if user-facing CLI/config behaviour changed)*
- [ ] No new runtime dependency without a matching `pyproject.toml` extra
- [ ] Lazy/patch data access preserved (no full-volume reads added)

## Breaking changes & migration

<!-- Describe any breaking change and how users should migrate. Delete if none. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for stateless Streamable HTTP deployments and optional JSON responses.
  * Added command-line and environment-variable configuration for HTTP settings.
  * Added batch-size controls for fine-tuning and GPU selection for transform jobs.
  * Server information now reports active HTTP transport settings.

* **Bug Fixes**
  * Added validation for incompatible HTTP and session-based transport options.
  * Job waits now return a timeout status instead of raising an error.

* **Documentation**
  * Documented deployment modes, configuration, responses, and operational limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->