### PR TITLE
feat(config): a strict read of the file, in the binder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ KonfAI is a modular, fully-configurable deep-learning framework for medical imag
 
 Three pillars run through the codebase:
 
-1. **Config-by-reflection.** `apply_config(path)` reads a callable's signature and builds its arguments from the YAML subtree it owns (`@config("Key")`), recursing into nested `@config` objects. Resolved defaults are written *back* to the file, so a run leaves a fully-resolved config on disk. **Reading a config mutates it.**
+1. **Config-by-reflection.** `apply_config(path)` reads a callable's signature and builds its arguments from the YAML subtree it owns (`@config("Key")`), recursing into nested `@config` objects. Resolved defaults are written *back* to the file, so a run leaves a fully-resolved config on disk. **Reading a config mutates it.** Each workflow builder reads its file inside `strict_config(root)`: a key nothing bound reads is reported by path (TRANSFORM refuses, the other three warn), so everything a workflow reads from its file must be bound at construction, not lazily.
 2. **Lazy, patch-based imaging.** A volume is never loaded whole into RAM on a route that can stream: data is read as overlapping patches (optionally streamed) and predictions are reassembled with overlap blending. **Mandatory invariant.** The one declared exception is TRANSFORM's whole-volume route, taken only when a stage cannot serve a region: the plan names it `WHOLE-VOLUME`, sizes it against the memory budget (`Transform.working_multiple`) and refuses the case when it does not fit. Never an implicit `read_data()`.
 3. **Declarative models.** Networks are routed `add_module` graphs, written as Python classes in `konfai/models/`, or entirely as a `.yml` via the YAML model builder.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ no longer stops a run. Two things a run already wrote come out differently, see 
 - **mcp**: transform runs steer GPUs, a finished job carries its `outputs`, and `read_dataset_file`
   summarises an ITK transform HDF5
 - **apps**: batch size as a first-class fine-tune knob (`--set`, `install_fine_tune`)
+- **config**: the binder reads a file strictly. `strict_config(root)` records, per level, what the
+  file holds against what the binder read, and reports the difference by path with the keys read
+  at that level and the closest one. TRANSFORM refuses; TRAIN, PREDICTION and EVALUATION warn
 
 ### 🐛 Bug Fixes
 
@@ -75,6 +78,8 @@ no longer stops a run. Two things a run already wrote come out differently, see 
 - **network**: a criterion is moved onto the output's device before it is called
 - **studio**: a fresh workspace tree, and a job launch brings its run forward
 - **mcp**: `Transform.yml` is exempt from the model lint
+- **predictor**: a built-in reduction (`Mean`, `Median`, `Concat`) binds from its own block like a
+  custom one; the `Mean:` block a resolved config carries was read by nothing
 
 ### ⚡ Performance
 
@@ -108,6 +113,12 @@ no longer stops a run. Two things a run already wrote come out differently, see 
   SLURM grant that no cgroup enforces; the plan's header names which bound won.
 - **The written geometry sidecar no longer carries `ITK_*` keys** the reader had added; a consumer
   that read them from a KonfAI output finds them absent.
+- **A `Config.yml`, `Prediction.yml` or `Evaluation.yml` carrying a key nothing reads now warns**
+  at build, naming the key by path. Files written back by earlier versions carry a few
+  (`Patch.mask`, `Model.<name>.yaml_str`, `schedulers.<name>.verbose`, `is_input` under an
+  evaluation group): remove them; the run is otherwise unchanged. A `Transform.yml` refuses them, as
+  it already refused a typo'd structural key, and the check now covers a `Reduce` operator's own
+  parameters and a wrapped foreign class's.
 
 ## v1.8.0 (2026-08-07)
 

--- a/docs/source/concepts/configuration.md
+++ b/docs/source/concepts/configuration.md
@@ -126,6 +126,19 @@ the exact constructor argument names (typically `snake_case`). A missing key
 falls back to the parameter default, or to a `default|...` marker when one is
 provided (see below).
 
+## Keys nothing reads
+
+The binder reads a key when a parameter names it and materializes the default
+when none does, so a key nothing reads (a typo, a parameter an older version
+had) is carried along and the default used in its place. Each workflow builder
+reads its file inside `konfai.utils.config.strict_config(root)`, which records,
+level by level, what the file holds against what the binder read, and reports
+the difference by path with the keys read at that level: `TRANSFORM` refuses
+(its config is the deliverable), `TRAIN`/`PREDICTION`/`EVALUATION` warn, since
+files written back by earlier versions carry such keys. The check closes when
+the builder returns, so everything a workflow reads from its file is bound at
+construction.
+
 ## Config modes
 
 `KONFAI_CONFIG_MODE` selects how KonfAI reacts to a missing file or missing keys:

--- a/docs/source/config_guide/transform.md
+++ b/docs/source/config_guide/transform.md
@@ -218,12 +218,14 @@ a byte is read:
   streaming re-reads the source while writing, so an in-place transform would
   read its own half-written output;
 - a `Save` with no `dataset` of its own, which would write next to the source;
-- **any structural key the grammar does not list, and any stage argument its
-  constructor does not take.** A typo'd `memory_budge:` or
-  `Clip: {min_val: …}` would otherwise be ignored and its default used
-  silently; here it is an error naming the exact path and the legal keys. (A
-  stage that takes `**kwargs` or resolves nowhere is left to the loader's own
-  error, and the contents of `subset:` are not walked.)
+- **any key nothing reads**: a structural key the workflow does not know, a
+  stage argument its constructor does not take, an operator parameter under a
+  `Reduce` that the operator does not declare. A typo'd `memory_budge:` or
+  `Clip: {min_val: …}` would otherwise be carried along and its default used
+  silently; here it is an error naming the exact path, the keys read at that
+  level and the closest of them. The read is what the binder did, not a
+  grammar kept beside it: whatever a stage's constructor names is legal there,
+  and a stage that resolves nowhere is refused by the loader before that.
 
 ## Fields
 

--- a/examples/Registration/Config.yml
+++ b/examples/Registration/Config.yml
@@ -84,7 +84,6 @@ Trainer:
       - 256
       - 256
       overlap: None
-      mask: None
       pad_value: 0
       extend_slice: 0
     subset: None

--- a/examples/Registration/Evaluation.yml
+++ b/examples/Registration/Evaluation.yml
@@ -25,7 +25,6 @@ Evaluator:
               TensorCast:
                 dtype: float32
                 inverse: true
-            is_input: true
       MOVING:  # Un-registered moving image (baseline)
         groups_dest:
           MOVING:
@@ -33,7 +32,6 @@ Evaluator:
               TensorCast:
                 dtype: float32
                 inverse: true
-            is_input: true
       MOVED:  # Registered image produced by PREDICTION
         groups_dest:
           MOVED:
@@ -41,7 +39,6 @@ Evaluator:
               TensorCast:
                 dtype: float32
                 inverse: true
-            is_input: true
     subset: None
     validation: None
     dataset_filenames:  # Ground-truth pair + predicted registered image

--- a/examples/Registration/Prediction.yml
+++ b/examples/Registration/Prediction.yml
@@ -48,7 +48,6 @@ Predictor:
       - 256
       - 256
       overlap: None
-      mask: None
       pad_value: 0
       extend_slice: 0
     subset: None

--- a/examples/Segmentation/Config.yml
+++ b/examples/Segmentation/Config.yml
@@ -62,10 +62,8 @@ Trainer:
           step_size: 20
           gamma: 0.5
           last_epoch: -1
-          verbose: deprecated
           nb_step: 0
       ModelPatch: None
