### PR TITLE
fix: an orphaned backup, Crop's last row, ITK's share, and two folds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,11 @@ no longer stops a run. Two things a run already wrote come out differently, see 
   memory it holds and not the page cache, honours a SLURM grant, and reads `--mem=0` as the whole node
 - **runtime**: shards are balanced by bytes, and an inline run puts the caller's RNG (CPU and CUDA)
   and cudnn flags back
-- **runtime**: the per-rank thread share sizes ITK's pool along with torch's, and counts as applied
-  only once it is
+- **runtime**: the per-rank thread share bounds ITK's pool as well as torch's, and counts as applied
+  only once it is. The two take that share differently: torch's is capped at 12 (past memory-bus
+  saturation its intraop pool only adds contention), ITK's takes it whole, because its resampler
+  keeps scaling with it (one fold region: 10.98 s at 1 thread, 1.11 s at 12, 0.65 s at 24). Capping
+  ITK at torch's number left a third of a 24-core node idle: 15 s on a measured fold
 - **dataset**: a dead writer's debris is told apart portably (`psutil.pid_exists`), Windows included
 - **dataset**: a streamed `.mha` writes MetaIO's `TransformMatrix`, which is the TRANSPOSE of
   ITK's `Direction`: a non-symmetric orientation used to read back mirrored
@@ -108,6 +111,8 @@ no longer stops a run. Two things a run already wrote come out differently, see 
   the host baseline did not finish in 1 h 47, at 4.5 GiB of VRAM, and the same bytes every run
 - **transform**: on a host with no GPU that `Resample` goes through ITK's own resampler, 27 ns per
   voxel against the host walk's 326: the full CPU fold of the same round, 2005 s to 892 s
+- **runtime**: ITK's pool takes the rank's whole share instead of torch's cap: on a 24-core node
+  the resample of a measured fold goes 61.1 s to 46.6 s, the round 104 s to 97 s
 - **omezarr**: a pyramid appended to a streamed store no longer rewrites level 0, the coarser
   levels are derived from it lazily (that round's update pass 103 s to 53 s, the 4.9 GB template's
   level 1 53 s to 4 s), and a store is created empty for zarr to fill (2.3 s where the rechunk took 14.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,9 @@ no longer stops a run. Two things a run already wrote come out differently, see 
 
 - **transform**: the plan prices the route on what the chain reads: a destination that does not
   exist yet is not a read, so h5 to mha and h5 to omezarr stream instead of loading
-- **transform**: `Crop` keeps the last row of foreground on every axis. The box carried the LAST
-  foreground index where the crop reads a margin, so the far row was cut off
+- **transform**: `Crop` keeps the last row of foreground on every axis. The scan reports the last
+  foreground INDEX and the box carries the margin after it, so converting one into the other left
+  the far margin one voxel too large and the crop stopped short of that row
 - **transform**: `Crop` finds its box by a bounded quantile scan (exactly `numpy.quantile`) instead
   of holding the volume, and the plan reads no voxel for a global statistic: the rank reads it at
   first access, a LOAD case on the volume it holds
@@ -125,10 +126,11 @@ no longer stops a run. Two things a run already wrote come out differently, see 
   where the pass it replaces took 31 s) and `Median` reads the middle off a sort (1.5-2x on CPU,
   3.5x on CUDA); the folds a statistics pass computed are kept for the write pass when they fit
 - **transform**: a case is planned without listing the whole output directory
-- **reduction**: a fold that is not incremental reads its members several at a time. Each read is
+- **reduction**: a fold that is not incremental reads its members up to four at a time. Each read is
   a decode plus a replay of that case's chain, the members are independent, and such a fold holds
-  every member anyway, so nothing is spent that the plan did not already charge: a five-case fold
-  of a compressed cohort through `Clip` and `Resample`, 2.39 s to 0.97 s, the same bytes out
+  every member anyway, so nothing is spent that the plan did not already charge. The members reach
+  the operator in cohort order whatever order they arrive in, so the fold writes the same bytes: a
+  five-case fold of a compressed cohort through `Clip` and `Resample`, 2.39 s to 0.97 s
 - **dataset**: a volume's statistics come from one block walk, folded in cache-sized pieces, and a
   `.npy` entry answers its shape from the header instead of reading the array
 - **cli**: `import konfai` 0.9 to 0.08 s, `konfai --help` 2.9 to 0.3 s: torch, dicom and ome-zarr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,12 @@ no longer stops a run. Two things a run already wrote come out differently, see 
 - **omezarr**: a coarser level reads its own geometry. The sidecar describes the level the writer
   was handed, so taken at its word on level 1 it put level 0's spacing and origin on level 1's
   voxels: a volume read at `@1` came back four times too small in world coordinates
-- **reduction**: `Median` charges the working set its sort allocates (four buffers, measured)
+- **reduction**: `Median` selects the middle with a network of element-wise min/max up to five
+  members instead of sorting the stack, and charges what that route holds. Same values to the
+  bit (`torch.quantile` is the reference), a fraction of the time (three members: 7.20 to
+  0.45 ms on CUDA, 55 to 26 ms on the host) and a third of the working set, so the planner
+  cuts taller slabs for the same budget. A `Reduction` may now answer `working_multiple_for`
+  per cohort size; the class attribute stays the contract and the worst case
 - **transform**: a bare stage name past the `Expand` marker is the draw (`Flip`, `Mask`, `Permute`,
   `Foreign` exist as both); the qualified spelling still forces either
 - **transform**: the working set counts what the widest stage allocates; a `Save` cache the run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,12 @@ no longer stops a run. Two things a run already wrote come out differently, see 
 - **dataset**: a dead writer's debris is told apart portably (`psutil.pid_exists`), Windows included
 - **dataset**: a streamed `.mha` writes MetaIO's `TransformMatrix`, which is the TRANSPOSE of
   ITK's `Direction`: a non-symmetric orientation used to read back mirrored
+- **dataset**: an entry whose writer was killed between moving the old version aside and
+  publishing the new one is served again. The previous, complete version survived under the
+  `<name>.replaced-<pid>` backup that every listing hides, so the output was preserved and not
+  served, which reads as data loss. A single backup from a writer that no longer runs is put back
+  (h5, MetaImage/NIfTI and OME-Zarr alike) with a warning saying which write to run again; a live
+  writer's backup is still left alone
 - **dataset**: an h5 replace keeps the old entry until the new one is in place; a streamed transform
   entry lands under the `.h5` name; an entry whose attributes fail is not left behind; one staging
   marker for every backend's temporary; the reader's own `ITK_*` keys do not travel with the volume

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ no longer stops a run. Two things a run already wrote come out differently, see 
 
 - **transform**: the plan prices the route on what the chain reads: a destination that does not
   exist yet is not a read, so h5 to mha and h5 to omezarr stream instead of loading
+- **transform**: `Crop` keeps the last row of foreground on every axis. The box carried the LAST
+  foreground index where the crop reads a margin, so the far row was cut off
 - **transform**: `Crop` finds its box by a bounded quantile scan (exactly `numpy.quantile`) instead
   of holding the volume, and the plan reads no voxel for a global statistic: the rank reads it at
   first access, a LOAD case on the volume it holds
