### PR TITLE
refactor(data): the data sources split, the statistics fold, a level's own geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ no longer stops a run. Two things a run already wrote come out differently, see 
   the store its probe created
 - **omezarr**: each scale factor shrinks the level above it, as the docs said (`[2, 2]` gives three
   levels at 1, 1/2, 1/4)
+- **omezarr**: a coarser level reads its own geometry. The sidecar describes the level the writer
+  was handed, so taken at its word on level 1 it put level 0's spacing and origin on level 1's
+  voxels: a volume read at `@1` came back four times too small in world coordinates
 - **reduction**: `Median` charges the working set its sort allocates (four buffers, measured)
 - **transform**: a bare stage name past the `Expand` marker is the draw (`Flip`, `Mask`, `Permute`,
   `Foreign` exist as both); the qualified spelling still forces either
@@ -104,6 +107,8 @@ no longer stops a run. Two things a run already wrote come out differently, see 
   where the pass it replaces took 31 s) and `Median` reads the middle off a sort (1.5-2x on CPU,
   3.5x on CUDA); the folds a statistics pass computed are kept for the write pass when they fit
 - **transform**: a case is planned without listing the whole output directory
+- **dataset**: a volume's statistics come from one block walk, folded in cache-sized pieces, and a
+  `.npy` entry answers its shape from the header instead of reading the array
 - **cli**: `import konfai` 0.9 to 0.08 s, `konfai --help` 2.9 to 0.3 s: torch, dicom and ome-zarr
   load on first use
 
@@ -114,6 +119,11 @@ no longer stops a run. Two things a run already wrote come out differently, see 
   shards and the run; the report is assembled from per-block helpers
 - **utils**: the memory budget lives in `konfai.utils.budget`; `State` in `konfai.utils`, importable
   without torch
+- **data**: `DataSources` holds what the four workflow datasets share (the roots, the case names
+  common to every group, one manager per destination group and case, the resolved budget); `Data`
+  adds the batch-loading mechanics and `DataTransform` builds on `DataSources` alone, so it no
+  longer forwards eleven loader parameters it never used. The managers and case names are public
+  on the base, which is what `Transformer` now reads
 
 ### ⚠️ Behaviour changes
 

--- a/docs/source/concepts/datasets.md
+++ b/docs/source/concepts/datasets.md
@@ -136,7 +136,7 @@ The `dataset_filenames` field accepts strings in the form:
 - `path:format`
 - `path:flag:format`
 
-This behavior is implemented in `konfai.data.data_manager.Data._resolve_dataset_sources()`,
+This behavior is implemented in `konfai.data.data_manager.DataSources._resolve_dataset_sources()`,
 which delegates the parsing to `konfai.utils.utils.split_path_spec()`.
 
 The most important conventions are:

--- a/examples/Registration/Prediction.yml
+++ b/examples/Registration/Prediction.yml
@@ -14,7 +14,6 @@ Predictor:
       int_steps: 7
       int_downsize: 2
       outputs_criterions: None  # No losses at prediction time; metrics are computed in Evaluation.yml
-      ModelPatch: None
       BlockConfig:
         kernel_size: 3
         stride: 1

--- a/examples/Synthesis/Prediction.yml
+++ b/examples/Synthesis/Prediction.yml
@@ -93,7 +93,6 @@ Predictor:
         group: sCT # Name of the predicted modality
         same_as_group: MR:MR # Use MR geometry (spacing/origin/orientation)
         patch_combine: None  # No patch combination needed because 512*512 patches cover the full image slice
-        inverse_transform: false # If true, apply the inverse of transforms marked with inverse=true from the reference group
         reduction: Mean # Combine predictions from TTA using the Mean or Median
         Mean: {}
         attributes: None

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -808,224 +808,51 @@ class PredictionSubset(Subset):
         super().__init__(subset, False, None)
 
 
-class Data(ABC):
-    """Abstract base class shared by training, prediction, and evaluation datasets."""
+class DataSources(ABC):
+    """The source resolution the four workflow datasets share.
 
-    @staticmethod
-    def _configured_transform_requires_single_process(classpath: str) -> bool:
-        for transform_name in classpath.split("|"):
-            candidate = transform_name.split(":")[-1].split(".")[-1].split("/")[0]
-            if candidate == "KonfAIInference":
-                return True
-        return False
-
-    @classmethod
-    def _groups_require_single_process_loading(cls, groups_src: Mapping[str, Group | GroupMetric | GroupOut]) -> bool:
-        for group in groups_src.values():
-            for group_transform in group.values():
-                for configured_transforms in (group_transform._transforms, group_transform._patch_transforms):
-                    if configured_transforms is None:
-                        continue
-                    if any(
-                        cls._configured_transform_requires_single_process(classpath)
-                        for classpath in configured_transforms
-                    ):
-                        return True
-        return False
-
-    @staticmethod
-    def _read_names_from_file(filename: str) -> list[str]:
-        with open(filename) as f:
-            return [name.strip() for name in f if name.strip()]
-
-    @classmethod
-    def _resolve_name_selectors(cls, selectors: list[str]) -> set[str]:
-        resolved_names: set[str] = set()
-        for selector in selectors:
-            if os.path.exists(selector):
-                resolved_names.update(cls._read_names_from_file(selector))
-            else:
-                resolved_names.add(selector)
-        return resolved_names
+    Which cases, from which file, under which destination group: the ``dataset_filenames`` roots,
+    the case names common to every source group and kept by ``subset``, and one
+    :class:`~konfai.data.patching.DatasetManager` per (destination group, case), all resolved by
+    :meth:`prepare`. :class:`Data` adds the batch-loading mechanics; :class:`DataTransform` builds
+    on this alone.
+    """
 
     @abstractmethod
     def __init__(
         self,
         dataset_filenames: list[str],
         groups_src: Mapping[str, Group | GroupMetric | GroupOut],
-        patch: DatasetPatch | None,
-        use_cache: bool,
         subset: Subset,
-        batch_size: int,
-        validation: float | str | list[int] | list[str] | None,
-        validation_augmentations: bool,
-        inline_augmentations: bool,
-        data_augmentations_list: dict[str, DataAugmentationsList],
-        num_workers: int | None,
-        pin_memory: bool,
-        prefetch_factor: int | None,
-        persistent_workers: bool | None,
         memory_budget: str | float | None,
     ) -> None:
         self.dataset_filenames = dataset_filenames
-        self.subset = subset
         self.groups_src = groups_src
-        self.patch = patch
-        self.validation = validation
-        self.validation_augmentations = validation_augmentations
-        self.data_augmentations_list = data_augmentations_list
-        self.batch_size = batch_size
-        self.inline_augmentations = inline_augmentations
+        self.subset = subset
         self.memory_budget = memory_budget
-        self.requires_single_process_loading = self._groups_require_single_process_loading(groups_src)
-
-        # A window keeps ``shuffle_window`` cases resident, so the FIFO buffer must be at least that
-        # large or a window would evict its own cases before their patches are consumed. Unwindowed,
-        # one batch plus the case being read is all a loader ever holds at once.
-        window = subset.shuffle_window
-        self._buffer_size = batch_size + 1 if window is None else max(batch_size + 1, window)
-        self._num_workers = num_workers
-        self._pin_memory = pin_memory
-        self._prefetch_factor = prefetch_factor
-        self._persistent_workers = persistent_workers
-        # ``memory_budget`` may later override ``use_cache`` (once the dataset size is known, in
-        # ``get_data``), which reshapes the loader; both paths funnel through the same builder.
-        self._configure_data_loading(use_cache)
-        self.data: list[list[dict[str, list[DatasetManager]]]] = []
-        self.mapping: list[list[list[tuple[int, int, int]]]] = []
         self.datasets: dict[str, Dataset] = {}
-        self._prepared_data: dict[str, list[DatasetManager]] | None = None
-        self._prepared_validation_data: dict[str, list[DatasetManager]] | None = None
-        self._prepared_mapping: list[tuple[int, int, int]] = []
-        self._prepared_validation_mapping: list[tuple[int, int, int]] = []
-        self._prepared_train_names: list[str] = []
-        self._prepared_validation_names: list[str] = []
+        #: The selected case names in run order; filled by :meth:`prepare`.
+        self.case_names: list[str] = []
+        self._managers: dict[str, list[DatasetManager]] | None = None
+
+    @property
+    def managers(self) -> dict[str, list[DatasetManager]]:
+        """One manager per case of every destination group, in ``case_names`` order, keyed by
+        destination group; built by :meth:`prepare`."""
+        if self._managers is None:
+            raise DatasetManagerError("The dataset was not prepared.", "Call prepare() before reading its managers.")
+        return self._managers
 
     def resolved_budget(self) -> MemoryBudget:
         """The configured memory budget as an object that knows its own scope (``resolve_memory_budget``)."""
         return resolve_memory_budget(self.memory_budget)
 
-    def _configure_data_loading(self, use_cache: bool) -> None:
-        """Build the loader from the cache regime: the DatasetIter factory and the worker settings.
-
-        Called once from ``__init__`` with the declared ``use_cache`` and, when a ``memory_budget``
-        overrides it, again from ``get_data`` with the derived value. Caching preloads every case up
-        front, so it defaults to zero DataLoader workers; the streaming/buffer path spins workers up.
-        """
-        self.use_cache = use_cache
-        self.datasetIter = partial(
-            DatasetIter,
-            groups_src=self.groups_src,
-            inline_augmentations=self.inline_augmentations,
-            patch_size=self.patch.patch_size if self.patch is not None else None,
-            overlap=self.patch.overlap if self.patch is not None else None,
-            buffer_size=self._buffer_size,
-            use_cache=use_cache,
-        )
-        resolved_num_workers = self._num_workers
-        if self.requires_single_process_loading:
-            resolved_num_workers = 0
-        elif resolved_num_workers is None:
-            resolved_num_workers = max(1, min(os.cpu_count() or 1, 4)) if not use_cache else 0
-        self.resolved_num_workers: int = resolved_num_workers
-        self.dataLoader_args: dict[str, object] = {
-            "num_workers": resolved_num_workers,
-            "pin_memory": self._pin_memory,
-            "collate_fn": collate_konfai,
-        }
-        if resolved_num_workers > 0:
-            self.dataLoader_args["prefetch_factor"] = 2 if self._prefetch_factor is None else self._prefetch_factor
-            # Persistent workers keep a fork-time copy of the dataset and never see the main process's
-            # per-epoch reset_augmentation redraw, so inline augmentations freeze at their first-epoch draw.
-            # An explicit persistent_workers=True cannot override that: correctness wins over the request.
-            inline_augmentation_active = self.inline_augmentations and len(self.data_augmentations_list) > 0
-            if inline_augmentation_active:
-                persistent_workers = False
-            elif self._persistent_workers is not None:
-                persistent_workers = self._persistent_workers
-            else:
-                persistent_workers = True
-            self.dataLoader_args["persistent_workers"] = persistent_workers
-
-    def _estimate_cached_bytes(self) -> int:
-        """Raw in-RAM size of the whole prepared dataset, from headers alone (no voxel read).
-
-        Sums ``prod(shape) x 4`` over every case of every source group, once per COPY the cache holds:
-        a cached case is its base tensor PLUS one per augmentation draw, which validation only makes
-        when ``validation_augmentations``. See ``_CACHE_ELEMENT_BYTES``: this is an honest header-only
-        estimate that ignores size-changing transforms (an augmentation's ``Mask`` included). It also
-        counts the tensors themselves, not the allocator's arenas around them: those settle about a
-        third higher (measured), which is over the "auto" safety fraction, so a dataset landing within
-        a few percent of an "auto" budget can still be caching more than the budget names.
-        """
-        total = 0
-        for prepared, copies in (
-            (self._prepared_data, Data._get_nb_augmentation(self._get_data_augmentations(True))),
-            (
-                self._prepared_validation_data,
-                Data._get_nb_augmentation(self._get_data_augmentations(self.validation_augmentations)),
-            ),
-        ):
-            for managers in (prepared or {}).values():
-                for manager in managers:
-                    total += int(np.prod(manager.base_shape, dtype=np.int64)) * _CACHE_ELEMENT_BYTES * copies
-        return total
-
-    #: Whether a ``memory_budget`` that fits may choose the cache. True for training (epochs
-    #: re-read every case); overridden False by the one-pass workflows, where a cache is never
-    #: re-read and the regime is always stream/buffer.
-    _budget_caches_when_fit = True
-
-    def _resolve_cache_regime(self, world_size: int) -> None:
-        """Derive ``use_cache`` from ``memory_budget``. ``None`` means ``"auto"``.
-
-        The cache is chosen iff the per-rank dataset (``dataset / world_size``: ``Data._split``
-        shards cases across ranks) fits the per-rank budget: an explicit budget is taken as declared
-        per rank; ``"auto"``: also what an absent key means: divides the detected node memory
-        (cgroup-capped) by the ranks sharing THAT node, so on a single node the two divisions cancel
-        and the test reduces to "does the whole dataset fit the node". The decision is logged once
-        here: ``get_data`` runs on the launcher alone, before any worker is spawned.
-        """
-        if not self._budget_caches_when_fit:
-            # One-pass workflows (prediction, evaluation) read each case exactly once: a cache is
-            # never re-read, so the regime is always stream/buffer and there is nothing to derive.
-            return
-        world_size = max(1, world_size)
-        n_cases = len(self._prepared_train_names) + len(self._prepared_validation_names)
-        dataset_bytes = self._estimate_cached_bytes()
-        per_rank_bytes = dataset_bytes / world_size
-
-        budget = self.resolved_budget()
-        per_rank_budget = budget.per_rank_bytes(node_local_ranks(world_size))
-        budget_desc = f"{budget.description}, per-rank"
-
-        use_cache = per_rank_bytes <= per_rank_budget
-        self._configure_data_loading(use_cache)
-
-        decision = f"CACHE the whole dataset in RAM ({self.resolved_num_workers} loader workers)"
-        if not use_cache:
-            case_bytes = dataset_bytes / max(1, n_cases)
-            decision = (
-                f"STREAM/BUFFER, no cache; FIFO working set ~= {self._buffer_size} cases x "
-                f"{format_bytes(case_bytes)} = {format_bytes(self._buffer_size * case_bytes)} per worker"
-            )
-        print(
-            f"[KonfAI] memory_budget: dataset ~= {format_bytes(dataset_bytes)} over {n_cases} cases | "
-            f"per-rank ~= {format_bytes(per_rank_bytes)} across {world_size} rank(s) | "
-            f"budget {format_bytes(per_rank_budget)} ({budget_desc}) -> {decision}"
-        )
-
-    def _get_data_augmentations(self, apply_augmentations: bool = True) -> list[DataAugmentationsList]:
-        return list(self.data_augmentations_list.values()) if apply_augmentations else []
-
-    @staticmethod
-    def _get_nb_augmentation(data_augmentations_list: list[DataAugmentationsList]) -> int:
-        return max(int(np.sum([data_augmentation.nb for data_augmentation in data_augmentations_list]) + 1), 1)
-
-    def _get_validation_mapping(self) -> list[tuple[int, int, int]]:
-        if self.validation_augmentations:
-            return self._prepared_validation_mapping
-        return [entry for entry in self._prepared_validation_mapping if entry[1] == 0]
+    def get_groups_dest(self):
+        groups_dest = []
+        for group_src in self.groups_src:
+            for group_dest in self.groups_src[group_src]:
+                groups_dest.append(group_dest)
+        return groups_dest
 
     def _check_destination_groups_are_unique(self) -> None:
         """A destination group names ONE chain, whatever source group it reads.
@@ -1049,8 +876,8 @@ class Data(ABC):
             owner[group_dest] = group_src
 
     def prepare(self) -> None:
-        """Instantiate config-driven transforms and augmentations before runtime."""
-        if self._prepared_data is not None and self._prepared_validation_data is not None:
+        """Bind the chains, resolve the sources and build the managers. Idempotent."""
+        if self._managers is not None:
             return
 
         self._check_destination_groups_are_unique()
@@ -1059,73 +886,28 @@ class Data(ABC):
             chain.prepare(group_src, group_dest)
             model_have_input |= chain.is_input
 
-        if self.patch is not None:
-            self.patch.init()
-
         if not model_have_input:
             raise DatasetManagerError(
                 "At least one group must be defined with 'is_input: true' to provide input to the network."
             )
 
-        for key, data_augmentations in self.data_augmentations_list.items():
-            data_augmentations.prepare(key)
         self._prepare_datasets()
 
-    def worst_case_shape(self) -> list[int] | None:
-        """Per-axis maximum spatial extent over every prepared case and augmentation copy.
+    def _prepare_datasets(self) -> None:
+        """Resolve the sources, select the cases and build their managers."""
+        names, dataset_name = self._select_cases()
+        self.case_names = names
+        self._managers = self._build_managers(names, dataset_name, patch=None, data_augmentations_list=[])
 
