### PR TITLE
perf(runtime): ITK's pool takes the rank's share, not torch's cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,11 @@ no longer stops a run. Two things a run already wrote come out differently, see 
   memory it holds and not the page cache, honours a SLURM grant, and reads `--mem=0` as the whole node
 - **runtime**: shards are balanced by bytes, and an inline run puts the caller's RNG (CPU and CUDA)
   and cudnn flags back
-- **runtime**: the per-rank thread share sizes ITK's pool along with torch's, and counts as applied
-  only once it is
+- **runtime**: the per-rank thread share bounds ITK's pool as well as torch's, and counts as applied
+  only once it is. The two take that share differently: torch's is capped at 12 (past memory-bus
+  saturation its intraop pool only adds contention), ITK's takes it whole, because its resampler
+  keeps scaling with it (one fold region: 10.98 s at 1 thread, 1.11 s at 12, 0.65 s at 24). Capping
+  ITK at torch's number left a third of a 24-core node idle: 15 s on a measured fold
 - **dataset**: a dead writer's debris is told apart portably (`psutil.pid_exists`), Windows included
 - **dataset**: a streamed `.mha` writes MetaIO's `TransformMatrix`, which is the TRANSPOSE of
   ITK's `Direction`: a non-symmetric orientation used to read back mirrored
@@ -100,6 +103,8 @@ no longer stops a run. Two things a run already wrote come out differently, see 
   the host baseline did not finish in 1 h 47, at 4.5 GiB of VRAM, and the same bytes every run
 - **transform**: on a host with no GPU that `Resample` goes through ITK's own resampler, 27 ns per
   voxel against the host walk's 326: the full CPU fold of the same round, 2005 s to 892 s