@@ -146,6 +148,12 @@ no longer stops a run. Two things a run already wrote come out differently, see 
   list; a caller that relied on the first failure raising mid-run reads the list instead.
 - **The auto memory budget is larger on a host that has streamed a cohort** and smaller under a
   SLURM grant that no cgroup enforces; the plan's header names which bound won.
+- **A `Crop` output is one voxel wider per axis than every earlier version wrote.** The box kept
+  the last foreground index as the far margin, so the crop stopped one row short and dropped that
+  row on each axis. Same config, same data: the volume this version writes is not the one an
+  earlier version wrote, and an output partly written before and resumed after mixes the two.
+  Run those outputs once with `--overwrite`, and re-derive anything (a model, a metric) that was
+  trained or measured on a cropped dataset if the missing row mattered.
 - **A streamed `.mha` written by an earlier version can carry mirrored geometry.** The streamed
   writer wrote the `Direction` where MetaIO expects its transpose, so an entry whose orientation
   is not symmetric (an oblique acquisition, an axis-permuting direction) reads back mirrored.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,10 @@ no longer stops a run. Two things a run already wrote come out differently, see 
   where the pass it replaces took 31 s) and `Median` reads the middle off a sort (1.5-2x on CPU,
   3.5x on CUDA); the folds a statistics pass computed are kept for the write pass when they fit
 - **transform**: a case is planned without listing the whole output directory
+- **reduction**: a fold that is not incremental reads its members several at a time. Each read is
+  a decode plus a replay of that case's chain, the members are independent, and such a fold holds
+  every member anyway, so nothing is spent that the plan did not already charge: a five-case fold
+  of a compressed cohort through `Clip` and `Resample`, 2.39 s to 0.97 s, the same bytes out
 - **dataset**: a volume's statistics come from one block walk, folded in cache-sized pieces, and a
   `.npy` entry answers its shape from the header instead of reading the array
 - **cli**: `import konfai` 0.9 to 0.08 s, `konfai --help` 2.9 to 0.3 s: torch, dicom and ome-zarr

--- a/konfai/data/case_reduction.py
+++ b/konfai/data/case_reduction.py
@@ -29,6 +29,8 @@ operator can accumulate.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -45,6 +47,12 @@ from konfai.utils.dataset import (
     _update_running_statistics,
 )
 from konfai.utils.errors import ReductionError
+
+#: How many members of a non-incremental fold are read at once. Their reads are independent and each
+#: one is a decode plus a chain replay; a fold that holds every member anyway pays no extra memory
+#: for overlapping them. Four rather than the cohort's size: the reads share the rank's thread budget
+#: with the numeric work they feed, and a wider pool only trades one queue for another.
+_MEMBER_READERS = 4
 
 #: Geometry keys compared between cases under ``grid: strict``. Direction is in because a flipped
 #: axis shows in neither extent nor spacing: averaging two volumes that disagree on it mirrors half
@@ -446,9 +454,31 @@ class CaseReduction:
         without it. The axis matters to any operator that places things side by side.
         """
         self.operator.start()
-        for manager in self.managers:
-            self.operator.accumulate(manager.read_region(region).unsqueeze(0))
+        for member in self._members(region):
+            self.operator.accumulate(member)
         return self.operator.finalize().squeeze(0)
+
+    def _members(self, region: tuple[slice, ...]) -> Iterator[torch.Tensor]:
+        """Each case's region, in cohort order, read one at a time or several at once.
+
+        A member's read is a decode plus a replay of that case's chain: minutes of one core while a
+        node has many, and the members are independent of each other. A fold that is NOT incremental
+        holds every member at once anyway -- the plan charges exactly that -- so reading them
+        together costs no memory that was not already budgeted, and the futures are consumed in
+        cohort order, so the operator sees the same members in the same order: the same bytes.
+
+        An incremental fold holds ONE member (that is what makes it incremental), so it reads one:
+        overlapping there would spend memory the plan did not charge.
+        """
+        readers = 1 if self.operator.incremental else min(len(self.managers), _MEMBER_READERS)
+        if readers < 2:
+            for manager in self.managers:
+                yield manager.read_region(region).unsqueeze(0)
+            return
+        with ThreadPoolExecutor(max_workers=readers) as pool:
+            pending = [pool.submit(manager.read_region, region) for manager in self.managers]
+            for future in pending:  # cohort order, whatever order they finish in
+                yield future.result().unsqueeze(0)
 
     def _folds(self, spatial: list[int]):
         """Every region's fold, in order: the loop both passes share."""

--- a/konfai/data/case_reduction.py
+++ b/konfai/data/case_reduction.py
@@ -423,7 +423,7 @@ class CaseReduction:
             source_channels=int(reference.base_shape[0]),
             slab_rows=self.slab_rows,
             incremental=self.operator.incremental,
-            working_multiple=float(self.operator.working_multiple),
+            working_multiple=float(self.operator.working_multiple_for(len(self.managers))),
             stat_pass=self._needs_stat_pass(),
             unbounded=self._unbounded_members(),
             refusal=self._first_refusal(),