-        A provisional auto-patch grid starts from this worst case at full extent: one GLOBAL patch
-        size, which smaller cases clamp to fewer (or single whole-volume) patches for free.
-        """
-        shapes = [
-            shape
-            for prepared in (self._prepared_data, self._prepared_validation_data)
-            for managers in (prepared or {}).values()
-            for manager in managers
-            for shape in manager.shapes
-        ]
-        if not shapes:
-            return None
-        return [max(int(shape[axis]) for shape in shapes) for axis in range(len(shapes[0]))]
-
-    def set_free_axis_multiple(self, multiple: list[int] | None) -> None:
-        """Record the model's per-axis downsampling factor on the shared patch BEFORE ``prepare()`` cuts
-        the grids, so every case's free (``0``) axis rounds up to a valid model input. A no-op without a
-        patch (evaluation) or without a free axis; harmless once a re-plan has made the sizes concrete.
-        """
-        if self.patch is not None:
-            self.patch.free_axis_multiple = multiple
-
-    def replan_patch(self, patch_size: list[int]) -> None:
-        """Re-cut every prepared grid for a new GLOBAL patch size (the OOM-restart path).
-
-        The managers are rebuilt against the already-resolved sources and the SAME case lists --
-        NOT through ``prepare()`` (its idempotence guard would skip the rebuild): so a later
-        ``get_data`` shards cases identically across the restart: only the grids and the patch mapping change.
-        Each manager copies the shared ``DatasetPatch`` (with ``pad_to_patch``) at construction,
-        which is why the new sizes are written into that shared list IN PLACE: the loader factory
-        holds a reference to it too.
-        """
-        if self.patch is None or self._prepared_data is None or self._prepared_validation_data is None:
-            raise DatasetManagerError(
-                "replan_patch requires a prepared dataset with a patch definition.",
-                "Call prepare() first; a dataset without 'patch' has no grid to re-cut.",
-            )
-        self.patch.patch_size[:] = [int(size) for size in patch_size]
+    def _select_cases(self) -> tuple[list[str], dict[str, dict[str, list[str]]]]:
+        """The case names common to every group and kept by ``subset``, in run order (sorted, or
+        drawn once when ``subset.shuffle``), with the names each root holds per group."""
         datasets = self._resolve_dataset_sources()
-        dataset_name = {
-            group: {filename: self.datasets[filename].get_names(group) for filename, _ in entries}
-            for group, entries in datasets.items()
-        }
-        self._prepared_data, self._prepared_mapping = self._get_datasets(
-            self._prepared_train_names, dataset_name, self._get_data_augmentations(True)
-        )
-        self._prepared_validation_data, self._prepared_validation_mapping = self._get_datasets(
-            self._prepared_validation_names,
-            dataset_name,
-            self._get_data_augmentations(self.validation_augmentations),
-            index_offset=len(self._prepared_train_names),
-        )
+        dataset_name, subset_names = self._resolve_common_names(datasets)
+        names = sorted(subset_names)
+        if self.subset.shuffle:
+            names = random.sample(names, len(names))  # nosec B311
+        return names, dataset_name
 
     def _resolve_dataset_sources(self) -> dict[str, list[tuple[str, bool]]]:
         datasets: dict[str, list[tuple[str, bool]]] = {}
@@ -1172,11 +954,6 @@ class Data(ABC):
 
             for group_dest in self.groups_src[group_src]:
                 self.groups_src[group_src][group_dest].set_datasets(list(self.datasets.values()))
-
-        for _group_src, entries in datasets.items():
-            for _key, data_augmentations in self.data_augmentations_list.items():
-                data_augmentations.set_datasets([self.datasets[filename] for filename, _ in entries])
-            break
         return datasets
 
     def _resolve_common_names(
@@ -1269,36 +1046,363 @@ class Data(ABC):
                         )
         return source_filename_by_group
 
+    def _build_managers(
+        self,
+        names: list[str],
+        dataset_name: dict[str, dict[str, list[str]]],
+        patch: DatasetPatch | None,
+        data_augmentations_list: list[DataAugmentationsList],
+        index_offset: int = 0,
+    ) -> dict[str, list[DatasetManager]]:
+        """One manager per (destination group, case), the case read from the first declared root
+        that holds it. ``index_offset`` keeps the manager index unique across the partitions
+        :class:`Data` builds: the augmentations they share cache a case's draw by index."""
+        source_filename_by_group = self._get_source_filename_by_group(dataset_name)
+        return {
+            group_dest: [
+                DatasetManager(
+                    index_offset + i,
+                    group_src,
+                    group_dest,
+                    name,
+                    self.datasets[source_filename_by_group[group_src][name]],
+                    patch=patch,
+                    transforms=self.groups_src[group_src][group_dest].transforms,
+                    data_augmentations_list=data_augmentations_list,
+                )
+                for i, name in enumerate(names)
+            ]
+            for group_src in self.groups_src
+            for group_dest in self.groups_src[group_src]
+        }
+
+    def _params(self) -> dict[str, object]:
+        return {
+            "dataset_filenames": self.dataset_filenames,
+            "groups_src": self.groups_src,
+            "memory_budget": self.memory_budget,
+            "subset": self.subset,
+        }
+
+    def __str__(self) -> str:
+        return str(self._params())
+
+    def __repr__(self) -> str:
+        return str(self)
+
+
+class Data(DataSources):
+    """The batch-loading layer over :class:`DataSources`, shared by training, prediction and
+    evaluation: a patch grid, an optional RAM cache, a train/validation split, augmentation copies,
+    and one torch DataLoader per rank and partition (:meth:`get_data`).
+
+    ``case_names``/``managers`` hold the first partition (the training cases); the validation split
+    has its own.
+    """
+
+    @staticmethod
+    def _configured_transform_requires_single_process(classpath: str) -> bool:
+        for transform_name in classpath.split("|"):
+            candidate = transform_name.split(":")[-1].split(".")[-1].split("/")[0]
+            if candidate == "KonfAIInference":
+                return True
+        return False
+
+    @classmethod
+    def _groups_require_single_process_loading(cls, groups_src: Mapping[str, Group | GroupMetric | GroupOut]) -> bool:
+        for group in groups_src.values():
+            for group_transform in group.values():
+                for configured_transforms in (group_transform._transforms, group_transform._patch_transforms):
+                    if configured_transforms is None:
+                        continue
+                    if any(
+                        cls._configured_transform_requires_single_process(classpath)
+                        for classpath in configured_transforms
+                    ):
+                        return True
+        return False
+
+    @staticmethod
+    def _read_names_from_file(filename: str) -> list[str]:
+        with open(filename) as f:
+            return [name.strip() for name in f if name.strip()]
+
+    @classmethod
+    def _resolve_name_selectors(cls, selectors: list[str]) -> set[str]:
+        resolved_names: set[str] = set()
+        for selector in selectors:
+            if os.path.exists(selector):
+                resolved_names.update(cls._read_names_from_file(selector))
+            else:
+                resolved_names.add(selector)
+        return resolved_names
+
+    @abstractmethod
+    def __init__(
+        self,
+        dataset_filenames: list[str],
+        groups_src: Mapping[str, Group | GroupMetric | GroupOut],
+        subset: Subset,
+        memory_budget: str | float | None,
+        patch: DatasetPatch | None,
+        use_cache: bool,
+        batch_size: int,
+        validation: float | str | list[int] | list[str] | None,
+        num_workers: int | None,
+        pin_memory: bool,
+        prefetch_factor: int | None,
+        persistent_workers: bool | None,
+        data_augmentations_list: dict[str, DataAugmentationsList] | None = None,
+        inline_augmentations: bool = False,
+        validation_augmentations: bool = True,
+    ) -> None:
+        super().__init__(dataset_filenames, groups_src, subset, memory_budget)
+        self.patch = patch
+        self.validation = validation
+        self.validation_augmentations = validation_augmentations
+        self.data_augmentations_list = data_augmentations_list or {}
+        self.batch_size = batch_size
+        self.inline_augmentations = inline_augmentations
+        self.requires_single_process_loading = self._groups_require_single_process_loading(groups_src)
+
+        # A window keeps ``shuffle_window`` cases resident, so the FIFO buffer must be at least that
+        # large or a window would evict its own cases before their patches are consumed. Unwindowed,
+        # one batch plus the case being read is all a loader ever holds at once.
+        window = subset.shuffle_window
+        self._buffer_size = batch_size + 1 if window is None else max(batch_size + 1, window)
+        self._num_workers = num_workers
+        self._pin_memory = pin_memory
+        self._prefetch_factor = prefetch_factor
+        self._persistent_workers = persistent_workers
+        # ``memory_budget`` may later override ``use_cache`` (once the dataset size is known, in
+        # ``get_data``), which reshapes the loader; both paths funnel through the same builder.
+        self._configure_data_loading(use_cache)
+        self.data: list[list[dict[str, list[DatasetManager]]]] = []
+        self.mapping: list[list[list[tuple[int, int, int]]]] = []
+        self._validation_managers: dict[str, list[DatasetManager]] = {}
+        self._prepared_mapping: list[tuple[int, int, int]] = []
+        self._prepared_validation_mapping: list[tuple[int, int, int]] = []
+        self._validation_names: list[str] = []
+
+    def _configure_data_loading(self, use_cache: bool) -> None:
+        """Build the loader from the cache regime: the DatasetIter factory and the worker settings.
+
+        Called once from ``__init__`` with the declared ``use_cache`` and, when a ``memory_budget``
+        overrides it, again from ``get_data`` with the derived value. Caching preloads every case up
+        front, so it defaults to zero DataLoader workers; the streaming/buffer path spins workers up.
+        """
+        self.use_cache = use_cache
+        self.datasetIter = partial(
+            DatasetIter,
+            groups_src=self.groups_src,
+            inline_augmentations=self.inline_augmentations,
+            patch_size=self.patch.patch_size if self.patch is not None else None,
+            overlap=self.patch.overlap if self.patch is not None else None,
+            buffer_size=self._buffer_size,
+            use_cache=use_cache,
+        )
+        resolved_num_workers = self._num_workers
+        if self.requires_single_process_loading:
+            resolved_num_workers = 0
+        elif resolved_num_workers is None:
+            resolved_num_workers = max(1, min(os.cpu_count() or 1, 4)) if not use_cache else 0
+        self.resolved_num_workers: int = resolved_num_workers
+        self.dataLoader_args: dict[str, object] = {
+            "num_workers": resolved_num_workers,
+            "pin_memory": self._pin_memory,
+            "collate_fn": collate_konfai,
+        }
+        if resolved_num_workers > 0:
+            self.dataLoader_args["prefetch_factor"] = 2 if self._prefetch_factor is None else self._prefetch_factor
+            # Persistent workers keep a fork-time copy of the dataset and never see the main process's
+            # per-epoch reset_augmentation redraw, so inline augmentations freeze at their first-epoch draw.
+            # An explicit persistent_workers=True cannot override that: correctness wins over the request.
+            inline_augmentation_active = self.inline_augmentations and len(self.data_augmentations_list) > 0
+            if inline_augmentation_active:
+                persistent_workers = False
+            elif self._persistent_workers is not None:
+                persistent_workers = self._persistent_workers
+            else:
+                persistent_workers = True
+            self.dataLoader_args["persistent_workers"] = persistent_workers
+
+    def _estimate_cached_bytes(self) -> int:
+        """Raw in-RAM size of the whole prepared dataset, from headers alone (no voxel read).
+
+        Sums ``prod(shape) x 4`` over every case of every source group, once per COPY the cache holds:
+        a cached case is its base tensor PLUS one per augmentation draw, which validation only makes
+        when ``validation_augmentations``. See ``_CACHE_ELEMENT_BYTES``: this is an honest header-only
+        estimate that ignores size-changing transforms (an augmentation's ``Mask`` included). It also
+        counts the tensors themselves, not the allocator's arenas around them: those settle about a
+        third higher (measured), which is over the "auto" safety fraction, so a dataset landing within
+        a few percent of an "auto" budget can still be caching more than the budget names.
+        """
+        total = 0
+        for prepared, copies in (
+            (self._managers, Data._get_nb_augmentation(self._get_data_augmentations(True))),
+            (
+                self._validation_managers,
+                Data._get_nb_augmentation(self._get_data_augmentations(self.validation_augmentations)),
+            ),
+        ):
+            for managers in (prepared or {}).values():
+                for manager in managers:
+                    total += int(np.prod(manager.base_shape, dtype=np.int64)) * _CACHE_ELEMENT_BYTES * copies
+        return total
+
+    #: Whether a ``memory_budget`` that fits may choose the cache. True for training (epochs
+    #: re-read every case); overridden False by the one-pass workflows, where a cache is never
+    #: re-read and the regime is always stream/buffer.
+    _budget_caches_when_fit = True
+
+    def _resolve_cache_regime(self, world_size: int) -> None:
+        """Derive ``use_cache`` from ``memory_budget``. ``None`` means ``"auto"``.
+
+        The cache is chosen iff the per-rank dataset (``dataset / world_size``: ``Data._split``
+        shards cases across ranks) fits the per-rank budget: an explicit budget is taken as declared
+        per rank; ``"auto"``: also what an absent key means: divides the detected node memory
+        (cgroup-capped) by the ranks sharing THAT node, so on a single node the two divisions cancel
+        and the test reduces to "does the whole dataset fit the node". The decision is logged once
+        here: ``get_data`` runs on the launcher alone, before any worker is spawned.
+        """
+        if not self._budget_caches_when_fit:
+            # One-pass workflows (prediction, evaluation) read each case exactly once: a cache is
+            # never re-read, so the regime is always stream/buffer and there is nothing to derive.
+            return
+        world_size = max(1, world_size)
+        n_cases = len(self.case_names) + len(self._validation_names)
+        dataset_bytes = self._estimate_cached_bytes()
+        per_rank_bytes = dataset_bytes / world_size
+
+        budget = self.resolved_budget()
+        per_rank_budget = budget.per_rank_bytes(node_local_ranks(world_size))
+        budget_desc = f"{budget.description}, per-rank"
+
+        use_cache = per_rank_bytes <= per_rank_budget
+        self._configure_data_loading(use_cache)
+
+        decision = f"CACHE the whole dataset in RAM ({self.resolved_num_workers} loader workers)"
+        if not use_cache:
+            case_bytes = dataset_bytes / max(1, n_cases)
+            decision = (
+                f"STREAM/BUFFER, no cache; FIFO working set ~= {self._buffer_size} cases x "
+                f"{format_bytes(case_bytes)} = {format_bytes(self._buffer_size * case_bytes)} per worker"
+            )
+        print(
+            f"[KonfAI] memory_budget: dataset ~= {format_bytes(dataset_bytes)} over {n_cases} cases | "
+            f"per-rank ~= {format_bytes(per_rank_bytes)} across {world_size} rank(s) | "
+            f"budget {format_bytes(per_rank_budget)} ({budget_desc}) -> {decision}"
+        )
+
+    def _get_data_augmentations(self, apply_augmentations: bool = True) -> list[DataAugmentationsList]:
+        return list(self.data_augmentations_list.values()) if apply_augmentations else []
+
+    @staticmethod
+    def _get_nb_augmentation(data_augmentations_list: list[DataAugmentationsList]) -> int:
+        return max(int(np.sum([data_augmentation.nb for data_augmentation in data_augmentations_list]) + 1), 1)
+
+    def _get_validation_mapping(self) -> list[tuple[int, int, int]]:
+        if self.validation_augmentations:
+            return self._prepared_validation_mapping
+        return [entry for entry in self._prepared_validation_mapping if entry[1] == 0]
+
+    def _resolve_dataset_sources(self) -> dict[str, list[tuple[str, bool]]]:
+        datasets = super()._resolve_dataset_sources()
+        # The augmentations get the roots of the first group resolved.
+        for entries in datasets.values():
+            for data_augmentations in self.data_augmentations_list.values():
+                data_augmentations.set_datasets([self.datasets[filename] for filename, _ in entries])
+            break
+        return datasets
+
+    def _prepare_datasets(self) -> None:
+        """Bind the patch and the augmentations, then split the selected cases and build both
+        partitions: a manager copies the patch and counts the draws at construction."""
+        if self.patch is not None:
+            self.patch.init()
+        for key, data_augmentations in self.data_augmentations_list.items():
+            data_augmentations.prepare(key)
+        names, dataset_name = self._select_cases()
+        self.case_names, self._validation_names = self._split_train_validation_names(names, dataset_name)
+        self._build_partitions(dataset_name)
+
+    def _build_partitions(self, dataset_name: dict[str, dict[str, list[str]]]) -> None:
+        """(Re)build the managers and patch mappings of both partitions from ``case_names`` and
+        ``_validation_names``; the validation indices continue the training ones. Nothing is
+        assigned until both are built, so a failure leaves the dataset unprepared."""
+        managers, mapping = self._get_datasets(self.case_names, dataset_name, self._get_data_augmentations(True))
+        validation_managers, validation_mapping = self._get_datasets(
+            self._validation_names,
+            dataset_name,
+            self._get_data_augmentations(self.validation_augmentations),
+            index_offset=len(self.case_names),
+        )
+        self._managers, self._prepared_mapping = managers, mapping
+        self._validation_managers, self._prepared_validation_mapping = validation_managers, validation_mapping
+
+    def worst_case_shape(self) -> list[int] | None:
+        """Per-axis maximum spatial extent over every prepared case and augmentation copy.
+
+        A provisional auto-patch grid starts from this worst case at full extent: one GLOBAL patch
+        size, which smaller cases clamp to fewer (or single whole-volume) patches for free.
+        """
+        shapes = [
+            shape
+            for prepared in (self._managers, self._validation_managers)
+            for managers in (prepared or {}).values()
+            for manager in managers
+            for shape in manager.shapes
+        ]
+        if not shapes:
+            return None
+        return [max(int(shape[axis]) for shape in shapes) for axis in range(len(shapes[0]))]
+
+    def set_free_axis_multiple(self, multiple: list[int] | None) -> None:
+        """Record the model's per-axis downsampling factor on the shared patch BEFORE ``prepare()`` cuts
+        the grids, so every case's free (``0``) axis rounds up to a valid model input. A no-op without a
+        patch (evaluation) or without a free axis; harmless once a re-plan has made the sizes concrete.
+        """
+        if self.patch is not None:
+            self.patch.free_axis_multiple = multiple
+
+    def replan_patch(self, patch_size: list[int]) -> None:
+        """Re-cut every prepared grid for a new GLOBAL patch size (the OOM-restart path).
+
+        The managers are rebuilt against the already-resolved sources and the SAME case lists --
+        NOT through ``prepare()`` (its idempotence guard would skip the rebuild): so a later
+        ``get_data`` shards cases identically across the restart: only the grids and the patch mapping change.
+        Each manager copies the shared ``DatasetPatch`` (with ``pad_to_patch``) at construction,
+        which is why the new sizes are written into that shared list IN PLACE: the loader factory
+        holds a reference to it too.
+        """
+        if self.patch is None or self._managers is None:
+            raise DatasetManagerError(
+                "replan_patch requires a prepared dataset with a patch definition.",
+                "Call prepare() first; a dataset without 'patch' has no grid to re-cut.",
+            )
+        self.patch.patch_size[:] = [int(size) for size in patch_size]
+        datasets = self._resolve_dataset_sources()
+        dataset_name = {
+            group: {filename: self.datasets[filename].get_names(group) for filename, _ in entries}
+            for group, entries in datasets.items()
+        }
+        self._build_partitions(dataset_name)
+
+    @staticmethod
+    def _patch_counts(managers: dict[str, list[DatasetManager]], nb_augmentation: int) -> list[list[int]]:
+        """Per case, per copy, the number of patches, counted on the last destination group."""
+        last = next(reversed(managers.values()), [])
+        return [[manager.get_size(a) for a in range(nb_augmentation)] for manager in last]
+
     def _get_case_entry_counts(
         self,
         names: list[str],
         dataset_name: dict[str, dict[str, list[str]]],
         data_augmentations_list: list[DataAugmentationsList],
     ) -> list[int]:
-        if len(names) == 0:
-            return []
-
-        source_filename_by_group = self._get_source_filename_by_group(dataset_name)
+        managers = self._build_managers(names, dataset_name, self.patch, data_augmentations_list)
         nb_augmentation = self._get_nb_augmentation(data_augmentations_list)
-        nb_patch = [[0] * nb_augmentation for _ in names]
-
-        for group_src, group_dest, chain in _chains(self.groups_src):
-            datasets = [
-                DatasetManager(
-                    i,
-                    group_src,
-                    group_dest,
-                    name,
-                    self.datasets[source_filename_by_group[group_src][name]],
-                    patch=self.patch,
-                    transforms=chain.transforms,
-                    data_augmentations_list=data_augmentations_list,
-                )
-                for i, name in enumerate(names)
-            ]
-            nb_patch = [[dataset.get_size(a) for a in range(nb_augmentation)] for dataset in datasets]
-
-        return [int(np.sum(case_patch_counts)) for case_patch_counts in nb_patch]
+        return [int(sum(counts)) for counts in self._patch_counts(managers, nb_augmentation)]
 
     def _resolve_validation_indices(
         self,
@@ -1401,36 +1505,6 @@ class Data(ABC):
 
         return train_names, validation_names
 
-    def _prepare_datasets(self) -> None:
-        """Resolve dataset files, validate subsets, and precompute train/validation mappings."""
-        datasets = self._resolve_dataset_sources()
-        dataset_name, subset_names = self._resolve_common_names(datasets)
-        subset_names_list = sorted(subset_names)
-        if self.subset.shuffle:
-            subset_names_list = random.sample(subset_names_list, len(subset_names_list))  # nosec B311
-        train_names, validation_names = self._split_train_validation_names(
-            subset_names_list,
-            dataset_name,
-        )
-        train_data, train_mapping = self._get_datasets(
-            train_names,
-            dataset_name,
-            self._get_data_augmentations(True),
-        )
-        validation_data, validate_mapping = self._get_datasets(
-            validation_names,
-            dataset_name,
-            self._get_data_augmentations(self.validation_augmentations),
-            index_offset=len(train_names),
-        )
-
-        self._prepared_data = train_data
-        self._prepared_validation_data = validation_data
-        self._prepared_mapping = train_mapping
-        self._prepared_validation_mapping = validate_mapping
-        self._prepared_train_names = train_names
-        self._prepared_validation_names = validation_names
-
     def _get_datasets(
         self,
         names: list[str],
@@ -1438,45 +1512,21 @@ class Data(ABC):
         data_augmentations_list: list[DataAugmentationsList],
         index_offset: int = 0,
     ) -> tuple[dict[str, list[DatasetManager]], list[tuple[int, int, int]]]:
-        nb_dataset = len(names)
-        nb_patch: list[list[int]]
-        data = {}
-        mapping: list[tuple[int, int, int]] = []
-        source_filename_by_group = self._get_source_filename_by_group(dataset_name)
+        """A partition: its managers and its ``(case, copy, patch)`` mapping in loader order."""
+        managers = self._build_managers(names, dataset_name, self.patch, data_augmentations_list, index_offset)
         nb_augmentation = self._get_nb_augmentation(data_augmentations_list)
-
-        for group_src, group_dest, chain in _chains(self.groups_src):
-            data[group_dest] = [
-                DatasetManager(
-                    # A globally-unique augmentation index (offset for validation) so the shared
-                    # augmentation objects do not collide train and validation draws in their cache.
-                    index_offset + i,
-                    group_src,
-                    group_dest,
-                    name,
-                    self.datasets[source_filename_by_group[group_src][name]],
-                    patch=self.patch,
-                    transforms=chain.transforms,
-                    data_augmentations_list=data_augmentations_list,
-                )
-                for i, name in enumerate(names)
-            ]
-            nb_patch = [[dataset.get_size(a) for a in range(nb_augmentation)] for dataset in data[group_dest]]
-
+        mapping: list[tuple[int, int, int]] = []
         # PREDICTION walks the mapping in order, and the copies of a TTA case must advance together
         # along the slab axis for the streamed write to hold a bounded window (see
         # ``_interleaved_case_entries``). TRAIN shuffles the mapping anyway and keeps the plain
         # order, as does a dataset prepared outside any workflow, where no state is set at all.
         interleave = nb_augmentation > 1 and os.environ.get("KONFAI_STATE") == str(State.PREDICTION)
-        for x in range(nb_dataset):
-            entries = [(y, z) for y in range(nb_augmentation) for z in range(nb_patch[x][y])]
+        for x, counts in enumerate(self._patch_counts(managers, nb_augmentation)):
+            entries = [(y, z) for y in range(nb_augmentation) for z in range(counts[y])]
             if interleave:
-                entries = _interleaved_case_entries([managers[x].patch for managers in data.values()], entries)
+                entries = _interleaved_case_entries([group[x].patch for group in managers.values()], entries)
             mapping.extend((x, y, z) for y, z in entries)
-        return data, mapping
-
-    def get_groups_dest(self):
-        return [group_dest for _group_src, group_dest, _chain in _chains(self.groups_src)]
+        return managers, mapping
 
     @staticmethod
     def _split(mapping: list[tuple[int, int, int]], world_size: int) -> list[list[tuple[int, int, int]]]:
@@ -1533,7 +1583,7 @@ class Data(ABC):
         return local_indices, remapped_mapping
 
     def get_data(self, world_size: int) -> tuple[list[list[DataLoader]], list[str], list[str]]:
-        if self._prepared_data is None or self._prepared_validation_data is None:
+        if self._managers is None:
             raise DatasetManagerError("Dataset configuration was not prepared before runtime data loading.")
 
         self._resolve_cache_regime(world_size)
@@ -1545,12 +1595,12 @@ class Data(ABC):
             self.data.append([])
             self.mapping.append([])
             train_indices, train_remapped_mapping = self._remap_dataset_indices(train_mapping)
-            self.data[i].append({k: [v[it] for it in train_indices] for k, v in self._prepared_data.items()})
+            self.data[i].append({k: [v[it] for it in train_indices] for k, v in self._managers.items()})
             self.mapping[i].append(train_remapped_mapping)
             if len(validate_mapping):
                 validation_indices, validation_remapped_mapping = self._remap_dataset_indices(validate_mapping)
                 self.data[i].append(
-                    {k: [v[it] for it in validation_indices] for k, v in self._prepared_validation_data.items()}
+                    {k: [v[it] for it in validation_indices] for k, v in self._validation_managers.items()}
                 )
                 self.mapping[i].append(validation_remapped_mapping)
 
@@ -1584,26 +1634,19 @@ class Data(ABC):
                         **self.dataLoader_args,
                     )
                 )
-        return data_loaders, self._prepared_train_names, self._prepared_validation_names
+        return data_loaders, self.case_names, self._validation_names
 