-      yaml_str: None
   Dataset:
     groups_src:  # Mapping between dataset modalities and how the model consumes them
       CT:
@@ -106,7 +104,6 @@ Trainer:
       - 256
       - 256
       overlap: None
-      mask: None
       pad_value: 0
       extend_slice: 0
     subset: None

--- a/examples/Segmentation/Evaluation.yml
+++ b/examples/Segmentation/Evaluation.yml
@@ -15,7 +15,6 @@ Evaluator:
               TensorCast:
                 dtype: uint8
                 inverse: false
-            is_input: true
       SEG:
         groups_dest:
           SEG:
@@ -23,7 +22,6 @@ Evaluator:
               TensorCast:
                 dtype: uint8
                 inverse: false
-            is_input: true
     subset: None
     validation: None
     dataset_filenames:

--- a/examples/Segmentation/Prediction.yml
+++ b/examples/Segmentation/Prediction.yml
@@ -2,7 +2,6 @@ Predictor:
   Model:
     classpath: UNet.yml
     UNet:
-      Patch: None
       parameters:
         dim: 2
         channels:
@@ -35,7 +34,6 @@ Predictor:
       - 256
       - 256
       overlap: None
-      mask: None
       pad_value: 0
       extend_slice: 0
     subset: None

--- a/examples/Synthesis/Config.yml
+++ b/examples/Synthesis/Config.yml
@@ -80,7 +80,6 @@ Trainer:
           step_size: 10
           gamma: 0.75
           last_epoch: -1
-          verbose: deprecated
           nb_step: 0
       dim: 2
       ModelPatch: None
@@ -147,7 +146,6 @@ Trainer:
       - 320
       - 320
       overlap: None # Overlap between patches (None = no overlap)
-      mask: None
       pad_value: -1 # Value used when padding outside image boundaries
       extend_slice: 4 # Number of neighboring slices used as context (2 above and 2 below for 2.5D input)
     subset: None  # Use the full dataset (or give a case-list file / list of files; prefix entries with ~ to exclude cases)

--- a/examples/Synthesis/Config_GAN.yml
+++ b/examples/Synthesis/Config_GAN.yml
@@ -22,7 +22,6 @@ Trainer:
             step_size: 10
             gamma: 0.75
             last_epoch: -1
-            verbose: deprecated
             nb_step: 0
         outputs_criterions:
           Discriminator_pB:Head:Conv: # Adversarial loss seen by the generator
@@ -127,7 +126,6 @@ Trainer:
             step_size: 10
             gamma: 0.75
             last_epoch: -1
-            verbose: deprecated
             nb_step: 0
         outputs_criterions:
           Discriminator_B:Head:Conv: # Real 3D CT chunk
@@ -224,7 +222,6 @@ Trainer:
       - 128
       - 128
       overlap: None
-      mask: None
       pad_value: -1
       extend_slice: 0
     subset: None

--- a/examples/Synthesis/Evaluation.yml
+++ b/examples/Synthesis/Evaluation.yml
@@ -19,7 +19,6 @@ Evaluator:
               TensorCast: # Ensure CT tensors are in float32 for metric computation
                 dtype: float32
                 inverse: true
-            is_input: true
       sCT:
         groups_dest:
           sCT:
@@ -27,7 +26,6 @@ Evaluator:
               TensorCast: # Convert predicted sCT to float32 before computing metrics
                 dtype: float32
                 inverse: true
-            is_input: true
       MASK:
         groups_dest:
           MASK:
@@ -35,7 +33,6 @@ Evaluator:
               TensorCast: # Mask used to restrict metric computation
                 dtype: uint8
                 inverse: true
-            is_input: true
     subset: None # Use the full dataset
     validation: None # Optional validation selector: case-list file, list of files, or case names; produces a separate metrics JSON
     dataset_filenames: # Dataset sources (ground truth CT + predicted sCT)

--- a/examples/Synthesis/Prediction.yml
+++ b/examples/Synthesis/Prediction.yml
@@ -64,7 +64,6 @@ Predictor:
       - 512
       - 512
       overlap: None
-      mask: None
       pad_value: -1
       extend_slice: 4 # 2 slices above + 2 below for 2.5D context
     subset: None # Use the full dataset

--- a/konfai/data/case_reduction.py
+++ b/konfai/data/case_reduction.py
@@ -29,7 +29,6 @@ operator can accumulate.
 
 from __future__ import annotations
 
-import inspect
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -38,7 +37,6 @@ import torch
 from konfai.data.patching import DatasetManager, RegionWriter, save_destination
 from konfai.data.reduction import Reduction
 from konfai.data.transform import LocalityKind, PatchLocality, Reduce, Save, Transform, stat_seed_valid