--- a/konfai/data/reduction.py
+++ b/konfai/data/reduction.py
@@ -24,6 +24,7 @@ A reduction is an extension point: subclass :class:`Reduction`, reference it by 
 """
 
 from abc import ABC, abstractmethod
+from typing import ClassVar
 
 import torch
 
@@ -55,6 +56,15 @@ class Reduction(ABC):
     #: Buffers-worth this operator allocates on top of the regions it is handed (a stack, a sorted
     #: copy). The plan multiplies it into the peak it sizes regions against.
     working_multiple: float = 0.0
+
+    def working_multiple_for(self, cases: int) -> float:
+        """:attr:`working_multiple` for a fold of ``cases`` members, which is what the plan asks.
+
+        The attribute is the contract and the worst case; an operator whose route depends on the
+        count (``Median`` selects the middle by network up to five members, and sorts past that)
+        answers what THAT route holds, so the plan can cut taller slabs where the cheaper route runs.
+        """
+        return float(self.working_multiple)
 
     @abstractmethod
     def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
@@ -177,23 +187,65 @@ class Median(Reduction):
     voxel_local = True
     # ``torch.stack`` copies the buffer and the sort along the case axis returns values and
     # int64 indices over that: measured at 4x the stack it is handed (6 x 16 MiB float32 cases).
+    # A fold of three, four or five members takes the network instead and costs far less; the
+    # attribute is the worst case, :meth:`working_multiple_for` is what the plan asks.
     working_multiple = 4.0
+
+    #: What the selection networks below hold beside the members they are handed, measured on a
+    #: 24 MiB member (float32): the sort's own 4.0 is what anything wider still costs.
+    _NETWORK_MULTIPLE: ClassVar[dict[int, float]] = {1: 1.0, 2: 1.5, 3: 1.0, 4: 2.5, 5: 1.5}
+
+    def working_multiple_for(self, cases: int) -> float:
+        return self._NETWORK_MULTIPLE.get(cases, float(self.working_multiple))
+
+    @staticmethod
+    def _median_of_three(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor) -> torch.Tensor:
+        return torch.maximum(torch.minimum(a, b), torch.minimum(torch.maximum(a, b), c))
 
     def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
         dtype = _averaged_dtype(tensors[0].dtype)
-        if len(tensors) == 1:
-            return tensors[0].to(dtype)
-        # The sort along the case axis, and the middle read off it: what torch.quantile computes,
-        # without its interpolation machinery around it (1.5-2x on CPU, 3.5x on CUDA over three
-        # cases, measured), in the dtype the average belongs in, so a float64 cohort keeps its
-        # precision. The even-count middle is the same lerp quantile uses, so the two agree.
-        ranked = torch.stack(tensors, dim=0).to(dtype).sort(dim=0).values
-        cases = ranked.shape[0]
-        if cases % 2:
-            middle = ranked[cases // 2]
-        else:
-            middle = torch.lerp(ranked[cases // 2 - 1], ranked[cases // 2], 0.5)
-        return middle
+        members = [tensor.to(dtype) for tensor in tensors]
+        if len(members) == 1:
+            return members[0]
+        # Three to five members is what a fold has, and there the middle is SELECTED by a network of
+        # element-wise min/max rather than found by sorting the whole stack: same values to the bit,
+        # a fraction of the time (CUDA 7.20 -> 0.45 ms at three, 8.42 -> 1.10 at five; CPU 55 -> 26
+        # at three), and no stack to hold, which is what lets the planner cut taller slabs. Beyond
+        # five the sort is simpler and no slower: what torch.quantile computes without its
+        # interpolation machinery (1.5-2x on CPU, 3.5x on CUDA, measured).
+        low, high = self._middle_pair(members)
+        return low if low is high else torch.lerp(low, high, 0.5)
+
+    def _middle_pair(self, members: list[torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
+        """The one middle member of an odd fold (the same tensor twice), or the two an even fold
+        averages: by network up to five members, off a sorted stack past it."""
+        minimum, maximum = torch.minimum, torch.maximum
+        count = len(members)
+        if count == 2:
+            first, second = members
+            return minimum(first, second), maximum(first, second)
+        if count == 3:
+            middle = self._median_of_three(*members)
+            return middle, middle
+        if count == 4:
+            a, b, c, d = members
+            a, b = minimum(a, b), maximum(a, b)
+            c, d = minimum(c, d), maximum(c, d)
+            second, third = maximum(a, c), minimum(b, d)
+            return minimum(second, third), maximum(second, third)
+        if count == 5:
+            a, b, c, d, e = members
+            a, b = minimum(a, b), maximum(a, b)
+            c, d = minimum(c, d), maximum(c, d)
+            a, c = minimum(a, c), maximum(a, c)  # a is the fold's smallest: out of the running
+            b, d = minimum(b, d), maximum(b, d)  # d is its largest: out too
+            middle = self._median_of_three(b, c, e)
+            return middle, middle
+        ranked = torch.stack(members, dim=0).sort(dim=0).values
+        if count % 2:
+            middle = ranked[count // 2]
+            return middle, middle
+        return ranked[count // 2 - 1], ranked[count // 2]
 
 
 class Vote(Reduction):

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -3869,7 +3869,9 @@ class Crop(TransformInverse):
             return shape
         box = self._foreground_box(source, group_src, name)
         for i, ((_, b), s) in enumerate(zip(box, shape, strict=False)):
-            box[i][1] = s - b
+            # The scan reports the LAST foreground index; the box carries the margin AFTER it, so
+            # the far margin is what lies past that row. Off by one, the crop cut it off.
+            box[i][1] = max(int(s - b - 1), 0)
         cache_attribute["box"] = box
         return [int(s - a - b) for (a, b), s in zip(box, shape, strict=False)]
 

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -923,8 +923,18 @@ def _recover_orphaned_backup(final: Path) -> bool:
     backups = _orphaned_backup_names(siblings, final.name)
     if len(backups) != 1:
         return False
+    backup = final.parent.joinpath(backups[0])
     try:
-        final.parent.joinpath(backups[0]).rename(final)
+        # Never over a publish that landed while this was deciding. A second existence check would
+        # only move the window, so the move itself has to refuse: os.link fails EEXIST (and Windows
+        # rename fails outright), and a directory rename fails ENOTEMPTY against a complete store --
+        # a store is only ever published by renaming a full staging directory into place, so the
+        # final name is never an empty directory a rename could swallow.
+        if backup.is_dir() or os.name == "nt":
+            backup.rename(final)
+        else:
+            os.link(backup, final)
+            backup.unlink()
     except OSError:
         return False
     warnings.warn(
@@ -1627,6 +1637,10 @@ class Dataset:
                     # ``.tmp`` keys are in-flight (or hard-kill-orphaned) DataStream writes, not entries.
                     if isinstance(dataset, h5py.Dataset) and not is_staging_entry(dataset.name)
                 ]
+                # A backup a dead writer orphaned IS its entry (see _recover_orphaned_backup), and a
+                # listing that hid it while the probe and the read recover it would name fewer cases
+                # than the store serves: a run would silently skip one.
+                names.extend(self._orphaned_entries(h5_group, names))
             elif group == "*":
                 for k in h5_group.keys():
                     if isinstance(h5_group[k], h5py.Group):
@@ -1635,6 +1649,13 @@ class Dataset:
                 if group in h5_group:
                     names.extend(self.get_names("/".join(groups.split("/")[1:]), h5_group[group]))
             return names
+
+        @staticmethod
+        def _orphaned_entries(h5_group: h5py.Group, present: list[str]) -> list[str]:
+            """The names whose only version left in this group is one dead writer's backup."""
+            keys = list(h5_group.keys())
+            missing = {key.split(_REPLACED_MARKER)[0] for key in keys if _REPLACED_MARKER in key} - set(present)
+            return sorted(name for name in missing if len(_orphaned_backup_names(keys, name)) == 1)
 
         def get_group(self) -> list[str]:
             return list(self.h5.keys()) if self.h5 is not None else []
@@ -1949,8 +1970,12 @@ class Dataset:
             if any(os.path.exists(base + "." + ext) for ext in SUPPORTED_EXTENSIONS):
                 return True
             # A writer killed mid-replacement left the previous entry under its backup name, which
-            # every listing hides: it is the entry, and it goes back under it.
-            return any(_recover_orphaned_backup(Path(f"{base}.{ext}")) for ext in SUPPORTED_EXTENSIONS)
+            # every listing hides: it is the entry, and it goes back under it. Then the question is
+            # asked of disk again, because the recovery may have declined to a publish that landed
+            # meanwhile -- and that publish is an entry too.
+            for ext in SUPPORTED_EXTENSIONS:
+                _recover_orphaned_backup(Path(f"{base}.{ext}"))
+            return any(os.path.exists(base + "." + ext) for ext in SUPPORTED_EXTENSIONS)
 
         def get_names(self, group: str) -> list[str]:
             raise NotImplementedError()
@@ -2031,7 +2056,8 @@ class Dataset:
                 if candidate.is_dir():
                     return candidate
             for candidate in candidates:  # a writer killed mid-replacement left the previous store aside
-                if _recover_orphaned_backup(candidate):
+                _recover_orphaned_backup(candidate)
+                if candidate.is_dir():  # recovered here, or published by whoever won the race
                     return candidate
             raise NameError(f"OME-Zarr group '{name}' not found in '{self.filename}'.")
 