-    def __str__(self) -> str:
-        params = {
-            "dataset_filenames": self.dataset_filenames,
-            "groups_src": self.groups_src,
+    def _params(self) -> dict[str, object]:
+        return {
+            **super()._params(),
             "patch": self.patch,
             "use_cache": self.use_cache,
-            "memory_budget": self.memory_budget,
-            "subset": self.subset,
             "batch_size": self.batch_size,
             "validation": self.validation,
             "validation_augmentations": self.validation_augmentations,
             "inline_augmentations": self.inline_augmentations,
             "data_augmentations_list": self.data_augmentations_list,
         }
-        return str(params)
-
-    def __repr__(self) -> str:
-        return str(self)
 
 
 @config("Dataset")
@@ -1630,21 +1673,21 @@ class DataTrain(Data):
         super().__init__(
             dataset_filenames,
             groups_src,
-            patch,
+            subset,
+            memory_budget,
+            patch=patch,
             # Training re-reads every case each epoch: cache when the dataset fits the
             # 'memory_budget' fit-test, stream when it does not.
-            True,
-            subset,
-            batch_size,
-            validation,
-            validation_augmentations,
-            inline_augmentations,
-            augmentations if augmentations else {},
-            num_workers,
-            pin_memory,
-            prefetch_factor,
-            persistent_workers,
-            memory_budget,
+            use_cache=True,
+            batch_size=batch_size,
+            validation=validation,
+            num_workers=num_workers,
+            pin_memory=pin_memory,
+            prefetch_factor=prefetch_factor,
+            persistent_workers=persistent_workers,
+            data_augmentations_list=augmentations,
+            inline_augmentations=inline_augmentations,
+            validation_augmentations=validation_augmentations,
         )
 
 
@@ -1671,21 +1714,19 @@ class DataPrediction(Data):
     ) -> None:
 
         super().__init__(
-            dataset_filenames=dataset_filenames,
-            groups_src=groups_src,
+            dataset_filenames,
+            groups_src,
+            subset,
+            memory_budget,
             patch=patch,
             use_cache=False,
-            subset=subset,
             batch_size=batch_size,
             validation=None,
-            validation_augmentations=True,
-            inline_augmentations=False,
-            data_augmentations_list=augmentations if augmentations else {},
             num_workers=num_workers,
             pin_memory=pin_memory,
             prefetch_factor=prefetch_factor,
             persistent_workers=False if persistent_workers is None else persistent_workers,
-            memory_budget=memory_budget,
+            data_augmentations_list=augmentations,
         )
 
 
@@ -1777,42 +1818,36 @@ class DataMetric(Data):
     ) -> None:
 
         super().__init__(
-            dataset_filenames=dataset_filenames,
-            groups_src=groups_src,
+            dataset_filenames,
+            groups_src,
+            subset,
+            memory_budget,
             patch=None,
             # Evaluation reads each case exactly once (no augmentations, one pass): a cache is never
             # re-read, it only fronts the whole dataset's RAM. Stream.
             use_cache=False,
-            subset=subset,
             batch_size=1,
             validation=validation,
-            validation_augmentations=True,
-            data_augmentations_list={},
-            inline_augmentations=False,
             num_workers=num_workers,
             pin_memory=pin_memory,
             prefetch_factor=prefetch_factor,
             # One pass: workers are never reused across epochs, and persistent workers race the
             # process teardown (the terminated worker trips torch's failure handler at exit).
             persistent_workers=False if persistent_workers is None else persistent_workers,
-            memory_budget=memory_budget,
         )
 
 
 @config("Dataset")
-class DataTransform(Data):
+class DataTransform(DataSources):
     """Dataset configuration used by the transform workflow.
 
-    The amputated grammar, on the DataMetric precedent: no patch (the planner cuts slabs, never the
-    user), no batch, no validation split, no shuffle, and no ``augmentations`` section: a draw is a
-    stage, so it is declared IN the chain, at the place it applies, after an
-    :class:`~konfai.data.transform.Expand` marker. What remains is what the workflow is: sources,
-    chains, a budget. Everything decidable from the config alone is refused here, before a single
-    byte is read.
+    Sources, chains, a budget: the workflow reads :class:`DataSources` alone, its engine being
+    :class:`~konfai.data.materialize.CaseMaterializer` over the managers, never a DataLoader. So no
+    patch (the planner cuts slabs, never the user), no batch, no validation split, no shuffle, and
+    no ``augmentations`` section: a draw is a stage, declared IN the chain, at the place it applies,
+    after an :class:`~konfai.data.transform.Expand` marker. Everything decidable from the config
+    alone is refused here, before a single byte is read.
     """
-
-    # One pass: each case is read once, a cache is never re-read, always stream/buffer.
-    _budget_caches_when_fit = False
 
     def __init__(
         self,
@@ -1821,24 +1856,7 @@ class DataTransform(Data):
         memory_budget: str | float = "auto",
         subset: PredictionSubset = PredictionSubset(),
     ) -> None:
-        super().__init__(
-            dataset_filenames=dataset_filenames,
-            groups_src=groups_src,
-            patch=None,
-            use_cache=False,
-            subset=subset,
-            batch_size=1,
-            validation=None,
-            validation_augmentations=False,
-            inline_augmentations=False,
-            data_augmentations_list={},
-            # The engine is materialize(), never a DataLoader: no torch workers, no FIFO.
-            num_workers=0,
-            pin_memory=False,
-            prefetch_factor=None,
-            persistent_workers=False,
-            memory_budget=memory_budget,
-        )
+        super().__init__(dataset_filenames, groups_src, subset, memory_budget)
         #: The run's seed, set by the workflow before :meth:`prepare`. Stamped onto every ``Expand``
         #: below, which is where the only randomness of a transform run lives.
         self.manual_seed = 0

--- a/konfai/transformer.py
+++ b/konfai/transformer.py
@@ -332,12 +332,6 @@ class Transformer(DistributedObject):
         self._reductions: dict[str, CaseReduction | None] = {}
         self._planned: dict[tuple[str, str], Verdict] = {}
 
-    def _managers(self) -> dict[str, list[DatasetManager]]:
-        prepared = self.dataset._prepared_data
-        if prepared is None:
-            raise TransformerError("The dataset was not prepared before planning.")
-        return prepared
-
     def _group_src_of(self, group_dest: str) -> str:
         for group_src in self.dataset.groups_src:
             if group_dest in self.dataset.groups_src[group_src]:
@@ -410,7 +404,7 @@ class Transformer(DistributedObject):
         if self._items is not None:
             return self._items
         items: list[WorkItem] = []
-        for group_dest, managers in self._managers().items():
+        for group_dest, managers in self.dataset.managers.items():
             if not managers:
                 continue
             group_src = self._group_src_of(group_dest)
@@ -537,7 +531,7 @@ class Transformer(DistributedObject):
         finds it without parsing the plan or re-reading the config.
         """
         destinations: list[dict[str, str]] = []
-        for group_dest, managers in self._managers().items():
+        for group_dest, managers in self.dataset.managers.items():
             if not managers:
                 continue
             destination, group = self._terminal_destination(managers[0])
@@ -703,7 +697,7 @@ class Transformer(DistributedObject):
             if item.kind == "case" and planned[0].verdict is Verdict.STREAM and item.engine.sub_cap_sweep():
                 sub_cap_sweeps = True
         dropped: dict[str, int] = {}
-        kept = set(self.dataset._prepared_train_names)
+        kept = set(self.dataset.case_names)
         for group_src in self.dataset.groups_src:
             available: set[str] = set()
             for dataset in self.dataset.datasets.values():
@@ -735,7 +729,7 @@ class Transformer(DistributedObject):
         """The notes the plan prints beside its lines: the workflow's own, then what the stages ask
         (``Transform.plan_note``), in chain order, each distinct one once."""
         notes: list[str] = [self._SUB_CAP_NOTE] if sub_cap_sweeps else []
-        for group_dest, managers in self._managers().items():
+        for group_dest, managers in self.dataset.managers.items():
             for manager in managers:
                 for note in CaseMaterializer(manager).plan_notes(group_dest):
                     if note not in notes:
@@ -780,7 +774,7 @@ class Transformer(DistributedObject):
         """Multi-rank runs refuse a single-file Save destination before anything is written."""
         if world_size <= 1:
             return
-        for managers in self._managers().values():
+        for managers in self.dataset.managers.values():
             for transform in managers[0].transforms if managers else []:
                 if not isinstance(transform, Save):
                     continue
@@ -835,7 +829,7 @@ class Transformer(DistributedObject):
             )
         if plan.refused_entries:
             first = plan.refused_entries[0]
-            reduction = self._reduction(first.group_dest, self._managers().get(first.group_dest, []))
+            reduction = self._reduction(first.group_dest, self.dataset.managers.get(first.group_dest, []))
             # A grid disagreement gets its own remedy: a Save changes nothing about the grids, so
             # the generic advice would send the reader in a circle.
             remedy = (

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -714,9 +714,9 @@ def ome_zarr_attributes(metadata: dict[str, Any]) -> Attribute:
 
     THE SIDECAR DESCRIBES ONE LEVEL: the one the writer was handed, and it writes the finest. Every
     level of a pyramid carries its own scale and translation, so a sidecar taken at its word on a
-    coarser level put level 0's spacing and origin on level 1's voxels: a brain four times smaller,
-    read by anything that asks for ``@1``. The sidecar is therefore trusted for Spacing and Origin
-    only where its Spacing IS this level's scale; on any other level those two come from the level's
+    coarser level put level 0's spacing and origin on level 1's voxels: half the extent along every
+    axis, a brain that reads at half its size for anything that asks for ``@1``. The sidecar is
+    therefore trusted for Spacing and Origin only where its Spacing IS this level's scale; on any other level those two come from the level's
     own transforms, and the sidecar still supplies what NGFF cannot: the Direction, and every other
     key it recorded.
     """
@@ -1900,11 +1900,16 @@ class Dataset:
                 # Reverse the spatial size for every rank (see the module-level get_infos).
                 size = list(reversed(file_reader.GetSize()))
                 size = [file_reader.GetNumberOfComponents(), *size]
-            elif path is not None and path.endswith(".npy"):
-                size = list(np.load(path, mmap_mode="r").shape)  # the header alone, no page of the map
             else:
-                data, attributes = self.file_to_data(group if group is not None else "", name)
-                size = list(data.shape)
+                size = None
+                if path is not None and path.endswith(".npy"):
+                    try:
+                        size = list(np.load(path, mmap_mode="r").shape)  # the header alone, no page of the map
+                    except ValueError:
+                        size = None  # an object array cannot be mapped: the full read answers for it
+                if size is None:
+                    data, attributes = self.file_to_data(group if group is not None else "", name)
+                    size = list(data.shape)
             return size, attributes
 
     class OmeZarrFile(AbstractFile):

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -1325,15 +1325,6 @@ class Dataset:
             return False
 
         @abstractmethod
