### PR TITLE
Storage backends: regions off memmaps, pooled handles, single-copy decodes

### DIFF
--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -1623,7 +1623,7 @@ class Resample(TransformInverse):
         """This case's stored transforms, decoded and composed, in application order."""
         if name in self._stored:
             return self._stored[name]
-        from konfai.utils.ITK import decode_transform_stages, invert_stages
+        from konfai.utils.ITK import invert_stages, read_transform_stages
 
         _require_simpleitk()
         rank = self._source_grid(name).rank
@@ -1633,18 +1633,17 @@ class Resample(TransformInverse):
         # application order, so the declared list is reversed here to mean the same thing it did.
         for group in reversed(list(cast("dict[str, bool]", self.transforms))):
             invert = self.transforms[group] if self.transforms else False
-            stored = None
+            decoded = None
             for dataset in self.datasets:
                 if dataset.is_dataset_exist(group, name):
-                    stored = dataset.read_transform(group, name)
+                    decoded = read_transform_stages(dataset, group, name)
                     break
-            if stored is None:
+            if decoded is None:
                 raise TransformError(
                     f"'Resample' found no transform for case '{name}' in group '{group}'.",
                     "Every case needs an entry in every group named under 'transforms:'. Check the"
                     " group name, or drop the cases that have no transform with 'subset'.",
                 )
-            decoded = decode_transform_stages(stored)
             if invert:
                 inverted = invert_stages(decoded, rank)
                 if inverted is None:

--- a/konfai/utils/ITK.py
+++ b/konfai/utils/ITK.py
@@ -19,7 +19,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 
@@ -155,8 +155,8 @@ def box_with_mask(mask: sitk.Image, label: list[int], dilatations: list[int]) ->
 
     dilatations = [int(np.ceil(d / s)) for d, s in zip(dilatations, reversed(mask.GetSpacing()), strict=False)]
 
-    data = sitk.GetArrayFromImage(mask)
-    border = np.where(np.isin(sitk.GetArrayFromImage(mask), label))
+    data = sitk.GetArrayViewFromImage(mask)  # a view: the mask is read for its shape and its labels, not held
+    border = np.where(np.isin(data, label))
     box = []
     for w, dilatation, s in zip(border, dilatations, data.shape, strict=False):
         box.append([max(np.min(w) - dilatation, 0), min(np.max(w) + dilatation, s)])
@@ -205,10 +205,12 @@ def _grid_of_image(image: sitk.Image) -> Grid:
     )
 
 
-def _displacement_stage(grid: Grid, per_component: list[np.ndarray], order: int, what: str) -> DisplacementStage:
+def _displacement_stage(grid: Grid, values: np.ndarray, order: int, what: str) -> DisplacementStage:
+    """A stage over ``values``, component-first ``(rank, *grid)``, contiguous float64: one copy where
+    they are not that already, none where they are."""
     from konfai.data.geometry import DisplacementStage
 
-    values = np.stack([component.astype(np.float64, copy=False) for component in per_component])
+    values = np.ascontiguousarray(values, dtype=np.float64)
     if not np.isfinite(values).all():
         raise TransformError(
             f"{what} carries a non-finite displacement value, so no bound on its reach exists.",
@@ -236,18 +238,22 @@ def decode_transform_stages(transform: sitk.Transform) -> SpatialStages:
     from konfai.data.geometry import AffineStage
 
     if isinstance(transform, sitk.BSplineTransform):
+        # One copy per component, into the stack: the images stay alive for as long as the views do.
         coefficients = transform.GetCoefficientImages()
-        arrays = [sitk.GetArrayFromImage(component) for component in coefficients]
+        values = np.stack([sitk.GetArrayViewFromImage(component) for component in coefficients])
         return (
             _displacement_stage(
-                _grid_of_image(coefficients[0]), arrays, int(transform.GetOrder()), "this BSpline transform"
+                _grid_of_image(coefficients[0]), values, int(transform.GetOrder()), "this BSpline transform"
             ),
         )
     if isinstance(transform, sitk.DisplacementFieldTransform):
+        # One copy of the field: the view is (Z, Y, X, rank) with the components (x, y, z) fastest,
+        # and the stage's component-first float64 layout is written straight from it (measured
+        # 159 MiB of peak against 50 MiB of content on a 128^3 field through GetArrayFromImage,
+        # a per-component ascontiguousarray and a stack).
         field = transform.GetDisplacementField()
-        array = sitk.GetArrayFromImage(field)  # (Z, Y, X, rank), components (x, y, z)
-        components = [np.ascontiguousarray(array[..., k]) for k in range(array.shape[-1])]
-        return (_displacement_stage(_grid_of_image(field), components, 1, "this displacement field"),)
+        values = np.array(np.moveaxis(sitk.GetArrayViewFromImage(field), -1, 0), dtype=np.float64, order="C")
+        return (_displacement_stage(_grid_of_image(field), values, 1, "this displacement field"),)
     if transform.IsLinear():
         return (AffineStage(_linear_map(transform)),)
     raise TransformError(
@@ -255,6 +261,31 @@ def decode_transform_stages(transform: sitk.Transform) -> SpatialStages:
         " reaches into its source is unknown, so the region it must read is unbounded.",
         "Convert it to a displacement field when it is written, or use a rigid/affine/BSpline"
         " transform, which all decompose.",
+    )
+
+
+def read_transform_stages(dataset: Any, group: str, name: str) -> SpatialStages:
+    """The stored transform ``(group, name)`` of ``dataset`` as geometry stages in APPLICATION order.
+
+    A displacement entry becomes its stage straight from the array the store hands over, on the
+    grid its attributes describe: the field never passes through a SimpleITK image (a float32 store
+    widens to float64 exactly, where the image route copied it three times over on the way in and
+    once more on the way out). Every other entry decodes through :func:`decode_transform_stages`,
+    as does everything a store that serves transforms alone (``read_transform`` and nothing else)
+    hands over.
+    """
+    from konfai.data.geometry import Grid
+    from konfai.utils.dataset import DISPLACEMENT_FIELD_ATTRIBUTE, data_to_transform
+
+    read_data = getattr(dataset, "read_data", None)
+    if read_data is None:
+        return decode_transform_stages(dataset.read_transform(group, name))
+    data, attribute = read_data(group, name)
+    if DISPLACEMENT_FIELD_ATTRIBUTE not in attribute:
+        return decode_transform_stages(data_to_transform(data, attribute, name))
+    what = f"the displacement field '{group}' of case '{name}'"
+    return (
+        _displacement_stage(Grid.of([int(extent) for extent in np.shape(data)[1:]], attribute, what), data, 1, what),
     )
 
 

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -2664,11 +2664,13 @@ class Dataset:
                 with self._field_file(name) as file:
                     header = self._field_header(file)
                     if header is not None:
-                        # The parameters ARE the field, float64: one span off the file, where ITK's
-                        # transform reader holds the field twice before the array is even copied out
-                        # (a 128^3 field: +147 MiB of RSS through ITK, +100 MiB off the span).
+                        # The parameters ARE the field: one span off the file, where ITK's transform
+                        # reader holds the field twice before the array is even copied out (a 128^3
+                        # field: +147 MiB of RSS through ITK, +100 MiB off the span). Read at the
+                        # dtype a region read takes, so the two routes carry the same values: the
+                        # file keeps ITK's double, the pipeline does not.
                         shape, attributes = header
-                        return self._field_region(file, shape[1:], (slice(None),) * 4, np.float64), attributes
+                        return self._field_region(file, shape[1:], (slice(None),) * 4), attributes
             transform = sitk.ReadTransform(self._path(name))
             attributes = Attribute()
             if "DisplacementFieldTransform" in transform.GetName():  # a field in a text transform file

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -29,6 +29,7 @@ import math
 import os
 import re
 import shutil
+import struct
 import sys
 import threading
 import time
@@ -84,10 +85,16 @@ def _get_h5_file_lock(filename: str) -> threading.RLock:
 
 class _PooledRead(NamedTuple):
     """An open read handle and the store it was opened on, as one thing: the two travel together through
-    eviction and re-insertion, so no site can pair a handle with a view it never had."""
+    eviction and re-insertion, so no site can pair a handle with a view it never had.
+
+    The sidecars travel with them: an entry's attributes, read off the handle once and kept for its
+    life, so a patch read costs one hyperslab and not one HDF5 attribute open per key on top (measured
+    15 opens, 327 us, on a 15-key sidecar beside a 222 us slice). A handle replaced or dropped takes
+    its sidecars with it, which is every way the store can have changed underneath them."""
 
     file: Any
     opened_on: tuple[int, int] | None
+    sidecars: dict[str, Attribute]
 
 
 class _H5ReadPool:
@@ -132,14 +139,14 @@ class _H5ReadPool:
         for remaining in reversed(range(self._OPEN_ATTEMPTS)):
             stamp = self._stamp(filename)
             try:
-                return _PooledRead(_open_h5(filename, "r", **open_kwargs), stamp)
+                return _PooledRead(_open_h5(filename, "r", **open_kwargs), stamp, {})
             except OSError:
                 if not remaining:
                     raise
                 time.sleep(self._OPEN_BACKOFF)
         raise AssertionError("unreachable: the last attempt either returns or raises")
 
-    def get(self, filename: str, **open_kwargs: Any) -> Any:
+    def get(self, filename: str, **open_kwargs: Any) -> _PooledRead:
         # Read before the open, never after: a write landing in between then leaves a stamp older than
         # the handle, and the next call reopens. The reverse would record a view it never had.
         stamp = self._stamp(filename)
@@ -163,7 +170,7 @@ class _H5ReadPool:
                 evicted.append((oldest, self._handles.pop(oldest)))
         for stale_name, stale in evicted:
             self._close_idle(stale_name, stale)
-        return pooled.file
+        return pooled
 
     def drop(self, filename: str) -> None:
         with self._guard:
@@ -225,6 +232,8 @@ def _attribute_text(value: Any) -> str:
     path of one chain disagree by that much (measured: a Min/Max rescale, 28% of voxels one ulp
     apart on CUDA).
     """
+    if type(value) is str:
+        return value.replace("\n", "")  # what the printing below does to a str, without entering it
     if isinstance(value, torch.Tensor):
         # Accept a tensor from any device: attributes are host-side strings, and finalize transforms
         # (Normalize, Statistics, ...) may hand over stats computed on a CUDA-resident volume.
@@ -284,13 +293,21 @@ class Attribute(dict[str, Any]):
     Values are text, always. Both doors normalize (assignment and construction), so an attribute
     built from a store's own sidecar, which JSON hands back as live lists, is the same thing as one
     assigned in Python. Anything less and a value can be stored and not written back out.
+
+    Copying one is a dict copy: its values are text already, and the streamed route of every
+    workflow copies the case's attributes three to five times per patch (measured 69 us for a
+    23-key copy through the normalising door, 2 us at dict level).
     """
 
     def __init__(self, attributes: dict[str, Any] | None = None) -> None:
         super().__init__()
-        attributes = attributes or {}
+        if not attributes:
+            return
+        if type(attributes) is Attribute:
+            super().update(attributes)
+            return
         for k, v in attributes.items():
-            super().__setitem__(copy.deepcopy(k), _attribute_text(v))
+            super().__setitem__(k if type(k) is str else copy.deepcopy(k), _attribute_text(v))
 
     @staticmethod
     def _is_stack_member(stored_key: str, key: str) -> bool:
@@ -708,13 +725,14 @@ def image_to_data(image: sitk.Image) -> tuple[np.ndarray, Attribute]:
     attributes["Origin"] = np.asarray(image.GetOrigin())
     attributes["Spacing"] = np.asarray(image.GetSpacing())
     attributes["Direction"] = np.asarray(image.GetDirection())
-    data = sitk.GetArrayFromImage(image)
-
     if image.GetNumberOfComponentsPerPixel() == 1:
-        data = np.expand_dims(data, 0)
-    else:
-        data = np.transpose(data, (len(data.shape) - 1, *list(range(len(data.shape) - 1))))
-    return data, attributes
+        return np.expand_dims(sitk.GetArrayFromImage(image), 0), attributes
+    # One copy, written channel-first straight off ITK's interleaved buffer: the array is contiguous
+    # for whatever holds it next, where the copy of the buffer transposed was a strided view every
+    # consumer needing a contiguous field copied again (a 3x128^3 float64 field: 50 MiB each time).
+    # np.array and not ascontiguousarray: a one-voxel image is contiguous however its axes are moved,
+    # and a view of ITK's buffer would outlive the image.
+    return np.array(np.moveaxis(sitk.GetArrayViewFromImage(image), -1, 0), order="C"), attributes
 
 
 def ome_zarr_attributes(metadata: dict[str, Any]) -> Attribute:
@@ -809,6 +827,21 @@ def _decode_transform(transform_type: str, name: str) -> sitk.Transform:
         if transform_type == type_tag:
             return factory()
     raise DatasetManagerError(f"Unsupported transform type '{transform_type}' for entry '{name}'.")
+
+
+def data_to_transform(data: np.ndarray, attributes: Attribute, name: str) -> sitk.Transform:
+    """The transform a stored entry holds: a displacement field is its image in float64, what
+    ``DisplacementFieldTransform`` requires, widened here exactly so the image is built once in that
+    type; any other entry is the parameter rows and type keys of ``_encode_transform_leaves``."""
+    if DISPLACEMENT_FIELD_ATTRIBUTE in attributes:
+        return sitk.DisplacementFieldTransform(data_to_image(np.asarray(data, dtype=np.float64), attributes))
+    transforms = []
+    for i, transform_type in enumerate(v for k, v in attributes.items() if k.endswith(":Transform_0")):
+        transform = _decode_transform(transform_type, name)
+        transform.SetFixedParameters(ast.literal_eval(attributes[f"{i}:FixedParameters"]))
+        transform.SetParameters(tuple(data[i]))
+        transforms.append(transform)
+    return sitk.CompositeTransform(transforms) if len(transforms) > 1 else transforms[0]
 
 
 def get_infos(filename: str | Path) -> tuple[list[int], Attribute]:
@@ -1191,8 +1224,6 @@ class _NiftiDataStream(DataStream):
     affine's first two rows are negated on the way out, the one convention this class owns."""
 
     def __init__(self, path: str, shape: list[int], dtype: np.dtype, attributes: Attribute) -> None:
-        import struct
-
         self.path = path
         self.published_path = Path(path)
         self._temporary_path = f"{path}.{self.temporary_suffix()}"
@@ -1378,6 +1409,198 @@ class _OmeZarrDataStream(DataStream):
 
 _T = TypeVar("_T")
 
+#: NumPy dtype of each element type the raw-block route reads (the inverses of the writers' tables).
+_NIFTI_DTYPES = {code: np.dtype(name) for name, code in _NIFTI_DATATYPES.items()}
+_MHA_DTYPES = {token: np.dtype(name) for name, token in _MHA_ELEMENT_TYPES.items()}
+#: How much of a file a MetaImage header is looked for in: MetaIO writes a few hundred bytes, user
+#: fields a few more; a header that runs past this is read by ITK.
+_MHA_HEADER_PROBE_BYTES = 1 << 16
+
+
+@functools.cache
+def _sitk_component_dtypes() -> dict[int, np.dtype]:
+    """The NumPy dtype ITK stores each of its scalar and vector pixel types in."""
+    kinds = (
+        ("UInt8", np.uint8),
+        ("Int8", np.int8),
+        ("UInt16", np.uint16),
+        ("Int16", np.int16),
+        ("UInt32", np.uint32),
+        ("Int32", np.int32),
+        ("UInt64", np.uint64),
+        ("Int64", np.int64),
+        ("Float32", np.float32),
+        ("Float64", np.float64),
+    )
+    return {getattr(sitk, f"sitk{prefix}{name}"): np.dtype(kind) for prefix in ("", "Vector") for name, kind in kinds}
+
+
+class _PixelBlock(NamedTuple):
+    """An uncompressed MetaImage or NIfTI as a memmap serves it: where its raw pixels start, how
+    they are stored, and what ITK reads in its header."""
+
+    offset: int
+    dtype: np.dtype  # as stored, byte order included
+    interleaved: bool  # MetaIO keeps a pixel's components together; NIfTI keeps each component's volume whole
+    shape: tuple[int, ...]  # channel-first
+    metadata: Attribute  # the header's own keys, as image_to_data imports them
+    probe: Any  # a one-voxel sitk.Image carrying the header's geometry: ITK's own index-to-world arithmetic
+
+    @property
+    def origin(self) -> np.ndarray:
+        return np.asarray(self.probe.GetOrigin())
+
+    @property
+    def spacing(self) -> np.ndarray:
+        return np.asarray(self.probe.GetSpacing())
+
+    @property
+    def direction(self) -> np.ndarray:
+        return np.asarray(self.probe.GetDirection())
+
+
+def _mha_raw_block(path: str) -> tuple[int, np.dtype] | None:
+    """Where an uncompressed local-data MetaImage keeps its pixels and how; ``None`` for any other."""
+    with open(path, "rb") as file:
+        head = file.read(_MHA_HEADER_PROBE_BYTES)
+    fields: dict[str, str] = {}
+    position = 0
+    while "ElementDataFile" not in fields:
+        end = head.find(b"\n", position)
+        if end < 0:
+            return None
+        key, separator, value = head[position:end].decode("latin-1").partition("=")
+        position = end + 1
+        if separator:
+            fields[key.strip()] = value.strip()
+    dtype = _MHA_DTYPES.get(fields.get("ElementType", ""))
+    if (
+        dtype is None
+        or fields["ElementDataFile"] != "LOCAL"
+        or "HeaderSize" in fields  # a seek MetaIO applies to LOCAL data too
+        or fields.get("BinaryData", "").lower() != "true"
+        or fields.get("CompressedData", "false").lower() != "false"
+    ):
+        return None
+    big_endian = fields.get("BinaryDataByteOrderMSB", fields.get("ElementByteOrderMSB", "false")).lower() == "true"
+    return position, dtype.newbyteorder(">" if big_endian else "<")
+
+
+def _nifti_raw_block(path: str) -> tuple[int, np.dtype] | None:
+    """Where a single-file uncompressed NIfTI-1 keeps its pixels and how; ``None`` for any other.
+
+    A stored intensity scaling (``scl_slope``/``scl_inter``) is left to ITK, which applies it and
+    promotes the pixel type; the block's bytes are then not the volume's values.
+    """
+    with open(path, "rb") as file:
+        header = file.read(348)
+    if len(header) < 348 or header[344:348] != b"n+1\x00":  # a .hdr/.img pair keeps its block elsewhere
+        return None
+    order = next((order for order in ("<", ">") if struct.unpack(f"{order}i", header[:4])[0] == 348), None)
+    if order is None:
+        return None
+    dtype = _NIFTI_DTYPES.get(struct.unpack(f"{order}h", header[70:72])[0])
+    (vox_offset,) = struct.unpack(f"{order}f", header[108:112])
+    slope, inter = struct.unpack(f"{order}2f", header[112:120])
+    if dtype is None or slope not in (0.0, 1.0) or inter != 0.0 or vox_offset < 352 or vox_offset != int(vox_offset):
+        return None
+    return int(vox_offset), dtype.newbyteorder(order)
+
+
+@functools.lru_cache(maxsize=4096)
+def _pixel_block_at(path: str, stamp: tuple[int, int]) -> _PixelBlock | None:
+    """The raw block of ``path`` as it was at ``stamp``, with its header read by ITK once.
+
+    Qualified against ITK's own reading of the header: the element type it reports must be the one
+    stored, and the file must hold every element the shape announces. A file that fails either is
+    read by ITK, which then answers for it, so a mismatch costs speed and never a wrong value.
+
+    The geometry and the metadata are taken off a one-voxel region ITK extracts, not off its header
+    read alone: ITK's NIfTI IO reads the header again before it reads pixels, and the direction it
+    then carries differs from the first read's in the sign of its zeros, which the record keeps as
+    text. A vector NIfTI, which ITK cannot extract a region of, is the one file whose record comes
+    from the header read.
+    """
+    del stamp  # part of the key: a rewritten file gets a record of its own
+    image_io = sitk.ImageFileReader.GetImageIOFromFileName(path)
+    if image_io == "MetaImageIO":
+        raw, interleaved = _mha_raw_block(path), True
+    elif image_io == "NiftiImageIO":
+        raw, interleaved = _nifti_raw_block(path), False
+    else:
+        return None
+    if raw is None:
+        return None
+    offset, dtype = raw
+    reader = sitk.ImageFileReader()
+    reader.SetFileName(path)
+    reader.ReadImageInformation()
+    rank = reader.GetDimension()
+    shape = (reader.GetNumberOfComponents(), *reversed(reader.GetSize()))
+    if (
+        rank not in (2, 3)
+        or _sitk_component_dtypes().get(reader.GetPixelID()) != dtype.newbyteorder("=")
+        or os.path.getsize(path) < offset + int(np.prod(shape, dtype=np.int64)) * dtype.itemsize
+    ):
+        return None
+    if not interleaved and shape[0] > 1:
+        probe = sitk.Image([1] * rank, sitk.sitkUInt8)
+        probe.SetOrigin(reader.GetOrigin())
+        probe.SetSpacing(reader.GetSpacing())
+        probe.SetDirection(reader.GetDirection())
+        for key in reader.GetMetaDataKeys():
+            probe.SetMetaData(key, reader.GetMetaData(key))
+    else:
+        reader.SetExtractIndex([0] * rank)
+        reader.SetExtractSize([1] * rank)
+        probe = reader.Execute()
+    metadata = Attribute()
+    for key in probe.GetMetaDataKeys():
+        if not key.startswith("ITK_"):  # the reader's own bookkeeping, as image_to_data drops it
+            metadata[key] = probe.GetMetaData(key)
+    return _PixelBlock(offset, dtype, interleaved, shape, metadata, probe)
+
+
+def _pixel_block(path: str) -> _PixelBlock | None:
+    """The raw block of ``path`` as it is now, or ``None`` when only ITK can read the file."""
+    try:
+        info = os.stat(path)
+    except OSError:
+        return None
+    return _pixel_block_at(path, (info.st_mtime_ns, info.st_size))
+
+
+def _pixel_block_region(block: _PixelBlock, path: str, normalized: tuple[slice, ...]) -> np.ndarray:
+    """One region off the raw block, channel-first and in the native byte order: the bytes ITK
+    would decode, read through a memmap that touches the region's pages and no other.
+
+    A copy, always: a slab of whole planes is contiguous on the map, and an array that only
+    guaranteed contiguity would be the map's own pages, read-only and unmapped with the map."""
+    if block.interleaved:
+        mapped = np.memmap(path, block.dtype, "r", block.offset, (*block.shape[1:], block.shape[0]))
+        region = np.moveaxis(mapped[(*normalized[1:], normalized[0])], -1, 0)
+    else:
+        mapped = np.memmap(path, block.dtype, "r", block.offset, block.shape)
+        region = mapped[normalized]
+    return np.array(region, dtype=block.dtype.newbyteorder("="), order="C")
+
+
+def _pixel_block_attributes(block: _PixelBlock, index_xyz: list[int] | None) -> Attribute:
+    """The attributes ITK's route records: the header's keys, then the geometry, the origin being
+    the region's (at ``index_xyz``) as ITK's extract computes it, then the region's origin again as
+    the module computes it. ``None`` is the whole volume's record, as ``file_to_data`` returns it."""
+    attributes = Attribute(block.metadata)
+    if index_xyz is None:
+        attributes["Origin"] = block.origin
+    else:
+        attributes["Origin"] = np.asarray(block.probe.TransformIndexToPhysicalPoint(index_xyz))
+    attributes["Spacing"] = block.spacing
+    attributes["Direction"] = block.direction
+    if index_xyz is not None:
+        direction = block.direction.reshape(len(block.spacing), len(block.spacing))
+        attributes["Origin"] = block.origin + direction @ (np.asarray(index_xyz, dtype=np.float64) * block.spacing)
+    return attributes
+
 
 class Dataset:
     """Filesystem or HDF5-backed dataset abstraction used across KonfAI."""