-from konfai.utils.config import apply_config
 from konfai.utils.dataset import (
     Attribute,
     Dataset,
@@ -47,7 +45,6 @@ from konfai.utils.dataset import (
     _update_running_statistics,
 )
 from konfai.utils.errors import ReductionError
-from konfai.utils.utils import get_module
 
 #: Geometry keys compared between cases under ``grid: strict``. Direction is in because a flipped
 #: axis shows in neither extent nor spacing: averaging two volumes that disagree on it mirrors half
@@ -60,10 +57,6 @@ _POST_KINDS = frozenset({LocalityKind.POINTWISE, LocalityKind.GLOBAL_STAT})
 
 #: Bytes per sample assumed when sizing regions from headers alone, before a dtype is known.
 _ASSUMED_ITEMSIZE = 4
-
-#: Keys the ``Reduce`` stage reads from its own mapping. An operator sharing one of these names
-#: would silently be handed the stage's value, so the collision is refused instead.
-_REDUCE_OWN_KEYS = frozenset({"operator", "output", "grid", "grid_tolerance", "provenance"})
 
 
 @dataclass(frozen=True)
@@ -209,53 +202,6 @@ def split_chain(transforms: list[Transform]) -> tuple[list[Transform], Reduce | 
     return list(transforms), None, []
 
 
-def resolve_operator(reduce: Reduce) -> Reduction:
-    """The operator the stage names, as an instance, refusing one that cannot fold a region.
-
-    Configured like every other extension point: its constructor arguments are bound from the same
-    mapping the ``Reduce`` itself was read from, so a custom operator takes parameters exactly as a
-    custom transform or a custom draw does::
-
-        Reduce:
-          operator: mypkg:TrimmedMean
-          output: template
-          trim: 0.2            # the operator's own parameter
-
-    A chain assembled in Python has no configuration to read, and the operator is then built from
-    its own defaults.
-    """
-    module, name = get_module(reduce.operator_classpath, "konfai.data.reduction")
-    factory = getattr(module, name)
-    shadowed = sorted(set(inspect.signature(factory.__init__).parameters) & _REDUCE_OWN_KEYS)
-    if shadowed:
-        raise ReductionError(
-            f"'{reduce.operator_classpath}' has parameter(s) {shadowed}, which the Reduce stage"
-            " reads for itself from the same mapping.",
-            f"Rename them: {sorted(_REDUCE_OWN_KEYS)} belong to Reduce, everything else in the"
-            " mapping is the operator's.",
-        )
-    try:
-        operator = apply_config(reduce.konfai_args)(factory)()
-    except TypeError as error:
-        raise ReductionError(
-            f"'{reduce.operator_classpath}' could not be built: {error}.",
-            "Give its parameters under the Reduce stage, next to 'operator' and 'output', or give them defaults.",
-        ) from error
-    if not isinstance(operator, Reduction):
-        raise ReductionError(
-            f"'{reduce.operator_classpath}' is not a Reduction.",
-            "Subclass konfai.data.reduction.Reduction, or use Mean / Median / Concat.",
-        )
-    if not operator.voxel_local:
-        raise ReductionError(
-            f"'{reduce.operator_classpath}' does not declare itself voxel-local, so it cannot be"
-            " folded one region at a time.",
-            "Set voxel_local = True when every output voxel depends only on the same voxel of each"
-            " case; an operator reading across space cannot stream.",
-        )
-    return operator
-
-
 def check_post_stages(post: list[Transform], output: str) -> None:
     """What may follow a ``Reduce`` in the same chain.
 
@@ -317,7 +263,7 @@ class CaseReduction:
                 "Check the dataset and its subset: a reduction over nothing has no result.",
             )
         self.slab_rows = max(1, int(self.slab_rows))
-        self.operator = resolve_operator(self.reduce)
+        self.operator = self.reduce.operator
         check_post_stages(self.post, self.reduce.output)
 
     def fit_budget(self, budget_bytes: float | None, cap: int = 64) -> None:

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -16,6 +16,7 @@
 
 """Tensor and image transforms used in KonfAI preprocessing and postprocessing."""
 
+import inspect
 import os
 import tempfile
 from abc import ABC, abstractmethod
@@ -46,6 +47,7 @@ from konfai.data.geometry import (
     TransformBound,
     bound_of,
 )
+from konfai.data.reduction import Reduction
 from konfai.data.sampling import (
     blend_order,
     gather,
@@ -56,7 +58,7 @@ from konfai.data.sampling import (
 )
 from konfai.utils.config import _escape_key_component, apply_config, record_given_arguments
 from konfai.utils.dataset import Attribute, Dataset, DataStream, data_to_image, image_to_data
-from konfai.utils.errors import TransformError
+from konfai.utils.errors import ReductionError, TransformError
 from konfai.utils.ITK import _require_simpleitk
 from konfai.utils.runtime import NeedDevice
 from konfai.utils.utils import get_module, split_path_spec
@@ -2581,6 +2583,58 @@ class _DisplacementSource:
         return field
 
 
+#: Keys the ``Reduce`` stage reads from its own mapping. An operator sharing one of these names
+#: would silently be handed the stage's value, so the collision is refused instead.
+_REDUCE_OWN_KEYS = frozenset({"operator", "output", "grid", "grid_tolerance", "provenance"})
+
+
+def resolve_operator(reduce: "Reduce") -> Reduction:
+    """The operator the stage names, as an instance, refusing one that cannot fold a region.
+
+    Configured like every other extension point: its constructor arguments are bound from the same
+    mapping the ``Reduce`` itself was read from, so a custom operator takes parameters exactly as a
+    custom transform or a custom draw does::
+
+        Reduce:
+          operator: mypkg:TrimmedMean
+          output: template
+          trim: 0.2            # the operator's own parameter
+
+    A chain assembled in Python has no configuration to read, and the operator is then built from
+    its own defaults.
+    """
+    module, name = get_module(reduce.operator_classpath, "konfai.data.reduction")
+    factory = getattr(module, name)
+    shadowed = sorted(set(inspect.signature(factory.__init__).parameters) & _REDUCE_OWN_KEYS)
+    if shadowed:
+        raise ReductionError(
+            f"'{reduce.operator_classpath}' has parameter(s) {shadowed}, which the Reduce stage"
+            " reads for itself from the same mapping.",
+            f"Rename them: {sorted(_REDUCE_OWN_KEYS)} belong to Reduce, everything else in the"
+            " mapping is the operator's.",
+        )
+    try:
+        operator = apply_config(reduce.konfai_args)(factory)()
+    except TypeError as error:
+        raise ReductionError(
+            f"'{reduce.operator_classpath}' could not be built: {error}.",
+            "Give its parameters under the Reduce stage, next to 'operator' and 'output', or give them defaults.",
+        ) from error
+    if not isinstance(operator, Reduction):
+        raise ReductionError(
+            f"'{reduce.operator_classpath}' is not a Reduction.",
+            "Subclass konfai.data.reduction.Reduction, or use Mean / Median / Concat.",
+        )
+    if not operator.voxel_local:
+        raise ReductionError(
+            f"'{reduce.operator_classpath}' does not declare itself voxel-local, so it cannot be"
+            " folded one region at a time.",
+            "Set voxel_local = True when every output voxel depends only on the same voxel of each"
+            " case; an operator reading across space cannot stream.",
+        )
+    return operator
+
+
 class Reduce(Transform):
     """Fold every case of a group into one volume, at fixed voxel.
 
@@ -2631,13 +2685,24 @@ class Reduce(Transform):
         # Where this stage was configured from, so its operator binds its own parameters from the
         # same mapping: None when the chain was built in Python, where there is no config to read.
         self.konfai_args: str | None = None
+        self._operator: Reduction | None = None
         self.output = str(output).strip()
         self.grid = f"reference:{reference}" if reference else policy
         self.grid_tolerance = float(grid_tolerance)
         self.provenance = bool(provenance)
 
     def prepare(self, konfai_args: str) -> None:
+        # Bound here, not when the reduction engine first needs it: its parameters sit in the
+        # stage's mapping, and a strict read of the config counts them only if something read them.
         self.konfai_args = konfai_args
+        self._operator = resolve_operator(self)
+
+    @property
+    def operator(self) -> Reduction:
+        """The bound operator; a stage built in Python, never prepared, binds it from its defaults."""
+        if self._operator is None:
+            self._operator = resolve_operator(self)
+        return self._operator
 
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
         # A cardinality marker, not a per-case stage: the reduction engine SPLITS it out of the chain

--- a/konfai/evaluator.py
+++ b/konfai/evaluator.py
@@ -30,7 +30,7 @@ from torch.utils.data import DataLoader
 from konfai import config_file, cuda_visible_devices, evaluations_directory, konfai_root
 from konfai.data.data_manager import BatchDataItem, BatchSample, DataMetric, DatasetIter
 from konfai.network.network import build_configured_criterions
-from konfai.utils.config import apply_config, config
+from konfai.utils.config import apply_config, config, strict_config
 from konfai.utils.dataset import Attribute, Dataset, DataStream
 from konfai.utils.errors import ConfigError, EvaluatorError
 from konfai.utils.runtime import (
@@ -673,7 +673,8 @@ def build_evaluate(
         path_env={"KONFAI_EVALUATIONS_DIRECTORY": evaluations_dir},
     )
     os.environ["KONFAI_CONFIG_MODE"] = "Done"
-    return apply_config()(Evaluator)()
+    with strict_config("Evaluator", refuse=False):
+        return apply_config()(Evaluator)()
 
 
 @run_distributed_app

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -74,7 +74,7 @@ from konfai.data.transform import (
 )
 from konfai.network.network import Model, ModelLoader, NetState, Network
 from konfai.utils.budget import node_local_ranks, resolve_memory_budget
-from konfai.utils.config import _escape_key_component, apply_config, config
+from konfai.utils.config import _escape_key_component, apply_config, config, strict_config
 from konfai.utils.dataset import Attribute, Dataset, DataStream
 from konfai.utils.errors import ConfigError, PredictorError
 from konfai.utils.runtime import (
@@ -2316,7 +2316,8 @@ def build_predict(
         path_env={"KONFAI_PREDICTIONS_DIRECTORY": predictions_dir},
     )
     os.environ["KONFAI_CONFIG_MODE"] = "Done"
-    predictor = apply_config()(Predictor)()
+    with strict_config("Predictor", refuse=False):
+        predictor = apply_config()(Predictor)()
     predictor.set_models(models)
     return predictor
 

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -48,7 +48,7 @@ from konfai import (
 )
 from konfai.data.data_manager import BatchSample, DataTrain
 from konfai.network.network import Model, ModelLoader, NetState, Network
-from konfai.utils.config import apply_config, config
+from konfai.utils.config import apply_config, config, strict_config
 from konfai.utils.errors import ConfigError, TrainerError
 from konfai.utils.live_control import LiveControl
 from konfai.utils.runtime import (
@@ -1124,7 +1124,9 @@ def build_train(
         },
     )
     os.environ["KONFAI_CONFIG_MODE"] = "Done"
-    trainer = apply_config()(Trainer)()
+    # A warning, not a refusal: files written back by earlier versions carry keys nothing reads now.
+    with strict_config("Trainer", refuse=False):
+        trainer = apply_config()(Trainer)()
     if model is not None:
         # Keep https:// checkpoint URLs as raw strings: Path() collapses the '//' into
         # 'https:/…', which then fails both the startswith('https://') check and Path.exists().

--- a/konfai/transformer.py
+++ b/konfai/transformer.py
@@ -26,7 +26,6 @@ Nothing here falls back silently: a chain that cannot stream says which stage re
 """
 
 import contextlib
-import inspect
 import json
 import os
 import shutil
@@ -39,7 +38,6 @@ from typing import Literal, cast
 import numpy as np
 import torch
 import tqdm
-from ruamel.yaml import YAML
 
 from konfai import config_file, transforms_directory
 from konfai.data.case_reduction import CaseReduction, split_chain
@@ -51,9 +49,9 @@ from konfai.data.patching import (
     DatasetManager,
     save_destination,
 )
-from konfai.data.transform import Expand, Reduce, Save, split_expand
+from konfai.data.transform import Save, split_expand
 from konfai.utils.budget import format_bytes, node_local_ranks
-from konfai.utils.config import apply_config, config
+from konfai.utils.config import apply_config, config, strict_config
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import ConfigError, TransformerError
 from konfai.utils.runtime import (
@@ -65,7 +63,6 @@ from konfai.utils.runtime import (
     record,
     run_distributed_app,
 )
-from konfai.utils.utils import get_module
 
 _PROBE_ENTRY = "__konfai_plan_probe__"
 
@@ -1001,153 +998,18 @@ class Transformer(DistributedObject):
         return counts
 
 
-#: The grammar the strict mode accepts, level by level. ``None`` marks free-form levels (group
-#: names); ``"chain"`` marks a transforms mapping, whose keys are classpaths and whose arguments
-#: are checked against each stage's own signature.
-_STRICT_GRAMMAR: dict[str, object] = {
-    "name": None,
-    "on_fallback": None,
-    "manual_seed": None,
-    "Dataset": {
-        "dataset_filenames": None,
-        "memory_budget": None,
-        "subset": None,
-        "groups_src": {"*": {"groups_dest": {"*": {"transforms": "chain"}}}},
-    },
-}
-
-
-_STAGE_PACKAGES = ("konfai.data.transform", "konfai.data.augmentation")
-
-
-def _stage_class(
-    classpath: str, default_classpath: str = "konfai.data.transform", prefer_augmentation: bool = False
-) -> type | None:
-    """The class a chain stage's key names, resolved exactly as ``TransformLoader`` will resolve it
-    (a bare name: the transform package first, or the augmentation package first past an Expand).
-
-    ``None`` when it resolves nowhere: the loader raises its own error for that case, and refusing
-    the arguments of a class that does not exist would report the wrong problem.
-    """
-    try:
-        packages: tuple[str, ...] = tuple(reversed(_STAGE_PACKAGES)) if prefer_augmentation else _STAGE_PACKAGES
-        if default_classpath != "konfai.data.transform":
-            packages = (default_classpath,)
-        module, name = get_module(classpath, packages[0])
-        if not hasattr(module, name) and ":" not in classpath and len(packages) > 1:
-            module, name = get_module(classpath, packages[1])
-        candidate = getattr(module, name, None)
-    except Exception:  # an unresolvable stage is the loader's error to raise, with its own message
-        return None
-    return candidate if isinstance(candidate, type) else None
-
-
-def _stage_arguments(classpath: str, mapping: dict, prefer_augmentation: bool = False) -> set[str] | None:
-    """The argument names one stage accepts, or ``None`` when they cannot be known from here.
-
-    A ``Reduce`` also accepts its operator's own parameters (``resolve_operator`` binds them from
-    the same mapping), so its allowed set is the union of the two signatures.
-    """
-    stage = _stage_class(str(classpath), prefer_augmentation=prefer_augmentation)
-    if stage is None:
-        return None
-    classes = [stage]
-    if issubclass(stage, Reduce):
-        operator = _stage_class(str(mapping.get("operator", "Median")), "konfai.data.reduction")
-        if operator is None:
-            return None
-        classes.append(operator)
-    allowed: set[str] = set()
-    for cls in classes:
-        if all("__init__" not in vars(base) for base in cls.__mro__ if base is not object):
-            # No __init__ anywhere in the MRO: the class takes no arguments at all, and object's
-            # own (*args, **kwargs) signature must not read as "accepts anything".
-            continue
-        try:
-            parameters = dict(inspect.signature(cls).parameters)
-        except (TypeError, ValueError):
-            return None
-        if any(p.kind in (p.VAR_KEYWORD, p.VAR_POSITIONAL) for p in parameters.values()):
-            return None
-        allowed |= set(parameters)
-    return allowed
-
-
-def _reject_unknown_stage_arguments(chain: object, path: str) -> None:
-    """A typo'd stage argument is refused like a typo'd structural key.
-
-    The binder reads only the parameters a stage's signature names and materializes the default
-    beside anything else: ``Clip: {min_val: 0}`` clips at -1024 and exits 0. A stage that resolves
-    nowhere, takes ``**kwargs`` or hides its signature is left to the loader's own error.
-    """
-    if not isinstance(chain, dict):
-        return
-    past_expand = False
-    for classpath, arguments in chain.items():
-        if not isinstance(arguments, dict):
-            continue
-        allowed = _stage_arguments(str(classpath), arguments, prefer_augmentation=past_expand)
-        stage = _stage_class(str(classpath), prefer_augmentation=past_expand)
-        past_expand = past_expand or (stage is not None and issubclass(stage, Expand))
-        if allowed is None:
-            continue
-        for argument in arguments:
-            if str(argument) not in allowed:
-                raise ConfigError(
-                    f"Unknown argument '{argument}' for '{classpath}' at '{path}.{classpath}'.",
-                    f"'{classpath}' takes: {sorted(allowed)}. A typo'd argument would otherwise be"
-                    " ignored and its default silently used in its place.",
-                )
-
-
-def _reject_unknown_keys(config_path: Path) -> None:
-    """Strict mode: any key the TRANSFORM grammar does not know is a parse error.
-
-    The binder reads a key when it exists and materializes the default when it does not: a typo'd
-    ``memory_budge:`` silently becomes ``memory_budget: auto``. On this workflow the config IS the
-    product, so an unknown key is refused with its exact path instead of being carried along. The
-    same bar holds inside a chain: a stage's arguments are checked against its own signature.
-    """
-    if not config_path.exists():
-        return
-    with open(config_path) as stream:
-        tree = YAML().load(stream)
-    if not isinstance(tree, dict):
-        return
-    if "Transformer" not in tree:
-        raise ConfigError(
-            f"'{config_path}' declares no 'Transformer' root (found: {sorted(str(key) for key in tree)}).",
-            "The TRANSFORM workflow reads the 'Transformer:' block; anything else would be ignored"
-            " and a full default block appended to the file in its place.",
-        )
-
-    def walk(node: object, grammar: dict[str, object], path: str) -> None:
-        if not isinstance(node, dict):
-            return
-        for key, value in node.items():
-            child = grammar.get(str(key), grammar.get("*", "unknown"))
-            if child == "unknown":
-                raise ConfigError(
-                    f"Unknown key '{path}.{key}' in the Transformer configuration.",
-                    f"Known keys at this level: {sorted(k for k in grammar if k != '*')}. A typo'd"
-                    " key would otherwise be ignored and its default silently used.",
-                )
-            if child == "chain":
-                _reject_unknown_stage_arguments(value, f"{path}.{key}")
-            elif isinstance(child, dict):
-                walk(value, child, f"{path}.{key}")
-
-    walk(tree["Transformer"], _STRICT_GRAMMAR, "Transformer")
-
-
 def build_transform(
     transform_file: Path | str | dict = Path("./Transform.yml").resolve(),
     transforms_dir: Path | str = Path("./Transforms").resolve(),
 ) -> DistributedObject:
     """Build the configured transform workflow without executing it: ``compute_plan()`` is the
     dry run, ``setup()`` prints and enforces the plan. ``transform_file`` may be the config tree as
-    a dict; it is materialized to a file here, so the strict-grammar check reads what every other
-    reader will.
+    a dict; it is materialized to a file here, so the strict read sees what every other reader will.
+
+    The read is strict: a key nothing binds (a typo'd ``memory_budge:``, a ``Clip: {min_val: 0}``)
+    is refused with its path instead of being carried along with its default used in its place.
+    Everything the workflow reads from the file is bound inside ``__init__`` (the chains, their
+    draws, a ``Reduce``'s operator), which is what lets the check close when it returns.
     """
     if isinstance(transform_file, dict):
         transform_file = _materialized_config(transform_file, "Transformer")
@@ -1158,8 +1020,8 @@ def build_transform(
         path_env={"KONFAI_TRANSFORMS_DIRECTORY": transforms_dir},
     )
     os.environ["KONFAI_CONFIG_MODE"] = "Done"
-    _reject_unknown_keys(Path(transform_file))
-    return apply_config()(Transformer)()
+    with strict_config("Transformer"):
+        return apply_config()(Transformer)()
 
 
 def plan_transform(

--- a/konfai/utils/config.py
+++ b/konfai/utils/config.py
@@ -17,13 +17,16 @@
 """Configuration helpers that map YAML trees to KonfAI Python objects."""
 
 import collections
+import difflib
 import functools
 import inspect
 import logging
 import os
 import types
 import typing
-from collections.abc import Mapping, Sequence
+import warnings
+from collections.abc import Iterable, Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
@@ -79,6 +82,97 @@ def _unescape_key_component(component: str) -> str:
     return component.replace("%2E", ".").replace("%25", "%")
 
 
+def _load_tree(filename: Path | str) -> dict:
+    """The file's YAML tree (an empty file is an empty tree); a syntax error is a ConfigError with its line."""
+    with open(filename, encoding="utf-8") as stream:
+        try:
+            tree = yaml.load(stream)
+        except ruamel.yaml.YAMLError as exc:
+            mark = getattr(exc, "problem_mark", None)
+            location = f" at line {mark.line + 1}" if mark is not None else ""
+            raise ConfigError(f"Invalid YAML syntax in '{filename}'{location}.", str(exc)) from exc
+    return {} if tree is None else tree
+
+
+class _KeyLedger:
+    """What the file holds against what the binder read, per level (dotted path) of the file."""
+
+    def __init__(self) -> None:
+        self.present: dict[tuple[str, ...], set[str]] = collections.defaultdict(set)
+        self.consumed: dict[tuple[str, ...], set[str]] = collections.defaultdict(set)
+
+    def opened(self, level: tuple[str, ...], keys: Iterable[object]) -> None:
+        """A context opened at LEVEL over a mapping holding KEYS: they are present there, and the
+        subtree's own key is read at the level above."""
+        self.present[level].update(str(key) for key in keys)
+        if len(level) > 1:
+            self.consumed[level[:-1]].add(level[-1])
+
+    def read(self, level: tuple[str, ...], *keys: str) -> None:
+        self.consumed[level].update(keys)
+
+    def unknown(self, root: str) -> list[str]:
+        """One line per key under ROOT nothing read: its path, the keys read at that level, the closest."""
+        lines = []
+        for level in sorted(self.present):
+            if level[0] != root:
+                continue
+            read = sorted(self.consumed[level])
+            for key in sorted(self.present[level] - self.consumed[level]):
+                close = difflib.get_close_matches(key, read, n=1)
+                hint = f" Did you mean '{close[0]}'?" if close else ""
+                lines.append(f"'{'.'.join(level)}.{key}' (keys read at that level: {read}).{hint}")
+        return lines
+
+
+# The ledgers of the open strict_config() blocks; empty outside them, where the binder records nothing.
+_ledgers: list[_KeyLedger] = []
+
+
+@contextmanager
+def strict_config(root: str, refuse: bool = True) -> Iterator[None]:
+    """Report, when the block ends, every key of the config file that nothing bound inside it read.
+
+    The binder reads a key when a parameter names it and materializes the default when none does,
+    so a typo'd key is carried along and its default used in its place. Inside this block every
+    ``Config`` context records the keys its level held and the keys read there; on a clean exit
+    the difference is reported by path, with the keys read at that level and the closest of them:
+    a :class:`ConfigError` when ``refuse``, a warning otherwise. The block must contain everything
+    the workflow binds from the file: a key a later, lazily bound callable would read is unknown to
+    it. On entry the file must hold ROOT: a missing root binds an all-defaults workflow and writes
+    the whole block back over the user's file.
+    """
+    filename = os.environ.get("KONFAI_config_file")
+    if filename and Path(filename).exists():
+        tree = _load_tree(filename)
+        if root not in tree:
+            _report(
+                refuse,
+                f"'{filename}' declares no '{root}' root (found: {sorted(str(key) for key in tree)}).",
+                f"This workflow reads the '{root}:' block; anything else is ignored and a full default"
+                " block appended to the file in its place.",
+            )
+    ledger = _KeyLedger()
+    _ledgers.append(ledger)
+    try:
+        yield
+    finally:
+        _ledgers.remove(ledger)
+    if unknown := ledger.unknown(root):
+        _report(
+            refuse,
+            f"Unknown key(s) in the {root} configuration: nothing reads them.",
+            *unknown,
+            "A key nothing reads is carried along and the default used in its place; fix the spelling or remove it.",
+        )
+
+
+def _report(refuse: bool, *messages: str) -> None:
+    if refuse:
+        raise ConfigError(*messages)
+    warnings.warn(str(ConfigError(*messages)), UserWarning, stacklevel=4)
+
+
 class Config:
     """
     Context manager for reading and updating a subtree of the active YAML
@@ -109,21 +203,7 @@ class Config:
                     "or set KONFAI_CONFIG_MODE=default.",
                 )
 
-        self.yml = open(self.filename, encoding="utf-8")
-        try:
-            self.data = yaml.load(self.yml)
-        except ruamel.yaml.YAMLError as exc:
-            self.yml.close()
-            location = ""
-            if hasattr(exc, "problem_mark") and exc.problem_mark is not None:
-                location = f" at line {exc.problem_mark.line + 1}"
-            raise ConfigError(
-                f"Invalid YAML syntax in '{self.filename}'{location}.",
-                str(exc),
-            ) from exc
-        if self.data is None:
-            self.data = {}
-
+        self.data = _load_tree(self.filename)
         self.config = self.data
 
         for key in self.keys:
@@ -131,6 +211,8 @@ class Config:
                 self.config = {key: {}}
 
             self.config = self.config[key]
+        for ledger in _ledgers:
+            ledger.opened(tuple(self.keys), self.config if isinstance(self.config, collections.abc.Mapping) else ())
         return self
 
     def create_dictionary(self, data, keys, i) -> dict:
@@ -154,15 +236,11 @@ class Config:
         return result
 
     def __exit__(self, exc_type, value, traceback) -> None:
-        self.yml.close()
         if os.environ["KONFAI_CONFIG_MODE"] == "remove":
             if os.path.exists(config_file()):
                 os.remove(config_file())
             return
-        with open(self.filename) as yml:
-            data = yaml.load(yml)
-            if data is None:
-                data = {}
+        data = _load_tree(self.filename)
         # Only the currently visited subtree is rewritten; the recursive merge preserves the rest of the
         # YAML file untouched. Write to a sibling temp file then os.replace (atomic on the same
         # filesystem) so a concurrent independent launch reading this file never observes a truncated or
@@ -235,6 +313,8 @@ class Config:
     def get_value(self, name, default) -> object:
         if not isinstance(self.config, collections.abc.MutableMapping):
             return None
+        for ledger in _ledgers:
+            ledger.read(tuple(self.keys), name)
 
         if name in self.config and self.config[name] is not None:
             value = self.config[name]
@@ -641,6 +721,8 @@ def apply_config(konfai_args: str | None = None):
                     with Config(key_tmp) as config:
                         if not isinstance(config.config, collections.abc.Mapping):
                             return None
+                        for ledger in _ledgers:  # a parameter the caller supplies itself is a read one
+                            ledger.read(tuple(config.keys), *without)
 
                         kwargs = {}
                         params = list(inspect.signature(function).parameters.values())

--- a/konfai/utils/config.py
+++ b/konfai/utils/config.py
@@ -252,7 +252,7 @@ class Config:
         target = Path(self.filename)
         tmp = target.with_name(f"{target.name}.{os.getpid()}.tmp")
         try:
-            with open(tmp, "w") as yml:
+            with open(tmp, "w", encoding="utf-8") as yml:
                 yaml.dump(merged, yml)
             try:
                 os.replace(tmp, target)
@@ -261,7 +261,7 @@ class Config:
                 # scanner or indexer touching the fresh temp file). Fall back to an in-place rewrite:
                 # POSIX (the DDP path) keeps the atomic guarantee, and Windows keeps its non-atomic
                 # behaviour instead of failing outright.
-                with open(target, "w") as yml:
+                with open(target, "w", encoding="utf-8") as yml:
                     yaml.dump(merged, yml)
         finally:
             if tmp.exists():

--- a/konfai/utils/config.py
+++ b/konfai/utils/config.py
@@ -22,6 +22,7 @@ import functools
 import inspect
 import logging
 import os
+import time
 import types
 import typing
 import warnings
@@ -254,15 +255,20 @@ class Config:
         try:
             with open(tmp, "w", encoding="utf-8") as yml:
                 yaml.dump(merged, yml)
-            try:
-                os.replace(tmp, target)
-            except OSError:
-                # Windows can deny the atomic replace when the target is briefly held (a virus
-                # scanner or indexer touching the fresh temp file). Fall back to an in-place rewrite:
-                # POSIX (the DDP path) keeps the atomic guarantee, and Windows keeps its non-atomic
-                # behaviour instead of failing outright.
-                with open(target, "w", encoding="utf-8") as yml:
-                    yaml.dump(merged, yml)
+            # Windows can deny the replace while the target is briefly held (a virus scanner or an
+            # indexer touching the fresh file): retried a few times, then refused. Never an in-place
+            # rewrite, which a concurrent reader would see truncated and bind all-defaults from.
+            for attempt in range(5):
+                try:
+                    os.replace(tmp, target)
+                    break
+                except OSError as error:
+                    if attempt == 4:
+                        raise ConfigError(
+                            f"Could not replace the config file '{target}' atomically: {error}.",
+                            "Release whatever holds the file (an editor, an indexer) and rerun; the file was left unchanged.",
+                        ) from error
+                    time.sleep(0.05 * (attempt + 1))
         finally:
             if tmp.exists():
                 tmp.unlink()

--- a/tests/unit/test_case_reduction.py
+++ b/tests/unit/test_case_reduction.py
@@ -26,10 +26,10 @@ from pathlib import Path
 import numpy as np
 import pytest
 import torch
-from konfai.data.case_reduction import CaseReduction, ReductionPlan, resolve_operator, split_chain
+from konfai.data.case_reduction import CaseReduction, ReductionPlan, split_chain
 from konfai.data.patching import DatasetManager
 from konfai.data.reduction import Concat, Mean, Median, Reduction, Vote
-from konfai.data.transform import Clip, Dilate, Normalize, Reduce, Save, TensorCast, Transform
+from konfai.data.transform import Clip, Dilate, Normalize, Reduce, Save, TensorCast, Transform, resolve_operator
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import ReductionError, TransformError
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -27,7 +27,7 @@ from typing import Literal
 
 import pytest
 import ruamel.yaml
-from konfai.utils.config import Config, apply_config, config
+from konfai.utils.config import Config, apply_config, config, strict_config
 from konfai.utils.errors import ConfigError
 
 
@@ -611,3 +611,103 @@ def test_union_with_literal_member_does_not_crash() -> None:
     from konfai.utils.config import _convert_union_sequence_value
 
     assert _convert_union_sequence_value("beta", (Literal["alpha", "beta"], str), "p") == "beta"
+
+
+# --------------------------------------------------------------------------------------
+# strict_config: a key nothing reads is refused, whoever would have read it
+# --------------------------------------------------------------------------------------
+
+
+class _Leaf:
+    def __init__(self, depth: int = 1) -> None:
+        self.depth = depth
+
+
+@config("Nested")
+class _Nested:
+    def __init__(self, width: int = 2) -> None:
+        self.width = width
+
+
+class _StrictRoot:
+    def __init__(self, kept: int = 0, leaf: _Leaf = _Leaf(), nested: _Nested = _Nested()) -> None:
+        self.kept, self.leaf, self.nested = kept, leaf, nested
+
+
+def test_strict_config_refuses_a_key_nothing_reads_with_its_path_and_the_closest_key(write_config) -> None:
+    write_config("Root:\n  kept: 1\n  kep: 2\n  Nested:\n    widht: 3\n")
+    with pytest.raises(ConfigError) as raised, strict_config("Root"):
+        apply_config("Root")(_StrictRoot)()
+    message = str(raised.value)
+    assert "'Root.kep'" in message and "Did you mean 'kept'?" in message
+    assert "'Root.Nested.widht'" in message and "Did you mean 'width'?" in message
+    # What the level's readers name: the parent's own parameters, the flat child's, the keyed child's key.
+    assert "'Root.kep' (keys read at that level: ['Nested', 'depth', 'kept'])" in message
+
+
+def test_strict_config_counts_what_a_flat_child_and_a_keyed_child_read(write_config) -> None:
+    """``leaf`` has no @config key: it binds on the SAME level as its parent and reads ``depth``
+    there; ``Nested`` owns a sub-level, and its key is read by the parent. Neither is unknown."""
+    write_config("Root:\n  kept: 1\n  depth: 4\n  Nested:\n    width: 5\n")
+    with strict_config("Root"):
+        root = apply_config("Root")(_StrictRoot)()
+    assert (root.kept, root.leaf.depth, root.nested.width) == (1, 4, 5)
+
+
+def test_strict_config_counts_a_konfai_without_parameter_as_read(write_config) -> None:
+    write_config("Root:\n  kept: 5\n  skipped: 42\n")
+
+    class Root:
+        def __init__(self, kept: int, skipped: int = 0) -> None:
+            self.kept, self.skipped = kept, skipped
+
+    with strict_config("Root"):
+        root = apply_config("Root")(Root)(konfai_without=["skipped"])
+    assert (root.kept, root.skipped) == (5, 0)
+
+
+def test_strict_config_leaves_a_dict_of_objects_entries_free_and_checks_inside_them(write_config) -> None:
+    write_config("Root:\n  children:\n    left:\n      value: 3\n    right:\n      valeu: 7\n")
+
+    class Child:
+        def __init__(self, value: int = 0) -> None:
+            self.value = value
+
+    class Root:
+        def __init__(self, children: dict[str, Child]) -> None:
+            self.children = children
+
+    with (
+        pytest.raises(ConfigError, match=r"'Root\.children\.right\.valeu'.*Did you mean 'value'"),
+        strict_config("Root"),
+    ):
+        apply_config("Root")(Root)()
+
+
+def test_strict_config_refuses_a_missing_root_before_anything_binds(write_config) -> None:
+    write_config("Rot:\n  kept: 2\n")
+    with pytest.raises(ConfigError, match="declares no 'Root' root"), strict_config("Root"):
+        raise AssertionError("refused before anything binds")
+
+
+def test_strict_config_can_warn_instead_of_refusing(write_config) -> None:
+    """The legacy workflows' setting: existing files carry keys older versions wrote back, so the
+    reader is told and the run goes on."""
+    write_config("Root:\n  kep: 2\n")
+    with pytest.warns(UserWarning, match=r"'Root\.kep'.*Did you mean 'kept'"), strict_config("Root", refuse=False):
+        root = apply_config("Root")(_StrictRoot)()
+    assert root.kept == 0
+
+
+def test_outside_strict_config_the_binder_records_nothing_and_refuses_nothing(write_config) -> None:
+    from konfai.utils import config as config_module
+
+    write_config("Root:\n  kep: 2\n")
+    root = apply_config("Root")(_StrictRoot)()
+    assert root.kept == 0 and config_module._ledgers == []
+
+
+def test_strict_config_reports_a_yaml_syntax_error_as_a_config_error(write_config) -> None:
+    write_config("Root:\n  kept: [1, 2\n")
+    with pytest.raises(ConfigError, match=r"Invalid YAML syntax .* at line"), strict_config("Root"):
+        raise AssertionError("refused before anything binds")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -531,24 +531,38 @@ def test_config_write_back_is_atomic_when_the_rename_fails(write_config, monkeyp
     assert list(config_path.parent.glob("*.tmp")) == []  # the temp file is removed on failure
 
 
-def test_config_write_back_denied_rename_falls_back_to_in_place_write(write_config, monkeypatch) -> None:
-    """An OSError from os.replace takes the in-place rewrite: the run continues and the file stays whole."""
+def test_config_write_back_retries_a_denied_rename_and_never_writes_in_place(write_config, monkeypatch) -> None:
+    """A transient OSError from os.replace (Windows: an indexer holding the target) is retried and the
+    file is replaced whole; a persistent one refuses with a ConfigError and leaves the file as it was.
+    Never an in-place rewrite: a concurrent reader would see it truncated and bind all-defaults."""
     config_path = write_config("Root:\n  count: 3\n")
 
     class Root:
         def __init__(self, count: int = 0) -> None:
             self.count = count
 
-    def denied_replace(src: object, dst: object) -> None:
-        raise OSError("target busy")
+    real_replace = os.replace
+    denials: list[int] = []
 
-    monkeypatch.setattr("konfai.utils.config.os.replace", denied_replace)
+    def transient_denial(src: object, dst: object) -> None:
+        if len(denials) < 2:
+            denials.append(1)
+            raise OSError("target busy")
+        real_replace(src, dst)
 
+    monkeypatch.setattr("konfai.utils.config.os.replace", transient_denial)
+    monkeypatch.setattr("konfai.utils.config.time.sleep", lambda _seconds: None)
     root = apply_config("Root")(Root)()
-
-    assert root.count == 3
+    assert root.count == 3 and len(denials) == 2
     data = ruamel.yaml.YAML().load(config_path.read_text(encoding="utf-8"))
     assert data == {"Root": {"count": 3}}
+    assert list(config_path.parent.glob("*.tmp")) == []
+
+    monkeypatch.setattr("konfai.utils.config.os.replace", lambda src, dst: (_ for _ in ()).throw(OSError("held")))
+    before = config_path.read_text(encoding="utf-8")
+    with pytest.raises(ConfigError, match="atomically"):
+        apply_config("Root")(Root)()
+    assert config_path.read_text(encoding="utf-8") == before  # the file was left unchanged
     assert list(config_path.parent.glob("*.tmp")) == []
 
 

--- a/tests/unit/test_transformer_workflow.py
+++ b/tests/unit/test_transformer_workflow.py
@@ -23,6 +23,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 from konfai.data.materialize import Regime, Verdict
+from konfai.data.reduction import Mean
+from konfai.data.transform import Reduce
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import ConfigError, TransformerError
 
@@ -95,6 +97,11 @@ _STREAMABLE = """\
               Clip:
                 min_value: 0.0
                 max_value: 50.0
+              Write:
+                dataset: {out}:h5
+"""
+
+_WRITE = """\
               Write:
                 dataset: {out}:h5
 """
@@ -883,62 +890,65 @@ def test_an_expanded_run_never_reads_a_whole_volume(tmp_path: Path, monkeypatch:
 
 def test_a_config_without_the_transformer_root_is_refused(tmp_path: Path) -> None:
     """A typo'd root ('Transformr:') must not bind an all-defaults workflow over the user's file."""
-    from konfai.transformer import _reject_unknown_keys
-
-    config = tmp_path / "Transform.yml"
-    config.write_text("Transformr:\n  name: X\n")
+    _write_source(tmp_path)
+    (tmp_path / "Transform.yml").write_text("Transformr:\n  name: X\n")
     with pytest.raises(ConfigError, match="no 'Transformer' root"):
-        _reject_unknown_keys(config)
+        _build(tmp_path)
 
 
 def test_a_typo_stage_argument_is_refused_instead_of_binding_its_default(tmp_path: Path) -> None:
     """A stage argument the signature does not name is a parse error: the binder would otherwise
     materialize the default beside the typo, and `Clip: {min_val: 0}` would clip at -1024, exit 0."""
-    from konfai.transformer import _reject_unknown_keys
-
-    config = tmp_path / "Transform.yml"
-    config.write_text(
-        "Transformer:\n  Dataset:\n    groups_src:\n      CT:\n        groups_dest:\n"
-        "          CT_out:\n            transforms:\n"
-        "              Clip: {min_val: 0.0, max_value: 400.0}\n"
-        "              Write: {dataset: ./Out:h5}\n"
+    _write_source(tmp_path)
+    _write_config(
+        tmp_path, "              Clip: {min_val: 0.0, max_value: 400.0}\n" + _WRITE.format(out=tmp_path / "out")
     )
-    with pytest.raises(ConfigError, match=r"Unknown argument 'min_val' for 'Clip'"):
-        _reject_unknown_keys(config)
+    with pytest.raises(ConfigError, match=r"transforms\.Clip\.min_val'.*Did you mean 'min_value'"):
+        _build(tmp_path)
 
 
 def test_a_reduce_mapping_carries_its_operator_arguments_and_refuses_a_typo(tmp_path: Path) -> None:
-    """A Reduce's mapping legitimately holds its operator's own parameters (resolve_operator binds
-    them from the same mapping); only a key neither signature names is refused."""
-    from konfai.transformer import _reject_unknown_keys
+    """A Reduce's mapping legitimately holds its operator's own parameters (the stage binds them at
+    prepare, from the same mapping); only a key neither signature names is refused."""
+    _write_source(tmp_path)
+    operator = f"{__name__}:_TrimmedMean"
+    template = "              Reduce: {{operator: " + operator + ", output: atlas{extra}}}\n" + _WRITE
+    _write_config(tmp_path, template.format(extra=", trim: 0.2", out=tmp_path / "out"))
+    workflow = _build(tmp_path)
+    reduce = next(s for s in workflow.dataset.groups_src["CT"]["CT_out"].transforms if isinstance(s, Reduce))
+    assert isinstance(reduce.operator, _TrimmedMean) and reduce.operator.trim == 0.2
 
-    config = tmp_path / "Transform.yml"
-    template = (
-        "Transformer:\n  Dataset:\n    groups_src:\n      CT:\n        groups_dest:\n"
-        "          CT_out:\n            transforms:\n"
-        "              Reduce: {{operator: Mean, output: atlas{extra}}}\n"
-        "              Write: {{dataset: ./Out:h5}}\n"
-    )
-    config.write_text(template.format(extra=", grid: shape_only"))
-    _reject_unknown_keys(config)
-    config.write_text(template.format(extra=", grib: shape_only"))
-    with pytest.raises(ConfigError, match=r"Unknown argument 'grib' for 'Reduce'"):
-        _reject_unknown_keys(config)
+    _write_config(tmp_path, template.format(extra=", grib: shape_only", out=tmp_path / "out"))
+    with pytest.raises(ConfigError, match=r"transforms\.Reduce\.grib'.*Did you mean 'grid'"):
+        _build(tmp_path)
+
+
+class _TrimmedMean(Mean):
+    """A custom operator with a parameter of its own, bound from the Reduce mapping."""
+
+    def __init__(self, trim: float = 0.0) -> None:
+        super().__init__()
+        self.trim = float(trim)
 
 
 def test_a_stage_that_resolves_nowhere_is_left_to_the_loader(tmp_path: Path) -> None:
     """An unresolvable stage name must not be reported as a wrong ARGUMENT: the loader owns that
     refusal and names the searched packages."""
-    from konfai.transformer import _reject_unknown_keys
+    from konfai.utils.errors import TransformError
 
-    config = tmp_path / "Transform.yml"
-    config.write_text(
-        "Transformer:\n  Dataset:\n    groups_src:\n      CT:\n        groups_dest:\n"
-        "          CT_out:\n            transforms:\n"
-        "              Clipp: {min_value: 0.0}\n"
-        "              Write: {dataset: ./Out:h5}\n"
-    )
-    _reject_unknown_keys(config)
+    _write_source(tmp_path)
+    _write_config(tmp_path, "              Clipp: {min_value: 0.0}\n" + _WRITE.format(out=tmp_path / "out"))
+    with pytest.raises(TransformError, match="No transform or augmentation is named 'Clipp'"):
+        _build(tmp_path)
+
+
+def test_a_key_of_a_wrapped_foreign_stage_that_it_cannot_take_is_refused(tmp_path: Path) -> None:
+    """The binder hands a foreign class only the parameters its signature names, so a key under a
+    class taking none (or **kwargs) goes nowhere: refused, not silently dropped."""
+    _write_source(tmp_path)
+    _write_config(tmp_path, "              torch.nn:Sigmoid: {inplace: true}\n" + _WRITE.format(out=tmp_path / "out"))
+    with pytest.raises(ConfigError, match=r"torch\.nn:Sigmoid\.inplace'"):
+        _build(tmp_path)
 
 
 def test_on_fallback_error_holds_at_run_time_too(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -992,22 +1002,6 @@ def test_a_failing_case_does_not_stop_the_shard_and_is_listed(tmp_path: Path, mo
     assert out.is_dataset_exist("CT_out", "CASE_000")
     assert out.is_dataset_exist("CT_out", "CASE_002"), "the cases after the broken one must still be written"
     assert not out.is_dataset_exist("CT_out", "CASE_001")
-
-
-def test_the_strict_grammar_knows_every_key_the_binder_can_read() -> None:
-    """The grammar mirrors the two __init__ signatures: a parameter added to either without a
-    grammar entry would be refused in every config that sets it."""
-    import inspect
-
-    from konfai.data.data_manager import DataTransform
-    from konfai.transformer import _STRICT_GRAMMAR, Transformer
-
-    workflow_params = set(inspect.signature(Transformer.__init__).parameters) - {"self", "dataset"}
-    assert workflow_params | {"Dataset"} == set(_STRICT_GRAMMAR)
-    dataset_grammar = _STRICT_GRAMMAR["Dataset"]
-    assert isinstance(dataset_grammar, dict)
-    dataset_params = set(inspect.signature(DataTransform.__init__).parameters) - {"self"}
-    assert dataset_params == set(dataset_grammar)
 
 
 def test_two_ranks_partition_the_cases_and_every_output_is_written_once(


### PR DESCRIPTION
Stacked on `feat/transform-audit` (merge that one first, then retarget to `main`). Kept apart on purpose: this is a behaviour change for all four workflows, to be decided on its own.

## What

`strict_config(root)` in the binder records, per level, what the file holds against what the binder read, and reports the difference by path (with the keys read at that level and the closest one). TRANSFORM refuses an unknown key (as it already refused a typo'd structural key: the hand-written `_STRICT_GRAMMAR` and `_stage_arguments` in `transformer.py` are gone, replaced by the binder's own ledger, which now also covers a `Reduce` operator's parameters and a wrapped foreign class's). TRAIN, PREDICTION and EVALUATION **warn**.

The example configs drop the keys nothing reads; a built-in predictor reduction (`Mean`, `Median`, `Concat`) binds from its own block like a custom one (the `Mean:` block a resolved config carries was read by nothing). Second commit: the changelog entry.

## Behaviour change (in the changelog)
A `Config.yml`, `Prediction.yml` or `Evaluation.yml` carrying a key nothing reads now warns at build, naming the key by path. Files written back by earlier versions carry a few (`Patch.mask`, `Model.<name>.yaml_str`, `schedulers.<name>.verbose`, `is_input` under an evaluation group): remove them; the run is otherwise unchanged. HF bundle configs are affected the same way (warning only).

## Verification
Tree-identical to the fine-grained tip verified green: `pixi run check` (core with integration, apps), konfai-mcp and Studio suites, mypy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added strict configuration validation with precise paths and close-match suggestions for unknown YAML keys.
  - Transformer configurations now reject unused or invalid settings during construction.
  - Evaluator, predictor, and trainer configurations warn about legacy or unused settings.
  - Improved configuration errors include YAML syntax locations and unresolved workflow stages.
  - Reduction operators now consistently apply their configured parameters.

- **Documentation**
  - Updated configuration guidance, changelog, and examples to reflect strict validation and remove obsolete settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->