-        def file_to_data_statistics(
-            self,
-            group: str,
-            name: str,
-            channels: list[int] | None = None,
-        ) -> dict[str, Any]:
-            pass
-
-        @abstractmethod
         def data_to_file(
             self,
             name: str,
@@ -1444,30 +1435,6 @@ class Dataset:
             dataset = self._get_dataset(groups, name)
             data = np.asarray(dataset[slices])
             return data, Attribute(dict(dataset.attrs))
-
-        def file_to_data_statistics(
-            self,
-            groups: str,
-            name: str,
-            channels: list[int] | None = None,
-        ) -> dict[str, Any]:
-            dataset = self._get_dataset(groups, name)
-            if dataset is None:
-                raise NameError(f"Dataset '{groups}/{name}' not found in '{self.filename}'.")
-
-            axis = 1 if dataset.ndim > 1 else 0
-            chunk_length = _statistics_chunk_length(dataset.shape, axis)
-            state: dict[str, Any] | None = None
-
-            for start in range(0, dataset.shape[axis], chunk_length):
-                slices = [slice(None)] * dataset.ndim
-                slices[axis] = slice(start, min(dataset.shape[axis], start + chunk_length))
-                chunk = np.asarray(dataset[tuple(slices)])
-                if channels is not None:
-                    chunk = chunk[channels]
-                state = _update_running_statistics(state, chunk)
-
-            return _finalize_running_statistics(state)
 
         def data_to_file(
             self,
@@ -1712,25 +1679,6 @@ class Dataset:
             attributes["Origin"] = origin + direction @ (np.asarray(extract_index_xyz, dtype=np.float64) * spacing)
             return data[normalized[:1] + tuple(slice(None) for _ in normalized[1:])], attributes
 
-        def _file_to_image_statistics(self, name: str, path: str, channels: list[int] | None) -> dict[str, float]:
-            reader = sitk.ImageFileReader()
-            reader.SetFileName(path)
-            reader.ReadImageInformation()
-            data_shape = [reader.GetNumberOfComponents(), *reversed(reader.GetSize())]
-
-            slab_length = _statistics_chunk_length(data_shape, 1)
-            state: dict[str, Any] | None = None
-
-            for start in range(0, data_shape[1], slab_length):
-                slices: list[slice] = [slice(None)] * len(data_shape)
-                slices[1] = slice(start, min(data_shape[1], start + slab_length))
-                slab, _ = self._file_to_image_slice(name, path, tuple(slices))
-                if channels is not None:
-                    slab = slab[channels]
-                state = _update_running_statistics(state, slab)
-
-            return _finalize_running_statistics(state)
-
         def file_to_data(self, group: str, name: str) -> tuple[np.ndarray, Attribute]:
             path = self._resolve_data_path(name)
             if path is None:
@@ -1794,43 +1742,6 @@ class Dataset:
             if path.endswith(".npy"):
                 return True  # np.load(mmap) reads the slice off the map
             return not path.endswith((".itk.txt", ".fcsv", ".xml", ".vtk")) and self._supports_region_read(path)
-
-        def file_to_data_statistics(
-            self,
-            group: str,
-            name: str,
-            channels: list[int] | None = None,
-        ) -> dict[str, Any]:
-            path = self._resolve_data_path(name)
-            if path is None:
-                raise NameError(f"Data '{name}' not found in dataset '{self.filename}'.")
-
-            if path.endswith(".npy"):
-                data = np.load(path, mmap_mode="r")
-                if channels is not None:
-                    data = data[channels]
-                return _finalize_running_statistics(_update_running_statistics(None, data))
-
-            if path.endswith((".itk.txt", ".fcsv", ".xml", ".vtk")):
-                data, _ = self.file_to_data(group, name)
-                if channels is not None:
-                    data = data[channels]
-                return _finalize_running_statistics(_update_running_statistics(None, data))
-
-            if self._supports_region_read(path):
-                return self._file_to_image_statistics(name, path, channels)
-
-            # The whole volume lands in memory here, which the streamed path above exists to avoid. Nothing
-            # better is left: a format that cannot serve a region would decode itself once per slab.
-            image = sitk.ReadImage(path)
-            data = sitk.GetArrayViewFromImage(image)
-            if image.GetNumberOfComponentsPerPixel() == 1:
-                data = np.expand_dims(data, 0)
-            else:
-                data = np.transpose(data, (len(data.shape) - 1, *list(range(len(data.shape) - 1))))
-            if channels is not None:
-                data = data[channels]
-            return _finalize_running_statistics(_update_running_statistics(None, data))
 
         def is_vtk_polydata(self, obj) -> bool:
             try:
@@ -2056,24 +1967,6 @@ class Dataset:
             del name
             return True  # zarr is chunked: a slice reads its chunks and nothing else
 
-        def file_to_data_statistics(
-            self,
-            group: str,
-            name: str,
-            channels: list[int] | None = None,
-        ) -> dict[str, Any]:
-            shape, _ = self.get_infos(group, name)
-            chunk_length = _statistics_chunk_length(shape, 1)
-            state: dict[str, Any] | None = None
-            for start in range(0, shape[1], chunk_length):
-                slices = [slice(None)] * len(shape)
-                slices[1] = slice(start, min(shape[1], start + chunk_length))
-                chunk, _ = self.file_to_data_slice(group, name, tuple(slices))
-                if channels is not None:
-                    chunk = chunk[channels]
-                state = _update_running_statistics(state, chunk)
-            return _finalize_running_statistics(state)
-
         def data_to_file(
             self,
             name: str,
@@ -2258,30 +2151,6 @@ class Dataset:
             info.update(origin=origin, spacing=spacing, direction=direction)
             return data, self._attributes(info)
 
-        def file_to_data_statistics(
-            self,
-            group: str,
-            name: str,
-            channels: list[int] | None = None,
-        ) -> dict[str, Any]:
-            from konfai.utils.dicom import get_dicom_info, read_dicom_series_slice
-
-            path = self._path(name)
-            info = get_dicom_info(path)
-            shape = info["shape"]
-            state: dict[str, Any] | None = None
-            for index in range(shape[1]):
-                chunk, _, _, _ = read_dicom_series_slice(
-                    path,
-                    (slice(None), slice(index, index + 1), slice(None), slice(None)),
-                    series_uid=info["series_uid"],
-                    info=info,
-                )
-                if channels is not None:
-                    chunk = chunk[channels]
-                state = _update_running_statistics(state, chunk)
-            return _finalize_running_statistics(state)
-
         def data_to_file(
             self,
             name: str,
@@ -2422,17 +2291,6 @@ class Dataset:
                 np.asarray(block[(slices[0], slice(None, None, leading[2]), *slices[2:])], dtype=np.float32),
                 attributes,
             )
-
-        def file_to_data_statistics(
-            self,
-            group: str,
-            name: str,
-            channels: list[int] | None = None,
-        ) -> dict[str, Any]:
-            data, _attributes = self.file_to_data(group, name)
-            if channels is not None:
-                data = data[channels]
-            return _finalize_running_statistics(_update_running_statistics(None, data))
 
         def data_to_file(
             self,
@@ -2803,10 +2661,10 @@ class Dataset:
     def iter_data_blocks(self, groups: str, name: str) -> Callable[[], Iterator[np.ndarray]]:
         """A factory of passes over one entry, block by block along the first spatial axis, each
         block about ``_STATISTICS_CHUNK_ELEMENTS`` elements: what a scan that must never hold the
-        volume iterates. A store that cannot serve bounded region reads (gzipped NIfTI, compressed
-        MetaImage) is read whole ONCE and kept for every pass the factory serves: decoding it once
-        per block would cost more than holding it, and holding it once is what such a store costs
-        anyway (the same policy as ``read_data_statistics``)."""
+        volume iterates (the statistics fold, the quantile scan). A store that cannot serve bounded
+        region reads (gzipped NIfTI, compressed MetaImage) is read whole ONCE and kept for every
+        pass the factory serves: decoding it once per block would cost more than holding it, and
+        holding it once is what such a store costs anyway."""
         shape, _ = self.get_infos(groups, name)
         if len(shape) < 2 or not self.bounded_region_reads(groups, name):
             resident: list[np.ndarray] = []
@@ -2860,9 +2718,12 @@ class Dataset:
         name: str,
         channels: list[int] | None = None,
     ) -> dict[str, Any]:
-        return self._resolve_entry(
-            groups, name, lambda file, group, entry: file.file_to_data_statistics(group, entry, channels)
-        )
+        """Min/max/mean/std of one entry, over the volume and per channel (``channels`` restricts
+        both to those), folded over :meth:`iter_data_blocks`: the volume is never held."""
+        state = None
+        for block in self.iter_data_blocks(groups, name)():
+            state = _update_running_statistics(state, block if channels is None else block[channels])
+        return _finalize_running_statistics(state)
 
     def read_transform(self, group: str, name: str) -> sitk.Transform:
         if not self.exists_on_disk():

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -2686,8 +2686,11 @@ class Dataset:
         block about ``_STATISTICS_CHUNK_ELEMENTS`` elements: what a scan that must never hold the
         volume iterates (the statistics fold, the quantile scan). A store that cannot serve bounded
         region reads (gzipped NIfTI, compressed MetaImage) is read whole ONCE and kept for every
-        pass the factory serves: decoding it once per block would cost more than holding it, and
-        holding it once is what such a store costs anyway."""
+        pass the factory serves: those formats have no bounded reader to use instead, a block read
+        decodes the whole volume anyway, so reading per block would hold the same peak N times over.
+        This is the declared whole-volume route, not a way around the streaming invariant: a case
+        that needs it plans as LOAD, and the plan refuses it when the volume does not fit the
+        budget, before a byte is written."""
         shape, _ = self.get_infos(groups, name)
         if len(shape) < 2 or not self.bounded_region_reads(groups, name):
             resident: list[np.ndarray] = []

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -695,16 +695,37 @@ def ome_zarr_attributes(metadata: dict[str, Any]) -> Attribute:
     scale/translation cannot express) otherwise geometry falls back to the NGFF transforms, Direction
     defaulting to identity. Shared by the Dataset OME-Zarr reader and ``ITK.read_displacement_field``
     so both recover geometry the one same way.
+
+    THE SIDECAR DESCRIBES ONE LEVEL: the one the writer was handed, and it writes the finest. Every
+    level of a pyramid carries its own scale and translation, so a sidecar taken at its word on a
+    coarser level put level 0's spacing and origin on level 1's voxels: a brain four times smaller,
+    read by anything that asks for ``@1``. The sidecar is therefore trusted for Spacing and Origin
+    only where its Spacing IS this level's scale; on any other level those two come from the level's
+    own transforms, and the sidecar still supplies what NGFF cannot: the Direction, and every other
+    key it recorded.
     """
     attributes = Attribute(metadata.get("attributes", {}))
     axes = metadata["axes"]
     scale = dict(zip(axes, metadata.get("scale", []), strict=False))
     translation = dict(zip(axes, metadata.get("translation", []), strict=False))
     spatial_axes = [axis for axis in ("x", "y", "z") if axis in axes]
+    level_spacing = np.asarray([scale.get(axis, 1.0) for axis in spatial_axes])
+    level_origin = np.asarray([translation.get(axis, 0.0) for axis in spatial_axes])
+    if "Spacing" in attributes:
+        recorded = attributes.get_np_array("Spacing")
+        if recorded.shape != level_spacing.shape or not np.allclose(recorded, level_spacing, rtol=1e-6, atol=0.0):
+            # Another level than the one the sidecar was written for: its own geometry, not the
+            # sidecar's. Popped then set, so the key keeps its place in the stack rather than
+            # gaining a rung that a later write would record twice.
+            attributes.pop("Spacing")
+            attributes["Spacing"] = level_spacing
+            if "Origin" in attributes:
+                attributes.pop("Origin")
+            attributes["Origin"] = level_origin
     if "Spacing" not in attributes:
-        attributes["Spacing"] = np.asarray([scale.get(axis, 1.0) for axis in spatial_axes])
+        attributes["Spacing"] = level_spacing
     if "Origin" not in attributes:
-        attributes["Origin"] = np.asarray([translation.get(axis, 0.0) for axis in spatial_axes])
+        attributes["Origin"] = level_origin
     if "Direction" not in attributes:
         attributes["Direction"] = np.eye(len(spatial_axes), dtype=np.float64).flatten()
     attributes["OMEAxes"] = np.asarray(axes)

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -345,18 +345,34 @@ class Attribute(dict[str, Any]):
         return key in self and self[key] == value
 
 
-# Elements held in memory at once while accumulating statistics chunk by chunk, whatever the backend.
+#: Elements a block of ``Dataset.iter_data_blocks`` holds: the read grain of a scan (the statistics
+#: fold, the quantile scan), whatever the backend.
 _STATISTICS_CHUNK_ELEMENTS = 8_000_000
+#: Elements one running-statistics update takes at once: its float64 temporaries then stay in cache,
+#: where a whole block's stream through memory. Below the block on purpose: the block is the READ
+#: grain, and a chunked store decodes a chunk once per read that touches it.
+_STATISTICS_UPDATE_ELEMENTS = 1 << 18
 
 
-def _statistics_chunk_length(shape: list[int] | tuple[int, ...], axis: int) -> int:
-    """How far along ``axis`` a chunk may reach to hold about ``_STATISTICS_CHUNK_ELEMENTS``.
+def _statistics_chunk_length(shape: list[int] | tuple[int, ...], axis: int, budget: int) -> int:
+    """How far along ``axis`` a chunk may reach to hold about ``budget`` elements.
 
     A chunk spans every other axis whole (channels included), so the per-step cost is the volume
     divided by ``axis``; the length is that budget over the per-step cost, floored to one step.
     """
     per_step = int(np.prod([extent for other, extent in enumerate(shape) if other != axis], dtype=np.int64))
-    return max(1, _STATISTICS_CHUNK_ELEMENTS // max(1, per_step))
+    return max(1, budget // max(1, per_step))
+
+
+def _update_pieces(block: np.ndarray) -> Iterator[np.ndarray]:
+    """``block`` in pieces of about ``_STATISTICS_UPDATE_ELEMENTS`` along its first spatial axis, one
+    running-statistics update each; a vector is one piece."""
+    if block.ndim < 2:
+        yield block
+        return
+    rows = _statistics_chunk_length(block.shape, 1, _STATISTICS_UPDATE_ELEMENTS)
+    for start in range(0, block.shape[1], rows):
+        yield block[:, start : start + rows]
 
 
 #: Values a quantile scan collects at once when a bin has narrowed this far: the one buffer it holds.
@@ -2677,7 +2693,7 @@ class Dataset:
                 yield resident[0]
 
             return whole
-        rows = _statistics_chunk_length(shape, 1)
+        rows = _statistics_chunk_length(shape, 1, _STATISTICS_CHUNK_ELEMENTS)
 
         def slabs() -> Iterator[np.ndarray]:
             for start in range(0, int(shape[1]), rows):
@@ -2724,7 +2740,8 @@ class Dataset:
         both to those), folded over :meth:`iter_data_blocks`: the volume is never held."""
         state = None
         for block in self.iter_data_blocks(groups, name)():
-            state = _update_running_statistics(state, block if channels is None else block[channels])
+            for piece in _update_pieces(block if channels is None else block[channels]):
+                state = _update_running_statistics(state, piece)
         return _finalize_running_statistics(state)
 
     def read_transform(self, group: str, name: str) -> sitk.Transform:

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -1884,6 +1884,8 @@ class Dataset:
                 # Reverse the spatial size for every rank (see the module-level get_infos).
                 size = list(reversed(file_reader.GetSize()))
                 size = [file_reader.GetNumberOfComponents(), *size]
+            elif path is not None and path.endswith(".npy"):
+                size = list(np.load(path, mmap_mode="r").shape)  # the header alone, no page of the map
             else:
                 data, attributes = self.file_to_data(group if group is not None else "", name)
                 size = list(data.shape)

--- a/tests/unit/test_data_manager.py
+++ b/tests/unit/test_data_manager.py
@@ -166,8 +166,8 @@ data._resolve_common_names = lambda datasets: ({}, set(names))
 data._get_datasets = lambda case_names, dataset_name, augmentations, index_offset=0: ({}, [])
 random.seed(1234)
 data._prepare_datasets()
-print(";".join(data._prepared_train_names))
-print(";".join(data._prepared_validation_names))
+print(";".join(data.case_names))
+print(";".join(data._validation_names))
 """
 
 
@@ -210,8 +210,8 @@ def test_train_split_shuffle_draws_from_sorted_names(monkeypatch):
     data._prepare_datasets()
 
     assert captured["population"] == sorted(names)
-    assert data._prepared_validation_names == ["CASE_010", "CASE_005"]
-    assert data._prepared_train_names == ["CASE_003", "CASE_002", "CASE_001"]
+    assert data._validation_names == ["CASE_010", "CASE_005"]
+    assert data.case_names == ["CASE_003", "CASE_002", "CASE_001"]
 
 
 def test_data_train_validation_accepts_mixed_case_names_and_case_files(tmp_path: Path) -> None:
@@ -279,10 +279,10 @@ def test_data_train_prepare_skips_validation_augmentation_layout_when_disabled(t
 
     dataset.prepare()
 
-    assert dataset._prepared_data is not None
-    assert dataset._prepared_validation_data is not None
-    assert dataset._prepared_data["CT"][0].total_augmentations == 1
-    assert dataset._prepared_validation_data["CT"][0].total_augmentations == 0
+    assert dataset.managers is not None
+    assert dataset._validation_managers is not None
+    assert dataset.managers["CT"][0].total_augmentations == 1
+    assert dataset._validation_managers["CT"][0].total_augmentations == 0
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -419,7 +419,7 @@ def test_a_statistics_chunk_is_budgeted_with_its_channels() -> None:
 
     for channels in (1, 4, 122):
         shape = [channels, 400, 512, 512]
-        length = _statistics_chunk_length(shape, axis=1)
+        length = _statistics_chunk_length(shape, axis=1, budget=_STATISTICS_CHUNK_ELEMENTS)
         held = channels * length * 512 * 512
         # One step is the floor, so a volume whose step alone overflows is read a step at a time.
         assert held <= max(_STATISTICS_CHUNK_ELEMENTS, channels * 512 * 512)
@@ -428,7 +428,8 @@ def test_a_statistics_chunk_is_budgeted_with_its_channels() -> None:
 def test_a_statistics_chunk_reaches_further_on_a_thin_volume() -> None:
     from konfai.utils.dataset import _statistics_chunk_length
 
-    assert _statistics_chunk_length([1, 400, 64, 64], axis=1) > _statistics_chunk_length([1, 400, 512, 512], axis=1)
+    thin, wide = [1, 400, 64, 64], [1, 400, 512, 512]
+    assert _statistics_chunk_length(thin, 1, budget=1 << 20) > _statistics_chunk_length(wide, 1, budget=1 << 20)
 
 
 def test_directory_store_detects_extensionless_dicom(tmp_path: Path) -> None:

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -494,6 +494,24 @@ def test_get_infos_reads_only_the_header_for_a_mismatched_extension(tmp_path: Pa
     assert np.allclose(attributes.get_np_array("Spacing"), [1.5, 1.5, 2.0])
 
 
+def test_get_infos_reads_a_npy_header_off_the_map(tmp_path: Path, monkeypatch) -> None:
+    """A ``.npy`` entry answers its shape from the header: the statistics fold and the plan ask for it
+    before any block, and a whole load there is the volume in memory the fold exists to avoid."""
+    root = tmp_path / "Dataset" / "case"
+    root.mkdir(parents=True)
+    np.save(root / "params.npy", np.arange(2 * 3 * 4 * 5, dtype=np.float32).reshape(2, 3, 4, 5))
+    original = np.load
+
+    def mapped_only(path, *args, **kwargs):
+        assert kwargs.get("mmap_mode") == "r", "a .npy is never loaded whole for its header"
+        return original(path, *args, **kwargs)
+
+    monkeypatch.setattr(np, "load", mapped_only)
+    dataset = Dataset(str(tmp_path / "Dataset"), "mha")
+    assert dataset.get_infos("params", "case")[0] == [2, 3, 4, 5]
+    assert dataset.read_data_statistics("params", "case")["max"] == 119.0
+
+
 def test_a_group_written_through_another_dataset_object_is_seen(tmp_path: Path) -> None:
     """A group can be produced through one Dataset and read through another over the same folder: a
     ``Save`` builds its own (``Save.destination``) while the reader keeps the DataManager's.

--- a/tests/unit/test_dataset_statistics.py
+++ b/tests/unit/test_dataset_statistics.py
@@ -1,0 +1,314 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""``Dataset.read_data_statistics`` is one fold over ``iter_data_blocks``, whatever the backend.
+
+Each backend used to own its walk (slabs, slices, or the whole volume); those walks are recopied
+here as oracles, and the fold is held against them key by key, next to numpy in float64 on the
+whole volume. Welford in floating point is not associative: a backend whose blocks are the ones it
+walked before folds to the same bits, a backend regrouped by the fold to within a few ulp."""
+
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from konfai.utils import dataset as dataset_module
+from konfai.utils.dataset import (
+    Dataset,
+    _finalize_running_statistics,
+    _statistics_chunk_length,
+    _update_running_statistics,
+)
+
+sitk = pytest.importorskip("SimpleITK")
+
+_KEYS = ("min", "max", "mean", "std", "min_per_channel", "max_per_channel", "mean_per_channel", "std_per_channel")
+
+
+def _volume(shape: tuple[int, ...], seed: int = 0, dtype: type = np.float32) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return (rng.random(shape, dtype=np.float32) * 300.0 - 100.0).astype(dtype)
+
+
+def _numpy_reference(volume: np.ndarray) -> dict[str, Any]:
+    values = np.asarray(volume, dtype=np.float64)
+    per_channel = values.reshape(values.shape[0], -1)
+    return {
+        "min": float(values.min()),
+        "max": float(values.max()),
+        "mean": float(values.mean()),
+        "std": float(values.std(ddof=1)),
+        "min_per_channel": per_channel.min(axis=1).tolist(),
+        "max_per_channel": per_channel.max(axis=1).tolist(),
+        "mean_per_channel": per_channel.mean(axis=1).tolist(),
+        "std_per_channel": per_channel.std(axis=1, ddof=1).tolist(),
+    }
+
+
+def _former_walk(chunks: Iterator[np.ndarray], channels: list[int] | None = None) -> dict[str, Any]:
+    """What every backend's ``file_to_data_statistics`` did around its own chunks."""
+    state = None
+    for chunk in chunks:
+        state = _update_running_statistics(state, chunk if channels is None else chunk[channels])
+    return _finalize_running_statistics(state)
+
+
+def _assert_same_bits(new: dict[str, Any], old: dict[str, Any]) -> None:
+    for key in _KEYS:
+        assert np.array_equal(np.asarray(new[key]), np.asarray(old[key])), key
+
+
+def _assert_within_ulps(new: dict[str, Any], old: dict[str, Any], ulps: int = 64) -> None:
+    for key in _KEYS:
+        a, b = np.asarray(new[key], dtype=np.float64), np.asarray(old[key], dtype=np.float64)
+        assert np.all(np.abs(a - b) <= ulps * np.spacing(np.maximum(np.abs(a), np.abs(b)))), (key, a, b)
+
+
+def _assert_close_to_numpy(new: dict[str, Any], volume: np.ndarray) -> None:
+    reference = _numpy_reference(volume)
+    for key in _KEYS:
+        np.testing.assert_allclose(new[key], reference[key], rtol=1e-10, atol=0, err_msg=key)
+
+
+@pytest.fixture
+def small_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Blocks of about a thousand elements: several per volume, so the fold's merges are exercised."""
+    monkeypatch.setattr(dataset_module, "_STATISTICS_CHUNK_ELEMENTS", 1000)
+
+
+def _former_h5_walk(path: Path, group: str, name: str) -> Iterator[np.ndarray]:
+    """Chunks along axis 1 (axis 0 for a vector), the dataset held open across them."""
+    with dataset_module._open_h5(str(path), "r") as file:  # the pool's handle is unlocked: agree with it
+        dataset = file[group][name]
+        axis = 1 if dataset.ndim > 1 else 0
+        length = _statistics_chunk_length(dataset.shape, axis)
+        for start in range(0, dataset.shape[axis], length):
+            slices = [slice(None)] * dataset.ndim
+            slices[axis] = slice(start, min(dataset.shape[axis], start + length))
+            yield np.asarray(dataset[tuple(slices)])
+
+
+@pytest.mark.parametrize("channels", [None, [1]])
+def test_h5_folds_to_the_bits_of_its_former_walk(
+    tmp_path: Path, image_attributes, small_blocks: None, channels: list[int] | None
+) -> None:
+    pytest.importorskip("h5py")
+    volume = _volume((2, 37, 12, 10))
+    dataset = Dataset(tmp_path / "store", "h5")
+    dataset.write("CT", "P0", volume, image_attributes([0.0, 0.0, 0.0], [1.0, 1.0, 1.0]))
+
+    got = dataset.read_data_statistics("CT", "P0", channels)
+
+    _assert_same_bits(got, _former_walk(_former_h5_walk(tmp_path / "store.h5", "CT", "P0"), channels))
+    _assert_close_to_numpy(got, volume if channels is None else volume[channels])
+
+
+def test_a_vector_takes_the_whole_read_and_folds_to_its_former_bits(tmp_path: Path, small_blocks: None) -> None:
+    """A 1-D entry (a parameter list) has no spatial axis to walk: one block, the former one chunk."""
+    pytest.importorskip("h5py")
+    vector = _volume((50,), dtype=np.float64)
+    dataset = Dataset(tmp_path / "store", "h5")
+    dataset.write("P", "P0", vector)
+
+    got = dataset.read_data_statistics("P", "P0")
+
+    _assert_same_bits(got, _former_walk(_former_h5_walk(tmp_path / "store.h5", "P", "P0")))
+    _assert_close_to_numpy(got, vector.reshape(1, -1))
+
+
+def _former_image_slab_walk(directory: Path, name: str, group: str, extension: str) -> Iterator[np.ndarray]:
+    """``SitkFile._file_to_image_statistics``: slabs along axis 1 through ``_file_to_image_slice``."""
+    path = str(directory / name / f"{group}.{extension}")
+    reader = sitk.ImageFileReader()
+    reader.SetFileName(path)
+    reader.ReadImageInformation()
+    shape = [reader.GetNumberOfComponents(), *reversed(reader.GetSize())]
+    length = _statistics_chunk_length(shape, 1)
+    file = Dataset.SitkFile(f"{directory / name}/", True, extension)
+    for start in range(0, shape[1], length):
+        slices = [slice(None)] * len(shape)
+        slices[1] = slice(start, min(shape[1], start + length))
+        yield file._file_to_image_slice(group, path, tuple(slices))[0]
+
+
+def _former_image_whole_pass(directory: Path, name: str, group: str, extension: str) -> Iterator[np.ndarray]:
+    """The whole image, channel-first, in one chunk: what a store without region reads got."""
+    image = sitk.ReadImage(str(directory / name / f"{group}.{extension}"))
+    data = sitk.GetArrayViewFromImage(image)
+    if image.GetNumberOfComponentsPerPixel() == 1:
+        yield np.expand_dims(data, 0)
+    else:
+        yield np.transpose(data, (len(data.shape) - 1, *list(range(len(data.shape) - 1))))
+
+
+@pytest.mark.parametrize(
+    ("extension", "former"),
+    [("mha", _former_image_slab_walk), ("nii.gz", _former_image_whole_pass)],
+    ids=["region reads", "whole read"],
+)
+@pytest.mark.parametrize("channels", [None, [1]])
+def test_an_image_folds_to_the_bits_of_its_former_pass(
+    tmp_path: Path,
+    image_attributes,
+    small_blocks: None,
+    extension: str,
+    former: Callable[..., Iterator[np.ndarray]],
+    channels: list[int] | None,
+) -> None:
+    volume = _volume((2, 37, 12, 10))
+    dataset = Dataset(tmp_path / "store", extension)
+    dataset.write("CT", "P0", volume, image_attributes([0.0, 0.0, 0.0], [1.0, 1.0, 1.0]))
+    assert dataset.bounded_region_reads("CT", "P0") is (extension == "mha")
+
+    got = dataset.read_data_statistics("CT", "P0", channels)
+
+    _assert_same_bits(got, _former_walk(former(tmp_path / "store", "P0", "CT", extension), channels))
+    _assert_close_to_numpy(got, volume if channels is None else volume[channels])
+
+
+def test_parameter_rows_take_the_whole_read_and_fold_to_their_former_bits(tmp_path: Path, small_blocks: None) -> None:
+    """An ``.itk.txt`` entry is 2-D (one row per transform), but not an image: no region reads."""
+    transform = sitk.AffineTransform(3)
+    transform.SetParameters(tuple(_volume((12,), dtype=np.float64)))
+    dataset = Dataset(tmp_path / "store", "mha")
+    dataset.write("T", "P0", transform)
+    assert not dataset.bounded_region_reads("T", "P0")
+
+    got = dataset.read_data_statistics("T", "P0")
+
+    rows = Dataset.SitkFile(f"{tmp_path / 'store' / 'P0'}/", True, "mha").file_to_data("", "T")[0]
+    _assert_same_bits(got, _former_walk(iter([rows])))
+    _assert_close_to_numpy(got, rows)
+
+
+def test_a_npy_folds_within_ulps_of_its_former_whole_pass(tmp_path: Path, small_blocks: None) -> None:
+    """The former pass ran on the whole map in one update; the fold reads it slab by slab off the map."""
+    volume = _volume((2, 37, 12, 10), dtype=np.float64)
+    dataset = Dataset(tmp_path / "store", "mha")
+    dataset.write("CT", "P0", volume)  # no geometry: stored as CT.npy
+    assert dataset.bounded_region_reads("CT", "P0")
+
+    got = dataset.read_data_statistics("CT", "P0")
+
+    former = _former_walk(iter([np.load(tmp_path / "store" / "P0" / "CT.npy", mmap_mode="r")]))
+    _assert_within_ulps(got, former)
+    _assert_close_to_numpy(got, volume)
+
+
+def _former_zarr_walk(directory: Path, name: str, group: str) -> Iterator[np.ndarray]:
+    file = Dataset.OmeZarrFile(f"{directory / name}/", True)
+    shape, _ = file.get_infos("", group)
+    length = _statistics_chunk_length(shape, 1)
+    for start in range(0, shape[1], length):
+        slices = [slice(None)] * len(shape)
+        slices[1] = slice(start, min(shape[1], start + length))
+        yield file.file_to_data_slice("", group, tuple(slices))[0]
+
+
+@pytest.mark.parametrize("channels", [None, [1]])
+def test_an_ome_zarr_folds_to_the_bits_of_its_former_walk(
+    tmp_path: Path, image_attributes, small_blocks: None, channels: list[int] | None
+) -> None:
+    pytest.importorskip("ngff_zarr")
+    volume = _volume((2, 37, 12, 10))
+    dataset = Dataset(tmp_path / "store", "omezarr")
+    dataset.write("CT", "P0", volume, image_attributes([0.0, 0.0, 0.0], [1.0, 1.0, 1.0]))
+
+    got = dataset.read_data_statistics("CT", "P0", channels)
+
+    _assert_same_bits(got, _former_walk(_former_zarr_walk(tmp_path / "store", "P0", "CT"), channels))
+    _assert_close_to_numpy(got, volume if channels is None else volume[channels])
+
+
+def _former_dicom_slice_walk(series: Path) -> Iterator[np.ndarray]:
+    from konfai.utils.dicom import get_dicom_info, read_dicom_series_slice
+
+    info = get_dicom_info(series)
+    for index in range(info["shape"][1]):
+        yield read_dicom_series_slice(
+            series,
+            (slice(None), slice(index, index + 1), slice(None), slice(None)),
+            series_uid=info["series_uid"],
+            info=info,
+        )[0]
+
+
+def test_a_dicom_series_folds_within_ulps_of_its_former_slice_walk(
+    tmp_path: Path, image_attributes, small_blocks: None
+) -> None:
+    """The former walk read one slice at a time; the fold reads the slices a block holds at once."""
+    pytest.importorskip("pydicom")
+    volume = np.round(_volume((1, 37, 12, 10)))
+    dataset = Dataset(tmp_path / "store", "dicom")
+    dataset.write("CT", "P0", volume, image_attributes([0.0, 0.0, 0.0], [1.0, 1.0, 1.0]))
+    stored = dataset.read_data("CT", "P0")[0]  # the series stores a rescaled integer encoding
+
+    got = dataset.read_data_statistics("CT", "P0")
+
+    _assert_within_ulps(got, _former_walk(_former_dicom_slice_walk(tmp_path / "store" / "P0" / "CT")))
+    _assert_close_to_numpy(got, stored)
+
+
+def test_a_displacement_field_folds_within_ulps_of_its_former_whole_pass(
+    tmp_path: Path, image_attributes, small_blocks: None
+) -> None:
+    """The former pass decoded the field whole (float64); the fold reads it row span by row span."""
+    pytest.importorskip("h5py")
+    field = _volume((3, 37, 12, 10))
+    dataset = Dataset(tmp_path / "store", "itktransform")
+    dataset.write("Transform", "P0", field, image_attributes([0.0, 0.0, 0.0], [1.0, 1.0, 1.0]))
+    assert dataset.bounded_region_reads("Transform", "P0")
+
+    got = dataset.read_data_statistics("Transform", "P0")
+
+    whole = Dataset.ItkTransformFile(f"{tmp_path / 'store' / 'P0'}/", True).file_to_data("", "Transform")[0]
+    _assert_within_ulps(got, _former_walk(iter([whole])))
+    _assert_close_to_numpy(got, field)
+
+
+def test_the_fold_reads_a_bounded_store_by_blocks_and_never_whole(
+    tmp_path: Path, image_attributes, small_blocks: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dataset = Dataset(tmp_path / "store", "mha")
+    dataset.write("CT", "P0", _volume((1, 37, 12, 10)), image_attributes([0.0, 0.0, 0.0], [1.0, 1.0, 1.0]))
+    monkeypatch.setattr(Dataset, "read_data", lambda *_: pytest.fail("a bounded store is never read whole"))
+    blocks: list[tuple[int, ...]] = []
+    real = Dataset.read_data_slice
+
+    def counted(self: Dataset, groups: str, name: str, slices: tuple[slice, ...]) -> Any:
+        data, attributes = real(self, groups, name, slices)
+        blocks.append(data.shape)
+        return data, attributes
+
+    monkeypatch.setattr(Dataset, "read_data_slice", counted)
+    dataset.read_data_statistics("CT", "P0")
+    assert len(blocks) > 1 and all(shape[0] == 1 and shape[2:] == (12, 10) for shape in blocks)
+    assert sum(shape[1] for shape in blocks) == 37
+
+
+def test_the_fold_reads_an_unbounded_store_whole_once(
+    tmp_path: Path, image_attributes, small_blocks: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dataset = Dataset(tmp_path / "store", "nii.gz")
+    dataset.write("CT", "P0", _volume((1, 37, 12, 10)), image_attributes([0.0, 0.0, 0.0], [1.0, 1.0, 1.0]))
+    monkeypatch.setattr(Dataset, "read_data_slice", lambda *_: pytest.fail("no region read on an unbounded store"))
+    reads: list[str] = []
+    real = Dataset.read_data
+    monkeypatch.setattr(Dataset, "read_data", lambda self, g, n: reads.append(n) or real(self, g, n))
+    dataset.read_data_statistics("CT", "P0")
+    assert reads == ["P0"]

--- a/tests/unit/test_dataset_statistics.py
+++ b/tests/unit/test_dataset_statistics.py
@@ -18,8 +18,8 @@
 
 Each backend used to own its walk (slabs, slices, or the whole volume); those walks are recopied
 here as oracles, and the fold is held against them key by key, next to numpy in float64 on the
-whole volume. Welford in floating point is not associative: a backend whose blocks are the ones it
-walked before folds to the same bits, a backend regrouped by the fold to within a few ulp."""
+whole volume. Welford in floating point is not associative, and the fold merges in cache-sized
+pieces of its own, so the bound is a few ulp, whatever the backend walked before."""
 
 from collections.abc import Callable, Iterator
 from pathlib import Path
@@ -32,6 +32,7 @@ from konfai.utils.dataset import (
     Dataset,
     _finalize_running_statistics,
     _statistics_chunk_length,
+    _update_pieces,
     _update_running_statistics,
 )
 
@@ -68,11 +69,6 @@ def _former_walk(chunks: Iterator[np.ndarray], channels: list[int] | None = None
     return _finalize_running_statistics(state)
 
 
-def _assert_same_bits(new: dict[str, Any], old: dict[str, Any]) -> None:
-    for key in _KEYS:
-        assert np.array_equal(np.asarray(new[key]), np.asarray(old[key])), key
-
-
 def _assert_within_ulps(new: dict[str, Any], old: dict[str, Any], ulps: int = 64) -> None:
     for key in _KEYS:
         a, b = np.asarray(new[key], dtype=np.float64), np.asarray(old[key], dtype=np.float64)
@@ -87,8 +83,10 @@ def _assert_close_to_numpy(new: dict[str, Any], volume: np.ndarray) -> None:
 
 @pytest.fixture
 def small_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Blocks of about a thousand elements: several per volume, so the fold's merges are exercised."""
+    """Blocks of about a thousand elements, folded in pieces of about a hundred: several of each per
+    volume, so both grains of the fold are exercised."""
     monkeypatch.setattr(dataset_module, "_STATISTICS_CHUNK_ELEMENTS", 1000)
+    monkeypatch.setattr(dataset_module, "_STATISTICS_UPDATE_ELEMENTS", 100)
 
 
 def _former_h5_walk(path: Path, group: str, name: str) -> Iterator[np.ndarray]:
@@ -96,7 +94,7 @@ def _former_h5_walk(path: Path, group: str, name: str) -> Iterator[np.ndarray]:
     with dataset_module._open_h5(str(path), "r") as file:  # the pool's handle is unlocked: agree with it
         dataset = file[group][name]
         axis = 1 if dataset.ndim > 1 else 0
-        length = _statistics_chunk_length(dataset.shape, axis)
+        length = _statistics_chunk_length(dataset.shape, axis, dataset_module._STATISTICS_CHUNK_ELEMENTS)
         for start in range(0, dataset.shape[axis], length):
             slices = [slice(None)] * dataset.ndim
             slices[axis] = slice(start, min(dataset.shape[axis], start + length))
@@ -104,7 +102,7 @@ def _former_h5_walk(path: Path, group: str, name: str) -> Iterator[np.ndarray]:
 
 
 @pytest.mark.parametrize("channels", [None, [1]])
-def test_h5_folds_to_the_bits_of_its_former_walk(
+def test_h5_folds_within_ulps_of_its_former_walk(
     tmp_path: Path, image_attributes, small_blocks: None, channels: list[int] | None
 ) -> None:
     pytest.importorskip("h5py")
@@ -114,11 +112,13 @@ def test_h5_folds_to_the_bits_of_its_former_walk(
 
     got = dataset.read_data_statistics("CT", "P0", channels)
 
-    _assert_same_bits(got, _former_walk(_former_h5_walk(tmp_path / "store.h5", "CT", "P0"), channels))
+    _assert_within_ulps(got, _former_walk(_former_h5_walk(tmp_path / "store.h5", "CT", "P0"), channels))
     _assert_close_to_numpy(got, volume if channels is None else volume[channels])
 
 
-def test_a_vector_takes_the_whole_read_and_folds_to_its_former_bits(tmp_path: Path, small_blocks: None) -> None:
+def test_a_vector_takes_the_whole_read_and_folds_within_ulps_of_its_former_pass(
+    tmp_path: Path, small_blocks: None
+) -> None:
     """A 1-D entry (a parameter list) has no spatial axis to walk: one block, the former one chunk."""
     pytest.importorskip("h5py")
     vector = _volume((50,), dtype=np.float64)
@@ -127,7 +127,7 @@ def test_a_vector_takes_the_whole_read_and_folds_to_its_former_bits(tmp_path: Pa
 
     got = dataset.read_data_statistics("P", "P0")
 
-    _assert_same_bits(got, _former_walk(_former_h5_walk(tmp_path / "store.h5", "P", "P0")))
+    _assert_within_ulps(got, _former_walk(_former_h5_walk(tmp_path / "store.h5", "P", "P0")))
     _assert_close_to_numpy(got, vector.reshape(1, -1))
 
 
@@ -138,7 +138,7 @@ def _former_image_slab_walk(directory: Path, name: str, group: str, extension: s
     reader.SetFileName(path)
     reader.ReadImageInformation()
     shape = [reader.GetNumberOfComponents(), *reversed(reader.GetSize())]
-    length = _statistics_chunk_length(shape, 1)
+    length = _statistics_chunk_length(shape, 1, dataset_module._STATISTICS_CHUNK_ELEMENTS)
     file = Dataset.SitkFile(f"{directory / name}/", True, extension)
     for start in range(0, shape[1], length):
         slices = [slice(None)] * len(shape)
@@ -162,7 +162,7 @@ def _former_image_whole_pass(directory: Path, name: str, group: str, extension: 
     ids=["region reads", "whole read"],
 )
 @pytest.mark.parametrize("channels", [None, [1]])
-def test_an_image_folds_to_the_bits_of_its_former_pass(
+def test_an_image_folds_within_ulps_of_its_former_pass(
     tmp_path: Path,
     image_attributes,
     small_blocks: None,
@@ -177,11 +177,13 @@ def test_an_image_folds_to_the_bits_of_its_former_pass(
 
     got = dataset.read_data_statistics("CT", "P0", channels)
 
-    _assert_same_bits(got, _former_walk(former(tmp_path / "store", "P0", "CT", extension), channels))
+    _assert_within_ulps(got, _former_walk(former(tmp_path / "store", "P0", "CT", extension), channels))
     _assert_close_to_numpy(got, volume if channels is None else volume[channels])
 
 
-def test_parameter_rows_take_the_whole_read_and_fold_to_their_former_bits(tmp_path: Path, small_blocks: None) -> None:
+def test_parameter_rows_take_the_whole_read_and_fold_within_ulps_of_their_former_pass(
+    tmp_path: Path, small_blocks: None
+) -> None:
     """An ``.itk.txt`` entry is 2-D (one row per transform), but not an image: no region reads."""
     transform = sitk.AffineTransform(3)
     transform.SetParameters(tuple(_volume((12,), dtype=np.float64)))
@@ -192,7 +194,7 @@ def test_parameter_rows_take_the_whole_read_and_fold_to_their_former_bits(tmp_pa
     got = dataset.read_data_statistics("T", "P0")
 
     rows = Dataset.SitkFile(f"{tmp_path / 'store' / 'P0'}/", True, "mha").file_to_data("", "T")[0]
-    _assert_same_bits(got, _former_walk(iter([rows])))
+    _assert_within_ulps(got, _former_walk(iter([rows])))
     _assert_close_to_numpy(got, rows)
 
 
@@ -213,7 +215,7 @@ def test_a_npy_folds_within_ulps_of_its_former_whole_pass(tmp_path: Path, small_
 def _former_zarr_walk(directory: Path, name: str, group: str) -> Iterator[np.ndarray]:
     file = Dataset.OmeZarrFile(f"{directory / name}/", True)
     shape, _ = file.get_infos("", group)
-    length = _statistics_chunk_length(shape, 1)
+    length = _statistics_chunk_length(shape, 1, dataset_module._STATISTICS_CHUNK_ELEMENTS)
     for start in range(0, shape[1], length):
         slices = [slice(None)] * len(shape)
         slices[1] = slice(start, min(shape[1], start + length))
@@ -221,7 +223,7 @@ def _former_zarr_walk(directory: Path, name: str, group: str) -> Iterator[np.nda
 
 
 @pytest.mark.parametrize("channels", [None, [1]])
-def test_an_ome_zarr_folds_to_the_bits_of_its_former_walk(
+def test_an_ome_zarr_folds_within_ulps_of_its_former_walk(
     tmp_path: Path, image_attributes, small_blocks: None, channels: list[int] | None
 ) -> None:
     pytest.importorskip("ngff_zarr")
@@ -231,7 +233,7 @@ def test_an_ome_zarr_folds_to_the_bits_of_its_former_walk(
 
     got = dataset.read_data_statistics("CT", "P0", channels)
 
-    _assert_same_bits(got, _former_walk(_former_zarr_walk(tmp_path / "store", "P0", "CT"), channels))
+    _assert_within_ulps(got, _former_walk(_former_zarr_walk(tmp_path / "store", "P0", "CT"), channels))
     _assert_close_to_numpy(got, volume if channels is None else volume[channels])
 
 
@@ -312,3 +314,14 @@ def test_the_fold_reads_an_unbounded_store_whole_once(
     monkeypatch.setattr(Dataset, "read_data", lambda self, g, n: reads.append(n) or real(self, g, n))
     dataset.read_data_statistics("CT", "P0")
     assert reads == ["P0"]
+
+
+def test_a_block_is_folded_in_pieces_along_its_first_spatial_axis(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dataset_module, "_STATISTICS_UPDATE_ELEMENTS", 500)
+    block = _volume((2, 37, 12, 10))
+    pieces = list(_update_pieces(block))
+    assert [piece.shape for piece in pieces] == [(2, 2, 12, 10)] * 18 + [(2, 1, 12, 10)]  # 500 // 240 rows each
+    np.testing.assert_array_equal(np.concatenate(pieces, axis=1), block)
+    assert all(np.shares_memory(piece, block) for piece in pieces)
+    vector = _volume((50,))
+    assert [piece.shape for piece in _update_pieces(vector)] == [(50,)]

--- a/tests/unit/test_memory_budget.py
+++ b/tests/unit/test_memory_budget.py
@@ -217,10 +217,10 @@ def _make_train(memory_budget: str | float | None) -> DataTrain:
     """A DataTrain with an injected, header-free prepared dataset (no disk, no config file)."""
     data = DataTrain(augmentations=None, memory_budget=memory_budget)
     managers = {group: [SimpleNamespace(base_shape=list(_GROUP_SHAPE)) for _ in _CASES] for group in ("CT", "SEG")}
-    data._prepared_data = managers  # type: ignore[assignment]
-    data._prepared_validation_data = {}
-    data._prepared_train_names = list(_CASES)
-    data._prepared_validation_names = []
+    data._managers = managers  # type: ignore[assignment]
+    data._validation_managers = {}
+    data.case_names = list(_CASES)
+    data._validation_names = []
     return data
 
 
@@ -240,10 +240,10 @@ def test_estimate_counts_one_copy_per_augmentation_draw() -> None:
         validation=None,
     )
     managers = {group: [SimpleNamespace(base_shape=list(_GROUP_SHAPE)) for _ in _CASES] for group in ("CT", "SEG")}
-    data._prepared_data = managers  # type: ignore[assignment]
-    data._prepared_validation_data = {}
-    data._prepared_train_names = list(_CASES)
-    data._prepared_validation_names = []
+    data._managers = managers  # type: ignore[assignment]
+    data._validation_managers = {}
+    data.case_names = list(_CASES)
+    data._validation_names = []
 
     # 1 base copy + 4 draws.
     assert data._estimate_cached_bytes() == 5 * _DATASET_BYTES
@@ -288,10 +288,10 @@ def test_one_pass_workflows_never_cache_whatever_the_budget() -> None:
         DataPrediction(augmentations=None, memory_budget=f"{_DATASET_BYTES * 100}b"),
         DataMetric(memory_budget=f"{_DATASET_BYTES * 100}b"),
     ):
-        data._prepared_data = {"CT": [SimpleNamespace(base_shape=[1, 2, 2, 2])]}  # type: ignore[assignment]
-        data._prepared_validation_data = {}
-        data._prepared_train_names = ["case_a"]
-        data._prepared_validation_names = []
+        data._managers = {"CT": [SimpleNamespace(base_shape=[1, 2, 2, 2])]}  # type: ignore[assignment]
+        data._validation_managers = {}
+        data.case_names = ["case_a"]
+        data._validation_names = []
         data._resolve_cache_regime(world_size=1)
         assert data.use_cache is False, type(data).__name__
 

--- a/tests/unit/test_ome_zarr_data_surface.py
+++ b/tests/unit/test_ome_zarr_data_surface.py
@@ -144,9 +144,12 @@ def test_a_coarser_level_reads_its_own_geometry_not_the_sidecars(tmp_path: Path)
     # still comes from the sidecar.
     np.testing.assert_allclose(coarse.get_np_array("Spacing"), [4.0, 2.0, 2.0])
     np.testing.assert_allclose(coarse.get_np_array("Origin"), [11.0, 20.5, 30.5])
-    np.testing.assert_array_equal(coarse.get_np_array("Direction"), fine.get_np_array("Direction"))
+    direction = [0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+    np.testing.assert_array_equal(fine.get_np_array("Direction"), direction)
+    np.testing.assert_array_equal(coarse.get_np_array("Direction"), direction)
     # One rung per key, whichever level answered: a later write records the geometry once.
-    assert [key for key in coarse.keys() if key.startswith("Spacing")] == ["Spacing_0"]
+    for key in ("Spacing", "Origin", "Direction"):
+        assert [k for k in coarse.keys() if k.startswith(key)] == [f"{key}_0"]
 
 
 def test_default_downsampling_is_a_block_mean_not_a_gaussian(tmp_path: Path) -> None:

--- a/tests/unit/test_ome_zarr_data_surface.py
+++ b/tests/unit/test_ome_zarr_data_surface.py
@@ -121,8 +121,8 @@ def test_write_ome_zarr_builds_a_pyramid_by_position(tmp_path: Path) -> None:
 def test_a_coarser_level_reads_its_own_geometry_not_the_sidecars(tmp_path: Path) -> None:
     """The konfai sidecar records the geometry the writer was handed: level 0's. Read at ``@1``
     through the Dataset, it used to win over the level's own scale and translation, and level 1
-    came back with level 0's spacing on a quarter of the voxels: a brain four times smaller, for
-    every consumer that registers on the coarse level."""
+    came back with level 0's spacing on an eighth of the voxels (half the samples along each of the
+    three axes): half the extent per axis, for every consumer that registers on the coarse level."""
     root = tmp_path / "cases"
     store = root / "case_1" / "CT.ome.zarr"
     store.parent.mkdir(parents=True)

--- a/tests/unit/test_ome_zarr_data_surface.py
+++ b/tests/unit/test_ome_zarr_data_surface.py
@@ -34,7 +34,7 @@ from konfai.data import (
     read_ome_zarr_data_slice,
     write_ome_zarr,
 )
-from konfai.utils.dataset import _store_chunks
+from konfai.utils.dataset import Attribute, Dataset, _store_chunks
 from konfai.utils.errors import DatasetManagerError
 
 
@@ -116,6 +116,37 @@ def test_write_ome_zarr_builds_a_pyramid_by_position(tmp_path: Path) -> None:
     # centre-of-voxel convention, so the coarse first voxel sits at the centre of the block it
     # averages. Reusing the fine origin biases every voxel and still looks like a plausible image.
     assert [round(t, 6) for t in coarse["translation"]] == [0.0, 0.5, 0.5, 1.0]
+
+
+def test_a_coarser_level_reads_its_own_geometry_not_the_sidecars(tmp_path: Path) -> None:
+    """The konfai sidecar records the geometry the writer was handed: level 0's. Read at ``@1``
+    through the Dataset, it used to win over the level's own scale and translation, and level 1
+    came back with level 0's spacing on a quarter of the voxels: a brain four times smaller, for
+    every consumer that registers on the coarse level."""
+    root = tmp_path / "cases"
+    store = root / "case_1" / "CT.ome.zarr"
+    store.parent.mkdir(parents=True)
+    attributes = Attribute()
+    attributes["Spacing"] = np.asarray([2.0, 1.0, 1.0])
+    attributes["Origin"] = np.asarray([10.0, 20.0, 30.0])
+    attributes["Direction"] = np.asarray([0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+    write_ome_zarr(
+        store, _volume(), spacing=[2.0, 1.0, 1.0], origin=[10.0, 20.0, 30.0], attributes=attributes, scale_factors=[2]
+    )
+
+    _shape, fine = Dataset(str(root), "omezarr@0").get_infos("CT", "case_1")
+    _shape, coarse = Dataset(str(root), "omezarr@1").get_infos("CT", "case_1")
+    # Level 0 is the level the sidecar describes: read as recorded, Direction included.
+    np.testing.assert_array_equal(fine.get_np_array("Spacing"), [2.0, 1.0, 1.0])
+    np.testing.assert_array_equal(fine.get_np_array("Origin"), [10.0, 20.0, 30.0])
+    # Level 1 has its own scale and translation (x, y, z): the sidecar's Spacing and Origin are
+    # not this level's, so they yield to the transforms, while the Direction NGFF cannot express
+    # still comes from the sidecar.
+    np.testing.assert_allclose(coarse.get_np_array("Spacing"), [4.0, 2.0, 2.0])
+    np.testing.assert_allclose(coarse.get_np_array("Origin"), [11.0, 20.5, 30.5])
+    np.testing.assert_array_equal(coarse.get_np_array("Direction"), fine.get_np_array("Direction"))
+    # One rung per key, whichever level answered: a later write records the geometry once.
+    assert [key for key in coarse.keys() if key.startswith("Spacing")] == ["Spacing_0"]
 
 
 def test_default_downsampling_is_a_block_mean_not_a_gaussian(tmp_path: Path) -> None:

--- a/tests/unit/test_perf_hot_paths.py
+++ b/tests/unit/test_perf_hot_paths.py
@@ -134,7 +134,7 @@ def test_dicom_slice_info_threading_is_byte_identical_and_removes_rescans(tmp_pa
     from konfai.utils import dicom
     from konfai.utils.errors import DatasetManagerError
 
-    root = tmp_path / "case"
+    root = tmp_path / "P000" / "CT"
     vol = (np.arange(1 * 4 * 5 * 6).reshape(1, 4, 5, 6) % 97).astype(np.float32)
     dicom.write_dicom_series(root, vol, origin=(1.0, 2.0, 3.0), spacing=(0.7, 0.8, 2.5), direction=np.eye(3).flatten())
 
@@ -169,13 +169,13 @@ def test_dicom_slice_info_threading_is_byte_identical_and_removes_rescans(tmp_pa
         dicom, "sort_series", lambda *a, **k: (calls.__setitem__("sort", calls["sort"] + 1), real_sort(*a, **k))[1]
     )
 
-    dataset_file = Dataset.DicomFile(str(tmp_path), read=True)
+    dataset_file = Dataset.DicomFile(str(tmp_path / "P000"), read=True)
 
     # one COLD patch read costs exactly 1 discovery + 2 sorts. get_dicom_info is memoised, so the
     # cache must be cleared for the spy to see the cold cost at all.
     calls["discover"] = calls["sort"] = 0
     dicom.get_dicom_info.cache_clear()
-    data, _attr = dataset_file.file_to_data_slice("", "case", sl)
+    data, _attr = dataset_file.file_to_data_slice("", "CT", sl)
     assert np.array_equal(np.asarray(data), np.asarray(ref[0]))
     assert calls["discover"] == 1
     assert calls["sort"] == 2
@@ -183,7 +183,7 @@ def test_dicom_slice_info_threading_is_byte_identical_and_removes_rescans(tmp_pa
     # a WARM read of the same case re-discovers nothing; only the per-read slab sort (pixel
     # loading of the selected files) remains
     calls["discover"] = calls["sort"] = 0
-    data, _attr = dataset_file.file_to_data_slice("", "case", sl)
+    data, _attr = dataset_file.file_to_data_slice("", "CT", sl)
     assert np.array_equal(np.asarray(data), np.asarray(ref[0]))
     assert calls["discover"] == 0
     assert calls["sort"] == 1
@@ -191,7 +191,7 @@ def test_dicom_slice_info_threading_is_byte_identical_and_removes_rescans(tmp_pa
     # statistics over Z: 1 cold discovery, not O(Z); numerics preserved (Welford, ddof=1)
     calls["discover"] = calls["sort"] = 0
     dicom.get_dicom_info.cache_clear()
-    stats = dataset_file.file_to_data_statistics("", "case")
+    stats = Dataset(tmp_path, "dicom").read_data_statistics("CT", "P000")
     assert calls["discover"] == 1
     assert np.isclose(stats["mean"], float(vol.mean()), atol=1e-4)
     assert np.isclose(stats["std"], float(np.std(vol, ddof=1)), atol=1e-4)

--- a/tests/unit/test_transformer_workflow.py
+++ b/tests/unit/test_transformer_workflow.py
@@ -497,7 +497,7 @@ def test_a_stage_is_asked_about_its_own_input_not_the_case_as_stored(tmp_path: P
     _write_source(tmp_path)
     _write_config(tmp_path, _RESAMPLED_THEN_REFERENCED.format(out=tmp_path / "out"))
     workflow = _build(tmp_path)
-    manager = workflow._managers()["CT_out"][0]
+    manager = workflow.dataset.managers["CT_out"][0]
     stored = [int(extent) for extent in manager.base_shape[1:]]
     reference = manager.transforms[1]
 
@@ -787,7 +787,7 @@ def test_the_run_seed_reaches_the_draws_through_the_real_config(tmp_path: Path) 
     _write_expand_config(tmp_path, _EXPAND_CHAIN.format(out=tmp_path / "out"))
     workflow = _build(tmp_path)
 
-    manager = workflow.dataset._prepared_data["CT_out"][0]
+    manager = workflow.dataset.managers["CT_out"][0]
     assert manager._expand is not None
     assert manager._expand.draw_seed == 7  # _EXPAND_HEADER declares manual_seed: 7
 
@@ -1248,14 +1248,14 @@ def test_a_bare_name_past_the_marker_is_the_draw(tmp_path: Path) -> None:
         "              Flip:\n                dims: '0'\n"
         f"              Write:\n                dataset: {tmp_path / 'out'}:h5\n",
     )
-    assert isinstance(next(iter(_build(tmp_path)._managers().values()))[0].transforms[0], FlipTransform)
+    assert isinstance(next(iter(_build(tmp_path).dataset.managers.values()))[0].transforms[0], FlipTransform)
     _write_config(
         tmp_path,
         "              Expand:\n                nb: 2\n"
         "              Flip:\n                f_prob: [1.0, 0.0, 0.0]\n"
         f"              Write:\n                dataset: {tmp_path / 'out2'}:h5\n",
     )
-    assert isinstance(next(iter(_build(tmp_path)._managers().values()))[0].transforms[1], FlipDraw)
+    assert isinstance(next(iter(_build(tmp_path).dataset.managers.values()))[0].transforms[1], FlipDraw)
 
 
 def test_the_shards_balance_bytes_not_counts(tmp_path: Path) -> None:
@@ -1468,7 +1468,7 @@ def test_the_plan_names_the_regime_the_resumed_copies_take(tmp_path: Path, monke
     _write_expand_config(tmp_path, _EXPAND_CHAIN.format(out=tmp_path / "out").replace("nb: 3", "nb: 4"))
     workflow = _build(tmp_path)
     workflow.setup(1)
-    engines = {manager.name: CaseMaterializer(manager) for manager in workflow._managers()["CT_out"]}
+    engines = {manager.name: CaseMaterializer(manager) for manager in workflow.dataset.managers["CT_out"]}
     assert set(engines["CASE_000"].materialize_copies([1, 2]).values()) == {(Verdict.STREAM, Regime.SHARED)}
     assert set(engines["CASE_001"].materialize_copies([1, 2, 3]).values()) == {(Verdict.STREAM, Regime.SHARED)}
 


### PR DESCRIPTION
Three pieces of finished work that were sitting on branches older than the audit line, rebased onto
it so **v1.8.1 ships them**. Stacked on #106; the diff to read is the last seven commits.

### `fix(data)`: a coarser OME-Zarr level reads its own geometry

The sidecar describes ONE level, the finest, and the reader trusted it on every level: reading a
store at `@1` put level 0's spacing and origin on level 1's voxels, so the volume came back four
times too small in world coordinates. The sidecar is now trusted for `Spacing`/`Origin` only where
its spacing IS this level's scale; on any other level those two come from the level's own
transforms, and the sidecar still supplies what NGFF cannot express (the `Direction`).

### `refactor`/`perf(dataset)`: one block walk for the statistics

The statistics of a volume came from several passes; they now come from one walk, folded in
cache-sized pieces, and a `.npy` entry answers its shape from the header instead of reading the
array. New `tests/unit/test_dataset_statistics.py` covers the fold.

### `refactor(data)`: `DataSources`, out of the batch-loading dataset

`DataSources` holds what the four workflow datasets share: the roots, the case names common to every
group and kept by `subset`, one `DatasetManager` per (destination group, case), `resolved_budget()`
and `get_groups_dest()`. `Data` builds on it with the batch-loading mechanics (patch grid, RAM cache,
train/validation split, augmentation copies, DataLoaders); `DataTransform` builds on `DataSources`
alone, so its constructor no longer forwards eleven loader parameters it never used. The managers and
case names are public on the base, which is what `Transformer` reads instead of the `_prepared_*`
privates.

Same managers, same case order, same mappings and shards; the four `Dataset:` grammars are unchanged.

### Verification

`pixi run test-fast` and the full `pytest tests/` green on this branch, mypy clean, plus the targeted
suites for each piece (`test_dataset_statistics.py`, `test_ome_zarr_data_surface.py`,
`test_transformer_workflow.py`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected OME-Zarr geometry handling across pyramid levels.
  * Improved block-wise volume statistics and memory efficiency.
  * Added header-based `.npy` shape detection without loading pixel data.
  * Improved metadata handling, 2-D NIfTI streaming, and staged file publishing.

* **Improvements**
  * Streamlined dataset preparation, source validation, and transform configuration.
  * Updated prediction examples for current configuration behavior.

* **Documentation**
  * Updated dataset documentation to reflect the current implementation reference.

* **Tests**
  * Expanded coverage for statistics, geometry, metadata, and workflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->