+- **runtime**: ITK's pool takes the rank's whole share instead of torch's cap: on a 24-core node
+  the resample of a measured fold goes 61.1 s to 46.6 s, the round 104 s to 97 s
 - **omezarr**: a pyramid appended to a streamed store no longer rewrites level 0, the coarser
   levels are derived from it lazily (that round's update pass 103 s to 53 s, the 4.9 GB template's
   level 1 53 s to 4 s), and a store is created empty for zarr to fill (2.3 s where the rechunk took 14.4)

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -994,11 +994,12 @@ def apply_cpu_thread_budget() -> None:
     """Give each rank a bounded share of the machine's cores instead of every library's every-core
     default -- torch's intraop pool AND ITK's, which does the host resample.
 
-    Past memory-bus saturation more intraop threads only add barrier contention; on a hybrid
-    24-core CPU the 498^3 separable gather measures 0.7 s at 12 threads and 67 s at 24. An
-    explicit ``OMP_NUM_THREADS`` keeps authority over torch (which already honors it at init) and
-    sizes ITK's pool the same. Otherwise each of the node's local ranks gets its share of
-    :func:`available_cpus`, capped at 12.
+    Each of the node's local ranks gets its share of :func:`available_cpus`, and the two pools take
+    that share differently. Torch's is capped at 12: past memory-bus saturation more intraop threads
+    only add barrier contention, and on a hybrid 24-core CPU the 498^3 separable gather measures
+    0.7 s at 12 threads and 67 s at 24. ITK's takes the share whole, because its resampler keeps
+    scaling with it (the same region: 10.98 s at 1 thread, 1.11 s at 12, 0.65 s at 24). An explicit
+    ``OMP_NUM_THREADS`` keeps authority over both (torch already honors it at init).
 
     Applied once per process, and never on macOS: torch documents ``set_num_threads`` as to be
     called before any parallel work, and the Python API runs several workflows in one process.
@@ -1010,13 +1011,20 @@ def apply_cpu_thread_budget() -> None:
     if sys.platform == "darwin" or _cpu_budget_applied:
         return
     explicit = os.environ.get("OMP_NUM_THREADS")
-    share = int(explicit) if explicit else max(1, min(available_cpus() // node_local_ranks(), 12))
+    cores = max(1, available_cpus() // node_local_ranks())
+    # The cap is torch's alone: past memory-bus saturation its intraop pool only adds barrier
+    # contention. ITK's pool is not the same animal -- its resampler, which does the host walk,
+    # keeps scaling to the whole share (a fold-sized region through a displacement field: 10.98 s
+    # at 1 thread, 1.11 s at 12, 0.65 s at 24), so capping it at 12 left a third of a 24-core node
+    # idle and cost 15 s on a measured fold.
+    share = int(explicit) if explicit else min(cores, 12)
+    itk_share = int(explicit) if explicit else cores
     if not explicit:
         torch.set_num_threads(share)
     try:
         import SimpleITK as sitk
 
-        sitk.ProcessObject.SetGlobalDefaultNumberOfThreads(share)
+        sitk.ProcessObject.SetGlobalDefaultNumberOfThreads(itk_share)
     except ImportError:
         pass
     # Marked applied only once it is: a raise above (a bad OMP_NUM_THREADS) leaves the next call free to retry.

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -710,16 +710,21 @@ def test_available_cpus_reads_a_cgroup_v1_quota(monkeypatch, tmp_path, mount: st
     assert bd.available_cpus() == 3  # 2.5 CPUs round up
 
 
-def test_cpu_thread_budget_sizes_itks_pool_with_torchs(monkeypatch) -> None:
-    """ITK does the host resample: an unbounded ITK pool beside a bounded torch one is the same
-    oversubscription moved one library over."""
+def test_cpu_thread_budget_gives_itk_the_rank_share_torch_is_capped_out_of(monkeypatch) -> None:
+    """Both pools are bounded by the RANK's share, and they take it differently: torch's cap is
+    memory-bus saturation (0.7 s at 12 threads against 67 s at 24 for one gather), which ITK's
+    resampler does not hit (10.98 s at 1, 1.11 s at 12, 0.65 s at 24 for one region). Capping ITK
+    at torch's 12 left a third of a 24-core node idle; leaving it unbounded would oversubscribe the
+    node across ranks. The share, whole, is neither."""
     sitk = pytest.importorskip("SimpleITK")
     before = sitk.ProcessObject.GetGlobalDefaultNumberOfThreads()
     try:
         assert _budget_applied(monkeypatch, cores=24, ranks="4", omp=None) == [6]
-        assert sitk.ProcessObject.GetGlobalDefaultNumberOfThreads() == 6
+        assert sitk.ProcessObject.GetGlobalDefaultNumberOfThreads() == 6  # the share, under the cap
+        assert _budget_applied(monkeypatch, cores=24, ranks=None, omp=None) == [12]
+        assert sitk.ProcessObject.GetGlobalDefaultNumberOfThreads() == 24  # the whole share, over it
         assert _budget_applied(monkeypatch, cores=24, ranks="4", omp="20") == []
-        assert sitk.ProcessObject.GetGlobalDefaultNumberOfThreads() == 20
+        assert sitk.ProcessObject.GetGlobalDefaultNumberOfThreads() == 20  # OMP_NUM_THREADS rules both
     finally:
         sitk.ProcessObject.SetGlobalDefaultNumberOfThreads(before)
 


### PR DESCRIPTION
Measured on the ExaSPIM fold this shipped for. **Resample 61.1 s → 46.6 s, the round 104 s → 97 s.**

v1.8.1 gave ITK's pool the same number as torch's, and that number is torch's own wall: past
memory-bus saturation its intraop pool only adds barrier contention (0.7 s at 12 threads against
67 s at 24 for one separable gather). ITK's resampler does not hit that wall. The same fold-sized
region through a displacement field:

| threads | 1 | 12 | 24 |
|---|---|---|---|
| `sitk.Resample` | 10.98 s | 1.11 s | 0.65 s |

So capping it at 12 left a third of a 24-core node idle for the stage that dominates a CPU fold.

Both pools stay bounded by the **rank's** share (`available_cpus() // node_local_ranks()`), so N
ranks still do not oversubscribe a node; only the cap that is torch's own stops applying to ITK. An
explicit `OMP_NUM_THREADS` keeps authority over both.

The test now pins the whole contract in one place: the share when it is under the cap, the share
whole when it is over it, and `OMP_NUM_THREADS` ruling both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved CPU thread allocation for resampling and round execution.
  * SimpleITK now uses the available per-rank CPU share, while PyTorch remains capped at 12 threads by default.
  * Explicit `OMP_NUM_THREADS` settings continue to control both processing pools.
* **Documentation**
  * Updated the v1.8.1 changelog with runtime behavior and measured performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->