@@ -2736,8 +2762,10 @@ class Dataset:
         if os.path.exists(on_disk):
             return path
         # Absent is not always absent: a writer killed mid-replacement leaves the previous version
-        # under its backup name, which the listings hide.
-        return path if _recover_orphaned_backup(Path(on_disk)) else None
+        # under its backup name, which the listings hide. Asked of disk again after the attempt: the
+        # recovery declines to a publish that landed meanwhile, and that publish is the entry.
+        _recover_orphaned_backup(Path(on_disk))
+        return path if os.path.exists(on_disk) else None
 
     def _resolve_entry(self, groups: str, name: str, action: Callable[[Dataset.AbstractFile, str, str], _T]) -> _T:
         """Run ``action`` on the open file holding ``(groups, name)``: THE place entry resolution lives.

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -34,7 +34,7 @@ import threading
 import time
 import warnings
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from functools import partial
 from pathlib import Path
 from typing import Any, NamedTuple, TypeVar, cast
@@ -889,6 +889,54 @@ def _writer_is_dead(pid: int) -> bool:
     return not psutil.pid_exists(pid)
 
 
+def _orphaned_backup_names(names: Iterable[str], entry: str) -> list[str]:
+    """Among ``names``, the backups a DEAD writer left of ``entry``: ``<entry>.replaced-<pid>``."""
+    marker = f"{entry}{_REPLACED_MARKER}"
+    kept = []
+    for candidate in names:
+        if not candidate.startswith(marker):
+            continue
+        pid = candidate[len(marker) :]
+        if pid.isdigit() and _writer_is_dead(int(pid)):
+            kept.append(candidate)
+    return kept
+
+
+def _recover_orphaned_backup(final: Path) -> bool:
+    """Put back the previous entry when a killed writer left it under its backup name alone.
+
+    A replacement moves the old entry aside as ``<name>.replaced-<pid>``, publishes the new one,
+    then drops the backup, and a failed publish moves it back. A writer killed BETWEEN the two moves
+    leaves the previous, complete entry under the backup name, which every listing hides
+    (:func:`is_staging_entry`): the output is preserved and not served, which reads as data loss.
+
+    Exactly one backup, from a writer that no longer runs, and no entry under the final name: that
+    backup IS the entry, so it goes back. Two backups, or a writer still running, is nobody's to
+    guess, and the entry stays missing.
+    """
+    if final.exists():
+        return False
+    try:
+        siblings = [path.name for path in final.parent.iterdir()]
+    except OSError:
+        return False
+    backups = _orphaned_backup_names(siblings, final.name)
+    if len(backups) != 1:
+        return False
+    try:
+        final.parent.joinpath(backups[0]).rename(final)
+    except OSError:
+        return False
+    warnings.warn(
+        f"'{final}' was missing and its previous version was recovered from '{backups[0]}': a writer "
+        "was killed between moving the entry aside and publishing its replacement. The entry is the one "
+        "that was there BEFORE that write; run the write again to replace it.",
+        UserWarning,
+        stacklevel=2,
+    )
+    return True
+
+
 def _retire_dead_debris(final: Path) -> None:
     """Remove what earlier, DEAD writers of ``final`` left beside it.
 
@@ -1531,13 +1579,38 @@ class Dataset:
             dataset = self._create_entry(h5_group, temporary_name, attributes, shape=tuple(shape), dtype=dtype)
             return _H5DataStream(dataset, name)
 
+        def _recovered_key(self, h5_group: h5py.Group, name: str) -> str | None:
+            """The key ``name`` answers to when it is missing: its own, or the single backup a DEAD
+            writer left of it (see :func:`_recover_orphaned_backup`, the same rule inside a file).
+
+            An h5 file open for READING cannot be renamed in, so the backup is served under its own
+            key and put back at the next write open, which is when the move is legal.
+            """
+            if name in h5_group:
+                return name
+            backups = _orphaned_backup_names(list(h5_group.keys()), name)
+            if len(backups) != 1:
+                return None
+            warnings.warn(
+                f"'{name}' was missing from '{self.filename}' and its previous version was recovered from "
+                f"'{backups[0]}': a writer was killed between moving the entry aside and publishing its "
+                "replacement. The entry is the one that was there BEFORE that write; run the write again "
+                "to replace it.",
+                UserWarning,
+                stacklevel=3,
+            )
+            if not self.read:
+                h5_group.move(backups[0], name)
+                return name
+            return backups[0]
+
         def is_exist(self, group: str, name: str | None = None) -> bool:
             if self.h5 is not None:
                 if group in self.h5:
                     if isinstance(self.h5[group], h5py.Dataset):
                         return True
                     elif name is not None:
-                        return name in self.h5[group]
+                        return self._recovered_key(self.h5[group], name) is not None
                     else:
                         return False
             return False
@@ -1575,8 +1648,9 @@ class Dataset:
                 group = ""
             result = None
             if group == "":
-                if name in h5_group:
-                    result = h5_group[name]
+                key = self._recovered_key(h5_group, name)
+                if key is not None:
+                    result = h5_group[key]
             elif group == "*":
                 for k in h5_group.keys():
                     if isinstance(h5_group[k], h5py.Group):
@@ -1872,7 +1946,11 @@ class Dataset:
 
         def is_exist(self, group: str, name: str | None = None) -> bool:
             base = f"{self.filename}{group}"
-            return any(os.path.exists(base + "." + ext) for ext in SUPPORTED_EXTENSIONS)
+            if any(os.path.exists(base + "." + ext) for ext in SUPPORTED_EXTENSIONS):
+                return True
+            # A writer killed mid-replacement left the previous entry under its backup name, which
+            # every listing hides: it is the entry, and it goes back under it.
+            return any(_recover_orphaned_backup(Path(f"{base}.{ext}")) for ext in SUPPORTED_EXTENSIONS)
 
         def get_names(self, group: str) -> list[str]:
             raise NotImplementedError()
@@ -1951,6 +2029,9 @@ class Dataset:
             candidates = [Path(f"{base}.ome.zarr"), Path(f"{base}.zarr"), base]
             for candidate in candidates:
                 if candidate.is_dir():
+                    return candidate
+            for candidate in candidates:  # a writer killed mid-replacement left the previous store aside
+                if _recover_orphaned_backup(candidate):
                     return candidate
             raise NameError(f"OME-Zarr group '{name}' not found in '{self.filename}'.")
 