@@ -1481,6 +1704,7 @@ class Dataset:
                 self.filename += ".h5"
             self.read = read
             self._lock: threading.RLock | None = None
+            self._sidecars: dict[str, Attribute] | None = None  # the pooled handle's, on a read open
 
         def __enter__(self):
             # A single HDF5 file cannot be opened concurrently from several threads:
@@ -1491,11 +1715,12 @@ class Dataset:
             self._lock.acquire()
             try:
                 if self.read:
-                    self.h5 = _h5_read_pool.get(
+                    pooled = _h5_read_pool.get(
                         self.filename,
                         rdcc_nbytes=self._READ_CHUNK_CACHE_BYTES,
                         rdcc_nslots=self._READ_CHUNK_CACHE_SLOTS,
                     )
+                    self.h5, self._sidecars = pooled.file, pooled.sidecars
                 else:
                     _h5_read_pool.drop(self.filename)
                     if not os.path.exists(self.filename):
@@ -1519,11 +1744,22 @@ class Dataset:
                     self._lock.release()
                     self._lock = None
 
+        def _sidecar(self, dataset: h5py.Dataset) -> Attribute:
+            """The entry's attributes, a copy of the pooled handle's record of them: one attribute open
+            per key on the first read of the entry through the handle, none after. A write handle is
+            not pooled and reads them off the file."""
+            if self._sidecars is None:
+                return Attribute(dict(dataset.attrs))
+            sidecar = self._sidecars.get(dataset.name)
+            if sidecar is None:
+                sidecar = self._sidecars[dataset.name] = Attribute(dict(dataset.attrs))
+            return Attribute(sidecar)
+
         def file_to_data(self, groups: str, name: str) -> tuple[np.ndarray, Attribute]:
             dataset = self._get_dataset(groups, name)
             data = np.zeros(dataset.shape, dataset.dtype)
             dataset.read_direct(data)
-            return data, Attribute(dict(dataset.attrs))
+            return data, self._sidecar(dataset)
 
         def bounded_region_reads(self, name: str) -> bool:
             del name
@@ -1534,7 +1770,7 @@ class Dataset:
         def file_to_data_slice(self, groups: str, name: str, slices: tuple[slice, ...]) -> tuple[np.ndarray, Attribute]:
             dataset = self._get_dataset(groups, name)
             data = np.asarray(dataset[slices])
-            return data, Attribute(dict(dataset.attrs))
+            return data, self._sidecar(dataset)
 
         def data_to_file(
             self,
@@ -1713,10 +1949,7 @@ class Dataset:
 
         def get_infos(self, groups: str, name: str) -> tuple[list[int], Attribute]:
             dataset = self._get_dataset(groups, name)
-            return (
-                dataset.shape,
-                Attribute(dict(dataset.attrs)),
-            )
+            return dataset.shape, self._sidecar(dataset)
 
     class SitkFile(AbstractFile):
         def __init__(self, filename: str, read: bool, file_format: str) -> None:
@@ -1751,6 +1984,8 @@ class Dataset:
 
             Cached: the patch path asks this per read, and it opens the file to read a header.
             """
+            if _pixel_block(path) is not None:
+                return True  # a memmap of the raw block reads the region's pages and no other
             image_io = sitk.ImageFileReader.GetImageIOFromFileName(path)
             if image_io == "MetaImageIO":
                 # MetaImage announces compression in its ASCII header, ahead of ElementDataFile.
@@ -1787,6 +2022,22 @@ class Dataset:
             return matches[0] if matches else None
 
         def _file_to_image_slice(self, name: str, path: str, slices: tuple[slice, ...]) -> tuple[np.ndarray, Attribute]:
+            block = _pixel_block(path)
+            if block is not None:
+                # The region's bytes off the file, where ITK's streaming reader decodes them through
+                # its pipeline: 3.5 ms against 0.09 ms for a 64^3 region of an uncompressed 256^3
+                # .mha, the same bytes. The record ITK's route leaves is kept: the region's origin
+                # for a direct slice, the volume's for a stepped one, which ITK reads whole.
+                normalized = self._normalize_slices(slices, list(block.shape))
+                if all(item.step > 0 for item in normalized):
+                    try:
+                        data = _pixel_block_region(block, path, normalized)
+                    except (OSError, ValueError):  # replaced under the stat: ITK answers for it
+                        pass
+                    else:
+                        index_xyz = [item.start for item in reversed(normalized[1:])]
+                        direct = self._supports_direct_slice(normalized)
+                        return data, _pixel_block_attributes(block, index_xyz if direct else None)
             reader = sitk.ImageFileReader()
             reader.SetFileName(path)
             reader.ReadImageInformation()
@@ -2408,9 +2659,19 @@ class Dataset:
             return f"{self.filename}{name}.h5"
 
         def file_to_data(self, group: str, name: str) -> tuple[np.ndarray, Attribute]:
+            header = None
+            if h5py.is_hdf5(self._path(name)):
+                with self._field_file(name) as file:
+                    header = self._field_header(file)
+                    if header is not None:
+                        # The parameters ARE the field, float64: one span off the file, where ITK's
+                        # transform reader holds the field twice before the array is even copied out
+                        # (a 128^3 field: +147 MiB of RSS through ITK, +100 MiB off the span).
+                        shape, attributes = header
+                        return self._field_region(file, shape[1:], (slice(None),) * 4, np.float64), attributes
             transform = sitk.ReadTransform(self._path(name))
             attributes = Attribute()
-            if "DisplacementFieldTransform" in transform.GetName():
+            if "DisplacementFieldTransform" in transform.GetName():  # a field in a text transform file
                 field = sitk.DisplacementFieldTransform(transform).GetDisplacementField()
                 data, attributes = image_to_data(field)
                 attributes[DISPLACEMENT_FIELD_ATTRIBUTE] = "true"
@@ -2426,35 +2687,87 @@ class Dataset:
             shape, _attributes = self.get_infos("", name)
             return len(shape) == 4 and shape[0] == 3
 
-        def file_to_data_slice(self, group: str, name: str, slices: tuple[slice, ...]) -> tuple[np.ndarray, Attribute]:
-            """A region of a displacement entry, decoded from the parameters it maps to alone.
+        @contextlib.contextmanager
+        def _field_file(self, name: str) -> Iterator[Any]:
+            """The entry's HDF5 file off the process's read pool: opened once per file, held while
+            a region is read, replaced by the pool when the file is rewritten."""
+            path = self._path(name)
+            with _get_h5_file_lock(path):
+                yield _h5_read_pool.get(path).file
 
-            The buffer is ``[z][y][x]`` with the component fastest, so a span of leading-axis rows
-            is one contiguous span of the parameters: read, reshaped, and sliced down to the exact
-            region: the peak is the row span, never the field.
+        @staticmethod
+        def _field_header(file: Any) -> tuple[list[int], Attribute] | None:
+            """Shape and geometry of a displacement entry off its fixed parameters (size, origin,
+            spacing, direction); ``None`` for a transform of another kind, which the whole read decodes."""
+            kind = bytes(file["TransformGroup/0/TransformType"][0])
+            if not kind.startswith(b"DisplacementFieldTransform"):
+                return None
+            fixed = np.asarray(file["TransformGroup/0/TransformFixedParameters"][()], dtype=np.float64)
+            attributes = Attribute()
+            attributes["Origin"] = fixed[3:6]
+            attributes["Spacing"] = fixed[6:9]
+            attributes["Direction"] = fixed[9:18]
+            attributes[DISPLACEMENT_FIELD_ATTRIBUTE] = "true"
+            size_xyz = [int(extent) for extent in fixed[0:3]]
+            return [3, *size_xyz[::-1]], attributes
+
+        @staticmethod
+        def _covered(item: slice, extent: int) -> tuple[int, int, slice]:
+            """The ``[low, high)`` range of an axis a slice touches, and the slice of that range it
+            takes: what a read of the range then subsamples, whichever way the slice runs."""
+            start, stop, step = item.indices(extent)
+            count = len(range(start, stop, step))
+            if count == 0:
+                return 0, 0, slice(0, 0, 1)
+            if step > 0:
+                return start, start + (count - 1) * step + 1, slice(0, None, step)
+            low, high = start + (count - 1) * step, start + 1
+            return low, high, slice(high - low - 1, None, step)
+
+        @classmethod
+        def _field_region(
+            cls, file: Any, spatial: list[int], slices: tuple[slice, ...], dtype: type = np.float32
+        ) -> np.ndarray:
+            """The region ``slices`` of the field, read as one HDF5 hyperslab of the parameters.
+
+            The buffer is ``[z][y][x]`` with the component fastest, so the rows of one plane the
+            region covers are one contiguous span, and the planes it covers are such spans a stride
+            apart: a hyperslab of ``count`` blocks reads them into one buffer, the bytes of the
+            region's planes and rows and no other (a 64^3 region of a 512^3 field reads 50 MB where
+            the leading-axis rows it sits on are 403 MB). A forward step on the leading axis is the
+            stride; every other step, and a reversed axis, subsamples the block after the read.
             """
-            shape, attributes = self.get_infos(group, name)
-            leading = slices[1].indices(shape[1]) if len(shape) == 4 else (0, 0, 1)
-            if (
-                len(shape) != 4
-                or shape[0] != 3
-                or DISPLACEMENT_FIELD_ATTRIBUTE not in attributes
-                or not h5py.is_hdf5(self._path(name))
-                or leading[2] < 0  # a reversed leading axis has no contiguous span to read
-            ):
-                data, attributes = self.file_to_data(group, name)
-                return data[slices], attributes
-            spatial = shape[1:]
-            row = 3 * int(np.prod(spatial[1:], dtype=np.int64))
-            with _open_h5(self._path(name), "r") as file:
-                span = file["TransformGroup/0/TransformParameters"][leading[0] * row : leading[1] * row]
-            block = np.moveaxis(span.reshape(leading[1] - leading[0], *spatial[1:], 3), -1, 0)
-            # The span is the axis WITHOUT its step: rows start..stop were read whole, so the step
-            # subsamples here, on the reshaped block.
-            return (
-                np.asarray(block[(slices[0], slice(None, None, leading[2]), *slices[2:])], dtype=np.float32),
-                attributes,
-            )
+            plane_low, plane_high, planes = cls._covered(slices[1], spatial[0])
+            row_low, row_high, rows = cls._covered(slices[2], spatial[1])
+            row_length = 3 * int(spatial[2])
+            plane_length = row_length * int(spatial[1])
+            if planes.step > 0:  # the hyperslab's stride: the planes in between are never read
+                stride, count, planes = planes.step, len(range(plane_low, plane_high, planes.step)), slice(None)
+            else:
+                stride, count = 1, plane_high - plane_low
+            block = (row_high - row_low) * row_length
+            span = np.empty(count * block, dtype=np.float64)
+            if span.size:
+                parameters = file["TransformGroup/0/TransformParameters"]
+                selection = parameters.id.get_space()
+                selection.select_hyperslab(
+                    (plane_low * plane_length + row_low * row_length,), (count,), (stride * plane_length,), (block,)
+                )
+                parameters.id.read(h5py.h5s.create_simple((span.size,)), selection, span)
+            region = span.reshape(count, row_high - row_low, int(spatial[2]), 3)[planes, rows, slices[3], slices[0]]
+            return np.ascontiguousarray(np.moveaxis(region, -1, 0), dtype=dtype)
+
+        def file_to_data_slice(self, group: str, name: str, slices: tuple[slice, ...]) -> tuple[np.ndarray, Attribute]:
+            """A region of a displacement entry, decoded from the parameters it maps to alone: the
+            header and the region come off one pooled handle, so a region read opens nothing."""
+            if h5py.is_hdf5(self._path(name)):
+                with self._field_file(name) as file:
+                    header = self._field_header(file)
+                    if header is not None and len(slices) == 4:
+                        shape, attributes = header
+                        return self._field_region(file, shape[1:], slices), attributes
+            data, attributes = self.file_to_data(group, name)
+            return data[slices], attributes
 
         def data_to_file(
             self,
@@ -2534,22 +2847,14 @@ class Dataset:
         def get_infos(self, group: str, name: str) -> tuple[list[int], Attribute]:
             # A legacy TEXT transform (`#Insight Transform File V1.0`) is served by the read side
             # too; only a real HDF5 file has the parameter datasets this fast path opens.
-            if not h5py.is_hdf5(self._path(name)):
+            header = None
+            if h5py.is_hdf5(self._path(name)):
+                with self._field_file(name) as file:
+                    header = self._field_header(file)
+            if header is None:
                 data, attributes = self.file_to_data(group, name)
                 return [int(extent) for extent in data.shape], attributes
-            with _open_h5(self._path(name), "r") as file:
-                kind = bytes(file["TransformGroup/0/TransformType"][0])
-                fixed = np.asarray(file["TransformGroup/0/TransformFixedParameters"][()], dtype=np.float64)
-            if not kind.startswith(b"DisplacementFieldTransform"):
-                data, attributes = self.file_to_data(group, name)
-                return [int(extent) for extent in data.shape], attributes
-            attributes = Attribute()
-            attributes["Origin"] = fixed[3:6]
-            attributes["Spacing"] = fixed[6:9]
-            attributes["Direction"] = fixed[9:18]
-            attributes[DISPLACEMENT_FIELD_ATTRIBUTE] = "true"
-            size_xyz = [int(extent) for extent in fixed[0:3]]
-            return [3, *size_xyz[::-1]], attributes
+            return header
 
     class File:
         def __init__(
@@ -2962,20 +3267,8 @@ class Dataset:
     def read_transform(self, group: str, name: str) -> sitk.Transform:
         if not self.exists_on_disk():
             raise NameError(f"Dataset {self.filename} not found")
-        transform_parameters, attribute = self.read_data(group, name)
-        if DISPLACEMENT_FIELD_ATTRIBUTE in attribute:
-            # A displacement field carries no parameter vector to decode: the entry IS the transform,
-            # and the store said so (NGFF RFC-5). float64 is what DisplacementFieldTransform requires.
-            field = sitk.Cast(data_to_image(transform_parameters, attribute), sitk.sitkVectorFloat64)
-            return sitk.DisplacementFieldTransform(field)
-        transforms_type = [v for k, v in attribute.items() if k.endswith(":Transform_0")]
-        transforms = []
-        for i, transform_type in enumerate(transforms_type):
-            transform = _decode_transform(transform_type, name)
-            transform.SetFixedParameters(ast.literal_eval(attribute[f"{i}:FixedParameters"]))
-            transform.SetParameters(tuple(transform_parameters[i]))
-            transforms.append(transform)
-        return sitk.CompositeTransform(transforms) if len(transforms) > 1 else transforms[0]
+        data, attribute = self.read_data(group, name)
+        return data_to_transform(data, attribute, name)
 
     def read_image(self, group: str, name: str) -> sitk.Image:
         data, attribute = self.read_data(group, name)

--- a/konfai/utils/dicom.py
+++ b/konfai/utils/dicom.py
@@ -50,7 +50,7 @@ import os
 import re
 from collections.abc import Sequence
 from datetime import datetime
-from functools import lru_cache
+from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -336,41 +336,47 @@ def read_volume(
     DatasetManagerError
         If pixel data cannot be read or slices have inconsistent shapes.
     """
-    slices = []
-    expected_shape: tuple[int, int] | None = None
+    return _decode_slices(datasets, (slice(None), slice(None)), apply_rescale)[np.newaxis]
 
+
+def _decode_slices(datasets: list[DicomDataset], window: tuple[slice, slice], apply_rescale: bool) -> np.ndarray:
+    """The ``window`` (rows, columns) of every slice, stacked ``(Z, y, x)`` in float32, into one buffer.
+
+    Each plane is cut to the window BEFORE the cast and the rescale, so a 64x64 patch of 512x512
+    slices pays for 64x64 of arithmetic and not 512x512. ``arr * slope + intercept``, elementwise on
+    the cut plane, is the same operation on the same values as on the whole one: bit-identical.
+    """
+    volume: np.ndarray | None = None
+    expected_shape: tuple[int, ...] | None = None
     for i, ds in enumerate(datasets):
         try:
-            arr = ds.pixel_array.astype(np.float32)
+            plane = ds.pixel_array
         except Exception as exc:
             raise DatasetManagerError(
                 f"Cannot read pixel data from DICOM slice {i}.",
                 f"Transfer syntax or compression may be unsupported: {exc}",
             ) from exc
-
         if expected_shape is None:
-            expected_shape = arr.shape
-        elif arr.shape != expected_shape:
+            expected_shape = plane.shape
+        elif plane.shape != expected_shape:
             raise DatasetManagerError(
-                f"Inconsistent slice shape at index {i}: expected {expected_shape}, got {arr.shape}.",
+                f"Inconsistent slice shape at index {i}: expected {expected_shape}, got {plane.shape}.",
                 "All slices in a series must have the same rows and columns.",
             )
-
+        arr = plane[window].astype(np.float32)
         if apply_rescale:
             slope = float(getattr(ds, "RescaleSlope", 1.0))
             intercept = float(getattr(ds, "RescaleIntercept", 0.0))
             arr = arr * slope + intercept
-
-        slices.append(arr)
-
-    if not slices:
+        if volume is None:
+            volume = np.empty((len(datasets), *arr.shape), dtype=np.float32)
+        volume[i] = arr
+    if volume is None:
         raise DatasetManagerError("Series contains no readable slices.")
-
-    volume = np.stack(slices, axis=0)  # (Z, Y, X)
-    return volume[np.newaxis]  # (1, Z, Y, X)
+    return volume
 
 
-@lru_cache(maxsize=64)
+@cache
 def get_dicom_info(
     directory: str | Path,
     *,
@@ -379,7 +385,10 @@ def get_dicom_info(
     """Read DICOM series shape and geometry without decoding pixel data.
 
     Memoised per directory: input DICOM is read-only for a run, so the series walk and header reads are
-    done once instead of on every patch read. Callers that mutate the result must copy it first.
+    done once instead of on every patch read. Unbounded, because a miss re-reads every slice header
+    (0.3 ms per slice, twice) where the record it rebuilds is 140 bytes per slice, and a cohort read
+    in any order but case by case would miss on every patch past a bound. ``write_dicom_series``
+    clears it. Callers that mutate the result must copy it first.
     """
     selected_uid, files = _select_series_files(directory, series_uid)
     datasets = sort_series(files, stop_before_pixels=True)
@@ -390,10 +399,11 @@ def get_dicom_info(
         columns = int(first.Columns)
     except AttributeError as exc:
         raise DatasetManagerError("DICOM Rows/Columns tags are required to determine the volume shape.") from exc
+    by_name = {str(path): path for path in files}  # the discovery's own Path objects, once each
     return {
         "series_uid": selected_uid,
         "files": files,
-        "sorted_files": [Path(ds.filename) for ds in datasets],
+        "sorted_files": [by_name[ds.filename] for ds in datasets],
         "shape": [1, len(datasets), rows, columns],
         "origin": origin,
         "spacing": spacing,
@@ -411,7 +421,8 @@ def read_dicom_series_slice(
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Read only the selected DICOM slices and return updated patch geometry."""
     if info is None:
-        info = get_dicom_info(directory, series_uid=series_uid)
+        # Spelled as the backend spells it: functools.cache keys ``series_uid=None`` apart from its absence.
+        info = get_dicom_info(directory) if series_uid is None else get_dicom_info(directory, series_uid=series_uid)
     elif series_uid is not None and series_uid != info["series_uid"]:
         raise DatasetManagerError(
             f"series_uid '{series_uid}' does not match the provided info series '{info['series_uid']}'."
@@ -424,11 +435,11 @@ def read_dicom_series_slice(
     if list(channel_indices) not in ([0], []):
         raise DatasetManagerError("DICOM stores scalar data and supports only channel 0.")
 
-    z_indices = list(range(*normalized[1].indices(shape[1])))
-    selected_files = [info["sorted_files"][index] for index in z_indices]
-    datasets = sort_series(selected_files)
-    volume = read_volume(datasets, apply_rescale=apply_rescale)
-    volume = volume[normalized[0], :, normalized[2], normalized[3]]
+    _require_pydicom()
+    # ``sorted_files`` is in slice order already: the selection is read in that order, not sorted again.
+    z_indices = range(*normalized[1].indices(shape[1]))
+    datasets = [pydicom.dcmread(str(info["sorted_files"][index])) for index in z_indices]
+    volume = _decode_slices(datasets, (normalized[2], normalized[3]), apply_rescale)[np.newaxis][normalized[0]]
 
     direction_matrix = np.asarray(info["direction"], dtype=np.float64).reshape(3, 3)
     start_xyz = np.asarray([normalized[3].start, normalized[2].start, normalized[1].start], dtype=np.float64)
@@ -488,6 +499,7 @@ def write_dicom_series(
 
     root = Path(directory)
     root.mkdir(parents=True, exist_ok=True)
+    get_dicom_info.cache_clear()  # what this directory holds is about to change
     # Remove only slices previously written by this function (its zero-padded NNNNNN.dcm
     # naming), never unrelated DICOM files that may share the directory.
     for existing in root.glob("*.dcm"):

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -751,3 +751,378 @@ def test_the_readers_own_itk_keys_do_not_travel_with_the_volume(tmp_path: Path) 
     _, attributes = image_to_data(read)
     assert attributes["Study"] == "phantom"
     assert not [key for key in attributes.keys() if key.startswith("ITK_")]
+
+
+# --------------------------------------------------------------------------------------
+# Region reads off the raw pixel block of an uncompressed MetaImage / NIfTI
+# --------------------------------------------------------------------------------------
+
+_BLOCK_ORIGIN, _BLOCK_SPACING = [10.0, -20.5, 30.25], [0.7, 1.3, 2.1]
+_BLOCK_DIRECTION = np.asarray([0.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+# A rotation: ITK's index-to-world arithmetic and numpy's matrix product then differ by an ulp,
+# which the record of a region read keeps apart (one rung each).
+_BLOCK_ROTATED = np.asarray(
+    [[np.cos(0.3), -np.sin(0.3), 0.0], [np.sin(0.3), np.cos(0.3), 0.0], [0.0, 0.0, 1.0]]
+).reshape(-1)
+# What the block route serves, and what it leaves to ITK: the fixtures of the tests below.
+_BLOCK_SERVED = (
+    "scalar.mha",
+    "vector.mha",
+    "rotated.mha",
+    "scalar.nii",
+    "vector.nii",
+    "streamed.mha",
+    "streamed.nii",
+    "bigendian.mha",
+    "plane.mha",
+    "identity.nii",
+)
+_BLOCK_LEFT_TO_ITK = ("compressed.mha", "scalar.nii.gz", "detached.mhd", "scaled.nii", "scalar.nrrd")
+
+
+def _block_image(data: np.ndarray, direction: np.ndarray) -> "sitk.Image":
+    rank = data.ndim - 1
+    if data.shape[0] == 1:
+        image = sitk.GetImageFromArray(data[0])
+    else:
+        image = sitk.GetImageFromArray(np.moveaxis(data, 0, -1), isVector=True)
+    image.SetOrigin(_BLOCK_ORIGIN[:rank])
+    image.SetSpacing(_BLOCK_SPACING[:rank])
+    image.SetDirection(direction.reshape(3, 3)[:rank, :rank].reshape(-1).tolist())
+    image.SetMetaData("Study", "phantom")
+    return image
+
+
+def _write_block_fixture(root: Path, kind: str) -> tuple[Path, np.ndarray]:
+    """One file of ``kind`` under ``root``, and the channel-first array it holds."""
+    from konfai.utils.dataset import _MhaDataStream, _NiftiDataStream
+
+    rng = np.random.default_rng(len(kind))
+    scalar = (rng.normal(size=(1, 12, 14, 16)) * 100).astype(np.float32)
+    vector = (rng.normal(size=(3, 12, 14, 16)) * 100).astype(np.int16)
+    path = root / kind
+    if kind == "vector.mha":
+        sitk.WriteImage(_block_image(vector, _BLOCK_DIRECTION), str(path))
+        return path, vector
+    if kind == "rotated.mha":
+        sitk.WriteImage(_block_image(scalar, _BLOCK_ROTATED), str(path))
+        return path, scalar
+    if kind == "scalar.nii":
+        stored = rng.integers(0, 4000, size=scalar.shape).astype(np.uint16)
+        sitk.WriteImage(_block_image(stored, _BLOCK_DIRECTION), str(path))
+        return path, stored
+    if kind == "vector.nii":
+        stored = vector.astype(np.float32)
+        sitk.WriteImage(_block_image(stored, _BLOCK_DIRECTION), str(path))
+        return path, stored
+    if kind in ("streamed.mha", "streamed.nii"):
+        stored = vector if kind == "streamed.mha" else vector.astype(np.float32)
+        attributes = Attribute()
+        attributes["Origin"] = np.asarray(_BLOCK_ORIGIN)
+        attributes["Spacing"] = np.asarray(_BLOCK_SPACING)
+        attributes["Direction"] = _BLOCK_DIRECTION
+        stream_class = _MhaDataStream if kind == "streamed.mha" else _NiftiDataStream
+        with stream_class(str(path), list(stored.shape), stored.dtype, attributes) as stream:
+            stream.write_slice(tuple(slice(0, extent) for extent in stored.shape), stored)
+        return path, stored
+    if kind == "bigendian.mha":
+        header = (
+            "ObjectType = Image\nNDims = 3\nBinaryData = True\nBinaryDataByteOrderMSB = True\n"
+            "CompressedData = False\nTransformMatrix = "
+            + " ".join(str(v) for v in _BLOCK_DIRECTION.reshape(3, 3).T.reshape(-1))
+            + "\nOffset = "
+            + " ".join(str(v) for v in _BLOCK_ORIGIN)
+            + "\nElementSpacing = "
+            + " ".join(str(v) for v in _BLOCK_SPACING)
+            + "\nDimSize = 16 14 12\nElementType = MET_FLOAT\nElementDataFile = LOCAL\n"
+        )
+        path.write_bytes(header.encode() + scalar[0].astype(">f4").tobytes())
+        return path, scalar
+    if kind == "plane.mha":
+        sitk.WriteImage(_block_image(scalar[:, 0], _BLOCK_DIRECTION), str(path))
+        return path, scalar[:, 0]
+    if kind == "identity.nii":
+        # An origin at zero on an identity grid: NIfTI speaks RAS, so the header holds negative
+        # zeros, whose sign the record's text keeps or drops exactly as ITK's route does.
+        image = _block_image(scalar, np.eye(3).reshape(-1))
+        image.SetOrigin([0.0, 0.0, 0.0])
+        sitk.WriteImage(image, str(path))
+        return path, scalar
+    if kind == "scaled.nii":
+        import struct
+
+        stored = rng.integers(0, 4000, size=scalar.shape).astype(np.uint16)
+        sitk.WriteImage(_block_image(stored, _BLOCK_DIRECTION), str(path))
+        header = bytearray(path.read_bytes())
+        struct.pack_into("<2f", header, 112, 2.0, 10.0)  # scl_slope, scl_inter: ITK rescales to float
+        path.write_bytes(bytes(header))
+        return path, stored
+    writer = sitk.ImageFileWriter()
+    writer.SetFileName(str(path))
+    writer.SetUseCompression(kind in ("compressed.mha", "scalar.nii.gz"))
+    writer.Execute(_block_image(scalar, _BLOCK_DIRECTION))
+    return path, scalar
+
+
+def _block_backend(path: Path) -> Dataset.SitkFile:
+    return Dataset.SitkFile(f"{path.parent}/", True, path.name.split(".", 1)[1])
+
+
+def _block_region(data: np.ndarray, corner: bool = False) -> tuple[slice, ...]:
+    if corner:  # at the volume's own origin, where a zero coordinate keeps or loses its sign
+        return (slice(None), *(slice(0, 4) for _ in data.shape[1:]))
+    if data.ndim == 4:
+        return (slice(None), slice(3, 9), slice(2, 11), slice(5, 13))
+    return (slice(None), slice(2, 11), slice(5, 13))
+
+
+@pytest.mark.parametrize("corner", [False, True], ids=["interior", "corner"])
+@pytest.mark.parametrize("kind", _BLOCK_SERVED)
+def test_a_region_off_the_raw_block_is_the_one_itk_decodes(
+    tmp_path: Path, monkeypatch, kind: str, corner: bool
+) -> None:
+    """Same bytes, same dtype, same attribute record (keys, order, text) as ITK's streaming reader."""
+    from konfai.utils import dataset as dataset_module
+
+    path, data = _write_block_fixture(tmp_path, kind)
+    assert dataset_module._pixel_block(str(path)) is not None
+    assert Dataset.SitkFile._supports_region_read(str(path))
+    region = _block_region(data, corner)
+    backend = _block_backend(path)
+    got, attributes = backend.file_to_data_slice("", path.name.split(".", 1)[0], region)
+
+    monkeypatch.setattr(dataset_module, "_pixel_block", lambda path: None)
+    want, want_attributes = backend.file_to_data_slice("", path.name.split(".", 1)[0], region)
+
+    assert got.dtype == want.dtype and got.dtype.isnative
+    np.testing.assert_array_equal(got, want)
+    np.testing.assert_array_equal(got, data[region])
+    if data.shape[0] > 1 and path.suffix == ".nii":
+        # ITK aborts on a region of a vector NIfTI, so its route reads the volume whole and records
+        # the volume's origin; the block route records the region's, like every other format.
+        index_xyz = np.asarray([item.start for item in reversed(region[1:])], dtype=np.float64)
+        direction = want_attributes.get_np_array("Direction").reshape(3, 3)
+        expected = want_attributes.get_np_array("Origin") + direction @ (
+            index_xyz * want_attributes.get_np_array("Spacing")
+        )
+        np.testing.assert_array_equal(attributes.get_np_array("Origin"), expected)
+        rungs = ("Origin_0", "Origin_1")
+        assert {k: v for k, v in attributes.items() if k not in rungs} == {
+            k: v for k, v in want_attributes.items() if k not in rungs
+        }
+    else:
+        assert dict(attributes) == dict(want_attributes)
+
+
+@pytest.mark.parametrize("kind", _BLOCK_LEFT_TO_ITK)
+def test_a_file_the_block_route_declines_is_still_read_by_itk(tmp_path: Path, kind: str) -> None:
+    """Compressed, detached, rescaled, or another format: the block route steps aside, ITK answers."""
+    from konfai.utils import dataset as dataset_module
+
+    path, data = _write_block_fixture(tmp_path, kind)
+    assert dataset_module._pixel_block(str(path)) is None
+    region = _block_region(data)
+    got, attributes = _block_backend(path).file_to_data_slice("", path.name.split(".", 1)[0], region)
+
+    if kind == "scaled.nii":
+        np.testing.assert_array_equal(got, data[region].astype(np.float32) * 2.0 + 10.0)
+    else:
+        np.testing.assert_array_equal(got, data[region])
+    assert "Origin" in attributes
+
+
+def test_a_stepped_region_off_the_raw_block_reads_as_itk_reads_it_whole(tmp_path: Path, monkeypatch) -> None:
+    """A step ITK cannot extract is served whole and sliced: the block serves the same values and
+    keeps the record ITK's route leaves, the volume's own geometry."""
+    from konfai.utils import dataset as dataset_module
+
+    path, data = _write_block_fixture(tmp_path, "vector.mha")
+    region = (slice(0, 3, 2), slice(1, 12, 3), slice(0, 14, 2), slice(2, 16, 3))
+    backend = _block_backend(path)
+    got, attributes = backend.file_to_data_slice("", "vector", region)
+    monkeypatch.setattr(dataset_module, "_pixel_block", lambda path: None)
+    want, want_attributes = backend.file_to_data_slice("", "vector", region)
+
+    np.testing.assert_array_equal(got, want)
+    np.testing.assert_array_equal(got, data[region])
+    assert dict(attributes) == dict(want_attributes)
+
+
+def test_the_raw_block_header_is_read_once_and_follows_a_rewrite(tmp_path: Path, monkeypatch) -> None:
+    """ITK reads the header once per file, not once per region; a file rewritten under the same
+    name gets a record of its own."""
+    from konfai.utils import dataset as dataset_module
+
+    path, data = _write_block_fixture(tmp_path, "scalar.mha")
+    reads = {"header": 0}
+    real = sitk.ImageFileReader.ReadImageInformation
+
+    def counting(self):
+        reads["header"] += 1
+        return real(self)
+
+    monkeypatch.setattr(sitk.ImageFileReader, "ReadImageInformation", counting)
+    dataset_module._pixel_block_at.cache_clear()
+    backend = _block_backend(path)
+    for plane in range(10):
+        region = (slice(None), slice(plane, plane + 1), slice(None), slice(None))
+        got, _ = backend.file_to_data_slice("", "scalar", region)
+        np.testing.assert_array_equal(got, data[:, plane : plane + 1])
+    assert reads["header"] == 1
+
+    replaced = np.flip(data, axis=1).copy()
+    image = _block_image(replaced, _BLOCK_DIRECTION)
+    image.SetMetaData("Rewritten", "yes")  # a longer header: the stamp changes even on a coarse clock
+    sitk.WriteImage(image, str(path))
+    got, attributes = backend.file_to_data_slice("", "scalar", (slice(None), slice(0, 1), slice(None), slice(None)))
+    np.testing.assert_array_equal(got, replaced[:, 0:1])
+    assert attributes["Rewritten"] == "yes"
+    assert reads["header"] == 2
+
+
+def test_an_h5_sidecar_is_read_once_per_pooled_handle_and_dropped_with_it(tmp_path: Path, monkeypatch) -> None:
+    """A patch read costs one hyperslab: the entry's attributes are read off the handle on its first
+    read and copied after, and a write of the entry (which drops the handle) brings the new ones."""
+    dataset = Dataset(tmp_path / "Sidecar", "h5")
+    attributes = Attribute()
+    attributes["Origin"] = np.asarray([1.0, 2.0, 3.0])
+    attributes["Spacing"] = np.asarray([0.5, 1.5, 2.0])
+    attributes["Direction"] = np.eye(3).reshape(-1)
+    for index in range(12):
+        attributes[f"Key{index}"] = f"value {index}"
+    volume = np.arange(4 * 5 * 6, dtype=np.float32).reshape(1, 4, 5, 6)
+    dataset.write("CT", "P0", volume, attributes)
+    opens = {"attribute": 0}
+    real = h5py.AttributeManager.__getitem__
+
+    def counting(self, key):
+        opens["attribute"] += 1
+        return real(self, key)
+
+    monkeypatch.setattr(h5py.AttributeManager, "__getitem__", counting)
+    region = (slice(None), slice(1, 3), slice(0, 5), slice(2, 6))
+    records = [dataset.read_data_slice("CT", "P0", region)[1] for _ in range(10)]
+    _, whole = dataset.read_data("CT", "P0")
+
+    assert opens["attribute"] == len(attributes)
+    assert all(dict(record) == dict(attributes) for record in records)
+    assert dict(whole) == dict(attributes)
+    records[0]["Origin"] = np.asarray([9.0, 9.0, 9.0])  # a copy: the caller's edits stay the caller's
+    assert dataset.read_data_slice("CT", "P0", region)[1]["Origin"] == attributes["Origin"]
+
+    attributes["Study"] = "rewritten"
+    dataset.write("CT", "P0", volume + 1, attributes)
+    data, record = dataset.read_data_slice("CT", "P0", region)
+    np.testing.assert_array_equal(data, (volume + 1)[region])
+    assert record["Study"] == "rewritten"
+
+
+def _attribute_text_through_printing(value) -> str:
+    """The normalising door as it stood before the str fast path: every value through the printer."""
+    import sys
+
+    if isinstance(value, torch.Tensor):
+        value = value.detach().cpu().numpy()
+    if isinstance(value, np.generic | np.ndarray) and np.issubdtype(value.dtype, np.floating):
+        value = np.asarray(value, dtype=np.float64)[()] if isinstance(value, np.generic) else value.astype(np.float64)
+    with np.printoptions(threshold=sys.maxsize, floatmode="unique"):
+        return str(value).replace("\n", "")
+
+
+def _former_attribute_copy(attributes: dict) -> Attribute:
+    """``Attribute(attributes)`` as it stood: every key deep-copied, every value through the printer."""
+    import copy
+
+    copied = Attribute()
+    for k, v in attributes.items():
+        dict.__setitem__(copied, copy.deepcopy(k), _attribute_text_through_printing(v))
+    return copied
+
+
+def _attribute_fixture_values() -> dict:
+    return {
+        "Origin": np.asarray([10.0, -20.5, 30.25]),
+        "Spacing_0": np.asarray([0.7, 1.3, 2.1], dtype=np.float32),
+        "Direction_0": np.eye(3).reshape(-1),
+        "Long": np.arange(2000, dtype=np.float64) / 7,
+        "Mean": np.float32(0.1),
+        "Std": 0.30000000000000004,
+        "Count": 12,
+        "Flag": True,
+        "Nested": [[1.5, 2.0], [3.0, 4.25]],
+        "Tensor": torch.tensor([1.0, 2.5, 3.0]),
+        "Zero": torch.tensor(0.0),
+        "Text": "phantom\nstudy",
+        "Empty": "",
+        "Ints": np.asarray([1, 2, 3]),
+    }
+
+
+def test_copying_an_attribute_is_the_same_record_as_normalising_it_again() -> None:
+    """Every door yields the same text as the printing door did, key for key: from live values,
+    from a plain dict of text, and from an Attribute (a dict-level copy)."""
+    values = _attribute_fixture_values()
+    former = _former_attribute_copy(values)
+
+    from_values = Attribute(values)
+    from_text = Attribute(dict(from_values))
+    from_attribute = Attribute(from_values)
+
+    assert list(dict(from_values).items()) == list(dict(former).items())
+    assert list(dict(from_text).items()) == list(dict(former).items())
+    assert list(dict(from_attribute).items()) == list(dict(former).items())
+    assert all(type(v) is str for v in dict(from_attribute).values())
+    np.testing.assert_array_equal(from_attribute.get_np_array("Long"), values["Long"])
+    assert from_attribute["Text"] == "phantomstudy"
+    assert Attribute(None) == Attribute({}) == Attribute()
+
+
+def test_a_copied_attribute_is_independent_of_its_source() -> None:
+    source = Attribute(_attribute_fixture_values())
+    copied = Attribute(source)
+    copied["Origin"] = np.asarray([0.0, 0.0, 0.0])
+    copied.pop("Std")
+
+    assert source["Origin"] == Attribute(_attribute_fixture_values())["Origin"]
+    assert "Std" in source
+    assert source["Std"] == "0.30000000000000004"
+
+
+def test_assigning_text_keeps_it_as_it_is_but_for_newlines() -> None:
+    """The printing door stripped a str's newlines and nothing else; the fast path does the same."""
+    attributes = Attribute()
+    attributes["Study"] = "phantom\nstudy"
+    attributes["Path"] = "a b:c"
+    assert attributes["Study"] == "phantomstudy" == _attribute_text_through_printing("phantom\nstudy")
+    assert attributes["Path"] == "a b:c"
+
+
+# --------------------------------------------------------------------------------------
+# An array read off a map or an ITK buffer owns its bytes
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", ["scalar.mha", "scalar.nii", "vector.nii"])
+def test_a_full_plane_region_off_the_raw_block_owns_its_bytes(tmp_path: Path, kind: str) -> None:
+    """A slab of whole planes is contiguous on the map, so a copy that only guarantees contiguity
+    would hand back the map's own pages: read-only, and unmapped once the array holding them is
+    gone, under a tensor still pointing at them."""
+    path, data = _write_block_fixture(tmp_path, kind)
+    region = (slice(None), slice(2, 5), slice(None), slice(None))
+    got, _ = _block_backend(path).file_to_data_slice("", path.name.split(".", 1)[0], region)
+
+    assert not isinstance(got, np.memmap) and got.flags.owndata and got.flags.writeable
+    tensor = torch.from_numpy(got)  # what the streamed route does with it next
+    got += 1
+    np.testing.assert_array_equal(tensor.numpy(), data[region] + 1)
+
+
+def test_image_to_data_owns_the_vector_image_bytes_whatever_its_size() -> None:
+    """A vector image of one voxel is contiguous however its axes are moved: the array must still be
+    a copy, not a view into a buffer the image takes with it."""
+    image = sitk.GetImageFromArray(np.asarray([[[[1.0, 2.0, 3.0]]]], dtype=np.float32), isVector=True)
+    data, _ = image_to_data(image)
+    del image
+
+    assert data.flags.owndata and data.shape == (3, 1, 1, 1)
+    np.testing.assert_array_equal(data.reshape(-1), [1.0, 2.0, 3.0])

--- a/tests/unit/test_imaging_formats.py
+++ b/tests/unit/test_imaging_formats.py
@@ -231,6 +231,77 @@ class TestDicomReadVolume:
             dicom.read_volume([ds0, ds1])
 
 
+class TestDicomRegionDecode:
+    """A region decodes the window of each selected slice, and nothing of the rest of the plane."""
+
+    @staticmethod
+    def _former_slice_read(root: Path, region: tuple[slice, ...]) -> np.ndarray:
+        """The full-plane route: every selected plane cast and rescaled whole, stacked, then cut."""
+        import pydicom
+        from konfai.utils import dicom
+
+        info = dicom.get_dicom_info(root)
+        z_indices = range(*region[1].indices(info["shape"][1]))
+        planes = []
+        for index in z_indices:
+            ds = pydicom.dcmread(str(info["sorted_files"][index]))
+            arr = ds.pixel_array.astype(np.float32)
+            planes.append(arr * float(ds.RescaleSlope) + float(ds.RescaleIntercept))
+        return np.stack(planes, axis=0)[np.newaxis][region[0], :, region[2], region[3]]
+
+    def test_a_window_cut_before_the_rescale_is_bit_identical_to_the_whole_plane(self, tmp_path: Path) -> None:
+        pytest.importorskip("pydicom")
+        from konfai.utils import dicom
+
+        root = tmp_path / "CT"
+        volume = (np.random.default_rng(3).normal(size=(1, 6, 24, 20)) * 300 - 200).astype(np.float32)
+        dicom.write_dicom_series(root, volume, origin=(1.0, 2.0, 3.0), spacing=(0.7, 0.8, 2.5))
+        region = (slice(None), slice(1, 5), slice(3, 17), slice(2, 19))
+
+        got, *_ = dicom.read_dicom_series_slice(root, region)
+        want = self._former_slice_read(root, region)
+
+        assert got.dtype == want.dtype == np.float32
+        assert got.tobytes() == want.tobytes()
+        whole, *_ = dicom.read_dicom_series(root)
+        assert whole.tobytes() == self._former_slice_read(root, (slice(None),) * 4).tobytes()
+
+    def test_a_region_reads_its_slices_in_order_without_sorting_them_again(self, tmp_path: Path, monkeypatch) -> None:
+        """``sorted_files`` is in slice order: the selection is decoded in that order, once each."""
+        pytest.importorskip("pydicom")
+        from konfai.utils import dicom
+
+        root = tmp_path / "CT"
+        volume = np.arange(1 * 5 * 4 * 4, dtype=np.int16).reshape(1, 5, 4, 4)
+        dicom.write_dicom_series(root, volume, origin=(0.0,) * 3, spacing=(1.0,) * 3)
+        dicom.get_dicom_info(root)
+        sorts = {"count": 0}
+        real_sort = dicom.sort_series
+
+        def counting(*args, **kwargs):
+            sorts["count"] += 1
+            return real_sort(*args, **kwargs)
+
+        monkeypatch.setattr(dicom, "sort_series", counting)
+        got, *_ = dicom.read_dicom_series_slice(root, (slice(None), slice(1, 4, 2), slice(None), slice(None)))
+
+        np.testing.assert_array_equal(got, volume[:, 1:4:2])
+        assert sorts["count"] == 0
+
+    def test_the_series_info_memo_is_unbounded_and_a_write_clears_it(self, tmp_path: Path) -> None:
+        """A miss re-reads every slice header twice; a bound of 64 series missed on every patch of a
+        cohort read in any order but case by case. A write of a series is what changes a directory."""
+        pytest.importorskip("pydicom")
+        from konfai.utils import dicom
+
+        assert dicom.get_dicom_info.cache_info().maxsize is None
+        root = tmp_path / "CT"
+        dicom.write_dicom_series(root, np.zeros((1, 3, 4, 4), dtype=np.int16), origin=(0.0,) * 3, spacing=(1.0,) * 3)
+        assert dicom.get_dicom_info(root)["shape"] == [1, 3, 4, 4]
+        dicom.write_dicom_series(root, np.zeros((1, 5, 4, 4), dtype=np.int16), origin=(0.0,) * 3, spacing=(1.0,) * 3)
+        assert dicom.get_dicom_info(root)["shape"] == [1, 5, 4, 4]
+
+
 # ---------------------------------------------------------------------------
 # OME-Zarr tests (no real Zarr store: uses unittest.mock)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_itk_transform_backend.py
+++ b/tests/unit/test_itk_transform_backend.py
@@ -262,6 +262,31 @@ def test_a_stepped_or_reversed_region_is_the_whole_field_sliced(tmp_path: Path, 
     np.testing.assert_array_equal(got, field[region])
 
 
+def test_a_field_carrying_more_than_float32_reads_the_same_whole_and_by_region(tmp_path: Path) -> None:
+    """The file keeps ITK's double, the pipeline carries float32. A value that needs more than 24
+    bits is rounded once, at the read, so the whole route and the region route hold the same one."""
+    import h5py
+
+    field = (np.random.default_rng(3).normal(size=(3, 4, 5, 6)) * 8).astype(np.float32)
+    dataset = Dataset(tmp_path / "out", "itktransform")
+    dataset.write("Transform", "P000", field, _attributes())
+
+    path = tmp_path / "out" / "P000" / "Transform.h5"
+    with h5py.File(path, "r+") as file:
+        parameters = file["TransformGroup/0/TransformParameters"]
+        exact = np.asarray(parameters[()], dtype=np.float64)
+        exact += np.float64(2.0) ** -30  # below one float32 ulp of these values: it cannot survive
+        parameters[...] = exact
+    assert not np.array_equal(exact, exact.astype(np.float32).astype(np.float64))
+
+    whole, _ = dataset.read_data("Transform", "P000")
+    region = (slice(0, 3), slice(1, 3), slice(2, 5), slice(0, 4))
+    got, _ = dataset.read_data_slice("Transform", "P000", region)
+
+    assert np.asarray(whole).dtype == got.dtype == np.float32
+    np.testing.assert_array_equal(got, np.asarray(whole)[region])
+
+
 def test_a_region_read_holds_its_planes_and_rows_and_not_the_rows_around_them(tmp_path: Path) -> None:
     """A 8^3 region of a 64^3 field reads 8 rows of 8 planes (98 KB of parameters), not the 8 whole
     planes those rows sit on (786 KB)."""
@@ -284,8 +309,8 @@ def test_a_region_read_holds_its_planes_and_rows_and_not_the_rows_around_them(tm
 
 
 def test_a_whole_read_of_a_field_entry_is_what_itk_decodes_off_the_same_file(tmp_path: Path) -> None:
-    """The parameters are the field in float64: read as one span, they are the bytes ITK's transform
-    reader hands over, under the same attribute record."""
+    """The parameters are the field: read as one span, they are the values ITK's transform reader
+    hands over, under the same attribute record, at the dtype the pipeline carries."""
     from konfai.utils.dataset import DISPLACEMENT_FIELD_ATTRIBUTE, image_to_data
 
     field = (np.random.default_rng(11).normal(size=(3, 5, 7, 6)) * 8).astype(np.float32)
@@ -297,6 +322,6 @@ def test_a_whole_read_of_a_field_entry_is_what_itk_decodes_off_the_same_file(tmp
     want, want_attributes = image_to_data(sitk.DisplacementFieldTransform(transform).GetDisplacementField())
     want_attributes[DISPLACEMENT_FIELD_ATTRIBUTE] = "true"
 
-    assert data.dtype == want.dtype == np.float64 and data.flags.c_contiguous
-    assert data.tobytes() == want.tobytes()
+    assert data.dtype == np.float32 and want.dtype == np.float64 and data.flags.c_contiguous
+    assert data.tobytes() == want.astype(np.float32).tobytes()
     assert dict(attributes) == dict(want_attributes)

--- a/tests/unit/test_itk_transform_backend.py
+++ b/tests/unit/test_itk_transform_backend.py
@@ -214,3 +214,89 @@ def test_without_h5py_the_backend_names_the_extra_to_install(tmp_path: Path, mon
 
     with pytest.raises(DatasetManagerError, match="h5py"):
         Dataset(tmp_path / "out", "itktransform").write("Transform", "P000", _field(), _attributes())
+
+
+def test_a_region_read_opens_the_file_once_for_the_process(tmp_path: Path, monkeypatch) -> None:
+    """The header and the region come off one pooled handle: past the first region, no open at all."""
+    from konfai.utils import dataset as dataset_module
+
+    dataset = Dataset(tmp_path / "out", "itktransform")
+    dataset.write("Transform", "P000", _field(6), _attributes())
+    opens = {"count": 0}
+    real = dataset_module._open_h5
+
+    def counting(*args, **kwargs):
+        opens["count"] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(dataset_module, "_open_h5", counting)
+    for start in range(3):
+        region = (slice(0, 3), slice(start, start + 2), slice(1, 4), slice(2, 6))
+        got, _ = dataset.read_data_slice("Transform", "P000", region)
+        np.testing.assert_array_equal(got, _field(6)[region])
+    dataset.get_infos("Transform", "P000")
+
+    assert opens["count"] == 1
+
+
+@pytest.mark.parametrize(
+    "region",
+    [
+        (slice(0, 3), slice(6, 1, -2), slice(0, 9), slice(0, 11)),  # the leading axis reversed
+        (slice(0, 3), slice(1, 7, 2), slice(8, None, -3), slice(10, 2, -1)),  # every axis stepped or reversed
+        (slice(2, None, -1), slice(None), slice(None, None, -1), slice(None)),  # channels and rows reversed
+        (slice(0, 3), slice(2, 2), slice(0, 9), slice(0, 11)),  # an empty span of planes
+    ],
+    ids=["reversed-planes", "stepped-every-axis", "reversed-channels-rows", "empty"],
+)
+def test_a_stepped_or_reversed_region_is_the_whole_field_sliced(tmp_path: Path, region: tuple[slice, ...]) -> None:
+    """Whatever the slice does, the region is what slicing the whole field gives, read bounded."""
+    field = (np.random.default_rng(9).normal(size=(3, 7, 9, 11)) * 8).astype(np.float32)
+    dataset = Dataset(tmp_path / "out", "itktransform")
+    dataset.write("Transform", "P000", field, _attributes())
+
+    whole, _ = dataset.read_data("Transform", "P000")
+    got, _ = dataset.read_data_slice("Transform", "P000", region)
+
+    np.testing.assert_array_equal(got, np.asarray(whole)[region])
+    np.testing.assert_array_equal(got, field[region])
+
+
+def test_a_region_read_holds_its_planes_and_rows_and_not_the_rows_around_them(tmp_path: Path) -> None:
+    """A 8^3 region of a 64^3 field reads 8 rows of 8 planes (98 KB of parameters), not the 8 whole
+    planes those rows sit on (786 KB)."""
+    import tracemalloc
+
+    field = (np.random.default_rng(4).normal(size=(3, 64, 64, 64)) * 8).astype(np.float32)
+    dataset = Dataset(tmp_path / "out", "itktransform")
+    dataset.write("Transform", "P000", field, _attributes())
+    region = (slice(0, 3), slice(20, 28), slice(30, 38), slice(40, 48))
+    dataset.read_data_slice("Transform", "P000", region)  # the pooled handle, opened outside the trace
+
+    tracemalloc.start()
+    got, _ = dataset.read_data_slice("Transform", "P000", region)
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    np.testing.assert_array_equal(got, field[region])
+    span_bytes = 8 * 8 * 64 * 3 * 8
+    assert peak < 4 * span_bytes, f"{peak} bytes at peak for a span of {span_bytes}"
+
+
+def test_a_whole_read_of_a_field_entry_is_what_itk_decodes_off_the_same_file(tmp_path: Path) -> None:
+    """The parameters are the field in float64: read as one span, they are the bytes ITK's transform
+    reader hands over, under the same attribute record."""
+    from konfai.utils.dataset import DISPLACEMENT_FIELD_ATTRIBUTE, image_to_data
+
+    field = (np.random.default_rng(11).normal(size=(3, 5, 7, 6)) * 8).astype(np.float32)
+    dataset = Dataset(tmp_path / "out", "itktransform")
+    dataset.write("Transform", "P000", field, _attributes())
+
+    data, attributes = dataset.read_data("Transform", "P000")
+    transform = sitk.ReadTransform(str(tmp_path / "out" / "P000" / "Transform.h5"))
+    want, want_attributes = image_to_data(sitk.DisplacementFieldTransform(transform).GetDisplacementField())
+    want_attributes[DISPLACEMENT_FIELD_ATTRIBUTE] = "true"
+
+    assert data.dtype == want.dtype == np.float64 and data.flags.c_contiguous
+    assert data.tobytes() == want.tobytes()
+    assert dict(attributes) == dict(want_attributes)

--- a/tests/unit/test_itk_transforms.py
+++ b/tests/unit/test_itk_transforms.py
@@ -86,3 +86,88 @@ def test_resample_transform_applies_displacement_in_physical_space() -> None:
     bright = torch.nonzero(out[0] > 0).tolist()
 
     assert bright == [[4, 4, 3]]  # moved 6 mm / 2 mm = 3 voxels along X, staying on z=4, y=4
+
+
+def _field_image(edge: int, seed: int = 0) -> tuple["sitk.Image", np.ndarray]:
+    """A displacement field image on a non-trivial grid, and its component-first float32 array."""
+    field = (np.random.default_rng(seed).normal(size=(3, edge, edge, edge)) * 4).astype(np.float32)
+    image = sitk.GetImageFromArray(np.moveaxis(field, 0, -1), isVector=True)
+    image.SetOrigin((7.0, -3.0, 10.0))
+    image.SetSpacing((1.5, 1.5, 2.0))
+    image.SetDirection((0.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0))
+    return image, field
+
+
+def test_decoding_a_displacement_field_copies_it_once() -> None:
+    """The stage's float64 component-first values are written straight off ITK's buffer: the same
+    values as the copy, the transpose per component and the stack, at one copy's worth of peak."""
+    import tracemalloc
+
+    from konfai.utils.ITK import decode_transform_stages
+
+    image, field = _field_image(64)
+    transform = sitk.DisplacementFieldTransform(sitk.Cast(image, sitk.sitkVectorFloat64))
+    tracemalloc.start()
+    (stage,) = decode_transform_stages(transform)
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    assert stage.values.dtype == np.float64 and stage.values.flags.c_contiguous
+    np.testing.assert_array_equal(stage.values, field.astype(np.float64))
+    np.testing.assert_array_equal(stage.grid.origin_xyz, image.GetOrigin())
+    assert peak < 2 * stage.values.nbytes, f"{peak} bytes at peak for {stage.values.nbytes} of values"
+
+
+def test_a_stored_displacement_entry_decodes_to_the_stage_the_image_route_gives(tmp_path) -> None:
+    """Straight from the store's array, on the grid its attributes describe: the same stage, bit
+    for bit, as reading the entry as a transform and decoding that."""
+    from konfai.utils.dataset import Attribute, Dataset
+    from konfai.utils.ITK import decode_transform_stages, read_transform_stages
+
+    image, field = _field_image(6, seed=2)
+    attributes = Attribute()
+    attributes["Origin"] = np.asarray(image.GetOrigin())
+    attributes["Spacing"] = np.asarray(image.GetSpacing())
+    attributes["Direction"] = np.asarray(image.GetDirection())
+    dataset = Dataset(tmp_path / "out", "itktransform")
+    dataset.write("Transform", "P000", field, attributes)
+
+    (direct,) = read_transform_stages(dataset, "Transform", "P000")
+    (through_itk,) = decode_transform_stages(dataset.read_transform("Transform", "P000"))
+
+    assert direct.order == through_itk.order == 1
+    assert direct.grid.size_zyx == through_itk.grid.size_zyx
+    for axis in ("origin_xyz", "spacing_xyz", "direction_xyz"):
+        np.testing.assert_array_equal(getattr(direct.grid, axis), getattr(through_itk.grid, axis))
+    assert direct.values.tobytes() == through_itk.values.tobytes()
+
+
+def test_a_store_serving_transforms_alone_still_decodes() -> None:
+    """The smallest thing a stored-transform Resample asks of a dataset is read_transform: a store
+    that offers nothing else is decoded through it."""
+    from konfai.data.geometry import AffineStage
+    from konfai.utils.ITK import read_transform_stages
+
+    translation = sitk.TranslationTransform(3, (6.0, 0.0, 0.0))
+
+    class _TransformStore:
+        def read_transform(self, group: str, name: str) -> "sitk.Transform":
+            return translation
+
+    (stage,) = read_transform_stages(_TransformStore(), "reg", "case")
+    assert isinstance(stage, AffineStage)
+    np.testing.assert_array_equal(stage.map.translation, [6.0, 0.0, 0.0])
+
+
+def test_box_with_mask_reads_the_mask_as_a_view() -> None:
+    from konfai.utils.ITK import box_with_mask
+
+    mask = np.zeros((20, 30, 40), dtype=np.uint8)
+    mask[3:9, 10:20, 5:35] = 2
+    image = sitk.GetImageFromArray(mask)
+    image.SetSpacing((1.0, 2.0, 0.5))
+
+    box = box_with_mask(image, [2], [2, 2, 2])
+
+    # (z, y, x): a 2 mm dilation is 4 voxels at 0.5 mm, 1 at 2 mm, 2 at 1 mm
+    assert box.tolist() == [[0, 12], [9, 20], [3, 36]]

--- a/tests/unit/test_perf_hot_paths.py
+++ b/tests/unit/test_perf_hot_paths.py
@@ -171,22 +171,22 @@ def test_dicom_slice_info_threading_is_byte_identical_and_removes_rescans(tmp_pa
 
     dataset_file = Dataset.DicomFile(str(tmp_path / "P000"), read=True)
 
-    # one COLD patch read costs exactly 1 discovery + 2 sorts. get_dicom_info is memoised, so the
-    # cache must be cleared for the spy to see the cold cost at all.
+    # one COLD patch read costs exactly 1 discovery + 1 sort (the headers, for the slice order).
+    # get_dicom_info is memoised, so the cache must be cleared for the spy to see the cold cost at all.
     calls["discover"] = calls["sort"] = 0
     dicom.get_dicom_info.cache_clear()
     data, _attr = dataset_file.file_to_data_slice("", "CT", sl)
     assert np.array_equal(np.asarray(data), np.asarray(ref[0]))
     assert calls["discover"] == 1
-    assert calls["sort"] == 2
+    assert calls["sort"] == 1
 
-    # a WARM read of the same case re-discovers nothing; only the per-read slab sort (pixel
-    # loading of the selected files) remains
+    # a WARM read of the same case re-discovers nothing and sorts nothing: the selected files are
+    # decoded in the order the memoised info already holds them
     calls["discover"] = calls["sort"] = 0
     data, _attr = dataset_file.file_to_data_slice("", "CT", sl)
     assert np.array_equal(np.asarray(data), np.asarray(ref[0]))
     assert calls["discover"] == 0
-    assert calls["sort"] == 1
+    assert calls["sort"] == 0
 
     # statistics over Z: 1 cold discovery, not O(Z); numerics preserved (Welford, ddof=1)
     calls["discover"] = calls["sort"] = 0


### PR DESCRIPTION

## Summary

One commit, `perf(dataset): serve a region off a memmap or a pooled handle`, folding seven. A region read of a
storage backend takes the shortest route its file allows. An uncompressed single-file `.mha` or `.nii` (binary,
`ElementDataFile = LOCAL`, no `HeaderSize`, no `scl_slope`/`scl_inter`, an element type from the writers' own tables)
is served off an `np.memmap` of its raw block; the header is read once per file (LRU keyed on path, mtime and size)
off a one-voxel region ITK extracts, so the record a read leaves is ITK's own; a detached `.mhd`, a gzip stream, a
rescaled NIfTI and NRRD stay on ITK's route. An h5 entry's sidecar travels with the pooled read handle: read on the
first read, copied on every read after, replaced or dropped with the handle. A DICOM plane is cut to the region
before the cast and the rescale, every slice lands in one preallocated `(Z, y, x)` float32 buffer, the selection is
decoded in the order the memoised info holds it, and `get_dicom_info`'s memo is unbounded. An `:itktransform` field
region is one HDF5 hyperslab off the pooled handle (403 MB were read for a 64^3 region of a 512^3 field whose content
is 3.1 MB). A displacement field decodes into its stage with one copy: `read_transform_stages` builds a stored entry's
stage from the array the store hands over, and `Resample` takes that route. `Attribute(attribute)` is a dict-level
copy, the values being text already. A test pins that an array off a map or an ITK buffer owns its bytes (a slab of
whole planes handed back the map's pages; the streamed TRANSFORM route crashed on it).

## Measured

| Route | Before | After | Method the commit body names |
|---|---|---|---|
| `.mha` 64^3 / 16^3 / 128^3 region | 6.05 / 1.68 / 23.5 ms | 0.54 / 0.39 / 2.50 ms | per region read, the two routes alternated, medians of 5x10 reads, load average 35 |
| `.nii` 64^3 / vector `.mha` region | 5.20 / 9.02 ms | 0.89 / 1.18 ms | same |
| `.mha` 64^3 region at load average 1.7 | 3.5 ms | 0.27 ms | same |
| h5 attribute opens per 1000 region reads | 15000 | 0 past the first read | `AttributeManager.__getitem__` counted, 15-key sidecar, medians of 5x200, load average 35 |
| h5 64^3 / 16^3 region | 637 / 447 us | 352 / 173 us | same |
| DICOM 16x64x64 region read | 53.7 ms | 7.0 ms | 64-slice 512x512 float series, 5x5 reads, load average 10-20 |
| DICOM `read_volume` peak | 193 MiB | 132 MiB | tracemalloc |
| DICOM memoised record, 64 slices | 8767 bytes | 2084 bytes | pickled |
| `:itktransform` 64^3 region, opens | 2 + 2 probes | 0 + 1 probe (1 open per process) | 256^3 float32 field, one fresh process per run, `_open_h5` and `h5py.is_hdf5` counted, load average 16 |
| same, peak / ru_maxrss | 99 MiB / +102 MiB | 27 MiB / +29 MiB | tracemalloc, ru_maxrss |
| same, first / warm read | 38.8 / 29 ms | 16.9 / 6 ms | same |
| `:itktransform` stepped (z/3, y/2, x/4) region | 291 MiB, 108.8 ms | 98 MiB, 33.9 ms | same |
| `decode_transform_stages` | 159 MiB, ru_maxrss +84 | 62 MiB, +0 | 3x128^3 float32 field, one fresh process per run, tracemalloc, ru_maxrss |
| stored `:itktransform` entry | 159 MiB, +223 MiB | 104 MiB, +115 MiB | `read_transform` + decode before, `read_transform_stages` after |
| stored h5 entry | image route 72 MiB, +123 MiB | direct route 86 MiB, +97 MiB | same |
| `box_with_mask` (128^3 uint8) | 12 MiB | 10 MiB | same |
| `Attribute(attribute)` / `Attribute(dict)` | 69.0 / 68.1 us | 0.3 / 4.6 us | timeit, 5x2000 copies of a 23-key Attribute, best of 5 |

**Values.** Nothing moves. Every route is pinned bit-identical or byte for byte against the one it replaces: region
reads with the record text compared key by key, `Attribute(Attribute(x)) == Attribute(x)`, a stage's values equal to
the field bit for bit, an `:itktransform` region equal to the whole field sliced. One record changes: a vector NIfTI
region now carries the region's origin like every other format, where its route read the volume whole and recorded
the volume's. The fallback for a reversed leading axis of an `:itktransform` region is gone (a reversed axis
subsamples the block after the read).

**Tests.** `tests/unit/test_dataset.py` (memmap route on scalar, vector, rotated and big-endian MetaImage, scalar,
vector and zero-origin NIfTI and a 2-D plane, interior and corner regions, stepped slices; 5 of the 15 fixture files
still take ITK's route; h5 sidecar before and after a rewrite; every Attribute door; an array off a map or an ITK
buffer owns its bytes), `tests/unit/test_imaging_formats.py` (DICOM cut plane byte for byte, region and whole volume),
`tests/unit/test_itk_transform_backend.py` (hyperslab region forward, stepped, reversed, empty; an 8^3 region of a
64^3 field holds under four times its span), `tests/unit/test_itk_transforms.py` (stage equals the field on both
routes).

**Stack.** Stacked on `pr/1.8.2-01-sweep`; merge after it. Before deleting this branch, retarget the next PR of the stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Faster region-based image and DICOM reads by decoding only requested areas and slices.
  - Improved repeated-read performance through metadata and file-handle caching.
  - Reduced memory use when loading displacement fields and vector images.

- **Bug Fixes**
  - Improved handling of stepped, reversed, empty, scalar, and vector image regions.
  - Preserved image metadata, orientation, writable output arrays, and attribute text consistently.
  - Improved transform loading and reconstruction across supported storage formats.
  - Cache contents are now refreshed correctly after DICOM or dataset updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->