### PR TITLE
test(apps): skip server tests when fastapi/uvicorn are absent

### DIFF
--- a/konfai-apps/tests/integration/test_konfai_app_client_remote.py
+++ b/konfai-apps/tests/integration/test_konfai_app_client_remote.py
@@ -38,6 +38,10 @@ ASSETS_DIR = Path(__file__).resolve().parents[1] / "assets"
 APP_ASSETS_DIR = ASSETS_DIR / "AppClientRemote" / "TinySynthesisApp"
 WORKFLOW_ASSETS_DIR = REPO_ROOT / "tests" / "assets" / "Workflows"
 SimpleITK = pytest.importorskip("SimpleITK")
+# The server subprocess runs under this interpreter (`sys.executable` + PYTHONPATH), so the server
+# stack has to be importable here or `konfai-apps-server` exits before it can bind the port.
+pytest.importorskip("fastapi")
+pytest.importorskip("uvicorn")
 
 
 @dataclass

--- a/konfai-apps/tests/unit/test_cli.py
+++ b/konfai-apps/tests/unit/test_cli.py
@@ -74,7 +74,15 @@ def _run_apps_server(monkeypatch: pytest.MonkeyPatch, apps_config: Path) -> str:
     `main_apps_server` opens with `import uvicorn`, so every path through it -- including the
     validation that never reaches `uvicorn.run` -- needs the server stack importable.
     """
-    pytest.importorskip("uvicorn")
+    uvicorn = pytest.importorskip("uvicorn")
+
+    def _refuse_to_serve(*args: object, **kwargs: object) -> None:
+        # Both callers must exit during validation. Should that validation ever regress, falling
+        # through to the real `uvicorn.run` would bind a port and serve forever, hanging the unit
+        # suite instead of failing it -- so make reaching this point a loud failure.
+        pytest.fail("main_apps_server reached uvicorn.run: --apps validation did not reject the config")
+
+    monkeypatch.setattr(uvicorn, "run", _refuse_to_serve)
     # --auth off keeps the test on config validation instead of token resolution; delenv first so
     # the pop the CLI performs on a real inherited token is restored at teardown.
     monkeypatch.delenv("KONFAI_API_TOKEN", raising=False)

--- a/konfai-apps/tests/unit/test_cli.py
+++ b/konfai-apps/tests/unit/test_cli.py
@@ -14,6 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import sys
 from pathlib import Path
 from typing import Any, cast
@@ -65,3 +66,38 @@ def test_main_apps_dispatches_local_infer(monkeypatch: pytest.MonkeyPatch, tmp_p
     assert infer_kwargs["tta"] == 2
     assert infer_kwargs["mc"] == 1
     assert infer_kwargs["inputs"] == [[(tmp_path / "input.mha").resolve()]]
+
+
+def _run_apps_server(monkeypatch: pytest.MonkeyPatch, apps_config: Path) -> str:
+    """Drive `main_apps_server` up to its `--apps` validation and return the exit message.
+
+    `main_apps_server` opens with `import uvicorn`, so every path through it -- including the
+    validation that never reaches `uvicorn.run` -- needs the server stack importable.
+    """
+    pytest.importorskip("uvicorn")
+    # --auth off keeps the test on config validation instead of token resolution; delenv first so
+    # the pop the CLI performs on a real inherited token is restored at teardown.
+    monkeypatch.delenv("KONFAI_API_TOKEN", raising=False)
+    monkeypatch.setattr(sys, "argv", ["konfai-apps-server", "--auth", "off", "--apps", str(apps_config)])
+
+    with pytest.raises(SystemExit) as excinfo:
+        apps_cli_module.main_apps_server()
+    return str(excinfo.value)
+
+
+def test_main_apps_server_rejects_a_missing_apps_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # A mistyped --apps must name the path it could not find, not start a server with no apps.
+    missing = tmp_path / "absent.json"
+
+    assert str(missing) in _run_apps_server(monkeypatch, missing)
+
+
+def test_main_apps_server_rejects_a_config_without_an_apps_list(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Valid JSON of the wrong shape must be refused up front: the server reads `apps` as a list, so
+    # binding the port first would only surface the mistake on the first request.
+    apps_config = tmp_path / "apps.json"
+    apps_config.write_text(json.dumps({"applications": ["demo/app"]}), encoding="utf-8")
+
+    assert "Invalid config file" in _run_apps_server(monkeypatch, apps_config)


### PR DESCRIPTION
## Problem

`konfai-apps/tests/integration/test_konfai_app_client_remote.py` failed outright — rather than skipping — in any environment without the server stack:

```
AssertionError: konfai-apps-server exited early with code 1
  File "konfai-apps/konfai_apps/cli.py", line 751, in main_apps_server
    import uvicorn
ModuleNotFoundError: No module named 'uvicorn'
```

The test launches a real `konfai-apps-server` subprocess, but under the *current* interpreter: `_write_cli_entrypoints` writes a shim invoking `sys.executable` with `REPO_ROOT` and `KONFAI_APPS_ROOT` prepended to `sys.path`. So `konfai_apps` is exercised straight from the source tree, without the package ever being installed — and therefore without `fastapi`/`uvicorn`, which `konfai-apps` declares in `setup.py` (`install_requires`). `main_apps_server` opens with `import uvicorn`, so the subprocess died with exit code 1 and the fixture's readiness loop surfaced it as a test failure.

Every other server-touching test in the suite already guards this — `test_app_server_http.py`, `test_app_server_helpers.py`, `test_remote_tunables_contract.py`, and three more all begin with `pytest.importorskip("fastapi")`. This file was the sole outlier, and so the only one turning a missing optional dependency into a red suite.

## Changes

**1. Guard the remote-server integration test** (`test_konfai_app_client_remote.py`)

Added `pytest.importorskip("fastapi")` and `pytest.importorskip("uvicorn")` alongside the existing `SimpleITK` guard. `uvicorn` is needed *in addition to* `fastapi` here specifically because this test spawns the ASGI server as a subprocess, rather than driving the app in-process via `TestClient` the way the other guarded tests do.

**2. Cover `main_apps_server`'s `--apps` validation** (`test_cli.py`)

The guard alone would have left a gap: `main_apps_server` (`konfai_apps/cli.py:749`) had **no unit test at all** — its only exercise was the integration test above, so skipping that test dropped its coverage to zero in a dependency-less environment. Two tests now cover its user-facing validation paths:

- `test_main_apps_server_rejects_a_missing_apps_config` — a mistyped `--apps` must name the path it could not find
- `test_main_apps_server_rejects_a_config_without_an_apps_list` — valid JSON of the wrong shape is refused before the port is bound

## Implementation notes

- **Assertions check the exit message, not just the exception type.** `argparse` also raises `SystemExit`, so asserting `pytest.raises(SystemExit)` alone would pass vacuously on a malformed-argument error and prove nothing about the validation under test.
- **The `importorskip("uvicorn")` sits inside the shared `_run_apps_server` helper, not at module scope**, so the pre-existing `test_main_apps_dispatches_local_infer` keeps running unguarded. Both new paths exit well before `uvicorn.run`, but the `import uvicorn` at the top of the function still gates them.
- **`--auth off`** keeps the tests on config validation rather than token resolution (already covered by `test_server_auth_env.py`); `monkeypatch.delenv` first so the `os.environ.pop` the CLI performs on a real inherited `KONFAI_API_TOKEN` is restored at teardown.
- **`konfai_apps/cli.py` is deliberately untouched.** Moving `import uvicorn` down to just before `uvicorn.run` would let the validation tests run without the server stack at all, but uvicorn is a *mandatory* dependency of the server, not an optional extra, and the repo's point-of-use import-guard convention is aimed at optional extras. Happy to change this if maintainers prefer it.

## Verification

| Environment | Result |
|---|---|
| pixi `dev` (no `fastapi`/`uvicorn`) | 134 passed, 9 skipped |
| venv + `fastapi` 0.141.1 / `uvicorn` 0.52.3 / `python-multipart` | **199 passed, 0 skipped** |

The second row is the CI-equivalent run — CI installs the package first (`pip install -e ./konfai-apps`, per `AGENTS.md` §6), so these tests still execute there and nothing is silently skipped where it counts. The skip only takes effect in a bare dev environment.

Also: CodeRabbit CLI review — 0 findings; `pre-commit run --files` — all hooks pass; `ruff check` / `ruff format` clean (run directly, since the hooks' `files` regex covers `tests/` but not `konfai-apps/tests/`); `cz check` validates the commit message.

## Scope

Test-only — no production code paths change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation coverage for missing application paths and incomplete JSON configurations.
  * Added safeguards so integration tests are skipped when optional server dependencies are unavailable.
  * Verified server startup behavior with authentication disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->