@@ -2651,7 +2732,12 @@ class Dataset:
         re-appends it on open.
         """
         path = f"{self.filename}{sub_directory}{name}"
-        return path if os.path.exists(f"{path}{'.h5' if self.file_format == 'h5' else ''}") else None
+        on_disk = f"{path}{'.h5' if self.file_format == 'h5' else ''}"
+        if os.path.exists(on_disk):
+            return path
+        # Absent is not always absent: a writer killed mid-replacement leaves the previous version
+        # under its backup name, which the listings hide.
+        return path if _recover_orphaned_backup(Path(on_disk)) else None
 
     def _resolve_entry(self, groups: str, name: str, action: Callable[[Dataset.AbstractFile, str, str], _T]) -> _T:
         """Run ``action`` on the open file holding ``(groups, name)``: THE place entry resolution lives.

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -994,11 +994,12 @@ def apply_cpu_thread_budget() -> None:
     """Give each rank a bounded share of the machine's cores instead of every library's every-core
     default -- torch's intraop pool AND ITK's, which does the host resample.
 
-    Past memory-bus saturation more intraop threads only add barrier contention; on a hybrid
-    24-core CPU the 498^3 separable gather measures 0.7 s at 12 threads and 67 s at 24. An
-    explicit ``OMP_NUM_THREADS`` keeps authority over torch (which already honors it at init) and
-    sizes ITK's pool the same. Otherwise each of the node's local ranks gets its share of
-    :func:`available_cpus`, capped at 12.
+    Each of the node's local ranks gets its share of :func:`available_cpus`, and the two pools take
+    that share differently. Torch's is capped at 12: past memory-bus saturation more intraop threads
+    only add barrier contention, and on a hybrid 24-core CPU the 498^3 separable gather measures
+    0.7 s at 12 threads and 67 s at 24. ITK's takes the share whole, because its resampler keeps
+    scaling with it (the same region: 10.98 s at 1 thread, 1.11 s at 12, 0.65 s at 24). An explicit
+    ``OMP_NUM_THREADS`` keeps authority over both (torch already honors it at init).
 
     Applied once per process, and never on macOS: torch documents ``set_num_threads`` as to be
     called before any parallel work, and the Python API runs several workflows in one process.
@@ -1010,13 +1011,20 @@ def apply_cpu_thread_budget() -> None:
     if sys.platform == "darwin" or _cpu_budget_applied:
         return
     explicit = os.environ.get("OMP_NUM_THREADS")
-    share = int(explicit) if explicit else max(1, min(available_cpus() // node_local_ranks(), 12))
+    cores = max(1, available_cpus() // node_local_ranks())
+    # The cap is torch's alone: past memory-bus saturation its intraop pool only adds barrier
+    # contention. ITK's pool is not the same animal -- its resampler, which does the host walk,
+    # keeps scaling to the whole share (a fold-sized region through a displacement field: 10.98 s
+    # at 1 thread, 1.11 s at 12, 0.65 s at 24), so capping it at 12 left a third of a 24-core node
+    # idle and cost 15 s on a measured fold.
+    share = int(explicit) if explicit else min(cores, 12)
+    itk_share = int(explicit) if explicit else cores
     if not explicit:
         torch.set_num_threads(share)
     try:
         import SimpleITK as sitk
 
-        sitk.ProcessObject.SetGlobalDefaultNumberOfThreads(share)
+        sitk.ProcessObject.SetGlobalDefaultNumberOfThreads(itk_share)
     except ImportError:
         pass
     # Marked applied only once it is: a raise above (a bad OMP_NUM_THREADS) leaves the next call free to retry.

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -772,7 +772,7 @@ class DistributedObject(ABC):
         global_rank, local_rank = setup_gpu(world_size, rank, process_group=self.uses_collectives)
         if global_rank is None or local_rank is None:
             return
-        apply_cpu_thread_budget()
+        apply_cpu_thread_budget(world_size)
         with Log(self.name, global_rank):
             if torch.cuda.is_available() and _PYNVML_AVAILABLE:
                 pynvml.nvmlInit()
@@ -990,7 +990,7 @@ def execute_distributed_object(
 _cpu_budget_applied = False
 
 
-def apply_cpu_thread_budget() -> None:
+def apply_cpu_thread_budget(world_size: int | None = None) -> None:
     """Give each rank a bounded share of the machine's cores instead of every library's every-core
     default -- torch's intraop pool AND ITK's, which does the host resample.
 
@@ -1011,7 +1011,10 @@ def apply_cpu_thread_budget() -> None:
     if sys.platform == "darwin" or _cpu_budget_applied:
         return
     explicit = os.environ.get("OMP_NUM_THREADS")
