### PR TITLE
Startup: one config tree, every case built once, the startup clock

### DIFF
--- a/konfai/api.py
+++ b/konfai/api.py
@@ -116,10 +116,11 @@ def _launch(
     lock's exit restores to the caller's. ``ranks`` sizes the lock and stays the caller's own
     expression: the entry points do not all derive it from ``gpu``/``cpu`` the same way.
     """
-    from konfai.utils.runtime import execute_distributed_object
+    from konfai.utils.runtime import execute_distributed_object, restart_startup_clock
 
     with _one_workflow_at_a_time(ranks):
-        workflow = build()
+        with restart_startup_clock().phase("build"):  # this call's own clock, not the previous workflow's
+            workflow = build()
         execute_distributed_object(workflow, gpu=list(gpu or []), cpu=cpu, overwrite=overwrite, quiet=quiet)
         return finish(workflow)
 

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -65,6 +65,7 @@ from konfai.utils.runtime import (
     get_memory,
     get_memory_info,
     memory_forecast,
+    startup_clock,
 )
 from konfai.utils.utils import SUPPORTED_FORMATS, OverlapSpec, resolve_patch, split_path_spec
 
@@ -768,11 +769,15 @@ class Subset:
         return isinstance(selector, str) and selector.startswith("~")
 
     def _included_names(self, selector: str | int) -> set[str] | None:
-        """The cases ``selector`` keeps, or ``None`` when only the cohort can say which they are."""
-        if isinstance(selector, int) or self._is_slice_selector(selector):
+        """The cases ``selector`` keeps, or ``None`` when only the cohort can say which they are.
+        Read in ``_resolve_selector``'s order, a file before a slice, so the walk asks for what the
+        selection then keeps."""
+        if isinstance(selector, int):
             return None  # a position, and positions are defined against the full sorted list
         if os.path.exists(selector):
             return set(self._read_names_from_file(selector))
+        if self._is_slice_selector(selector):
+            return None
         return {selector}
 
     def required_names(self) -> set[str] | None:
@@ -930,19 +935,28 @@ class DataSources(ABC):
     def _select_cases(self) -> tuple[list[str], dict[str, dict[str, list[str]]]]:
         """The case names common to every group and kept by ``subset``, in run order (sorted, or
         drawn once when ``subset.shuffle``), with the names each root holds per group."""
-        datasets = self._resolve_dataset_sources()
-        dataset_name, subset_names = self._resolve_common_names(datasets)
+        with startup_clock().phase("cases"):
+            requested = self.subset.required_names()
+            datasets = self._resolve_dataset_sources(requested)
+            dataset_name, subset_names = self._resolve_common_names(datasets, requested)
         names = sorted(subset_names)
         if self.subset.shuffle:
             names = random.sample(names, len(names))  # nosec B311
         return names, dataset_name
 
-    def _resolve_dataset_sources(self) -> dict[str, list[tuple[str, bool]]]:
+    def _resolve_dataset_sources(self, requested: set[str] | None = None) -> dict[str, list[tuple[str, bool]]]:
+        """The roots holding each source group, as ``(filename, append)`` in declaration order.
+
+        ``requested`` is what the subset can name (:meth:`Subset.required_names`), asked of a root
+        in place of its whole listing; ``None`` lists every case.
+        """
         datasets: dict[str, list[tuple[str, bool]]] = {}
         if self.dataset_filenames is None or len(self.dataset_filenames) == 0:
             raise DatasetManagerError("No dataset filenames were provided")
+        # A resolve after the first (the evaluation's sizing pass, an OOM re-plan) keeps each root's
+        # Dataset, and with it the listing it took and the headers it parsed.
+        kept = self.datasets
         self.datasets = {}
-        requested = self.subset.required_names()
         for dataset_filename in self.dataset_filenames:
             if dataset_filename is None:
                 raise DatasetManagerError(
@@ -965,7 +979,9 @@ class DataSources(ABC):
                     f"Supported formats are: {', '.join(SUPPORTED_FORMATS)}",
                 )
 
-            dataset = Dataset(filename, file_format)
+            dataset = kept.get(filename)
+            if dataset is None:
+                dataset = Dataset(filename, file_format)
             self.datasets[filename] = dataset
             for group in self.groups_src:
                 if dataset.is_group_exist(group, requested):
@@ -988,19 +1004,23 @@ class DataSources(ABC):
     def _resolve_common_names(
         self,
         datasets: dict[str, list[tuple[str, bool]]],
+        requested: set[str] | None,
     ) -> tuple[dict[str, dict[str, list[str]]], set[str]]:
+        """The names each root holds per group, and the cases every group holds that the subset
+        keeps; ``requested`` as in :meth:`_resolve_dataset_sources`."""
         dataset_name: dict[str, dict[str, list[str]]] = {}
         subset_requires_infos = self.subset.requires_infos()
         dataset_info: dict[str, dict[str, dict[str, tuple[list[int], Attribute]]]] | None = (
             {} if subset_requires_infos else None
         )
         empty_infos: dict[str, tuple[list[int], Attribute]] = {}
-        requested = self.subset.required_names()
         if requested is None:
             roots = sorted({filename for entries in datasets.values() for filename, _ in entries})
             print(f"[KonfAI] listing every case of {', '.join(sorted(datasets))} under {', '.join(roots)}")
         cohort: dict[str, set[str]] = {}
-        names: set[str] = set()
+        # Seeded from the first group, whatever it holds: an empty first group is a fact of the
+        # walk, not a walk that has not started, and it empties the intersection.
+        names: set[str] | None = None
         for group in self.groups_src:
             names_by_group = set()
             dataset_name[group] = {}
@@ -1015,52 +1035,59 @@ class DataSources(ABC):
                         name: self.datasets[filename].get_infos(group, name) for name in group_names
                     }
             cohort[group] = set(names_by_group)
-            if len(names) == 0:
-                names.update(names_by_group)
-            else:
-                names = names.intersection(names_by_group)
+            names = set(names_by_group) if names is None else names.intersection(names_by_group)
         self.cohort_names = cohort
-        if len(names) == 0:
+        if not names:
+            if requested is not None:
+                # The walk asked the roots for the subset's cases: what is missing is one of them.
+                raise self._subset_refusal(
+                    f"Subset requested: {', '.join(sorted(requested))}",
+                    *(f"Held by '{group}': {', '.join(sorted(found)) or 'none'}" for group, found in cohort.items()),
+                )
             raise DatasetManagerError(
                 f"No data was found for groups {list(self.groups_src.keys())}: although each group contains data "
                 "from a dataset, there are no common dataset names shared across all groups, the intersection is empty."
             )
 
-        subset_names: set[str] = set()
+        subset_names: set[str] | None = None
         for group in dataset_name:
-            subset_names_bygroup: set[str] = set()
+            subset_names_bygroup: set[str] | None = None
             for filename, append in datasets[group]:
                 resolved_subset = self.subset(
                     dataset_name[group][filename],
                     dataset_info[group][filename] if dataset_info is not None else empty_infos,
                 )
-                if append:
-                    subset_names_bygroup.update(resolved_subset)
-                elif len(subset_names_bygroup) == 0:
-                    subset_names_bygroup.update(resolved_subset)
+                # Seeded from the first root, not from the first NON-EMPTY one: an empty selection
+                # on a root is a member of the intersection, or the roots' order decides the run.
+                if subset_names_bygroup is None or append:
+                    subset_names_bygroup = (subset_names_bygroup or set()) | set(resolved_subset)
                 else:
                     subset_names_bygroup = subset_names_bygroup.intersection(resolved_subset)
-            if len(subset_names) == 0:
-                subset_names.update(subset_names_bygroup)
-            else:
-                subset_names = subset_names.intersection(subset_names_bygroup)
-
-        if len(subset_names) == 0:
-            raise DatasetManagerError(
-                "All data entries were excluded by the subset filter.",
-                f"Dataset entries found: {', '.join(names)}",
-                f"Subset object applied: {self.subset}",
-                f"Subset requested : {', '.join(subset_names)}",
-                "None of the dataset entries matched the given subset.",
-                "Please check your 'subset' configuration: it may be too restrictive or incorrectly formatted.",
-                "Examples of valid subset formats:",
-                "\tsubset: [0, 1]            # explicit indices",
-                "\tsubset: [./A.txt, ./B.txt]# union of multiple files",
-                "\tsubset: 0:10              # slice notation",
-                "\tsubset: ./Validation.txt  # external file",
-                "\tsubset: None              # to disable filtering",
+            subset_names_bygroup = subset_names_bygroup or set()
+            subset_names = (
+                set(subset_names_bygroup) if subset_names is None else subset_names.intersection(subset_names_bygroup)
             )
+
+        if not subset_names:
+            raise self._subset_refusal(f"Dataset entries found: {', '.join(sorted(names))}")
         return dataset_name, subset_names
+
+    def _subset_refusal(self, *found: str) -> DatasetManagerError:
+        """Nothing survives the subset: ``found`` says what the roots hold, then the subset and the
+        spellings it takes."""
+        return DatasetManagerError(
+            "All data entries were excluded by the subset filter.",
+            *found,
+            f"Subset object applied: {self.subset}",
+            "None of the dataset entries matched the given subset.",
+            "Please check your 'subset' configuration: it may be too restrictive or incorrectly formatted.",
+            "Examples of valid subset formats:",
+            "\tsubset: [0, 1]            # explicit indices",
+            "\tsubset: [./A.txt, ./B.txt]# union of multiple files",
+            "\tsubset: 0:10              # slice notation",
+            "\tsubset: ./Validation.txt  # external file",
+            "\tsubset: None              # to disable filtering",
+        )
 
     @staticmethod
     def _get_source_filename_by_group(
@@ -1094,23 +1121,24 @@ class DataSources(ABC):
         that holds it. ``index_offset`` keeps the manager index unique across the partitions
         :class:`Data` builds: the augmentations they share cache a case's draw by index."""
         source_filename_by_group = self._get_source_filename_by_group(dataset_name)
-        return {
-            group_dest: [
-                DatasetManager(
-                    index_offset + i,
-                    group_src,
-                    group_dest,
-                    name,
-                    self.datasets[source_filename_by_group[group_src][name]],
-                    patch=patch,
-                    transforms=self.groups_src[group_src][group_dest].transforms,
-                    data_augmentations_list=data_augmentations_list,
-                )
-                for i, name in enumerate(names)
-            ]
-            for group_src in self.groups_src
-            for group_dest in self.groups_src[group_src]
-        }
+        with startup_clock().phase("grids"):
+            return {
+                group_dest: [
+                    DatasetManager(
+                        index_offset + i,
+                        group_src,
+                        group_dest,
+                        name,
+                        self.datasets[source_filename_by_group[group_src][name]],
+                        patch=patch,
+                        transforms=self.groups_src[group_src][group_dest].transforms,
+                        data_augmentations_list=data_augmentations_list,
+                    )
+                    for i, name in enumerate(names)
+                ]
+                for group_src in self.groups_src
+                for group_dest in self.groups_src[group_src]
+            }
 
     def _params(self) -> dict[str, object]:
         return {
@@ -1342,8 +1370,8 @@ class Data(DataSources):
             return self._prepared_validation_mapping
         return [entry for entry in self._prepared_validation_mapping if entry[1] == 0]
 
-    def _resolve_dataset_sources(self) -> dict[str, list[tuple[str, bool]]]:
-        datasets = super()._resolve_dataset_sources()
+    def _resolve_dataset_sources(self, requested: set[str] | None = None) -> dict[str, list[tuple[str, bool]]]:
+        datasets = super()._resolve_dataset_sources(requested)
         # The augmentations get the roots of the first group resolved.
         for entries in datasets.values():
             for data_augmentations in self.data_augmentations_list.values():
@@ -1359,22 +1387,47 @@ class Data(DataSources):
         for key, data_augmentations in self.data_augmentations_list.items():
             data_augmentations.prepare(key)
         names, dataset_name = self._select_cases()
-        self.case_names, self._validation_names = self._split_train_validation_names(names, dataset_name)
-        self._build_partitions(dataset_name)
+        managers = counts = None
+        if isinstance(self.validation, float):
+            # A share by patch count, which only a built manager knows: every case is built once,
+            # in run order with the training draws, and the partitions are cut from that build.
+            managers = self._build_managers(names, dataset_name, self.patch, self._get_data_augmentations(True))
+            counts = self._case_entry_counts(managers)
+        self.case_names, self._validation_names = self._split_train_validation_names(names, counts)
+        split = len(self.case_names)
+        if managers is not None and (self.case_names, self._validation_names) != (names[:split], names[split:]):
+            managers = None  # not a cut of the run order: the built indices would not follow the partitions
+        self._build_partitions(dataset_name, managers)
 
-    def _build_partitions(self, dataset_name: dict[str, dict[str, list[str]]]) -> None:
+    def _build_partitions(
+        self, dataset_name: dict[str, dict[str, list[str]]], managers: dict[str, list[DatasetManager]] | None = None
+    ) -> None:
         """(Re)build the managers and patch mappings of both partitions from ``case_names`` and
         ``_validation_names``; the validation indices continue the training ones. Nothing is
-        assigned until both are built, so a failure leaves the dataset unprepared."""
-        managers, mapping = self._get_datasets(self.case_names, dataset_name, self._get_data_augmentations(True))
-        validation_managers, validation_mapping = self._get_datasets(
+        assigned until both are built, so a failure leaves the dataset unprepared.
+
+        ``managers`` are every selected case's, built in run order with the training draws: the
+        training partition is their head and, when validation keeps the draws, the validation
+        partition their tail, indices included. Unaugmented validation is built without them.
+        """
+        split = len(self.case_names)
+        training = validation = None
+        if managers is not None:
+            training = {group: cases[:split] for group, cases in managers.items()}
+            if self.validation_augmentations:
+                validation = {group: cases[split:] for group, cases in managers.items()}
+        training, mapping = self._get_datasets(
+            self.case_names, dataset_name, self._get_data_augmentations(True), managers=training
+        )
+        validation, validation_mapping = self._get_datasets(
             self._validation_names,
             dataset_name,
             self._get_data_augmentations(self.validation_augmentations),
-            index_offset=len(self.case_names),
+            index_offset=split,
+            managers=validation,
         )
-        self._managers, self._prepared_mapping = managers, mapping
-        self._validation_managers, self._prepared_validation_mapping = validation_managers, validation_mapping
+        self._managers, self._prepared_mapping = training, mapping
+        self._validation_managers, self._prepared_validation_mapping = validation, validation_mapping
 
     def worst_case_shape(self) -> list[int] | None:
         """Per-axis maximum spatial extent over every prepared case and augmentation copy.
@@ -1417,8 +1470,8 @@ class Data(DataSources):
                 "Call prepare() first; a dataset without 'patch' has no grid to re-cut.",
             )
         self.patch.patch_size[:] = [int(size) for size in patch_size]
-        datasets = self._resolve_dataset_sources()
         requested = self.subset.required_names()
+        datasets = self._resolve_dataset_sources(requested)
         dataset_name = {
             group: {filename: self.datasets[filename].select_names(group, requested) for filename, _ in entries}
             for group, entries in datasets.items()
@@ -1431,14 +1484,9 @@ class Data(DataSources):
         last = next(reversed(managers.values()), [])
         return [[manager.get_size(a) for a in range(nb_augmentation)] for manager in last]
 
-    def _get_case_entry_counts(
-        self,
-        names: list[str],
-        dataset_name: dict[str, dict[str, list[str]]],
-        data_augmentations_list: list[DataAugmentationsList],
-    ) -> list[int]:
-        managers = self._build_managers(names, dataset_name, self.patch, data_augmentations_list)
-        nb_augmentation = self._get_nb_augmentation(data_augmentations_list)
+    def _case_entry_counts(self, managers: dict[str, list[DatasetManager]]) -> list[int]:
+        """Per case, its ``(copy, patch)`` entries over the training draws: what the float split shares out."""
+        nb_augmentation = self._get_nb_augmentation(self._get_data_augmentations(True))
         return [int(sum(counts)) for counts in self._patch_counts(managers, nb_augmentation)]
 
     def _resolve_validation_indices(
@@ -1506,18 +1554,11 @@ class Data(DataSources):
     def _split_train_validation_names(
         self,
         subset_names: list[str],
-        dataset_name: dict[str, dict[str, list[str]]],
+        case_entry_counts: list[int] | None = None,
     ) -> tuple[list[str], list[str]]:
-        case_entry_counts = None
-        dataset_size = len(subset_names)
-        if isinstance(self.validation, float):
-            case_entry_counts = self._get_case_entry_counts(
-                subset_names,
-                dataset_name,
-                self._get_data_augmentations(True),
-            )
-            dataset_size = int(sum(case_entry_counts))
-
+        """The training and validation names, in run order; a float ``validation`` shares out
+        ``case_entry_counts`` (one per case, in that order) and takes the tail."""
+        dataset_size = len(subset_names) if case_entry_counts is None else int(sum(case_entry_counts))
         index = self._resolve_validation_indices(subset_names, case_entry_counts)
         index_set = set(index)
         validation_names = [name for i, name in enumerate(subset_names) if i in index_set]
@@ -1548,9 +1589,12 @@ class Data(DataSources):
         dataset_name: dict[str, dict[str, list[str]]],
         data_augmentations_list: list[DataAugmentationsList],
         index_offset: int = 0,
+        managers: dict[str, list[DatasetManager]] | None = None,
     ) -> tuple[dict[str, list[DatasetManager]], list[tuple[int, int, int]]]:
-        """A partition: its managers and its ``(case, copy, patch)`` mapping in loader order."""
-        managers = self._build_managers(names, dataset_name, self.patch, data_augmentations_list, index_offset)
+        """A partition: its managers (built here unless handed over) and its ``(case, copy, patch)``
+        mapping in loader order."""
+        if managers is None:
+            managers = self._build_managers(names, dataset_name, self.patch, data_augmentations_list, index_offset)
         nb_augmentation = self._get_nb_augmentation(data_augmentations_list)
         mapping: list[tuple[int, int, int]] = []
         # PREDICTION walks the mapping in order, and the copies of a TTA case must advance together
@@ -1795,13 +1839,13 @@ class DataMetric(Data):
         # An explicit patch or a non-reducible metric vetoes the sizing.
         if self.patch is not None or not self.auto_patch_allowed:
             return
-        sources = self._resolve_dataset_sources()
+        requested = self.subset.required_names()
+        sources = self._resolve_dataset_sources(requested)
         # Header-only scan: for each case, its resident bytes per spatial voxel is the sum of its
         # groups' channels (output + targets + masks all arrive as groups); the WORST case sizes the
         # one patch every case then shares (a smaller case simply yields fewer patches).
         channels_by_name: dict[str, int] = {}
         spatial_by_name: dict[str, list[int]] = {}
-        requested = self.subset.required_names()
         for group, entries in sources.items():
             for filename, _append in entries:
                 dataset = self.datasets[filename]

--- a/konfai/main.py
+++ b/konfai/main.py
@@ -39,6 +39,19 @@ def _positive_int(value: str) -> int:
     return ivalue
 
 
+class _VersionAction(argparse.Action):
+    """``--version``: the installed version, looked up when asked for. ``importlib.metadata.version``
+    scans the installed distributions (17 ms cold), which every other invocation would pay at
+    parser construction."""
+
+    def __init__(self, option_strings: list[str], dest: str, help: str | None = None) -> None:
+        super().__init__(option_strings, dest, default=argparse.SUPPRESS, nargs=0, help=help)
+
+    def __call__(self, parser: argparse.ArgumentParser, namespace: Any, values: Any, option_string=None) -> None:
+        print(importlib.metadata.version("konfai"))
+        parser.exit()
+
+
 def _add_common_args(parser: argparse.ArgumentParser) -> None:
     """The arguments TRAIN / RESUME / PREDICTION / EVALUATION share; TRANSFORM declares its own set."""
     parser.add_argument(
@@ -235,12 +248,7 @@ def _run(parser: argparse.ArgumentParser) -> None:
     _add_predict(subparsers)
     _add_evaluate(subparsers)
     _add_transform(subparsers)
-    parser.add_argument(
-        "--version",
-        action="version",
-        version=importlib.metadata.version("konfai"),
-        help="Print KonfAI version and exit.",
-    )
+    parser.add_argument("--version", action=_VersionAction, help="Print KonfAI version and exit.")
     _dispatch(parser, vars(parser.parse_args()))
 
 

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -88,6 +88,7 @@ from konfai.utils.runtime import (
     description,
     run_distributed_app,
     safe_torch_load,
+    startup_clock,
 )
 from konfai.utils.utils import concretize_patch_size, env_flag, get_module, size_free_axes, split_path_spec
 from konfai.utils.vram import next_patch_candidate, usable_vram
@@ -1955,7 +1956,8 @@ class Predictor(DistributedObject):
             self.combine = apply_config(f"{konfai_root()}.{combine}")(getattr(module, name))()
 
         self.autocast = autocast
-        self.model = model.get_model(train=False)
+        with startup_clock().phase("model"):
+            self.model = model.get_model(train=False)
         self.it = 0
         self.outputs_dataset_loader = outputs_dataset if outputs_dataset else {}
         self.outputs_dataset = {
@@ -2065,7 +2067,8 @@ class Predictor(DistributedObject):
                 "KonfAI Apps, declare it via the 'models' field in app.json).",
                 "Without a checkpoint its weights are random and prediction would silently produce garbage.",
             )
-        self.model_composite.load(self._load())
+        with startup_clock().phase("checkpoint"):
+            self.model_composite.load(self._load())
 
         self.size = len(self.gpu_checkpoints) + 1 if self.gpu_checkpoints else 1
 

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -62,6 +62,7 @@ from konfai.utils.runtime import (
     run_distributed_app,
     safe_torch_load,
     seed_all,
+    startup_clock,
     synchronize_data,
 )
 from konfai.utils.utils import concretize_patch_size, size_free_axes
@@ -813,7 +814,8 @@ class Trainer(DistributedObject):
         self.it = 0
         self.it_validation = it_validation
         self.it_lr_update = it_lr_update
-        self.model = model.get_model(train=True)
+        with startup_clock().phase("model"):
+            self.model = model.get_model(train=True)
         self.ema_decay = ema_decay
         self.model_ema: torch.optim.swa_utils.AveragedModel | None = None
         self.data_log = data_log
@@ -876,9 +878,10 @@ class Trainer(DistributedObject):
                 statistics_path.unlink()
 
         state_dict = {}
-        if state != State.TRAIN:
-            state_dict = self._load()
-        self.model.load(state_dict, init=True, ema=False, override_lr=self.override_lr)
+        with startup_clock().phase("checkpoint"):
+            if state != State.TRAIN:
+                state_dict = self._load()
+            self.model.load(state_dict, init=True, ema=False, override_lr=self.override_lr)
         if self.ema_decay > 0:
             self.model_ema = AveragedModel(self.model, avg_fn=self._avg_fn)
             if state_dict is not None:

--- a/konfai/utils/config.py
+++ b/konfai/utils/config.py
@@ -26,7 +26,7 @@ import time
 import types
 import typing
 import warnings
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, MutableMapping, Sequence
 from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass
@@ -95,6 +95,77 @@ def _load_tree(filename: Path | str) -> dict:
     return {} if tree is None else tree
 
 
+def _write_tree(target: Path, tree: dict) -> None:
+    """Write TREE to TARGET atomically: a sibling temp file, then ``os.replace``, so a concurrent
+    independent launch reading the file never observes it truncated and binds all-defaults."""
+    tmp = target.with_name(f"{target.name}.{os.getpid()}.tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8") as yml:
+            yaml.dump(tree, yml)
+        # Windows can deny the replace while the target is briefly held (a virus scanner or an
+        # indexer touching the fresh file): retried a few times, then refused. Never an in-place
+        # rewrite, which a concurrent reader would see truncated and bind all-defaults from.
+        for attempt in range(5):
+            try:
+                os.replace(tmp, target)
+                break
+            except OSError as error:
+                if attempt == 4:
+                    raise ConfigError(
+                        f"Could not replace the config file '{target}' atomically: {error}.",
+                        "Release whatever holds the file (an editor, an indexer) and rerun; the file was left unchanged.",
+                    ) from error
+                time.sleep(0.05 * (attempt + 1))
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def _merge_into(target: MutableMapping, source: Mapping) -> None:
+    """Fold SOURCE into TARGET in place: a mapping recurses, a value replaces, a ``None`` is not
+    written (a nested object's placeholder, materialized by its own context). A key TARGET lacks is
+    appended, so what a context sets lands after what the contexts opened inside it appended."""
+    for key, value in source.items():
+        existing = target.get(key)
+        if existing is value or value is None:
+            continue
+        if isinstance(value, Mapping):
+            if not isinstance(existing, MutableMapping):
+                existing = target[key] = {}
+            _merge_into(existing, value)
+        else:
+            target[key] = deepcopy(value)
+
+
+class _SharedTree:
+    """The config tree a ``strict_config`` block holds in memory.
+
+    Every ``Config`` context opened inside the block on this file reads and writes this one tree,
+    and the block writes the file once, when it ends. Outside a block a context loads and writes
+    the file itself.
+    """
+
+    def __init__(self, filename: Path, tree: dict) -> None:
+        self.filename = filename
+        self.tree = tree
+
+    def flush(self) -> None:
+        # A file no context created (refused as missing) is not created here either.
+        if self.filename.exists():
+            _write_tree(self.filename, self.tree)
+
+
+# The trees of the open strict_config() blocks, innermost last.
+_shared_trees: list[_SharedTree] = []
+
+
+def _shared_tree(filename: Path) -> _SharedTree | None:
+    for shared in reversed(_shared_trees):
+        if shared.filename == filename:
+            return shared
+    return None
+
+
 class _KeyLedger:
     """What the file holds against what the binder read, per level (dotted path) of the file."""
 
@@ -142,8 +213,14 @@ def strict_config(root: str, refuse: bool = True) -> Iterator[None]:
     the workflow binds from the file: a key a later, lazily bound callable would read is unknown to
     it. On entry the file must hold ROOT: a missing root binds an all-defaults workflow and writes
     the whole block back over the user's file.
+
+    The file is read once here and written once when the block ends, whatever the number of
+    contexts opened inside it: they all resolve against the tree held in memory. A build of N
+    nested objects otherwise parses the file 2N+1 times and writes it N times (Config_GAN.yml, 7 KB,
+    76 objects: 153 parses and 76 dumps, 2.96 s of a 4.7 s build; 0.05 s held in memory).
     """
     filename = os.environ.get("KONFAI_config_file")
+    tree: dict = {}
     if filename and Path(filename).exists():
         tree = _load_tree(filename)
         if root not in tree:
@@ -154,11 +231,19 @@ def strict_config(root: str, refuse: bool = True) -> Iterator[None]:
                 " block appended to the file in its place.",
             )
     ledger = _KeyLedger()
+    shared = _SharedTree(Path(filename), tree) if filename else None
     _ledgers.append(ledger)
+    if shared is not None:
+        _shared_trees.append(shared)
     try:
         yield
     finally:
         _ledgers.remove(ledger)
+        if shared is not None:
+            _shared_trees.remove(shared)
+            # Written whatever ended the block: what the contexts bound is on disk, as when each
+            # context wrote its own level.
+            shared.flush()
     if unknown := ledger.unknown(root):
         _report(
             refuse,
@@ -184,11 +269,15 @@ class Config:
     key : str
         Dot-separated path pointing to the configuration subtree to inspect or
         materialize.
+
+    Inside a :func:`strict_config` block the context reads the block's in-memory tree and folds
+    what it set back into it on exit; outside one it loads and writes the file itself.
     """
 
     def __init__(self, key: str) -> None:
         self.filename = Path(os.environ["KONFAI_config_file"])
         self.keys = [_unescape_key_component(part) for part in key.split(".")]
+        self._shared: _SharedTree | None = None
 
     def __enter__(self):
         if not self.filename.exists():
@@ -204,7 +293,8 @@ class Config:
                     "or set KONFAI_CONFIG_MODE=default.",
                 )
 
-        self.data = _load_tree(self.filename)
+        self._shared = _shared_tree(self.filename)
+        self.data = self._shared.tree if self._shared is not None else _load_tree(self.filename)
         self.config = self.data
 
         for key in self.keys:
@@ -212,6 +302,11 @@ class Config:
                 self.config = {key: {}}
 
             self.config = self.config[key]
+        if self._shared is not None and isinstance(self.config, collections.abc.MutableMapping):
+            # The context works on a copy of its level and folds it back on exit: what it sets is
+            # not seen by the contexts opened inside it, and lands after what they appended, as
+            # when every context read and wrote the file itself.
+            self.config = dict(self.config)
         for ledger in _ledgers:
             ledger.opened(tuple(self.keys), self.config if isinstance(self.config, collections.abc.Mapping) else ())
         return self
@@ -225,53 +320,19 @@ class Config:
             i -= 1
             return self.create_dictionary(data, keys, i)
 
-    def merge(self, dict1, dict2) -> dict:
-        result = deepcopy(dict1)
-
-        for key, value in dict2.items():
-            if isinstance(value, collections.abc.Mapping):
-                result[key] = self.merge(result.get(key, {}), value)
-            else:
-                if dict2[key] is not None:
-                    result[key] = deepcopy(dict2[key])
-        return result
-
     def __exit__(self, exc_type, value, traceback) -> None:
         if os.environ["KONFAI_CONFIG_MODE"] == "remove":
             if os.path.exists(config_file()):
                 os.remove(config_file())
             return
+        # Only the visited subtree is folded back; the merge preserves the rest of the tree untouched.
+        subtree = self.create_dictionary(self.config, self.keys, len(self.keys) - 1)
+        if self._shared is not None:
+            _merge_into(self._shared.tree, subtree)
+            return
         data = _load_tree(self.filename)
-        # Only the currently visited subtree is rewritten; the recursive merge preserves the rest of the
-        # YAML file untouched. Write to a sibling temp file then os.replace (atomic on the same
-        # filesystem) so a concurrent independent launch reading this file never observes a truncated or
-        # empty config and silently binds all-defaults.
-        merged = self.merge(
-            data,
-            self.create_dictionary(self.config, self.keys, len(self.keys) - 1),
-        )
-        target = Path(self.filename)
-        tmp = target.with_name(f"{target.name}.{os.getpid()}.tmp")
-        try:
-            with open(tmp, "w", encoding="utf-8") as yml:
-                yaml.dump(merged, yml)
-            # Windows can deny the replace while the target is briefly held (a virus scanner or an
-            # indexer touching the fresh file): retried a few times, then refused. Never an in-place
-            # rewrite, which a concurrent reader would see truncated and bind all-defaults from.
-            for attempt in range(5):
-                try:
-                    os.replace(tmp, target)
-                    break
-                except OSError as error:
-                    if attempt == 4:
-                        raise ConfigError(
-                            f"Could not replace the config file '{target}' atomically: {error}.",
-                            "Release whatever holds the file (an editor, an indexer) and rerun; the file was left unchanged.",
-                        ) from error
-                    time.sleep(0.05 * (attempt + 1))
-        finally:
-            if tmp.exists():
-                tmp.unlink()
+        _merge_into(data, subtree)
+        _write_tree(self.filename, data)
 
     @staticmethod
     def _get_input(name: str, default: str) -> str:

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -32,7 +32,7 @@ import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import closing, contextmanager
+from contextlib import AbstractContextManager, closing, contextmanager
 from enum import Enum
 from functools import wraps
 from pathlib import Path
@@ -692,6 +692,72 @@ def seed_all(seed: int) -> None:
     torch.manual_seed(seed)
 
 
+class StartupClock:
+    """Where a run's time went before its ranks start, phase by phase, in the sweep's format.
+
+    Built at the launcher's entry (:func:`run_distributed_app`), carried to the ranks on the
+    workflow object, reported once by rank 0 as it starts. The build's phases (``cases``: the
+    cohort listed, ``grids``: the managers built, ``model``: the network built) and the setup's
+    (``checkpoint``: the weights loaded) are taken out of ``build`` and ``setup``, which then read
+    as their remainders (the config bound, the workflow's own init; the loaders made); ``launch``
+    is spawn to the rank's start. The two stamps are ``time.time``: a rank reads them on another
+    node under a cluster launch, where a process counter means nothing; the phases are the
+    launcher's own and use the process counter.
+    """
+
+    def __init__(self) -> None:
+        from konfai.data.patching import SweepClock  # imports this module: bound at first use
+
+        self._phases = SweepClock()
+        self.started = time.time()
+        self.launched: float | None = None
+
+    def phase(self, name: str) -> AbstractContextManager[None]:
+        return self._phases.phase(name)
+
+    def spent(self, name: str) -> float:
+        return self._phases.spent(name)
+
+    def launch(self) -> None:
+        self.launched = time.time()
+
+    def report(self, min_seconds: float = 1.0) -> str | None:
+        """One line accounting for the wall clock since the launcher's entry, or ``None`` below
+        ``min_seconds``; ``other`` is what no phase names."""
+        now = time.time()
+        wall = now - self.started
+        if wall < min_seconds:
+            return None
+        nested = {name: self.spent(name) for name in ("cases", "grids", "model")}
+        named = {
+            "build": max(0.0, self.spent("build") - sum(nested.values())),
+            **nested,
+            "checkpoint": self.spent("checkpoint"),
+            "setup": max(0.0, self.spent("setup") - self.spent("checkpoint")),
+            "launch": 0.0 if self.launched is None else now - self.launched,
+        }
+        parts = " + ".join(f"{name} {value:.1f}" for name, value in named.items())
+        return f"[KonfAI] startup {wall:.1f} s = {parts} + other {wall - sum(named.values()):.1f}"
+
+
+_startup_clock: StartupClock | None = None
+
+
+def startup_clock() -> StartupClock:
+    """This process's startup clock, built on first use."""
+    global _startup_clock
+    if _startup_clock is None:
+        _startup_clock = StartupClock()
+    return _startup_clock
+
+
+def restart_startup_clock() -> StartupClock:
+    """A fresh startup clock: the Python API runs several workflows in one process, each its own."""
+    global _startup_clock
+    _startup_clock = StartupClock()
+    return _startup_clock
+
+
 class DistributedObject(ABC):
     """Base class for trainer, predictor, and evaluator distributed workflows."""
 
@@ -704,6 +770,8 @@ class DistributedObject(ABC):
         self.manual_seed: int | None = None
         self.name = name
         self.size = 1
+        #: The launcher's clock, handed over before the ranks start; rank 0 reports it.
+        self.startup_clock: StartupClock | None = None
 
     @abstractmethod
     def setup(self, world_size: int):
@@ -801,6 +869,8 @@ class DistributedObject(ABC):
             # honestly reads 0, and set_device would pin a GPU the launch explicitly excluded.
             if torch.cuda.is_available() and 0 <= local_rank < torch.cuda.device_count():
                 torch.cuda.set_device(local_rank)
+            if global_rank == 0 and self.startup_clock is not None and (startup := self.startup_clock.report()):
+                print(startup)
             try:
                 self.run_process(world_size, global_rank, local_rank, dataloaders)
             finally:
@@ -832,8 +902,10 @@ def run_distributed_app(
         previous_local_ranks = os.environ.get("KONFAI_LOCAL_RANKS")
         os.environ["KONFAI_LOCAL_RANKS"] = str(max(1, local_ranks))
         try:
+            with restart_startup_clock().phase("build"):
+                workflow = func(*args, **kwargs_fun)
             execute_distributed_object(
-                func(*args, **kwargs_fun),
+                workflow,
                 gpu=bound.arguments.get("gpu", []),
                 cpu=bound.arguments.get("cpu", 1),
                 overwrite=bool(bound.arguments.get("overwrite", False)),
@@ -951,6 +1023,7 @@ def execute_distributed_object(
                 os.environ["KONFAI_OVERWRITE"] = "True"
                 os.environ["KONFAI_CLUSTER"] = "True"
 
+            clock = startup_clock()
             with distributed_object as configured_object:
                 with Log(configured_object.name, 0):
                     if configured_object.manual_seed is not None:
@@ -963,7 +1036,10 @@ def execute_distributed_object(
                                 "auto-requeue at the time limit. Relaunch manually with the RESUME command "
                                 "pointing at the latest checkpoint to continue training."
                             )
-                        configured_object.setup(len(gpu_ids) * cluster_config["num_nodes"])
+                        with clock.phase("setup"):
+                            configured_object.setup(len(gpu_ids) * cluster_config["num_nodes"])
+                        clock.launch()
+                        configured_object.startup_clock = clock
                         import submitit
 
                         executor = submitit.AutoExecutor(folder="./Cluster/")
@@ -983,11 +1059,14 @@ def execute_distributed_object(
                     world_size = len(gpu_ids)
                     if world_size == 0:
                         world_size = cpu_workers
-                    configured_object.setup(world_size)
+                    with clock.phase("setup"):
+                        configured_object.setup(world_size)
                     # Share tensors through /dev/shm files instead of one file descriptor per tensor:
                     # spawning a worker that pickles a loaded model can otherwise exhaust the process
                     # open-file limit ("Too many open files"), e.g. under Slicer's embedded Python.
                     mp.set_sharing_strategy("file_system")
+                    clock.launch()
+                    configured_object.startup_clock = clock
                     with TensorBoard(configured_object.name):
                         if _runs_inline(world_size):
                             configured_object(0)
@@ -1006,14 +1085,15 @@ _T = TypeVar("_T")
 
 _cpu_budget_applied = False
 _rank_pool: ThreadPoolExecutor | None = None
+_rank_pool_share = 0  # the share the pool was sized for
 _rank_pool_lock = threading.Lock()
 
 
 def _forget_rank_pool() -> None:
     """A forked child inherits the executor's bookkeeping and none of its threads: work submitted to
     it waits forever. The child builds its own on first use."""
-    global _rank_pool, _rank_pool_lock
-    _rank_pool, _rank_pool_lock = None, threading.Lock()
+    global _rank_pool, _rank_pool_share, _rank_pool_lock
+    _rank_pool, _rank_pool_share, _rank_pool_lock = None, 0, threading.Lock()
 
 
 if hasattr(os, "register_at_fork"):  # POSIX only: a platform without fork inherits nothing to forget
@@ -1039,13 +1119,19 @@ def rank_pool() -> ThreadPoolExecutor | None:
 
     ``None`` at a share of one, where the work stays on the calling thread.
     """
-    global _rank_pool
+    global _rank_pool, _rank_pool_share
     workers = rank_cpu_share()
     if workers <= 1:
         return None
     with _rank_pool_lock:
+        # The share changes within one process when a multi-rank build is followed by an inline
+        # single-rank workflow: the pool is rebuilt at the new size, the old one's idle threads let go.
+        if _rank_pool is not None and _rank_pool_share != workers:
+            _rank_pool.shutdown(wait=False)
+            _rank_pool = None
         if _rank_pool is None:
             _rank_pool = ThreadPoolExecutor(max_workers=workers, thread_name_prefix="konfai-rank")
+            _rank_pool_share = workers
     return _rank_pool
 
 

--- a/tests/unit/test_cohort_walk.py
+++ b/tests/unit/test_cohort_walk.py
@@ -28,8 +28,9 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from konfai.data.data_manager import DataPrediction, Group, PredictionSubset, Subset
+from konfai.data.data_manager import DataPrediction, Group, GroupTransform, PredictionSubset, Subset
 from konfai.utils.dataset import Attribute, Dataset
+from konfai.utils.errors import DatasetManagerError
 
 pytest.importorskip("SimpleITK")
 
@@ -88,6 +89,14 @@ def test_a_subset_reading_its_names_from_a_file_names_them(tmp_path: Path) -> No
     names = tmp_path / "fold.txt"
     names.write_text("CASE_001\nCASE_004\n", encoding="utf-8")
     assert Subset(str(names)).required_names() == {"CASE_001", "CASE_004"}
+
+
+def test_a_names_file_spelled_like_a_slice_is_the_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The selection reads a file before it reads a slice (``_resolve_selector``); what the walk asks
+    the roots for must be what the selection then keeps."""
+    monkeypatch.chdir(tmp_path)
+    Path("0:4").write_text("CASE_001\n", encoding="utf-8")
+    assert Subset("0:4").required_names() == {"CASE_001"}
 
 
 def test_a_subset_selecting_on_geometry_still_gets_the_cohort() -> None:
@@ -215,3 +224,58 @@ def test_a_naming_subset_still_reports_the_cases_a_group_lacks(tmp_path: Path) -
     names, _ = data._select_cases()
     assert sorted(names) == ["CASE_002"]
     assert data.cohort_names == {"CT": {"CASE_002", "CASE_005"}, "SEG": {"CASE_002"}}
+
+
+@pytest.mark.parametrize("order", [("CT", "SEG"), ("SEG", "CT")])
+def test_a_requested_case_one_group_lacks_is_refused_as_a_subset_whatever_the_order(
+    tmp_path: Path, order: tuple[str, str]
+) -> None:
+    """CT holds every case and SEG the first four: asked for CASE_005 alone, the walk finds it in one
+    group and not the other, and the refusal names the subset and what each group holds. The same
+    refusal in both declaration orders: an empty first group used to read as a walk not started, so
+    the second group's find stood in for the intersection and the managers failed on a KeyError."""
+    dataset = Dataset(tmp_path / "cases", "mha")
+    for name in CASES:
+        dataset.write("CT", name, np.zeros((1, 2, 2, 2), np.float32), _attributes())
+    for name in CASES[:4]:
+        dataset.write("SEG", name, np.zeros((1, 2, 2, 2), np.float32), _attributes())
+    data = DataPrediction(
+        dataset_filenames=[f"{tmp_path / 'cases'}:mha"],
+        groups_src={
+            group: Group(groups_dest={group: GroupTransform(transforms=None, patch_transforms=None)}) for group in order
+        },
+        augmentations=None,
+        patch=None,
+        subset=PredictionSubset("CASE_005"),
+    )
+    with pytest.raises(DatasetManagerError) as refused:
+        data.prepare()
+    message = str(refused.value)
+    assert "excluded by the subset" in message and "Subset requested: CASE_005" in message
+    assert "Held by 'CT': CASE_005" in message and "Held by 'SEG': none" in message
+
+
+def test_a_groups_roots_are_intersected_from_the_first_root_whatever_it_holds(tmp_path: Path) -> None:
+    """A second root flagged ``:i`` keeps the cases both roots hold. A first root holding none of
+    the requested cases is a member of that intersection, not a blank the second root fills."""
+    first, second = Dataset(tmp_path / "first", "mha"), Dataset(tmp_path / "second", "mha")
+    for name in CASES[:4]:
+        first.write("CT", name, np.zeros((1, 2, 2, 2), np.float32), _attributes())
+    for name in CASES[2:]:
+        second.write("CT", name, np.zeros((1, 2, 2, 2), np.float32), _attributes())
+    roots = [f"{tmp_path / 'first'}:mha", f"{tmp_path / 'second'}:i:mha"]
+
+    def selected(subset) -> list[str]:
+        data = DataPrediction(
+            dataset_filenames=roots,
+            groups_src={"CT": Group()},
+            augmentations=None,
+            patch=None,
+            subset=PredictionSubset(subset),
+        )
+        names, _ = data._select_cases()
+        return sorted(names)
+
+    assert selected("CASE_003") == ["CASE_003"]
+    with pytest.raises(DatasetManagerError, match="excluded by the subset"):
+        selected("CASE_005")  # the second root alone holds it

--- a/tests/unit/test_cohort_walk.py
+++ b/tests/unit/test_cohort_walk.py
@@ -24,6 +24,7 @@ Counted, never timed: the count is what a narrow subset and a wide root differ b
 same count on a filesystem and on an object store.
 """
 
+import os
 from pathlib import Path
 
 import numpy as np
@@ -91,6 +92,7 @@ def test_a_subset_reading_its_names_from_a_file_names_them(tmp_path: Path) -> No
     assert Subset(str(names)).required_names() == {"CASE_001", "CASE_004"}
 
 
+@pytest.mark.skipif(os.name == "nt", reason="a colon cannot appear in a Windows file name")
 def test_a_names_file_spelled_like_a_slice_is_the_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The selection reads a file before it reads a slice (``_resolve_selector``); what the walk asks
     the roots for must be what the selection then keeps."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -22,6 +22,7 @@ keys), and the config env-var bookkeeping.
 """
 
 import os
+import sys
 from pathlib import Path
 from typing import Literal
 
@@ -725,3 +726,241 @@ def test_strict_config_reports_a_yaml_syntax_error_as_a_config_error(write_confi
     write_config("Root:\n  kept: [1, 2\n")
     with pytest.raises(ConfigError, match=r"Invalid YAML syntax .* at line"), strict_config("Root"):
         raise AssertionError("refused before anything binds")
+
+
+# --------------------------------------------------------------------------------------
+# strict_config: one read, one write, the same bytes as a write per context
+# --------------------------------------------------------------------------------------
+
+
+class _Entry:
+    def __init__(self, value: int = 1, tags: list[str] = ["a", "b"]) -> None:
+        self.value, self.tags = value, tags
+
+
+@config("Optional")
+class _Optional:
+    def __init__(self, depth: int = 3) -> None:
+        self.depth = depth
+
+
+class _WideRoot:
+    """Every shape the binder writes back: primitives, a flat child, a keyed child, a dict of
+    objects the file holds and one it lacks, a dict of primitives, a list, a literal, an optional
+    left None."""
+
+    def __init__(
+        self,
+        kept: int = 0,
+        leaf: _Leaf = _Leaf(),
+        present: dict[str, _Entry] = {"only": _Entry()},
+        nested: _Nested = _Nested(),
+        entries: dict[str, _Entry] = {"first": _Entry(), "second": _Entry(5)},
+        weights: dict[str, float] = {"mae": 1.0, "ssim": 0.5},
+        shape: list[int] = [1, 256, 256],
+        mode: Literal["train", "eval"] = "train",
+        optional: _Optional | None = None,
+        name: str = "run",
+    ) -> None:
+        self.kept, self.leaf, self.present, self.nested, self.entries = kept, leaf, present, nested, entries
+        self.weights, self.shape, self.mode, self.optional, self.name = weights, shape, mode, optional, name
+
+
+_PARTIAL_WIDE_CONFIG = """Root:  # a comment on the root
+  name: bound  # a comment on a key
+  present:
+    only:
+      tags: [x, y]  # a flow-style list, a missing sibling key
+  shape: [2, 2, 2]
+  Nested:
+    width: 7
+"""
+
+
+def _binder_io(monkeypatch) -> dict[str, int]:
+    from konfai.utils import config as config_module
+
+    counts = {"loads": 0, "dumps": 0}
+    load, dump = config_module._load_tree, config_module.yaml.dump
+
+    def counted_load(filename):
+        counts["loads"] += 1
+        return load(filename)
+
+    def counted_dump(*args, **kwargs):
+        counts["dumps"] += 1
+        return dump(*args, **kwargs)
+
+    monkeypatch.setattr(config_module, "_load_tree", counted_load)
+    monkeypatch.setattr(config_module.yaml, "dump", counted_dump)
+    return counts
+
+
+def test_a_strict_block_reads_once_writes_once_and_the_bytes_a_write_per_context_produced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The block resolves every context against one in-memory tree and writes the file at its end.
+    The per-context path (a context outside any block loads and writes the file itself) is the
+    oracle: the resolved file must be byte-identical, key order and comments included."""
+    monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
+    resolved: dict[str, bytes] = {}
+    for spelling in ("per_context", "strict_block"):
+        path = tmp_path / f"{spelling}.yml"
+        path.write_text(_PARTIAL_WIDE_CONFIG, encoding="utf-8")
+        monkeypatch.setenv("KONFAI_config_file", str(path))
+        counts = _binder_io(monkeypatch)
+        if spelling == "strict_block":
+            with strict_config("Root"):
+                root = apply_config("Root")(_WideRoot)()
+            assert (counts["loads"], counts["dumps"]) == (1, 1)
+        else:
+            root = apply_config("Root")(_WideRoot)()
+            assert counts["loads"] > 1 and counts["dumps"] > 1
+        assert (root.name, root.nested.width, root.present["only"].tags, root.shape) == (
+            "bound",
+            7,
+            ["x", "y"],
+            [2, 2, 2],
+        )
+        assert list(root.entries) == ["first", "second"] and root.optional is None
+        resolved[spelling] = path.read_bytes()
+    assert resolved["strict_block"] == resolved["per_context"]
+    # Comments and the flow style of what the file held are kept; what the contexts appended lands
+    # where the file-backed write-back put it: a context's own keys at its exit, after the keys the
+    # contexts opened inside it appended (``depth`` from the flat child, ``entries`` from the dict's
+    # entries, before ``kept``, which the root set first).
+    assert resolved["strict_block"].decode("utf-8") == (
+        "Root:  # a comment on the root\n"
+        "  name: bound  # a comment on a key\n"
+        "  present:\n"
+        "    only:\n"
+        "      tags: [x, y]  # a flow-style list, a missing sibling key\n"
+        "      value: 1\n"
+        "  shape: [2, 2, 2]\n"
+        "  Nested:\n"
+        "    width: 7\n"
+        "  depth: 1\n"
+        "  entries:\n"
+        "    first:\n"
+        "      value: 1\n"
+        "      tags:\n"
+        "      - a\n"
+        "      - b\n"
+        "    second:\n"
+        "      value: 1\n"
+        "      tags:\n"
+        "      - a\n"
+        "      - b\n"
+        "  kept: 0\n"
+        "  weights:\n"
+        "    mae: 1.0\n"
+        "    ssim: 0.5\n"
+        "  mode: train\n"
+        "  Optional: None\n"
+    )
+
+
+def test_a_strict_block_that_refuses_still_leaves_what_it_bound_on_disk(write_config) -> None:
+    """A context wrote its level before the block could report an unknown key; the block writes
+    the same resolved file before it reports."""
+    config_path = write_config("Root:\n  kep: 2\n")
+    with pytest.raises(ConfigError, match="Unknown key"), strict_config("Root"):
+        apply_config("Root")(_StrictRoot)()
+    written = ruamel.yaml.YAML().load(config_path.read_text(encoding="utf-8"))
+    assert written["Root"] == {"kep": 2, "depth": 1, "kept": 0, "Nested": {"width": 2}}
+
+
+def test_a_strict_block_does_not_create_a_file_a_context_refused(tmp_path: Path, monkeypatch) -> None:
+    config_path = tmp_path / "missing.yml"
+    monkeypatch.setenv("KONFAI_config_file", str(config_path))
+    monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
+    with pytest.raises(ConfigError, match="does not exist"), strict_config("Root"):
+        apply_config("Root")(_StrictRoot)()
+    assert not config_path.exists()
+
+
+def test_a_strict_block_writes_the_file_a_context_materialized(tmp_path: Path, monkeypatch) -> None:
+    config_path = tmp_path / "generated.yml"
+    monkeypatch.setenv("KONFAI_config_file", str(config_path))
+    monkeypatch.setenv("KONFAI_CONFIG_MODE", "default")
+    monkeypatch.setattr("builtins.input", _fail_input)
+    with strict_config("Root"):
+        root = apply_config("Root")(_StrictRoot)()
+    assert root.kept == 0
+    written = ruamel.yaml.YAML().load(config_path.read_text(encoding="utf-8"))
+    assert written["Root"] == {"depth": 1, "kept": 0, "Nested": {"width": 2}}
+
+
+_EXAMPLES = Path(__file__).resolve().parents[2] / "examples"
+_WORKFLOWS = {
+    "Trainer": ("konfai.trainer", "Trainer", "TRAIN", {"KONFAI_CHECKPOINTS_DIRECTORY", "KONFAI_STATISTICS_DIRECTORY"}),
+    "Predictor": ("konfai.predictor", "Predictor", "PREDICTION", {"KONFAI_PREDICTIONS_DIRECTORY"}),
+    "Evaluator": ("konfai.evaluator", "Evaluator", "EVALUATION", {"KONFAI_EVALUATIONS_DIRECTORY"}),
+    "Transformer": ("konfai.transformer", "Transformer", "TRANSFORM", {"KONFAI_TRANSFORMS_DIRECTORY"}),
+}
+
+
+def _shipped_workflow_configs() -> list[str]:
+    return sorted(
+        str(path.relative_to(_EXAMPLES))
+        for path in _EXAMPLES.glob("*/*.yml")
+        if next(iter(ruamel.yaml.YAML().load(path.read_text(encoding="utf-8")))) in _WORKFLOWS
+    )
+
+
+def _bind_shipped_config(relative: str, workdir: Path, strict: bool, monkeypatch: pytest.MonkeyPatch) -> bytes:
+    """Bind a shipped example config on a copy under WORKDIR, over a synthetic cohort holding every
+    group the config names, the way its workflow builder does (STRICT) or one context at a time."""
+    import importlib
+
+    import numpy as np
+    from konfai.utils.dataset import Attribute, Dataset
+    from konfai.utils.runtime import configure_workflow_environment
+    from konfai.utils.utils import split_path_spec
+
+    example = _EXAMPLES / Path(relative).parent
+    workdir.mkdir(parents=True)
+    for entry in example.iterdir():
+        if entry.suffix in (".yml", ".py"):
+            (workdir / entry.name).write_bytes(entry.read_bytes())
+    config_path = workdir / Path(relative).name
+    tree = ruamel.yaml.YAML().load(config_path.read_text(encoding="utf-8"))
+    root = next(iter(tree))
+    attribute = Attribute()
+    attribute["Origin"], attribute["Spacing"], attribute["Direction"] = np.zeros(3), np.ones(3), np.eye(3).flatten()
+    monkeypatch.chdir(workdir)
+    for spec in tree[root]["Dataset"]["dataset_filenames"]:
+        filename, _flag, file_format = split_path_spec(spec, default_format="mha", allowed_flags={"a", "i"})
+        store = Dataset(filename, file_format)
+        for group in tree[root]["Dataset"]["groups_src"]:
+            for index in range(4):
+                store.write(group, f"CASE_{index:03d}", np.zeros((1, 2, 32, 32), np.float32), attribute)
+    module_name, class_name, state, path_env = _WORKFLOWS[root]
+    configure_workflow_environment(
+        config_path=config_path, root=root, state=state, path_env={key: workdir / key for key in path_env}
+    )
+    monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
+    monkeypatch.syspath_prepend(str(workdir))
+    for local in ("Model", "UnNormalize"):  # the examples' own modules, one per example
+        monkeypatch.delitem(sys.modules, local, raising=False)
+    workflow = getattr(importlib.import_module(module_name), class_name)
+    if strict:
+        with strict_config(root, refuse=False):
+            apply_config()(workflow)()
+    else:
+        apply_config()(workflow)()
+    return config_path.read_bytes()
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("relative", _shipped_workflow_configs())
+def test_a_shipped_config_resolves_to_the_same_bytes_under_the_block_as_per_context(
+    relative: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every shipped workflow config, built as its workflow builds it (one strict block) and one
+    context at a time: the resolved file is byte-identical. Two of them gain keys the write-back
+    appends (Config_GAN.yml, Transform.yml), which is where the order of the appends shows."""
+    pytest.importorskip("SimpleITK")
+    per_context = _bind_shipped_config(relative, tmp_path / "per_context", False, monkeypatch)
+    strict_block = _bind_shipped_config(relative, tmp_path / "strict_block", True, monkeypatch)
+    assert strict_block == per_context

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -961,6 +961,10 @@ def test_a_shipped_config_resolves_to_the_same_bytes_under_the_block_as_per_cont
     context at a time: the resolved file is byte-identical. Two of them gain keys the write-back
     appends (Config_GAN.yml, Transform.yml), which is where the order of the appends shows."""
     pytest.importorskip("SimpleITK")
+    if relative.startswith("Synthesis/"):
+        # Its Model.py imports segmentation_models_pytorch, an extra the example declares and the
+        # suite does not: binding the config imports the model.
+        pytest.importorskip("segmentation_models_pytorch")
     per_context = _bind_shipped_config(relative, tmp_path / "per_context", False, monkeypatch)
     strict_block = _bind_shipped_config(relative, tmp_path / "strict_block", True, monkeypatch)
     assert strict_block == per_context

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -829,7 +829,8 @@ def test_a_strict_block_reads_once_writes_once_and_the_bytes_a_write_per_context
     # where the file-backed write-back put it: a context's own keys at its exit, after the keys the
     # contexts opened inside it appended (``depth`` from the flat child, ``entries`` from the dict's
     # entries, before ``kept``, which the root set first).
-    assert resolved["strict_block"].decode("utf-8") == (
+    # The dump goes through text mode, so the line ending is the platform's; the layout is not.
+    assert resolved["strict_block"].decode("utf-8").replace("\r\n", "\n") == (
         "Root:  # a comment on the root\n"
         "  name: bound  # a comment on a key\n"
         "  present:\n"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -962,7 +962,7 @@ def test_a_shipped_config_resolves_to_the_same_bytes_under_the_block_as_per_cont
     context at a time: the resolved file is byte-identical. Two of them gain keys the write-back
     appends (Config_GAN.yml, Transform.yml), which is where the order of the appends shows."""
     pytest.importorskip("SimpleITK")
-    if relative.startswith("Synthesis/"):
+    if Path(relative).parent.name == "Synthesis":
         # Its Model.py imports segmentation_models_pytorch, an extra the example declares and the
         # suite does not: binding the config imports the model.
         pytest.importorskip("segmentation_models_pytorch")

--- a/tests/unit/test_data_manager.py
+++ b/tests/unit/test_data_manager.py
@@ -43,7 +43,7 @@ from konfai.data.data_manager import (
 from konfai.data.patching import DatasetManager, DatasetPatch
 from konfai.data.transform import TensorCast, Transform, TransformLoader
 from konfai.utils.dataset import Attribute, Dataset
-from konfai.utils.runtime import State
+from konfai.utils.runtime import State, restart_startup_clock
 from konfai.utils.utils import split_path_spec
 
 # --------------------------------------------------------------------------------------
@@ -161,9 +161,9 @@ from konfai.data.data_manager import DataTrain
 
 names = [f"CASE_{i:03d}" for i in range(20)]
 data = DataTrain(augmentations=None, validation="0:4")
-data._resolve_dataset_sources = lambda: {}
-data._resolve_common_names = lambda datasets: ({}, set(names))
-data._get_datasets = lambda case_names, dataset_name, augmentations, index_offset=0: ({}, [])
+data._resolve_dataset_sources = lambda requested: {}
+data._resolve_common_names = lambda datasets, requested: ({}, set(names))
+data._get_datasets = lambda case_names, dataset_name, augmentations, index_offset=0, managers=None: ({}, [])
 random.seed(1234)
 data._prepare_datasets()
 print(";".join(data.case_names))
@@ -204,9 +204,9 @@ def test_train_split_shuffle_draws_from_sorted_names(monkeypatch):
 
     data = DataTrain(augmentations=None, validation="0:2")
     names = {"CASE_010", "CASE_002", "CASE_001", "CASE_005", "CASE_003"}
-    data._resolve_dataset_sources = lambda: {}
-    data._resolve_common_names = lambda datasets: ({}, names)
-    data._get_datasets = lambda case_names, dataset_name, augmentations, index_offset=0: ({}, [])
+    data._resolve_dataset_sources = lambda requested: {}
+    data._resolve_common_names = lambda datasets, requested: ({}, names)
+    data._get_datasets = lambda case_names, dataset_name, augmentations, index_offset=0, managers=None: ({}, [])
     data._prepare_datasets()
 
     assert captured["population"] == sorted(names)
@@ -224,7 +224,6 @@ def test_data_train_validation_accepts_mixed_case_names_and_case_files(tmp_path:
 
     train_names, validation_names = dataset._split_train_validation_names(
         ["CASE_000", "CASE_001", "CASE_002", "CASE_003"],
-        {},
     )
 
     assert train_names == ["CASE_000"]
@@ -239,7 +238,6 @@ def test_data_train_validation_none_keeps_full_dataset_for_training() -> None:
 
     train_names, validation_names = dataset._split_train_validation_names(
         ["CASE_000", "CASE_001", "CASE_002"],
-        {},
     )
 
     assert train_names == ["CASE_000", "CASE_001", "CASE_002"]
@@ -283,6 +281,63 @@ def test_data_train_prepare_skips_validation_augmentation_layout_when_disabled(t
     assert dataset._validation_managers is not None
     assert dataset.managers["CT"][0].total_augmentations == 1
     assert dataset._validation_managers["CT"][0].total_augmentations == 0
+
+
+@pytest.mark.parametrize(("validation_augmentations", "built"), [(True, 20), (False, 24)])
+def test_a_float_split_builds_each_case_once_and_cuts_the_partitions_from_that_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, validation_augmentations: bool, built: int
+) -> None:
+    """The float split shares out patch counts, which only a built manager knows. Every case is
+    built once, in run order with the training draws, and the partitions are that build's head and
+    tail: same names, same indices, one draw per case. Validation without the draws is rebuilt
+    (2 cases x 2 groups more), never cut with them."""
+    pytest.importorskip("SimpleITK")
+    from konfai.data import data_manager as data_manager_module
+    from konfai.data.augmentation import Prob
+
+    names = [f"CASE_{index:03d}" for index in range(10)]
+    store = Dataset(tmp_path / "Dataset", "mha")
+    for name in names:
+        for group in ("CT", "SEG"):
+            store.write(group, name, np.zeros((1, 4, 4), np.float32), _image_attributes([0.0, 0.0], [1.0, 1.0]))
+    constructed: list[tuple[str, int]] = []
+
+    class CountingManager(DatasetManager):
+        def __init__(self, index: int, group_src: str, group_dest: str, name: str, *args, **kwargs) -> None:
+            constructed.append((name, index))
+            super().__init__(index, group_src, group_dest, name, *args, **kwargs)
+
+    monkeypatch.setattr(data_manager_module, "DatasetManager", CountingManager)
+    monkeypatch.delenv("KONFAI_config_file")  # the draw binds its own defaults
+    monkeypatch.setenv("KONFAI_ROOT", "Trainer")
+    augmentations = DataAugmentationsList(nb=1, data_augmentations={"Flip": Prob(1)})
+    dataset = DataTrain(
+        dataset_filenames=[f"{tmp_path / 'Dataset'}:mha"],
+        groups_src={
+            group: Group(groups_dest={group: GroupTransform(transforms=None, patch_transforms=None)})
+            for group in ("CT", "SEG")
+        },
+        augmentations={"DataAugmentation_0": augmentations},
+        patch=None,
+        subset=TrainSubset(shuffle=False),
+        validation=0.2,
+        validation_augmentations=validation_augmentations,
+    )
+    torch.manual_seed(0)
+    clock = restart_startup_clock()
+    dataset.prepare()
+
+    assert clock.spent("cases") > 0 and clock.spent("grids") > 0  # the startup line's phases
+    assert len(constructed) == built
+    assert (dataset.case_names, dataset._validation_names) == (names[:8], names[8:])
+    assert [manager.index for manager in dataset.managers["SEG"]] == list(range(8))
+    assert [(manager.name, manager.index) for manager in dataset._validation_managers["SEG"]] == [
+        ("CASE_008", 8),
+        ("CASE_009", 9),
+    ]
+    assert dataset._validation_managers["CT"][0].total_augmentations == int(validation_augmentations)
+    flip = augmentations.data_augmentations[0]
+    assert sorted(flip.who_index) == list(range(10))  # one draw per case, keyed by its run index
 
 
 # --------------------------------------------------------------------------------------
@@ -971,6 +1026,47 @@ class InfoCountingDataset:
         return [1, 2, 2], _image_attributes([0.0, 0.0], [1.0, 1.0])
 
 
+def test_an_evaluation_keeps_its_roots_across_its_two_resolves(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``DataMetric.prepare`` resolves the sources twice (the sizing pass, then the selection) and a
+    re-plan resolves them again: one ``Dataset`` per root serves them all, so a header is parsed once
+    and answered from its cache after that."""
+    pytest.importorskip("SimpleITK")
+    from konfai.data.data_manager import DataMetric, GroupMetric, GroupTransformMetric
+
+    store = Dataset(tmp_path / "Dataset", "mha")
+    for index in range(4):
+        for group in ("CT", "SEG"):
+            store.write(
+                group, f"CASE_{index:03d}", np.zeros((1, 4, 4), np.float32), _image_attributes([0.0, 0.0], [1.0, 1.0])
+            )
+    counts = {"datasets": 0, "parsed": 0, "cached": 0}
+    dataset_init, dataset_get_infos = Dataset.__init__, Dataset.get_infos
+
+    def counting_init(self, *args, **kwargs):
+        counts["datasets"] += 1
+        dataset_init(self, *args, **kwargs)
+
+    def counting_get_infos(self, groups, name):
+        counts["cached" if (groups, name) in self._infos_cache else "parsed"] += 1
+        return dataset_get_infos(self, groups, name)
+
+    monkeypatch.setattr(Dataset, "__init__", counting_init)
+    monkeypatch.setattr(Dataset, "get_infos", counting_get_infos)
+    data = DataMetric(
+        dataset_filenames=[f"{tmp_path / 'Dataset'}:mha"],
+        groups_src={
+            group: GroupMetric(groups_dest={group: GroupTransformMetric(transforms=None)}) for group in ("CT", "SEG")
+        },
+    )
+    data.prepare()
+    assert counts == {"datasets": 1, "parsed": 8, "cached": 8}
+    roots = list(data.datasets.values())
+    data.patch = DatasetPatch(patch_size=[2, 2])
+    data.replan_patch([4, 4])
+    assert counts["datasets"] == 1 and counts["parsed"] == 8
+    assert list(data.datasets.values()) == roots  # the same objects, listing and headers included
+
+
 def test_builtin_subset_does_not_read_infos_during_common_name_resolution() -> None:
     dataset = DataPrediction(
         augmentations=None,
@@ -978,7 +1074,7 @@ def test_builtin_subset_does_not_read_infos_during_common_name_resolution() -> N
     )
     dataset.datasets = {"fake": cast(Dataset, InfoCountingDataset())}
 
-    dataset_name, subset_names = dataset._resolve_common_names({"CT": [("fake", True)]})
+    dataset_name, subset_names = dataset._resolve_common_names({"CT": [("fake", True)]}, None)
 
     assert dataset_name["CT"]["fake"] == ["CASE_000", "CASE_001"]
     assert subset_names == {"CASE_000", "CASE_001"}
@@ -1003,7 +1099,7 @@ def test_custom_subset_can_still_request_infos_during_common_name_resolution() -
     )
     dataset.datasets = {"fake": cast(Dataset, InfoCountingDataset())}
 
-    _dataset_name, subset_names = dataset._resolve_common_names({"CT": [("fake", True)]})
+    _dataset_name, subset_names = dataset._resolve_common_names({"CT": [("fake", True)]}, None)
 
     assert subset_names == {"CASE_000", "CASE_001"}
     assert subset.last_infos is not None

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -41,6 +41,27 @@ def test_konfai_help_exits_zero(monkeypatch: pytest.MonkeyPatch) -> None:
     assert exc_info.value.code == 0
 
 
+def test_the_version_is_looked_up_only_when_asked_for(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    """``importlib.metadata.version`` scans the installed distributions; every other invocation
+    builds the parser without paying for it."""
+    import importlib.metadata
+
+    looked_up: list[str] = []
+    real_version = importlib.metadata.version
+    monkeypatch.setattr(importlib.metadata, "version", lambda name: looked_up.append(name) or real_version(name))
+
+    monkeypatch.setattr(sys, "argv", ["konfai", "TRAIN", "--no-such-flag"])
+    with pytest.raises(SystemExit):
+        main_module.main()
+    assert looked_up == []
+
+    monkeypatch.setattr(sys, "argv", ["konfai", "--version"])
+    with pytest.raises(SystemExit) as exited:
+        main_module.main()
+    assert exited.value.code == 0 and looked_up == ["konfai"]
+    assert capsys.readouterr().out.strip() == real_version("konfai")
+
+
 @pytest.mark.parametrize(
     ("argv", "exit_code"),
     [

--- a/tests/unit/test_memory_budget.py
+++ b/tests/unit/test_memory_budget.py
@@ -344,7 +344,9 @@ def _metric_sizing_budget(
             get_infos=lambda group, name: ([1, 64, 64, 64], None),
         )
     }
-    monkeypatch.setattr(DataMetric, "_resolve_dataset_sources", lambda self: {"CT": [("f", False)]}, raising=False)
+    monkeypatch.setattr(
+        DataMetric, "_resolve_dataset_sources", lambda self, requested=None: {"CT": [("f", False)]}, raising=False
+    )
     monkeypatch.setattr(budget, "available_memory_bytes", lambda: (100 * 2**30, "host"))
     captured: dict[str, float] = {}
 

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -793,6 +793,72 @@ def test_zarr_keeps_a_small_share_whole(monkeypatch, cores: int, expected: int) 
         zarr.config.set({"async.concurrency": previous})
 
 
+def test_the_startup_line_takes_the_nested_phases_out_and_closes_on_other() -> None:
+    """The sweep's format: disjoint phases, ``other`` closing the wall clock exactly. The cohort,
+    the grids and the model are inside the build, the checkpoint inside the setup."""
+    import time
+
+    clock = rt.StartupClock()
+    clock._phases._spent = {"build": 1.0, "cases": 0.2, "grids": 0.1, "model": 0.3, "setup": 0.5, "checkpoint": 0.2}
+    now = time.time()
+    clock.started, clock.launched = now - 3.0, now - 0.5
+    assert clock.report() == (
+        "[KonfAI] startup 3.0 s = build 0.4 + cases 0.2 + grids 0.1 + model 0.3 + checkpoint 0.2"
+        " + setup 0.3 + launch 0.5 + other 1.0"
+    )
+    clock.started = now - 0.4
+    assert clock.report() is None  # a startup this short has nothing to account for
+
+
+def test_rank_zero_reports_the_launchers_clock_as_it_starts(monkeypatch, capsys) -> None:
+    """The clock built at the launcher's entry crosses to the rank on the workflow object and is
+    printed once, by rank 0, before the run: build, setup and launch each charged where they ran."""
+    ran: list[tuple[int, rt.StartupClock | None]] = []
+
+    class FakeObject(rt.DistributedObject):
+        uses_collectives = False
+
+        def __init__(self) -> None:
+            super().__init__("fake-startup")
+
+        def setup(self, world_size: int) -> None:
+            self.dataloader = [[]]
+
+        def run_process(self, world_size, global_rank, local_rank, dataloaders) -> None:
+            ran.append((global_rank, self.startup_clock))
+
+    monkeypatch.setattr(rt, "Log", lambda *a, **k: contextlib.nullcontext())
+    monkeypatch.setattr(rt, "TensorBoard", lambda *a, **k: contextlib.nullcontext())
+    monkeypatch.setattr(rt.torch.cuda, "is_available", lambda: False)
+    monkeypatch.setenv("KONFAI_INLINE_SINGLE_RANK", "1")
+    clock = rt.restart_startup_clock()
+    clock.started -= 5.0  # a startup long enough to be reported
+    rt.execute_distributed_object(FakeObject(), gpu=None, cpu=1)
+
+    assert ran == [(0, clock)]
+    assert clock.spent("setup") > 0 and clock.launched is not None
+    line = capsys.readouterr().out.strip().splitlines()[-1]
+    assert line.startswith("[KonfAI] startup 5.") and "+ launch 0.0 +" in line and "+ other" in line
+
+
+def test_the_rank_pool_is_rebuilt_when_the_share_changes(monkeypatch) -> None:
+    """A multi-rank build followed by an inline single-rank workflow changes the share within one
+    process: the pool follows it instead of keeping the size of its first use."""
+    monkeypatch.setattr(rt, "_rank_pool", None)
+    monkeypatch.setattr(rt, "_rank_pool_share", 0)
+    monkeypatch.setenv("OMP_NUM_THREADS", "4")
+    four = rt.rank_pool()
+    assert four is not None and four._max_workers == 4
+    assert rt.rank_pool() is four
+    monkeypatch.setenv("OMP_NUM_THREADS", "8")
+    eight = rt.rank_pool()
+    assert eight is not four and eight is not None and eight._max_workers == 8
+    assert rt.rank_pool() is eight
+    monkeypatch.setenv("OMP_NUM_THREADS", "1")
+    assert rt.rank_pool() is None
+    eight.shutdown(wait=False)
+
+
 def _map_in_child() -> None:
     seen: list[int] = []
     rt.map_over_rank_pool(seen.append, [1, 2, 3])


### PR DESCRIPTION

## Summary

A workflow's startup is spent resolving its config and building its cases before any patch is read; this branch removes the repeated work on that path and reports where the rest goes. `strict_config` loads the config tree once per workflow build, every `Config` context inside it reads that tree and folds what it set back on exit, and the block writes the file once when it ends, in the order the per-context write-back produced (a context outside a block keeps loading and writing the file itself). A float validation split builds every case once, in run order with the training draws, and cuts the training partition as that build's head and the validation partition as its tail (validation without the draws is rebuilt without them, its share only). A root's `Dataset` is kept across the resolves of one run (the sizing pass, the selection, an OOM re-plan), so each header is parsed once. `rank_pool()` records the share it was built for and rebuilds at another share, which the sequential Python API reaches. `--version` resolves the version only when asked. The cohort walk seeds its intersections from the first group and the first root whatever they hold, refuses a naming subset no group can serve with the subset refusal instead of the group-intersection error or a `KeyError`, mirrors the file-before-slice test between `Subset._included_names` and `_resolve_selector`, and computes `required_names()` once per entry point. Rank 0 prints one `[KonfAI] startup` line in the sweep's format, `build + cases + grids + model + checkpoint + setup + launch + other`, with disjoint phases, the cross-process stamps in `time.time`, and the clock restarted around each Python API call.

## Measured

Config: scratch harness counting `_load_tree` and `yaml.dump` calls, 3 runs each (build = the workflow builder on a scratch copy).

| Config | Loads + dumps | Build |
|---|---|---|
| Synthesis/Config_GAN.yml | 153 + 76 (2.96 s) -> 1 + 1 (0.03 s) | 4.60-4.97 s -> 1.66-2.64 s (median 4.70 -> 2.04) |
| Synthesis/Config.yml | 103 + 51 (1.24 s) -> 1 + 1 | median 3.19 -> 2.27 s |
| Segmentation/Config.yml | 67 + 33 (0.61 s) -> 1 + 1 | median 1.49 -> 1.05 s |
| Segmentation/Prediction.yml | 33 + 16 (0.14 s) -> 1 + 1 | median 0.20 -> 0.05 s |

Float split: scratch harness on a synthetic cohort (2 groups, Flip nb=1, validation 0.2, torch seed 0, 3 runs).
- 10 cases: managers built 40 -> 20 (unaugmented validation: 40 -> 24)
- 200 cases: 800 -> 400, `prepare()` 0.349-0.359 s -> 0.296-0.337 s (the cohort listing dominates there; the count is the evidence)

Kept `Dataset`: scratch harness over `DataMetric.prepare()` on a synthetic mha cohort, two groups, 5 and 3 runs.
- 10 cases: Dataset objects 2 -> 1, headers parsed 40 -> 20 (0 -> 20 hits), prepare 0.034-0.036 s -> 0.019-0.020 s
- 200 cases: 2 -> 1, parsed 800 -> 400 (0 -> 400 hits), prepare 0.722-0.816 s -> 0.363-0.412 s

`--version`: `importlib.metadata.version("konfai")` measured 16.8 ms cold in the dev env (1.2 ms once warm), paid only when `--version` is given.

Startup line: Segmentation example on a synthetic cohort, inline on CPU, 3 runs each, `utils/config.py` at 6af1202 against HEAD.
- before: startup 1.3 / 1.4 / 1.5 s = build 1.0-1.1 + model 0.3 + launch 0.1
- after: startup 0.6 / 0.8 / 0.6 s = build 0.5-0.7 + model 0.0 + launch 0.1

**Values:** the perf changes move nothing. The resolved config is byte-identical on the 12 example configs (sha256 before and after; Config_GAN.yml and Transform.yml gain keys, which is where the order shows); the float split's draws are sha-identical, with the same names and indices in both partitions; the kept Dataset changes no value. The cohort-walk fixes change which cases a run selects where the groups' or roots' order decided it, what a names file spelled like a slice selects, and which error a naming subset no group can serve fails on.

**Tests:** `tests/unit/test_config.py` pins the one-tree read and write against the per-context path kept as the oracle (including a shipped config resolving to the same bytes, a refusing block leaving what it bound, and a file a context refused not being created); `test_data_manager.py` pins the single build with the partitions cut from it and the roots kept across an evaluation's two resolves; `test_cohort_walk.py` the first-group and first-root seeding, the subset refusal whatever the order, and a names file spelled like a slice; `test_runtime.py` the pool rebuild, the startup line's disjoint phases and rank 0's report; `test_main_cli.py` the version looked up only when asked; the `_resolve_dataset_sources` stub in `test_memory_budget.py` takes the required names as an argument.

**Stack:** Stacked on `pr/1.8.2-02-storage`; merge after it. Before deleting this branch, retarget the next PR of the stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added startup timing visibility for workflow construction, setup, model loading, and launch phases.
  - The CLI now reports the installed version when `--version` is requested.
  - Dataset selection now supports subset-based requests and clearer handling of missing cases.

- **Bug Fixes**
  - Improved dataset reuse and partitioning consistency across repeated operations.
  - Configuration updates now use safer atomic writes and consolidated nested changes.
  - Clarified errors for invalid or empty dataset selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->