-    cores = max(1, available_cpus() // node_local_ranks())
+    # The world size stands in for a launcher that published no KONFAI_LOCAL_RANKS: without it four
+    # ranks of a direct execute_distributed_object() call would each size themselves for the whole
+    # node and oversubscribe it fourfold.
+    cores = max(1, available_cpus() // node_local_ranks(world_size))
     # The cap is torch's alone: past memory-bus saturation its intraop pool only adds barrier
     # contention. ITK's pool is not the same animal -- its resampler, which does the host walk,
     # keeps scaling to the whole share (a fold-sized region through a displacement field: 10.98 s

--- a/tests/unit/test_case_reduction.py
+++ b/tests/unit/test_case_reduction.py
@@ -29,7 +29,17 @@ import torch
 from konfai.data.case_reduction import CaseReduction, ReductionPlan, split_chain
 from konfai.data.patching import DatasetManager
 from konfai.data.reduction import Concat, Mean, Median, Reduction, Vote
-from konfai.data.transform import Clip, Dilate, Normalize, Reduce, Save, TensorCast, Transform, resolve_operator
+from konfai.data.transform import (
+    Clip,
+    Dilate,
+    Normalize,
+    Reduce,
+    Resample,
+    Save,
+    TensorCast,
+    Transform,
+    resolve_operator,
+)
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import ReductionError, TransformError
 
@@ -545,25 +555,29 @@ def test_reading_the_members_at_once_writes_the_same_bytes_as_one_at_a_time(
 ) -> None:
     """A member's read is a decode plus a replay of that case's chain, and the members are
     independent, so a non-incremental fold -- which holds every member anyway -- reads several at
-    once. Every case's chain shares the same stage OBJECTS, so this is where a shared cache would
-    show: what it must produce is the same volume, to the byte, as reading one at a time.
+    once. Every case of a cohort replays the SAME stage objects, so this is where a shared cache
+    would show: what it must produce is the same volume, to the byte, as reading one at a time.
 
-    The pre-chain here is deliberately stateful across cases: ``Crop`` memoises a content-derived box
-    per case on the dataset, and ``Resample`` caches a grid per name.
+    The chain is stateful on purpose: ``Resample`` resolves and caches a grid per case name, which
+    the concurrent run reaches from several threads at once. Each run builds its own stages, or the
+    second would read a cache the first left warm and exercise nothing.
     """
     import konfai.data.case_reduction as case_reduction
 
-    pre = [Clip(0.0, 50.0)]
+    def chain() -> list[Transform]:
+        return [Clip(0.0, 50.0), Resample(spacing=[1.0, 1.0, 1.0])]
+
     monkeypatch.setattr(case_reduction, "_MEMBER_READERS", 1)
-    engine, destination, _volumes = _run(tmp_path, pre, Reduce(operator="Median", output="serial"), [])
+    engine, destination, _volumes = _run(tmp_path, chain(), Reduce(operator="Median", output="serial"), [])
     engine.materialize()
     one_at_a_time, _ = destination.read_data("CT", "serial")
 
     monkeypatch.setattr(case_reduction, "_MEMBER_READERS", 4)
-    engine, destination, _volumes = _run(tmp_path, pre, Reduce(operator="Median", output="together"), [])
+    engine, destination, _volumes = _run(tmp_path, chain(), Reduce(operator="Median", output="together"), [])
     engine.materialize()
     together, _ = destination.read_data("CT", "together")
 
+    assert one_at_a_time.size > 0
     np.testing.assert_array_equal(together, one_at_a_time)
 
 

--- a/tests/unit/test_case_reduction.py
+++ b/tests/unit/test_case_reduction.py
@@ -540,6 +540,33 @@ def test_median_selects_the_middle_instead_of_sorting_the_stack(cases: int) -> N
     assert Median().working_multiple_for(cases) == {1: 1.0, 2: 1.5, 3: 1.0, 4: 2.5, 5: 1.5}.get(cases, 4.0)
 
 
+def test_reading_the_members_at_once_writes_the_same_bytes_as_one_at_a_time(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A member's read is a decode plus a replay of that case's chain, and the members are
+    independent, so a non-incremental fold -- which holds every member anyway -- reads several at
+    once. Every case's chain shares the same stage OBJECTS, so this is where a shared cache would
+    show: what it must produce is the same volume, to the byte, as reading one at a time.
+
+    The pre-chain here is deliberately stateful across cases: ``Crop`` memoises a content-derived box
+    per case on the dataset, and ``Resample`` caches a grid per name.
+    """
+    import konfai.data.case_reduction as case_reduction
+
+    pre = [Clip(0.0, 50.0)]
+    monkeypatch.setattr(case_reduction, "_MEMBER_READERS", 1)
+    engine, destination, _volumes = _run(tmp_path, pre, Reduce(operator="Median", output="serial"), [])
+    engine.materialize()
+    one_at_a_time, _ = destination.read_data("CT", "serial")
+
+    monkeypatch.setattr(case_reduction, "_MEMBER_READERS", 4)
+    engine, destination, _volumes = _run(tmp_path, pre, Reduce(operator="Median", output="together"), [])
+    engine.materialize()
+    together, _ = destination.read_data("CT", "together")
+
+    np.testing.assert_array_equal(together, one_at_a_time)
+
+
 def test_a_vote_tie_goes_to_the_smallest_label_whatever_the_cohort_order() -> None:
     """The reproducibility half of Vote's contract, which its docstring promises out loud.
 

--- a/tests/unit/test_case_reduction.py
+++ b/tests/unit/test_case_reduction.py
@@ -139,13 +139,14 @@ def test_averaging_keeps_a_floating_dtype_and_widens_an_integer_one(operator: Re
 def test_a_non_incremental_operator_holds_the_whole_cohort_per_region(tmp_path: Path) -> None:
     """One region per case, plus the output's, plus what the operator allocates over its buffer.
 
-    ``Median`` stacks the buffer into a new tensor and sorts a copy of that, so the buffer alone
-    under-states its peak threefold, and it is the operator a bare ``Reduce`` gets.
+    ``Median`` holds the cohort and what its route allocates beside it, so the buffer alone
+    under-states its peak, and it is the operator a bare ``Reduce`` gets. The route depends on the
+    cohort's SIZE (a network up to five members, a sort past it), so the plan asks for this cohort's.
     """
     engine, _destination, _volumes = _run(tmp_path, [], Reduce(operator="Median", output="t"), [])
     plan = engine.plan()
     assert plan.incremental is False
-    assert plan.resident_regions == CASES + 1 + Median.working_multiple * CASES
+    assert plan.resident_regions == CASES + 1 + Median().working_multiple_for(CASES) * CASES
     assert "resident region" in plan.describe() and "CASE_000" in plan.describe()
 
 
@@ -490,7 +491,7 @@ def test_a_single_case_is_its_own_vote() -> None:
     "operator,output_channels,member_regions,why",
     [
         (Mean(), 1, 2, "one running accumulator and the region coming into it"),
-        (Median(), 1, 5 * CASES + 1, "the cohort, the stack it is copied into, quantile's copies, the output"),
+        (Median(), 1, int(3.5 * CASES) + 1, "the cohort, what the four-member network holds beside it, the output"),
         (Vote(), 1, 3 * CASES + 1, "same shape of work: a mode sorts a copy of the stack too"),
         (Concat(), CASES, 2 * CASES, "the cohort, and the concatenation that IS the output"),
     ],
@@ -515,10 +516,28 @@ def test_the_peak_is_charged_at_each_side_s_own_width(
         slab_rows=rows,
         incremental=operator.incremental,
         stat_pass=False,
-        working_multiple=operator.working_multiple,
+        working_multiple=operator.working_multiple_for(CASES),
     )
     member = rows * spatial[1] * spatial[2] * source_channels * 4
     assert plan.peak_bytes == member_regions * member, why
+
+
+@pytest.mark.parametrize("cases", [1, 2, 3, 4, 5, 6, 7])
+def test_median_selects_the_middle_instead_of_sorting_the_stack(cases: int) -> None:
+    """Up to five members the middle is SELECTED by a network of element-wise min/max; past that a
+    sort finds it. The values are the same to the bit either way -- ``torch.quantile`` is the
+    reference the docstring names -- and the network holds far less, which is what
+    ``working_multiple_for`` reports so the planner can cut taller slabs where it runs.
+
+    Measured on a 24 MiB member: at three members 7.20 ms and 3x the stack by sort against 0.45 ms
+    and 1x by network on CUDA, 55 ms against 26 on the host.
+    """
+    torch.manual_seed(3)
+    members = [torch.rand((1, 2, 4, 5)) for _ in range(cases)]
+    folded = Median()(members)
+
+    assert torch.equal(folded, torch.quantile(torch.stack(members, dim=0), 0.5, dim=0))
+    assert Median().working_multiple_for(cases) == {1: 1.0, 2: 1.5, 3: 1.0, 4: 2.5, 5: 1.5}.get(cases, 4.0)
 
 
 def test_a_vote_tie_goes_to_the_smallest_label_whatever_the_cohort_order() -> None:

--- a/tests/unit/test_data_stream.py
+++ b/tests/unit/test_data_stream.py
@@ -544,3 +544,54 @@ def test_replacing_an_h5_entry_keeps_the_old_one_until_the_new_is_in_place(tmp_p
     assert [present for present, _ in seen] == [False, True]
     written, _ = dataset.read_data("G", "c")
     assert float(np.asarray(written).max()) == 0.0
+
+
+def _kill_between_the_two_moves(dataset: Dataset, name: str, volume: np.ndarray, attributes: Attribute) -> None:
+    """Leave on disk exactly what a writer killed between the move-aside and the publish leaves:
+    the previous entry under its backup name, nothing under its own."""
+    from konfai.utils.dataset import _replaced_name
+
+    dataset.write("CT", name, volume, attributes)
+    if dataset.file_format == "h5":
+        import h5py
+
+        with h5py.File(f"{str(dataset.filename).rstrip('/')}.h5", "r+") as handle:
+            handle["CT"].move(name, _replaced_name(name))
+        return
+    entry = next(path for path in (Path(dataset.filename) / name).iterdir() if path.name.startswith("CT"))
+    entry.rename(entry.with_name(_replaced_name(entry.name)))
+
+
+@pytest.mark.parametrize("file_format", ["mha", "h5", "omezarr"])
+def test_a_backup_orphaned_by_a_killed_writer_is_served_again(tmp_path: Path, file_format: str, monkeypatch) -> None:
+    """A replacement moves the old entry aside, publishes, then drops the backup. A writer killed
+    between the first two moves leaves the previous, COMPLETE entry under a name every listing
+    hides: the output is preserved and not served, which reads as data loss. It is served again."""
+    _skip_unavailable(file_format)
+    import konfai.utils.dataset as dataset_module
+
+    volume, attributes = _volume(), _image_attributes()
+    dataset = Dataset(tmp_path / "store", file_format)
+    _kill_between_the_two_moves(dataset, "CASE_001", volume, attributes)
+    monkeypatch.setattr(dataset_module, "_writer_is_dead", lambda pid: True)
+
+    fresh = Dataset(tmp_path / "store", file_format)
+    # Whichever question comes first recovers it, and says so: the probe a resume makes, or the read.
+    with pytest.warns(UserWarning, match="killed between moving the entry aside"):
+        assert fresh.is_dataset_exist("CT", "CASE_001")
+        recovered, _ = fresh.read_data("CT", "CASE_001")
+    np.testing.assert_array_equal(recovered, volume)
+    assert Dataset(tmp_path / "store", file_format).is_dataset_exist("CT", "CASE_001")  # and it stays back
+
+
+@pytest.mark.parametrize("file_format", ["mha", "h5", "omezarr"])
+def test_a_live_writers_backup_is_left_alone(tmp_path: Path, file_format: str) -> None:
+    """The pid in the name is the whole point: while its writer runs, the backup is that writer's
+    business (the publish it is about to make moves it back or drops it), so the entry stays
+    missing rather than resurrecting a version the run is replacing."""
+    _skip_unavailable(file_format)
+    dataset = Dataset(tmp_path / "store", file_format)
+    _kill_between_the_two_moves(dataset, "CASE_001", _volume(), _image_attributes())  # under THIS pid
+
+    fresh = Dataset(tmp_path / "store", file_format)
+    assert not fresh.is_dataset_exist("CT", "CASE_001")

--- a/tests/unit/test_data_stream.py
+++ b/tests/unit/test_data_stream.py
@@ -584,6 +584,43 @@ def test_a_backup_orphaned_by_a_killed_writer_is_served_again(tmp_path: Path, fi
     assert Dataset(tmp_path / "store", file_format).is_dataset_exist("CT", "CASE_001")  # and it stays back
 
 
+def test_the_listing_names_a_case_whose_only_version_is_an_orphaned_backup(tmp_path: Path, monkeypatch) -> None:
+    """A listing that hid what the probe and the read recover would name fewer cases than the store
+    serves, and a run walking the listing would skip that case without a word."""
+    pytest.importorskip("h5py")
+    import konfai.utils.dataset as dataset_module
+
+    dataset = Dataset(tmp_path / "store", "h5")
+    dataset.write("CT", "CASE_000", _volume(), _image_attributes())
+    _kill_between_the_two_moves(dataset, "CASE_001", _volume(), _image_attributes())
+    monkeypatch.setattr(dataset_module, "_writer_is_dead", lambda pid: True)
+
+    fresh = Dataset(tmp_path / "store", "h5")
+    assert sorted(fresh.get_names("CT")) == ["CASE_000", "CASE_001"]
+
+
+@pytest.mark.parametrize("file_format", ["mha", "omezarr"])
+def test_recovery_never_lands_on_a_publish_that_won_the_race(tmp_path: Path, file_format: str, monkeypatch) -> None:
+    """A writer can publish between the moment recovery finds the entry missing and the moment it
+    puts the backup back. The move itself must refuse then, because a second existence check would
+    only move the window: the previous version must never land on top of the new one."""
+    _skip_unavailable(file_format)
+    import konfai.utils.dataset as dataset_module
+
+    published, backed_up = _volume(), _volume() * 0 + 7
+    dataset = Dataset(tmp_path / "store", file_format)
+    _kill_between_the_two_moves(dataset, "CASE_001", backed_up, _image_attributes())
+
+    def publish_then_answer(pid: int) -> bool:  # runs between the listing and the rename
+        Dataset(tmp_path / "store", file_format).write("CT", "CASE_001", published, _image_attributes())
+        return True
+
+    monkeypatch.setattr(dataset_module, "_writer_is_dead", publish_then_answer)
+    fresh = Dataset(tmp_path / "store", file_format)
+    assert fresh.is_dataset_exist("CT", "CASE_001")
+    np.testing.assert_array_equal(fresh.read_data("CT", "CASE_001")[0], published)
+
+
 @pytest.mark.parametrize("file_format", ["mha", "h5", "omezarr"])
 def test_a_live_writers_backup_is_left_alone(tmp_path: Path, file_format: str) -> None:
     """The pid in the name is the whole point: while its writer runs, the backup is that writer's

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -648,7 +648,14 @@ def test_the_inline_path_is_the_default(monkeypatch) -> None:
     assert spawned == []
 
 
-def _budget_applied(monkeypatch, cores: int, ranks: str | None, omp: str | None, platform: str = "linux") -> list[int]:
+def _budget_applied(
+    monkeypatch,
+    cores: int,
+    ranks: str | None,
+    omp: str | None,
+    platform: str = "linux",
+    world_size: int | None = None,
+) -> list[int]:
     calls: list[int] = []
     monkeypatch.setattr(rt, "_cpu_budget_applied", False)
     monkeypatch.setattr(rt.sys, "platform", platform)
@@ -658,7 +665,7 @@ def _budget_applied(monkeypatch, cores: int, ranks: str | None, omp: str | None,
         monkeypatch.delenv(key, raising=False)
         if value is not None:
             monkeypatch.setenv(key, value)
-    rt.apply_cpu_thread_budget()
+    rt.apply_cpu_thread_budget(world_size)
     return calls
 
 
@@ -733,6 +740,14 @@ def test_cpu_thread_budget_caps_torchs_every_core_default(monkeypatch) -> None:
     """torch defaults to one intraop thread per core; past bus saturation that only adds barrier
     contention (measured 0.7 s at 12 threads vs 67 s at 24 for the same gather)."""
     assert _budget_applied(monkeypatch, cores=24, ranks=None, omp=None) == [12]
+
+
+def test_cpu_thread_budget_falls_back_to_the_world_size(monkeypatch) -> None:
+    """``KONFAI_LOCAL_RANKS`` is the launcher's, and a direct ``execute_distributed_object`` call has
+    no launcher: without the world size standing in, the divisor is 1 and each of four ranks sizes
+    itself for the whole node, oversubscribing it fourfold."""
+    assert _budget_applied(monkeypatch, cores=24, ranks=None, omp=None, world_size=4) == [6]
+    assert _budget_applied(monkeypatch, cores=24, ranks=None, omp=None) == [12], "no count, no divisor"
 
 
 def test_cpu_thread_budget_splits_the_node_between_ranks(monkeypatch) -> None:

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -710,16 +710,21 @@ def test_available_cpus_reads_a_cgroup_v1_quota(monkeypatch, tmp_path, mount: st
     assert bd.available_cpus() == 3  # 2.5 CPUs round up
 
 
-def test_cpu_thread_budget_sizes_itks_pool_with_torchs(monkeypatch) -> None:
-    """ITK does the host resample: an unbounded ITK pool beside a bounded torch one is the same
-    oversubscription moved one library over."""
+def test_cpu_thread_budget_gives_itk_the_rank_share_torch_is_capped_out_of(monkeypatch) -> None:
+    """Both pools are bounded by the RANK's share, and they take it differently: torch's cap is
+    memory-bus saturation (0.7 s at 12 threads against 67 s at 24 for one gather), which ITK's
+    resampler does not hit (10.98 s at 1, 1.11 s at 12, 0.65 s at 24 for one region). Capping ITK
+    at torch's 12 left a third of a 24-core node idle; leaving it unbounded would oversubscribe the
+    node across ranks. The share, whole, is neither."""
     sitk = pytest.importorskip("SimpleITK")
     before = sitk.ProcessObject.GetGlobalDefaultNumberOfThreads()
     try:
         assert _budget_applied(monkeypatch, cores=24, ranks="4", omp=None) == [6]
-        assert sitk.ProcessObject.GetGlobalDefaultNumberOfThreads() == 6
+        assert sitk.ProcessObject.GetGlobalDefaultNumberOfThreads() == 6  # the share, under the cap
+        assert _budget_applied(monkeypatch, cores=24, ranks=None, omp=None) == [12]
+        assert sitk.ProcessObject.GetGlobalDefaultNumberOfThreads() == 24  # the whole share, over it
         assert _budget_applied(monkeypatch, cores=24, ranks="4", omp="20") == []
-        assert sitk.ProcessObject.GetGlobalDefaultNumberOfThreads() == 20
+        assert sitk.ProcessObject.GetGlobalDefaultNumberOfThreads() == 20  # OMP_NUM_THREADS rules both
     finally:
         sitk.ProcessObject.SetGlobalDefaultNumberOfThreads(before)
 

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -278,7 +278,8 @@ def test_crop_finds_its_box_without_holding_the_volume(tmp_path: Path, monkeypat
     second.set_datasets([dataset])
     for crop in (first, second):
         attribute = _geometry()
-        assert crop.transform_shape("CT", "CASE", [30, 25, 20], attribute) == [int(b - a) for a, b in expected]
+        # b is the LAST foreground index, so the extent that keeps it is b - a + 1.
+        assert crop.transform_shape("CT", "CASE", [30, 25, 20], attribute) == [int(b - a + 1) for a, b in expected]
         assert np.array_equal(Crop._parse_box(attribute["box"])[:, 0], expected[:, 0])
     assert quantile_calls == [0.05], "one scan per volume, shared by every chain"
 


### PR DESCRIPTION
The remaining fixes for v1.8.1, in one PR. Three commits, each separable.

### `fix(dataset)`: an orphaned backup is served again (closes #111)

A replacement moves the old entry aside as `<name>.replaced-<pid>`, publishes the new one, then drops
the backup; a failed publish moves it back. A writer **killed between the two moves** left the
previous, complete entry under a name every listing hides (`is_staging_entry`): preserved on disk and
served to nobody, which reads as data loss.

Exactly one backup, from a writer that no longer runs, with nothing under the final name, IS the
entry: the existence probe and the read put it back and warn which write to run again. Two backups,
or a writer still running, is nobody's to guess and the entry stays missing. h5, MetaImage/NIfTI and
OME-Zarr alike; an h5 file open for reading cannot be renamed in, so the backup is served under its
own key there and moved back at the next write open.

Tests: recovery on the three formats (probe, read, and it stays back), and a live writer's backup
left alone.

### `fix(transform)`: Crop keeps the last row of foreground (closes #114)

The scan reports the LAST foreground index and the box carries the margin AFTER it, so storing that
index as the margin cut the row off: every `Crop` output was one voxel short per axis, foreground
included. Pre-existing (`main` computed the same box through `box_with_mask`), which is why it waited
for a release that can carry the note.

**Behaviour change**, spelled out in the changelog: a `Crop` output is one voxel wider per axis than
every earlier version wrote, an output partly written before and resumed after mixes the two, and
those outputs want one run with `--overwrite`. **Drop `42725a1` if v1.8.1 should not carry it.**

### `perf(runtime)`: ITK's pool takes the rank's share, not torch's cap

Measured on the ExaSPIM fold: **resample 61.1 s → 46.6 s, the round 104 s → 97 s.**

v1.8.1 gave ITK's pool the same number as torch's, and that number is torch's own wall: past
memory-bus saturation its intraop pool only adds barrier contention (0.7 s at 12 threads against
67 s at 24 for one separable gather). ITK's resampler does not hit that wall -- the same fold-sized
region through a displacement field measures 10.98 s at 1 thread, 1.11 s at 12, **0.65 s at 24** --
so capping it at 12 left a third of a 24-core node idle for the stage that dominates a CPU fold.

Both pools stay bounded by the **rank's** share, so N ranks still do not oversubscribe a node; only
the cap that is torch's own stops applying to ITK. `OMP_NUM_THREADS` keeps authority over both.


---

### `perf(reduction)`: Median selects the middle instead of sorting the stack

Up to five members -- what a fold has -- the middle is selected by a network of element-wise min/max.
Same values **to the bit** (`torch.quantile` is the reference, pinned for one to seven members), and:

| members | sort (CUDA) | network (CUDA) | sort (host) | network (host) | peak |
|---|---|---|---|---|---|
| 3 | 7.20 ms | **0.45 ms** | 55 ms | **26 ms** | 3.0x → **1.0x** |
| 4 | 7.67 ms | **1.39 ms** | 68 ms | **39 ms** | 3.0x → **2.5x** |
| 5 | 8.42 ms | **1.10 ms** | 57 ms | 61 ms | 3.0x → **1.4x** |

The working set is the bigger half: the plan multiplies it into the peak it sizes regions against, so
the same budget cuts taller slabs. `Reduction.working_multiple_for(cases)` is the hook that carries
it; the class attribute stays the contract and the worst case.

### `perf(reduction)`: a non-incremental fold reads its members at once

**2.39 s → 0.97 s** on a five-case fold of a compressed cohort through `Clip` and `Resample`, same
bytes out.

A member's read is a decode plus a replay of that case's chain, and the members are independent, so
the fold read them one after another while the node sat idle. A fold that is not incremental holds
every member anyway -- the plan charges exactly that -- so overlapping the reads spends no memory
that was not already budgeted. The futures are consumed in cohort order, so the operator sees the
same members in the same order. The test pins that against the one-at-a-time read on a chain whose
stages are **shared** between the cases, which is where a shared cache would show; the suite was run
five times over for a race that would be intermittent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected crop dimensions for inclusive bounding-box boundaries.
  - Improved interrupted-write recovery, preserving readable datasets and preventing active backups from being restored over published entries.
  - Updated CPU thread allocation for more balanced processing.

- **Performance**
  - Accelerated non-incremental reductions through bounded parallel reads while preserving cohort order and output bytes.
  - Improved median processing and adjusted memory requirements based on cohort size.

- **Documentation**
  - Clarified backup recovery, thread allocation, median behavior, and output overwrite or re-derivation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->