### PR TITLE
Metrics and evaluation: confusion-matrix Dice, torch SSIM, one-pass SaveMaps, and the halo reader

### DIFF
--- a/docs/source/config_guide/evaluation.md
+++ b/docs/source/config_guide/evaluation.md
@@ -81,13 +81,23 @@ Evaluation bounds itself by default: an absent `memory_budget` means `auto`
 fits the budget is evaluated whole, and a case that does not is cut into the largest
 DISJOINT patches that fit. Metrics accumulate running partial sums per patch and
 combine them into the exact whole-case value (never a mean of per-patch values).
-MAE, MSE, ME, PSNR and Dice (masked or not) support this, and the SaveMap
+MAE, MSE, ME, PSNR, SSIM and Dice (masked or not) support this, and the SaveMap
 error maps stream region by region into their `dataset` (mha, h5 or omezarr). One
 caveat on the first two: `MAE` and `MSE` are reducible only for `reduction: mean` or
 `sum`, so a `reduction: none` on either forces the whole-volume path for the whole
 run, by the same rule as a non-reducible metric below.
-One metric that cannot recombine (SSIM, LPIPS, or any custom metric that does
-not declare `reducible`) keeps the whole-volume path for the entire run: correct
+
+A metric that scores each voxel through a window declares the window's radius as
+its `halo`, and the reader serves it: SSIM (7-voxel window) declares 3, so every
+patch is read 3 voxels past each face of its slot, clamped at the volume's faces,
+and the sizing counts that band in the budget. SSIM sums the map voxels centred
+in the slot, which is exactly the whole-volume map's share of it (the whole-volume
+map is cropped by the same radius at the faces); the metrics without a halo see
+the slot alone, so their values are the ones they had without SSIM in the run.
+A custom metric declares `halo` beside `reducible` and receives `core=` in
+`partial_metric`, the slot's slices within the patch it is handed.
+One metric that cannot recombine (LPIPS, or any custom metric that does not
+declare `reducible`) keeps the whole-volume path for the entire run: correct
 beats bounded. Evaluation streams its data whatever the budget says, one pass,
 a cache is never re-read; in training the same budget also picks cache versus
 streaming.

--- a/docs/source/config_guide/evaluation.md
+++ b/docs/source/config_guide/evaluation.md
@@ -109,6 +109,23 @@ The JSON structure contains:
 
 This behavior comes from `konfai.evaluator.Statistics.write()`.
 
+### Where the split's time went
+
+A split that ran for more than a second closes with a line accounting for it,
+phase by phase, in the rank's log:
+
+```text
+[KonfAI] evaluation TRAIN 4.0 s = wait(load) 0.6 + h2d 0.0 + MAE 0.2 + PSNR 0.1 + SSIM 2.5 + map 0.3 + flush 0.0 + other 0.1
+```
+
+`wait(load)` is the wait for the loader's next case or patch, `h2d` the move to
+the metric device, then one figure per metric name, `map` the error-map writes of
+the SaveMap metrics and `flush` the combination of a streamed case's partial
+states; what the named phases do not account for is `other`. The sum closes
+exactly. On a GPU a metric's figure is the time to enqueue its kernels, not to
+run them: a slow kernel shows up in whatever next waits on the device, typically
+the next `h2d` or a metric that reads a value back.
+
 ## Examples
 
 See:

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -1818,9 +1818,10 @@ class DataMetric(Data):
     Evaluation never exposes a patch: each run sizes its own from ``memory_budget`` (a missing key
     means ``"auto"``): a case that fits the budget is evaluated whole (exact); one
     that does not is cut into the largest DISJOINT patches that fit (overlap 0, no padding) and the
-    reducible metrics combine their running partials into the exact whole-case value. The evaluator
-    disables this sizing when any of its metrics is not reducible, so a metric that needs the whole
-    volume always gets it.
+    reducible metrics combine their running partials into the exact whole-case value. A metric
+    scoring through a window declares a halo, and every patch is then read that much wider than its
+    slot. The evaluator disables this sizing when any of its metrics is not reducible, so a metric
+    that needs the whole volume always gets it.
     """
 
     # One pass: each case is read once, a cache is never re-read, always stream/buffer.
@@ -1834,6 +1835,9 @@ class DataMetric(Data):
     # The evaluator clears this when any of its metrics is not reducible: that metric needs whole
     # volumes, so the budget sizing must not cut the case.
     auto_patch_allowed = True
+    # The widest halo among the evaluator's metrics: the context every patch is read with past its
+    # slot, and what the sizing reserves on each face.
+    patch_halo = 0
 
     def _maybe_auto_patch(self) -> None:
         # An explicit patch or a non-reducible metric vetoes the sizing.
@@ -1862,24 +1866,45 @@ class DataMetric(Data):
             key=lambda name: channels_by_name[name] * int(np.prod(spatial_by_name[name], dtype=np.int64)),
         )
         budget = self.resolved_budget().per_rank_bytes(node_local_ranks())
-        sized = resolve_patch(
-            [0] * len(spatial_by_name[worst]),
-            spatial_by_name[worst],
-            channels_by_name[worst],
-            _CACHE_ELEMENT_BYTES,
-            budget,
-            resident_images=1,
-            intermediate_factor=DataMetric._METRIC_INTERMEDIATE_FACTOR,
-        )
-        if sized == spatial_by_name[worst]:
+        extent = spatial_by_name[worst]
+        halo = self.patch_halo
+        # What the budget bounds is the READ: a slot plus the halo past each face. Sized as one
+        # patch; an axis the budget cuts thinner than its two halos is spanned whole instead, since
+        # the halo there would cost more than the axis, and the other axes absorb it.
+        template = [0] * len(extent)
+        while True:
+            sized = resolve_patch(
+                template,
+                extent,
+                channels_by_name[worst],
+                _CACHE_ELEMENT_BYTES,
+                budget,
+                resident_images=1,
+                intermediate_factor=DataMetric._METRIC_INTERMEDIATE_FACTOR,
+            )
+            thin = [d for d, size in enumerate(sized) if template[d] == 0 and size < extent[d] and size <= 2 * halo]
+            if not thin:
+                break
+            for d in thin:
+                template[d] = extent[d]
+        if all(template):
+            raise DatasetManagerError(
+                f"The memory budget cannot hold a patch of '{worst}' ({channels_by_name[worst]}ch x {extent}) "
+                f"with the {halo}-voxel halo its metrics read past each face.",
+                "Raise 'memory_budget'.",
+            )
+        if sized == extent:
             return  # every case fits whole: the exact whole-volume path
-        patch = DatasetPatch(patch_size=sized, overlap=0)
+        core = [size - 2 * halo if size < axis else size for size, axis in zip(sized, extent, strict=True)]
+        patch = DatasetPatch(patch_size=core, overlap=0)
         patch.pad_to_patch = False  # reduced, not modelled: only in-volume voxels may reach the sums
+        patch.halo = halo
         self.patch = patch
+        read = f" read with a halo of {halo} ({sized} resident)" if halo else ""
         print(
             f"[KonfAI] memory_budget: worst case '{worst}' "
-            f"({channels_by_name[worst]}ch x {spatial_by_name[worst]}) exceeds the budget -> "
-            f"evaluating in disjoint patches of {sized} (overlap 0), metrics combined exactly."
+            f"({channels_by_name[worst]}ch x {extent}) exceeds the budget -> "
+            f"evaluating in disjoint patches of {core} (overlap 0){read}, metrics combined exactly."
         )
 
     def prepare(self) -> None:

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -1552,6 +1552,11 @@ class Patch(ABC):
         # A consumer that REDUCES patches instead (streamed evaluation) must see only in-volume voxels:
         # padded ones would pollute its running sums, so it turns this off and takes the cropped patch.
         self.pad_to_patch = True
+        #: Voxels of context read past each face of a grid patch, clamped to the volume, for a consumer
+        #: that reduces patches but scores through a window (a metric's halo). The grid keeps its
+        #: disjoint slots (``get_patch_slices``); ``core_in_read`` says where a slot sits in its read.
+        #: Unpadded only (``pad_to_patch`` False): a model input padded to the patch has no core.
+        self.halo = 0
         # The model's per-axis downsampling factor a FREE (``0``) axis rounds up to, set before the grids
         # are cut so each case's whole-axis extent lands on a valid model input. ``None`` outside a model
         # (evaluation) or for a network that never downsamples.
@@ -1589,33 +1594,43 @@ class Patch(ABC):
     def get_patch_slices(self, a: int = 0):
         return self._patch_slices[a]
 
+    def read_slices(self, a: int, index: int, shape: Sequence[int]) -> list[slice]:
+        """The region patch ``index`` of copy ``a`` reads: its grid slot, widened by the halo and
+        clamped to the volume (``shape`` may carry leading non-spatial axes)."""
+        slot = self._patch_slices[a][index]
+        if not self.halo:
+            return list(slot)
+        spatial = [int(extent) for extent in shape[len(shape) - len(slot) :]]
+        return _HaloPull([self.halo] * len(slot), spatial)(slot)
+
+    def core_in_read(self, a: int, index: int) -> tuple[slice, ...]:
+        """Where patch ``index``'s grid slot sits within its read: the halo in from each face, less
+        where the volume's own face cut the halo short."""
+        return tuple(
+            slice(min(self.halo, s.start), min(self.halo, s.start) + s.stop - s.start)
+            for s in self._patch_slices[a][index]
+        )
+
     def get_read_plan(
         self, data_shape: list[int] | tuple[int, ...], index: int, a: int, is_input: bool
     ) -> PatchReadPlan:
-        slices_pre = [slice(None) for _ in data_shape[: -len(self._patch_slices[a][0])]]
+        slot = self.read_slices(a, index, data_shape)
+        slices_pre = [slice(None) for _ in data_shape[: -len(slot)]]
         extend_slice = self.extend_slice if is_input else 0
 
         bottom = extend_slice // 2
         top = int(np.ceil(extend_slice / 2))
         s = slice(
-            (
-                self._patch_slices[a][index][0].start - bottom
-                if self._patch_slices[a][index][0].start - bottom >= 0
-                else 0
-            ),
-            (
-                self._patch_slices[a][index][0].stop + top
-                if self._patch_slices[a][index][0].stop + top <= data_shape[len(slices_pre)]
-                else data_shape[len(slices_pre)]
-            ),
+            (slot[0].start - bottom if slot[0].start - bottom >= 0 else 0),
+            (slot[0].stop + top if slot[0].stop + top <= data_shape[len(slices_pre)] else data_shape[len(slices_pre)]),
         )
-        slices = [s, *list(self._patch_slices[a][index][1:])]
+        slices = [s, *slot[1:]]
         reflect_padding = [0 for _ in range((len(slices) - 1) * 2)] + [0, 0]
         if extend_slice > 0 and (s.stop - s.start) < bottom + top + 1:
-            if self._patch_slices[a][index][0].start - bottom < 0:
-                reflect_padding[-2] = bottom - self._patch_slices[a][index][0].start
-            if self._patch_slices[a][index][0].stop + top > data_shape[len(slices_pre)]:
-                reflect_padding[-1] = self._patch_slices[a][index][0].stop + top - data_shape[len(slices_pre)]
+            if slot[0].start - bottom < 0:
+                reflect_padding[-2] = bottom - slot[0].start
+            if slot[0].stop + top > data_shape[len(slices_pre)]:
+                reflect_padding[-1] = slot[0].stop + top - data_shape[len(slices_pre)]
 
         constant_padding = []
         if self.pad_to_patch and self.patch_size is not None:
@@ -1800,6 +1815,7 @@ class DatasetManager:
             # The manager works on its own copy (per-case grids); carry the reduction-vs-model contract
             # with it, or a streamed evaluation would silently get padded border patches back.
             self.patch.pad_to_patch = patch.pad_to_patch
+            self.patch.halo = patch.halo
             # Carry the model's downsampling multiple too, so each per-case free axis rounds up to a valid
             # input size on this copy's grid, not just on the up-front worst-case sizing.
             self.patch.free_axis_multiple = patch.free_axis_multiple
@@ -2942,7 +2958,7 @@ class DatasetManager:
         which a Save sweep drives with slab targets instead of patch targets)."""
         if self._expand is not None:
             self._refold_copy_records(a, stream_source)
-        target_slices = tuple(self.patch.get_patch_slices(a)[index])
+        target_slices = tuple(self.patch.read_slices(a, index, self.shapes[a]))
         # Each patch re-runs the chain from the state the whole-volume pass started from: the case as
         # stored (plus planned stats), never the live attribute: that one carries the chain's own
         # output.

--- a/konfai/evaluator.py
+++ b/konfai/evaluator.py
@@ -303,18 +303,19 @@ class Evaluator(DistributedObject):
         self.statistics_validation = Statistics(self.metric_path / "Metric_VALIDATION.json")
         # A memory budget may patch the evaluation, but only when EVERY metric can rebuild its
         # whole-case value from partial states; one non-reducible metric keeps the whole-volume path
-        # for everything (correct beats bounded).
-        self.dataset.auto_patch_allowed = all(
-            getattr(metric, "reducible", False)
-            for targets in self.metrics.values()
-            for criterions in targets.values()
-            for metric in criterions
-        )
+        # for everything (correct beats bounded). A metric scoring through a window declares the
+        # halo its patches are read with, and the widest one is read for all.
+        criterions = [metric for targets in self.metrics.values() for group in targets.values() for metric in group]
+        self.dataset.auto_patch_allowed = all(getattr(metric, "reducible", False) for metric in criterions)
+        self.dataset.patch_halo = max((int(getattr(metric, "halo", 0)) for metric in criterions), default=0)
         self.dataset.prepare()
         set_chunk_cache_budget(self.dataset.resolved_budget().per_rank_bytes(node_local_ranks()))
         # Set iff the budget actually patched: batches then carry one disjoint patch of a case, and
         # update() accumulates partial states until the case's last patch before recording it.
         self._streamed = self.dataset.patch is not None
+        # The context each patch is read with past its slot, when the grid reads any: a metric that
+        # declared it is handed the read and told where the slot sits, the others the slot alone.
+        self._halo = self.dataset.patch.halo if self.dataset.patch is not None else 0
         self._pending: dict[tuple[str, str, int], tuple] = {}
         self._pending_name: str | None = None
         self._last_result: dict[str, float] = {}
@@ -502,16 +503,22 @@ class Evaluator(DistributedObject):
         moved = self._groups_on(batch_sample)
         for output_group in self.metrics:
             output_tensor = moved[output_group]
+            core = self._core_in_read(output_group, batch_sample[output_group])
             for target_group in self.metrics[output_group]:
                 targets = [moved[group] for group in target_group.split(";") if group in batch_sample]
+                tensors = [output_tensor, *targets]
+                cored = tensors if core is None else [t[(slice(None), slice(None), *core)] for t in tensors]
                 for index, metric in enumerate(self.metrics[output_group][target_group]):
+                    reads_halo = core is not None and int(getattr(metric, "halo", 0)) > 0
                     with self._clock.phase(metric.get_name()), torch.no_grad():
-                        state = metric.partial_metric(output_tensor, *targets)
+                        state = (
+                            metric.partial_metric(*tensors, core=core) if reads_halo else metric.partial_metric(*cored)
+                        )
                     entry = self._pending.setdefault((output_group, target_group, index), (metric, []))
                     entry[1].append(state)
                     if getattr(metric, "dataset", None) and hasattr(metric, "partial_map"):
                         with self._clock.phase(metric.get_name()), torch.no_grad():
-                            patch_map = metric.partial_map(output_tensor, *targets).squeeze(0)
+                            patch_map = metric.partial_map(*cored).squeeze(0)
                         with self._clock.phase("map"):
                             self._write_map_patch(
                                 (output_group, target_group, index),
@@ -521,6 +528,18 @@ class Evaluator(DistributedObject):
                                 patch_map,
                             )
         return self._last_result
+
+    def _manager(self, output_group: str, item: BatchDataItem):
+        """The manager whose grid cut the patch ``item`` carries."""
+        if self._iter_dataset is None:
+            raise EvaluatorError("Internal error: the streamed evaluation loop has no dataset iterator.")
+        return self._iter_dataset.get_dataset_from_index(output_group, int(item.x[0]))
+
+    def _core_in_read(self, output_group: str, item: BatchDataItem) -> tuple[slice, ...] | None:
+        """Where the patch's slot sits within its tensors; ``None`` when the grid reads no halo."""
+        if not self._halo:
+            return None
+        return self._manager(output_group, item).patch.core_in_read(int(item.a[0]), int(item.p[0]))
 
     def _write_map_patch(
         self,
@@ -535,9 +554,7 @@ class Evaluator(DistributedObject):
         ``partial_map`` is voxel-local, so the patch's map is exactly the region of the whole-case
         map; the disjoint unpadded evaluation grid writes every voxel once, never twice.
         """
-        if self._iter_dataset is None:
-            raise EvaluatorError("Internal error: the streamed evaluation loop has no dataset iterator.")
-        manager = self._iter_dataset.get_dataset_from_index(output_group, int(item.x[0]))
+        manager = self._manager(output_group, item)
         array = patch_map.numpy()
         sink = self._map_sinks.get(key)
         if sink is None:

--- a/konfai/evaluator.py
+++ b/konfai/evaluator.py
@@ -29,6 +29,7 @@ from torch.utils.data import DataLoader
 
 from konfai import config_file, cuda_visible_devices, evaluations_directory, konfai_root
 from konfai.data.data_manager import BatchDataItem, BatchSample, DataMetric, DatasetIter
+from konfai.data.patching import SweepClock
 from konfai.network.network import build_configured_criterions
 from konfai.utils.budget import node_local_ranks
 from konfai.utils.config import apply_config, config, strict_config
@@ -327,6 +328,8 @@ class Evaluator(DistributedObject):
         # ones that own a network (a perceptual metric moves its model to the tensor's device, and a
         # segmentation metric runs a whole nested inference). `run_process` sets the run's real device.
         self._device: torch.device | int = torch.device("cpu")
+        # Where a split's wall clock goes, one clock per split (see _evaluate_split).
+        self._clock = SweepClock()
         self._validate_metric_groups()
 
     def _validate_metric_groups(self) -> None:
@@ -392,47 +395,26 @@ class Evaluator(DistributedObject):
         if self._streamed:
             return self._update_streamed(batch_sample, statistics)
         result: dict[str, float] = {}
+        moved = self._groups_on(batch_sample)
         for output_group in self.metrics:
-            metric_device = self._device
-            output_tensor = self._on(batch_sample[output_group].tensor, metric_device)
+            output_tensor = moved[output_group]
             for target_group in self.metrics[output_group]:
-                targets = self._targets_on(batch_sample, target_group, metric_device)
+                targets = [moved[group] for group in target_group.split(";") if group in batch_sample]
                 target_attribute = [batch_sample[output_group].attribute] + [
                     batch_sample[group].attribute for group in target_group.split(";") if group in batch_sample
                 ]
                 name = batch_sample[output_group].name[0]
                 for metric in self.metrics[output_group][target_group]:
-                    if getattr(metric, "accepts_attributes", False):
-                        with torch.no_grad():
-                            loss = metric(
-                                output_tensor,
-                                *targets,
-                                attributes=target_attribute,
-                            )
-                    else:
-                        with torch.no_grad():
-                            loss = metric(
-                                output_tensor,
-                                *targets,
-                            )
+                    with self._clock.phase(metric.get_name()), torch.no_grad():
+                        if getattr(metric, "accepts_attributes", False):
+                            loss = metric(output_tensor, *targets, attributes=target_attribute)
+                        else:
+                            loss = metric(output_tensor, *targets)
                     if isinstance(loss, tuple):
                         true_loss = loss[1]
-                        if len(loss) == 3:
-                            if metric.dataset:
-                                filename, _, file_format = split_path_spec(metric.dataset)
-                                map_dataset = Dataset(filename, file_format)
-                                group = metric.group if metric.group else output_group
-                                for dataset in self.dataset.datasets.values():
-                                    for g in dataset.get_group():
-                                        if dataset.is_dataset_exist(g, name):
-                                            _, cache_attribute = dataset.get_infos(g, name)
-                                            map_dataset.write(
-                                                group,
-                                                name,
-                                                loss[2].squeeze(0).numpy(),
-                                                cache_attribute,
-                                            )
-                                            break
+                        if len(loss) == 3 and metric.dataset:
+                            with self._clock.phase("map"):
+                                self._write_map(metric, output_group, name, loss[2])
                     else:
                         true_loss = loss.item()
 
@@ -443,6 +425,18 @@ class Evaluator(DistributedObject):
             statistics.add(result, name)
         return result
 
+    def _write_map(self, metric: Any, output_group: str, name: str, map_: torch.Tensor) -> None:
+        """Write a metric's whole-case map beside the case, with the case's own geometry."""
+        filename, _, file_format = split_path_spec(metric.dataset)
+        map_dataset = Dataset(filename, file_format)
+        group = metric.group if metric.group else output_group
+        for dataset in self.dataset.datasets.values():
+            for g in dataset.get_group():
+                if dataset.is_dataset_exist(g, name):
+                    _, cache_attribute = dataset.get_infos(g, name)
+                    map_dataset.write(group, name, map_.squeeze(0).numpy(), cache_attribute)
+                    return
+
     @staticmethod
     def _on(tensor: torch.Tensor, metric_device: torch.device | int) -> torch.Tensor:
         """A tensor on the metric's device, moved only when it is not already there."""
@@ -450,16 +444,23 @@ class Evaluator(DistributedObject):
             return tensor
         return tensor.to(metric_device, non_blocking=tensor.device.type == "cpu")
 
-    @staticmethod
-    def _targets_on(
-        batch_sample: BatchSample, target_group: str, metric_device: torch.device | int
-    ) -> list[torch.Tensor]:
-        """The target tensors of a ``;``-joined group spec, moved to the metric's device."""
-        return [
-            Evaluator._on(batch_sample[group].tensor, metric_device)
-            for group in target_group.split(";")
+    def _groups_on(self, batch_sample: BatchSample) -> dict[str, torch.Tensor]:
+        """Every group a metric names, on the metric device, moved once per update.
+
+        A target named by two specs (``CT`` and ``CT;MASK``) or shared by two outputs was uploaded
+        once per spec per case, and per patch on the streamed path. Sharing one copy is safe: a
+        metric never writes into its inputs (a mask multiplies into a new tensor), and the metrics
+        of one spec already read the same tensor.
+        """
+        groups = {
+            group
+            for output_group, targets in self.metrics.items()
+            for spec in (output_group, *targets)
+            for group in spec.split(";")
             if group in batch_sample
-        ]
+        }
+        with self._clock.phase("h2d"):
+            return {group: self._on(batch_sample[group].tensor, self._device) for group in sorted(groups)}
 
     @staticmethod
     def _record_value(
@@ -495,28 +496,30 @@ class Evaluator(DistributedObject):
         """
         name = batch_sample[next(iter(self.metrics))].name[0]
         if self._pending_name is not None and name != self._pending_name:
-            self._flush_pending(statistics)
+            with self._clock.phase("flush"):
+                self._flush_pending(statistics)
         self._pending_name = name
+        moved = self._groups_on(batch_sample)
         for output_group in self.metrics:
-            metric_device = self._device
-            output_tensor = self._on(batch_sample[output_group].tensor, metric_device)
+            output_tensor = moved[output_group]
             for target_group in self.metrics[output_group]:
-                targets = self._targets_on(batch_sample, target_group, metric_device)
+                targets = [moved[group] for group in target_group.split(";") if group in batch_sample]
                 for index, metric in enumerate(self.metrics[output_group][target_group]):
-                    with torch.no_grad():
+                    with self._clock.phase(metric.get_name()), torch.no_grad():
                         state = metric.partial_metric(output_tensor, *targets)
                     entry = self._pending.setdefault((output_group, target_group, index), (metric, []))
                     entry[1].append(state)
                     if getattr(metric, "dataset", None) and hasattr(metric, "partial_map"):
-                        with torch.no_grad():
+                        with self._clock.phase(metric.get_name()), torch.no_grad():
                             patch_map = metric.partial_map(output_tensor, *targets).squeeze(0)
-                        self._write_map_patch(
-                            (output_group, target_group, index),
-                            metric,
-                            batch_sample[output_group],
-                            output_group,
-                            patch_map,
-                        )
+                        with self._clock.phase("map"):
+                            self._write_map_patch(
+                                (output_group, target_group, index),
+                                metric,
+                                batch_sample[output_group],
+                                output_group,
+                                patch_map,
+                            )
         return self._last_result
 
     def _write_map_patch(
@@ -629,25 +632,59 @@ class Evaluator(DistributedObject):
             )
 
         self._iter_dataset = dataloader.dataset
+        self._clock = SweepClock()
         try:
-            with tqdm.tqdm(
-                iterable=enumerate(dataloader),
-                leave=True,
-                desc=description(None),
-                total=len(dataloader),
-                ncols=0,
-            ) as batch_iter:
-                for _, batch_sample in batch_iter:
+            with (
+                self._clock.phase("split"),
+                tqdm.tqdm(
+                    iterable=enumerate(dataloader),
+                    leave=True,
+                    desc=description(None),
+                    total=len(dataloader),
+                    ncols=0,
+                ) as batch_iter,
+            ):
+                for _, batch_sample in self._clock.waiting("wait(load)", batch_iter):
                     batch_iter.set_description(description(self.update(batch_sample, statistics)))
-            self._flush_pending(statistics)  # close the split's last case
+                with self._clock.phase("flush"):
+                    self._flush_pending(statistics)  # close the split's last case
         except BaseException as error:
             # A half-written error map must not survive as a valid-looking file: abort the open
             # region-write sinks so their backends remove the partial entries, then re-raise.
             self._abort_map_sinks(error)
             raise
+        if global_rank == 0:
+            report = self._clock_report(label)
+            if report is not None:
+                print(report)
         outputs = synchronize_data(world_size, gpu, statistics.measures)
         if global_rank == 0:
             statistics.write(outputs)
+
+    def _clock_report(self, label: str, min_seconds: float = 1.0) -> str | None:
+        """One line accounting for a split's wall clock, or ``None`` below ``min_seconds``.
+
+        The phases: the wait for the loader's next batch, the move to the metric device, one per
+        metric name, the map writes and the streamed flushes; ``other`` is what none of them names.
+        On a GPU a metric's phase is its enqueue time, not its run: no synchronize is added for the
+        report's sake, so a slow kernel shows up in whatever next waits on the device.
+        """
+        wall = self._clock.spent("split")
+        if wall < min_seconds:
+            return None
+        names = ["wait(load)", "h2d"]
+        names += sorted(
+            {
+                metric.get_name()
+                for targets in self.metrics.values()
+                for metrics in targets.values()
+                for metric in metrics
+            }
+        )
+        names += ["map", "flush"]
+        named = {name: self._clock.spent(name) for name in names if self._clock.spent(name) > 0.0}
+        parts = " + ".join(f"{name} {value:.1f}" for name, value in named.items())
+        return f"[KonfAI] evaluation {label} {wall:.1f} s = {parts} + other {wall - sum(named.values()):.1f}"
 
 
 def build_evaluate(

--- a/konfai/metric/measure.py
+++ b/konfai/metric/measure.py
@@ -45,7 +45,7 @@ models_register: dict[str, Network] = {}
 def _require_optional(module: str, *, criterion: str, extra: str) -> ModuleType:
     """Import an optional criterion dependency or raise an actionable error.
 
-    Several criteria (SSIM, LPIPS, FID) rely on heavyweight optional packages
+    Several criteria (LPIPS, FID) rely on heavyweight optional packages
     that are not part of the base install. Importing them through this helper
     turns a missing dependency into a clear, install-ready message raised at
     criterion construction, instead of a raw ``ImportError`` surfacing mid-run.
@@ -322,24 +322,57 @@ class MAESaveMap(MAE):
         self.dataset = dataset
         self.group = group
 
+    @staticmethod
+    def _difference(output: torch.Tensor, *targets: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Per-voxel ``|output - target|``, zero outside the mask when one is given, and the bool mask.
+
+        The one buffer both readouts come from: ``L1Loss`` reduces exactly this tensor, so the
+        scalar and the map are what two passes computed. The mask multiplies in place as bool
+        (``torch.where(mask == 1, 1, 0)`` was 8 B/voxel of int64, made twice).
+        """
+        target = targets[0].to(device=output.device)
+        difference = (output.float() - target.float()).abs()
+        mask = MaskedLoss.get_mask(list(targets[1:]))
+        if mask is None:
+            return difference, None
+        mask = mask.to(device=output.device) == 1
+        return difference.mul_(mask), mask
+
+    @staticmethod
+    def _reduce(difference: torch.Tensor, reduction: str) -> torch.Tensor:
+        """What ``L1Loss(reduction)`` returns from the differences it reduces: the same kernel."""
+        if reduction == "mean":
+            return difference.mean()
+        if reduction == "sum":
+            return difference.sum()
+        return difference
+
     def partial_map(self, output: torch.Tensor, *targets: torch.Tensor) -> torch.Tensor:
         """Per-voxel ``|output - target|`` (masked where a mask is given). VOXEL-LOCAL by construction:
         a patch's map equals the same region of the whole-case map, which is what lets the streamed
         evaluation write it region by region instead of needing the whole case."""
-        if len(targets) == 2:
-            return (
-                torch.nn.L1Loss(reduction="none")(
-                    output.float() * torch.where(targets[1] == 1, 1, 0),
-                    targets[0].float() * torch.where(targets[1] == 1, 1, 0),
-                )
-                .to(output.dtype)
-                .cpu()
-            )
-        return torch.nn.L1Loss(reduction="none")(output.float(), targets[0].float()).to(output.dtype).cpu()
+        return self._difference(output, *targets)[0].to(output.dtype).cpu()
 
     def forward(self, output: torch.Tensor, *targets: torch.Tensor):  # type: ignore[override]
-        loss, true_loss = super().forward(output, *targets)
-        return loss, true_loss, self.partial_map(output, *targets)
+        difference, mask = self._difference(output, *targets)
+        if mask is None:
+            loss = self._reduce(difference, self._reduction)
+            return loss, loss.detach().item(), difference.to(output.dtype).cpu()
+        # Per batch item over its masked voxels, averaged over the items that have any: the
+        # structure of MaskedLoss.forward, read off the one difference buffer.
+        loss = output.new_tensor(0.0)
+        true_nb = 0
+        for batch in range(output.shape[0]):
+            mask_b = mask[batch, ...]
+            if not torch.any(mask_b):
+                continue
+            loss = loss + self._reduce(torch.masked_select(difference[batch, ...], mask_b), self._reduction)
+            true_nb += 1
+        map_ = difference.to(output.dtype).cpu()
+        if true_nb == 0:
+            return loss, np.nan, map_
+        loss = loss / true_nb
+        return loss, loss.detach().item(), map_
 
     def get_name(self) -> str:
         return "MAE"
@@ -369,36 +402,122 @@ class PSNR(MaskedLoss):
 
 
 class SSIM(MaskedLoss):
+    """Structural similarity as ``skimage.metrics.structural_similarity`` computes it with its
+    defaults: a 7-wide uniform window, K1 0.01, K2 0.03, the sample covariance, the mean over the
+    map cropped by the window's radius, one map per channel (``channel_axis=0``) all averaged. In
+    torch on the tensors' device, where skimage's numpy route was single-threaded and pulled the
+    volumes back to the host. The map is built slab by slab along the first spatial axis, so the
+    five window statistics it needs hold a few MiB at a time whatever the case.
+
+    A voxel's window reaches the window's radius past a patch's faces, which the evaluation's
+    disjoint patches do not carry: not reducible.
+    """
+
     maximize = True  # reported value is the structural similarity index (higher-is-better)
+    window = 7
+    k1 = 0.01
+    k2 = 0.03
+    #: Bytes of one statistic map per slab. Measured at 512^3 float32, 12 threads / one GPU: 0.94 s /
+    #: 0.12 s at 4 MiB, 1.08 / 0.09 at 8, 2.29 / 0.23 at 32, 7.58 / 0.28 at 64 (past glibc's 32 MiB
+    #: mmap threshold every map is fresh pages); at 256^3 a 1 MiB slab is 6.1 s of per-op overhead
+    #: against 0.15 s at 2 MiB.
+    slab_bytes = 8 << 20
+
+    def __init__(self, dynamic_range: float | None = None) -> None:
+        dynamic_range = dynamic_range if dynamic_range else 1024 + 3000
+        super().__init__(partial(SSIM._loss, dynamic_range), True)
+        self._dynamic_range = float(dynamic_range)
 
     @staticmethod
     def _loss(dynamic_range: float, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-        structural_similarity = _require_optional(
-            "skimage.metrics", criterion="SSIM", extra="ssim"
-        ).structural_similarity
-        value = structural_similarity(
-            x.detach().cpu().numpy(),
-            y.detach().cpu().numpy(),
-            data_range=dynamic_range,
-            channel_axis=0,
-            gradient=False,
-            full=False,
-        )
-        return x.new_tensor(float(value))
+        return x.new_tensor(SSIM._ssim(x.float(), y.float(), None, dynamic_range))
 
-    def __init__(self, dynamic_range: float | None = None) -> None:
-        _require_optional("skimage.metrics", criterion="SSIM", extra="ssim")
-        dynamic_range = dynamic_range if dynamic_range else 1024 + 3000
-        super().__init__(partial(SSIM._loss, dynamic_range), True)
+    @staticmethod
+    def _box_sum(tensor: torch.Tensor, window: int) -> torch.Tensor:
+        """The sum over the window along every spatial axis of ``[N, *spatial]``, valid part only:
+        window - 1 shifted in-place adds per axis (6 ms per 8 MiB map on 12 threads, where a conv3d
+        with a (7, 1, 1) kernel took 27)."""
+        for axis in range(1, tensor.dim()):
+            length = tensor.shape[axis] - window + 1
+            total = tensor.narrow(axis, 0, length).clone()
+            for shift in range(1, window):
+                total += tensor.narrow(axis, shift, length)
+            tensor = total
+        return tensor
+
+    @staticmethod
+    def _map_sum(x: torch.Tensor, y: torch.Tensor, data_range: float) -> tuple[torch.Tensor, int]:
+        """The sum (float64) and voxel count of skimage's SSIM map over the valid region of one
+        ``[N, *spatial]`` pair, its operations in skimage's order."""
+        window = SSIM.window
+        voxels = window ** (x.dim() - 1)
+        cov_norm = voxels / (voxels - 1)
+        c1, c2 = (SSIM.k1 * data_range) ** 2, (SSIM.k2 * data_range) ** 2
+        # float64: a variance is the difference of two moments near the square of the mean, and
+        # float32 keeps 0.4 of a moment of 6e6 (a mean of 2500 HU) where the variance is a few
+        # thousand. Measured against a float64 reference on a constant 1000 with a 5 HU step:
+        # 7e-6 off in float32 (skimage 6.5e-8), 1.3e-7 here.
+        x, y = x.to(torch.float64), y.to(torch.float64)
+        ux = SSIM._box_sum(x, window) / voxels
+        uy = SSIM._box_sum(y, window) / voxels
+        vx = (SSIM._box_sum(x * x, window) / voxels).sub_(ux * ux).mul_(cov_norm)
+        vy = (SSIM._box_sum(y * y, window) / voxels).sub_(uy * uy).mul_(cov_norm)
+        vxy = (SSIM._box_sum(x * y, window) / voxels).sub_(ux * uy).mul_(cov_norm)
+        a1 = (2 * ux * uy).add_(c1)
+        b1 = (ux * ux).add_(uy * uy).add_(c1)
+        a2 = vxy.mul_(2).add_(c2)
+        b2 = vx.add_(vy).add_(c2)
+        s = a1.mul_(a2).div_(b1.mul_(b2))
+        return s.sum(dtype=torch.float64), s.numel()
+
+    @staticmethod
+    @torch.no_grad()
+    def _ssim(x: torch.Tensor, y: torch.Tensor, mask: torch.Tensor | None, data_range: float) -> float:
+        """The SSIM of one ``[C, *spatial]`` pair. A mask multiplies both, slab by slab, and the
+        score is the mean over the whole cropped extent, as the masked mode always was."""
+        radius = (SSIM.window - 1) // 2
+        depth = x.shape[1] - 2 * radius
+        if depth < 1 or any(size < SSIM.window for size in x.shape[2:]):
+            raise MeasureError(
+                f"SSIM needs every spatial extent to be at least its {SSIM.window}-voxel window.",
+                f"Got a {tuple(x.shape[1:])} volume.",
+            )
+        planes = max(2 * radius + 2, SSIM.slab_bytes // (x[:, 0].numel() * 8))  # the maps are float64
+        total = torch.zeros((), dtype=torch.float64, device=x.device)
+        count = 0
+        for start in range(0, depth, planes):
+            stop = min(depth, start + planes) + 2 * radius
+            xs, ys = x[:, start:stop], y[:, start:stop]
+            if mask is not None:
+                # torch.where, not a float x bool product: on a cache-resident slab the mixed-dtype
+                # product runs an unvectorised cast path (10.4 ms per 14 MiB slab against 1.3).
+                keep = mask[:, start:stop]
+                xs, ys = torch.where(keep, xs, 0.0), torch.where(keep, ys, 0.0)
+            slab_total, slab_count = SSIM._map_sum(xs, ys, data_range)
+            total += slab_total
+            count += slab_count
+        return float(total) / count
 
     def forward(
         self,
         output: torch.Tensor,
         *targets: torch.Tensor,
     ) -> tuple[torch.Tensor, float]:
-        if len(targets) == 1:
-            targets = (targets[0], torch.ones_like(targets[0], dtype=torch.uint8))
-        return super().forward(output, *targets)
+        if len(targets) == 0:
+            raise ValueError("SSIM expects at least one target tensor.")
+        target = targets[0].to(device=output.device)
+        mask = self.get_mask(list(targets[1:]))
+        mask = None if mask is None else mask.to(device=output.device) == 1
+        values = []
+        for batch in range(output.shape[0]):
+            mask_b = None if mask is None else mask[batch, ...]
+            if mask_b is not None and not torch.any(mask_b):
+                continue
+            values.append(SSIM._ssim(output[batch].float(), target[batch].float(), mask_b, self._dynamic_range))
+        if not values:
+            return output.new_tensor(0.0), np.nan
+        value = float(np.mean(values))
+        return output.new_tensor(value), value
 
 
 class LPIPS(MaskedLoss):
@@ -444,6 +563,11 @@ class TRE(Criterion):
         return loss.mean(), {f"Landmarks_{i}": v.item() for i, v in enumerate(loss.mean(0))}
 
 
+#: Per-label sums of one (output, reference) pair, what every Dice is computed from and the state a
+#: streamed patch hands back: (intersection, predicted, reference, present in the reference).
+LabelSums = dict[int, tuple[float, float, float, bool]]
+
+
 class Dice(Criterion):
     maximize = True  # reported value is the Dice coefficient (higher-is-better); DiceSaveMap inherits it
 
@@ -458,32 +582,179 @@ class Dice(Criterion):
         return (2.0 * (tensor * target).sum() + 1e-6) / (tensor.sum() + target.sum() + 1e-6)
 
     @staticmethod
-    def _loss(labels: list[int] | None, output: torch.Tensor, *targets: torch.Tensor) -> torch.Tensor:
-        # Resampled in float: nearest-neighbour interpolation has no integer kernel, and a
-        # segmentation target is a label map. Nearest picks values rather than blending them, so
-        # every label comes back exactly.
-        target = F.interpolate(targets[0].float(), output.shape[2:], mode="nearest")
-        result = {}
-        loss = torch.tensor(0, dtype=torch.float32).to(output.device)
+    def on_grid(output: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        """A label map on the output's spatial grid.
+
+        Nearest picks values rather than blending them, so every label comes back exactly; on the
+        output's own grid it is the identity, and skipping it keeps the map's integer dtype (the
+        resample runs in float: nearest-neighbour interpolation has no integer kernel).
+        """
+        if tuple(target.shape[2:]) == tuple(output.shape[2:]):
+            return target
+        return F.interpolate(target.float(), output.shape[2:], mode="nearest")
+
+    @staticmethod
+    def _may_hold_a_negative(tensor: torch.Tensor) -> bool:
+        """Whether a map's dtype can hold a label below zero: an unsigned map is read as it is."""
+        return tensor.dtype not in (torch.bool, torch.uint8, torch.uint16, torch.uint32, torch.uint64)
+
+    @staticmethod
+    def _bins(maps: list[torch.Tensor], labels: list[int] | None) -> tuple[list[torch.Tensor], int, int, int]:
+        """The maps as bin indices, the offset a bin carries (label = bin + offset), the NaN bin (1
+        when there is one, at index 0, else 0) and the bins to count.
+
+        ``bincount`` takes no negative index and sizes its result by the largest one, so a signed
+        map is shifted by its smallest label when that is below zero (one sync for the lot), and
+        a float map's NaN voxels, no label at all, take bin 0 with every label moved up one. An
+        unsigned integer map is read as it is.
+        """
+        nan_masks = [torch.isnan(tensor).flatten() if tensor.is_floating_point() else None for tensor in maps]
+        indices = []
+        for tensor, nan_mask in zip(maps, nan_masks, strict=True):
+            dtype = torch.uint8 if tensor.dtype is torch.bool else torch.int64 if nan_mask is not None else tensor.dtype
+            index = tensor.to(dtype).flatten()
+            if nan_mask is not None:
+                index = index.masked_fill_(nan_mask, 0)  # a whole number, so the minimum below is a label's
+            indices.append(index)
+        signed = [index for index, tensor in zip(indices, maps, strict=True) if Dice._may_hold_a_negative(tensor)]
+        lowest = int(torch.stack([index.min() for index in signed]).min()) if signed else 0
+        nan_bin = int(any(nan_mask is not None for nan_mask in nan_masks))
+        offset = min(0, lowest, *(labels or [0])) - nan_bin
+        if offset:
+            indices = [index - offset for index in indices]
+        for index, nan_mask in zip(indices, nan_masks, strict=True):
+            if nan_mask is not None:
+                index.masked_fill_(nan_mask, 0)
+        return indices, offset, nan_bin, (max(labels) - offset + 1 if labels else 0)
+
+    @staticmethod
+    def _labels_held(offset: int, nan_bin: int, counts: list[list[int]]) -> list[int]:
+        """Every label some map holds, ascending, but the background and the NaN bin."""
+        return [
+            bin_ + offset
+            for bin_ in range(nan_bin, max(len(count) for count in counts))
+            if bin_ + offset != 0 and any(bin_ < len(count) and count[bin_] for count in counts)
+        ]
+
+    @staticmethod
+    def _reference_counts(target: torch.Tensor, labels: list[int] | None) -> tuple[list[int], list[int]]:
+        """The labels to score and each one's voxel count in the reference: one ``bincount``, one sync.
+
+        ``labels=None`` scores every label the reference holds except the background, ascending as
+        ``torch.unique`` listed them.
+        """
+        (reference,), offset, nan_bin, minlength = Dice._bins([target], labels)
+        counts = torch.bincount(reference, minlength=minlength).tolist()
         if labels is None:
-            labels = [int(label) for label in torch.unique(target) if int(label) != 0]
-        count = 0
+            labels = Dice._labels_held(offset, nan_bin, [counts])
+        return labels, [counts[label - offset] if 0 <= label - offset < len(counts) else 0 for label in labels]
+
+    @staticmethod
+    def _hard_sums(output: torch.Tensor, target: torch.Tensor, labels: list[int] | None) -> LabelSums:
+        """The sums of a hard-label pair, exact integers from three ``bincount`` passes over the flat
+        maps (the reference, the prediction, the reference where the two agree): every label at
+        once and one ``.tolist()`` for the lot, where a per-label ``==`` built two float volumes and
+        synchronised twice.
+
+        With ``labels=None`` every label either map holds gets its sums, so a patch's predicted mass
+        for a label its reference lacks still reaches the whole-case ratio in ``combine_metric``;
+        only the labels the reference holds are scored.
+        """
+        (predicted_labels, reference_labels), offset, nan_bin, minlength = Dice._bins([output, target], labels)
+        counts = [
+            torch.bincount(reference_labels[reference_labels == predicted_labels], minlength=minlength),
+            torch.bincount(predicted_labels, minlength=minlength),
+            torch.bincount(reference_labels, minlength=minlength),
+        ]
+        length = max(count.numel() for count in counts)
+        intersection, predicted, reference = torch.stack(
+            [F.pad(count, (0, length - count.numel())) for count in counts]
+        ).tolist()
+        if labels is None:
+            labels = Dice._labels_held(offset, nan_bin, [predicted, reference])
+        return {
+            label: (
+                (
+                    intersection[label - offset],
+                    predicted[label - offset],
+                    reference[label - offset],
+                    reference[label - offset] > 0,
+                )
+                if 0 <= label - offset < length
+                else (0, 0, 0, False)
+            )
+            for label in labels
+        }
+
+    @staticmethod
+    def _soft_sums(output: torch.Tensor, target: torch.Tensor, labels: list[int] | None) -> LabelSums:
+        """The sums of a probability map against a label map, per channel: the intersection is
+        taken only where the reference holds the label (it is zero elsewhere), and one
+        ``.tolist()`` brings every sum back."""
+        scored = labels if labels is not None else list(range(1, output.shape[1]))
+        _, reference = Dice._reference_counts(target, scored)
+        sums: list[torch.Tensor] = []
+        for label, count in zip(scored, reference, strict=True):
+            if label >= output.shape[1]:  # no channel: nothing predicted
+                sums.extend([output.new_zeros(()), output.new_zeros(())])
+                continue
+            predicted = output[:, label].unsqueeze(1).float()
+            sums.append(predicted.sum())
+            sums.append((predicted * (target == label).float()).sum() if count else predicted.new_zeros(()))
+        values = torch.stack(sums).tolist() if sums else []
+        return {
+            label: (values[2 * index + 1], values[2 * index], float(count), count > 0)
+            for index, (label, count) in enumerate(zip(scored, reference, strict=True))
+        }
+
+    @staticmethod
+    def _score(sums: LabelSums, labels: list[int]) -> tuple[float, dict[int, float]]:
+        """Every label's Dice from its sums, the smooth term applied once, NaN for a label the
+        reference lacks; and the loss ``1 - mean`` over the scored ones (0 when none is)."""
+        result: dict[int, float] = {}
+        total, count = 0.0, 0
         for label in labels:
-            tp = target == label
-            if tp.any().item():
-                if output.shape[1] > 1:
-                    pp = output[:, label].unsqueeze(1)
-                else:
-                    pp = output == label
-                loss_tmp = Dice.dice_per_channel(pp.float(), tp.float())
-                loss += loss_tmp
+            intersection, predicted, reference, present = sums.get(label, (0, 0, 0, False))
+            if present:
+                dice = (2.0 * intersection + 1e-6) / (predicted + reference + 1e-6)
+                result[label] = dice
+                total += dice
                 count += 1
-                result[label] = loss_tmp.item()
             else:
                 result[label] = np.nan
-        if count == 0:
+        return (1 - total / count if count else 0.0), result
+
+    @staticmethod
+    def _soft_loss(
+        labels: list[int] | None, output: torch.Tensor, target: torch.Tensor
+    ) -> tuple[torch.Tensor, dict[int, float]]:
+        """The differentiable soft Dice over a probability map's channels, one per label the
+        reference holds. The readouts come back in one ``.tolist()`` after the loop: a ``.item()``
+        per label drained the CUDA queue mid-loss, twice per label."""
+        labels, reference = Dice._reference_counts(target, labels)
+        loss = torch.tensor(0, dtype=torch.float32).to(output.device)
+        dices: list[torch.Tensor] = []
+        for label, count in zip(labels, reference, strict=True):
+            if count:
+                dice = Dice.dice_per_channel(output[:, label].unsqueeze(1).float(), (target == label).float())
+                loss += dice
+                dices.append(dice)
+        values = iter(torch.stack(dices).tolist() if dices else [])
+        result = {label: next(values) if count else np.nan for label, count in zip(labels, reference, strict=True)}
+        if not dices:
             return loss, result
-        return 1 - loss / count, result
+        return 1 - loss / len(dices), result
+
+    @staticmethod
+    def _loss(
+        labels: list[int] | None, output: torch.Tensor, *targets: torch.Tensor
+    ) -> tuple[torch.Tensor, dict[int, float]]:
+        target = Dice.on_grid(output, targets[0])
+        if output.shape[1] > 1:
+            return Dice._soft_loss(labels, output, target)
+        sums = Dice._hard_sums(output, target, labels)
+        value, result = Dice._score(sums, labels if labels is not None else [label for label in sums if sums[label][3]])
+        return torch.tensor(value, dtype=torch.float32, device=output.device), result
 
     reducible = True
 
@@ -492,66 +763,50 @@ class Dice(Criterion):
         self._labels = labels
         self.loss = partial(Dice._loss, labels)
 
-    def forward(self, output: torch.Tensor, *targets: torch.Tensor) -> tuple[torch.Tensor, float]:
+    @staticmethod
+    def _masked(output: torch.Tensor, targets: tuple[torch.Tensor, ...]) -> tuple[torch.Tensor, torch.Tensor]:
+        """The pair with every voxel outside the mask sent to the background, when a mask is given.
+        A bool mask multiplies in each tensor's own dtype: ``torch.where(mask == 1, 1, 0)`` was
+        8 B/voxel of int64 for the same product."""
         mask = MaskedLoss.get_mask(list(targets[1:]))
-        if mask is not None:
-            mask = torch.where(mask == 1, 1, 0)
-            return self.loss(
-                output * mask.to(output.dtype),
-                targets[0] * mask.to(targets[0].dtype),
-            )
-        else:
-            return self.loss(output, targets[0])
+        if mask is None:
+            return output, targets[0]
+        mask = mask == 1
+        return output * mask, targets[0] * mask
+
+    def forward(self, output: torch.Tensor, *targets: torch.Tensor) -> tuple[torch.Tensor, dict[int, float]]:
+        return self.loss(*self._masked(output, targets))
 
     def partial_metric(self, output: torch.Tensor, *targets: torch.Tensor) -> Any:
-        mask = MaskedLoss.get_mask(list(targets[1:]))
-        target = targets[0]
-        if mask is not None:
-            mask01 = torch.where(mask == 1, 1, 0)
-            output = output * mask01.to(output.dtype)
-            target = target * mask01.to(target.dtype)
+        output, target = self._masked(output, targets)
         if tuple(target.shape[2:]) != tuple(output.shape[2:]):
             raise MeasureError(
                 "Dice can only stream patches when output and target share the spatial grid",
                 f"output {tuple(output.shape[2:])} vs target {tuple(target.shape[2:])}",
                 "Evaluate this pair whole (unset the memory budget) or resample the prediction first.",
             )
-        labels = self._labels if self._labels is not None else [int(v) for v in torch.unique(target) if int(v) != 0]
-        state: dict[int, tuple[float, float, float, bool]] = {}
-        for label in labels:
-            tp = target == label
-            pp = output[:, label].unsqueeze(1) if output.shape[1] > 1 else (output == label)
-            ppf, tpf = pp.float(), tp.float()
-            state[label] = (
-                float((ppf * tpf).sum().item()),
-                float(ppf.sum().item()),
-                float(tpf.sum().item()),
-                bool(tp.any().item()),
-            )
-        return state
+        if output.shape[1] > 1:
+            return Dice._soft_sums(output, target, self._labels)
+        return Dice._hard_sums(output, target, self._labels)
 
     def combine_metric(self, states: list[Any]) -> Any:
-        # The whole volume's label set is exactly the union of the patches' label sets (sorted, as
-        # torch.unique returns them); every dice is the ratio of GLOBAL sums, the smooth term applied
-        # once here, never a mean of per-patch dices.
-        labels = self._labels if self._labels is not None else sorted({label for state in states for label in state})
-        result: dict[int, float] = {}
-        total = 0.0
-        count = 0
-        for label in labels:
-            inter = sum(state[label][0] for state in states if label in state)
-            output_sum = sum(state[label][1] for state in states if label in state)
-            target_sum = sum(state[label][2] for state in states if label in state)
-            if any(state[label][3] for state in states if label in state):
-                dice = (2.0 * inter + 1e-6) / (output_sum + target_sum + 1e-6)
-                result[label] = dice
-                total += dice
-                count += 1
-            else:
-                result[label] = np.nan
-        if count == 0:
-            return torch.tensor(0.0), result
-        return torch.tensor(1 - total / count), result
+        # The whole volume's sums are its patches' sums added, and every dice is the ratio of the
+        # GLOBAL sums, the smooth term applied once here, never a mean of per-patch dices. With
+        # ``labels: None`` the scored labels are those some patch's reference holds, ascending as
+        # torch.unique lists them.
+        sums: LabelSums = {}
+        for state in states:
+            for label, (intersection, predicted, reference, present) in state.items():
+                total = sums.get(label, (0, 0, 0, False))
+                sums[label] = (
+                    total[0] + intersection,
+                    total[1] + predicted,
+                    total[2] + reference,
+                    total[3] or present,
+                )
+        labels = self._labels if self._labels is not None else sorted(label for label in sums if sums[label][3])
+        value, result = Dice._score(sums, labels)
+        return torch.tensor(value), result
 
 
 class DiceSaveMap(Dice):
@@ -560,23 +815,22 @@ class DiceSaveMap(Dice):
         self.dataset = dataset
         self.group = group
 
+    @staticmethod
+    def _map(output: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        """Per-voxel label disagreement ``|output - target|`` as uint8, from ``max - min``: it needs
+        no signed intermediate, where a uint8 ``output - target`` wraps (|0 - 3| came out 253)."""
+        return (torch.maximum(output, target) - torch.minimum(output, target)).to(torch.uint8).cpu()
+
     def partial_map(self, output: torch.Tensor, *targets: torch.Tensor) -> torch.Tensor:
         """Per-voxel label disagreement (masked where a mask is given). VOXEL-LOCAL by construction:
         a patch's map equals the same region of the whole-case map, which is what lets the streamed
         evaluation write it region by region instead of needing the whole case."""
-        if len(targets) == 2:
-            return (
-                torch.nn.L1Loss(reduction="none")(
-                    output * torch.where(targets[1] == 1, 1, 0), targets[0] * torch.where(targets[1] == 1, 1, 0)
-                )
-                .to(torch.uint8)
-                .cpu()
-            )
-        return torch.nn.L1Loss(reduction="none")(output, targets[0]).to(torch.uint8).cpu()
+        return self._map(*self._masked(output, targets))
 
     def forward(self, output: torch.Tensor, *targets: torch.Tensor):  # type: ignore[override]
-        loss, true_loss = super().forward(output, *targets)
-        return loss, true_loss, self.partial_map(output, *targets)
+        output, target = self._masked(output, targets)
+        loss, true_loss = self.loss(output, target)
+        return loss, true_loss, self._map(output, target)
 
     def get_name(self) -> str:
         return "Dice"
@@ -867,7 +1121,7 @@ class FocalLoss(Criterion):
         self.reduction = reduction
 
     def forward(self, output: torch.Tensor, *targets: torch.Tensor) -> torch.Tensor:
-        target = F.interpolate(targets[0].float(), output.shape[2:], mode="nearest").long()
+        target = Dice.on_grid(output, targets[0]).long()
 
         logpt = F.log_softmax(output, dim=1)
         pt = torch.exp(logpt)

--- a/konfai/metric/measure.py
+++ b/konfai/metric/measure.py
@@ -75,6 +75,12 @@ class Criterion(torch.nn.Module, ABC):
     # ``forward`` exactly may set it.
     reducible: bool = False
 
+    # Voxels of context a partial state needs past a patch's faces on every spatial axis (a window's
+    # radius). A reducible metric declaring one is handed patches read that much wider than their
+    # grid slot, clamped at the volume's faces, and ``partial_metric`` receives ``core=``, the slot's
+    # slices within the patch: it scores the core through the context and nothing outside it.
+    halo: int = 0
+
     def __init_subclass__(cls, **kwargs: object) -> None:
         # A metric is config-built like a stage: record its constructor arguments as given, so
         # konfai.api can write the config tree back from live objects (see Transform).
@@ -409,12 +415,14 @@ class SSIM(MaskedLoss):
     volumes back to the host. The map is built slab by slab along the first spatial axis, so the
     five window statistics it needs hold a few MiB at a time whatever the case.
 
-    A voxel's window reaches the window's radius past a patch's faces, which the evaluation's
-    disjoint patches do not carry: not reducible.
+    A voxel's window reaches the window's radius past a patch's faces: reducible from patches read
+    with that radius of halo, each scoring the map voxels centred in its own grid slot.
     """
 
     maximize = True  # reported value is the structural similarity index (higher-is-better)
+    reducible = True
     window = 7
+    halo = (window - 1) // 2
     k1 = 0.01
     k2 = 0.03
     #: Bytes of one statistic map per slab. Measured at 512^3 float32, 12 threads / one GPU: 0.94 s /
@@ -472,52 +480,100 @@ class SSIM(MaskedLoss):
 
     @staticmethod
     @torch.no_grad()
-    def _ssim(x: torch.Tensor, y: torch.Tensor, mask: torch.Tensor | None, data_range: float) -> float:
-        """The SSIM of one ``[C, *spatial]`` pair. A mask multiplies both, slab by slab, and the
-        score is the mean over the whole cropped extent, as the masked mode always was."""
+    def _map_sum_over(
+        x: torch.Tensor,
+        y: torch.Tensor,
+        mask: torch.Tensor | None,
+        data_range: float,
+        core: tuple[slice, ...] | None,
+    ) -> tuple[float, int]:
+        """The sum and voxel count of one ``[C, *spatial]`` pair's SSIM map over the map voxels
+        centred in ``core`` (slices of the spatial axes; ``None`` is the whole pair). Each slab reads
+        the window's radius past the core and nothing more: a patch read with that radius of halo
+        scores its grid slot exactly as the whole volume does. A mask multiplies both, slab by slab,
+        and the count runs over the whole cropped extent, as the masked mode always was."""
         radius = (SSIM.window - 1) // 2
-        depth = x.shape[1] - 2 * radius
-        if depth < 1 or any(size < SSIM.window for size in x.shape[2:]):
-            raise MeasureError(
-                f"SSIM needs every spatial extent to be at least its {SSIM.window}-voxel window.",
-                f"Got a {tuple(x.shape[1:])} volume.",
-            )
-        planes = max(2 * radius + 2, SSIM.slab_bytes // (x[:, 0].numel() * 8))  # the maps are float64
+        spatial = x.shape[1:]
+        if core is None:
+            core = tuple(slice(0, extent) for extent in spatial)
+        # Per axis, the centres whose window lies inside the pair, restricted to the core.
+        spans = [(max(c.start, radius), min(c.stop, extent - radius)) for c, extent in zip(core, spatial, strict=True)]
+        if any(stop <= start for start, stop in spans):
+            return 0.0, 0
+        inner = tuple(slice(start - radius, stop + radius) for start, stop in spans[1:])
+        plane = x.shape[0] * int(np.prod([stop - start + 2 * radius for start, stop in spans[1:]]))
+        planes = max(2 * radius + 2, SSIM.slab_bytes // (plane * 8))  # the maps are float64
         total = torch.zeros((), dtype=torch.float64, device=x.device)
         count = 0
-        for start in range(0, depth, planes):
-            stop = min(depth, start + planes) + 2 * radius
-            xs, ys = x[:, start:stop], y[:, start:stop]
+        first, last = spans[0]
+        for start in range(first, last, planes):
+            rows = slice(start - radius, min(last, start + planes) + radius)
+            xs, ys = x[(slice(None), rows, *inner)], y[(slice(None), rows, *inner)]
             if mask is not None:
                 # torch.where, not a float x bool product: on a cache-resident slab the mixed-dtype
                 # product runs an unvectorised cast path (10.4 ms per 14 MiB slab against 1.3).
-                keep = mask[:, start:stop]
+                keep = mask[(slice(None), rows, *inner)]
                 xs, ys = torch.where(keep, xs, 0.0), torch.where(keep, ys, 0.0)
             slab_total, slab_count = SSIM._map_sum(xs, ys, data_range)
             total += slab_total
             count += slab_count
-        return float(total) / count
+        return float(total), count
+
+    @staticmethod
+    def _ssim(x: torch.Tensor, y: torch.Tensor, mask: torch.Tensor | None, data_range: float) -> float:
+        """The SSIM of one ``[C, *spatial]`` pair: the mean of its map over the cropped extent."""
+        if any(size < SSIM.window for size in x.shape[1:]):
+            raise MeasureError(
+                f"SSIM needs every spatial extent to be at least its {SSIM.window}-voxel window.",
+                f"Got a {tuple(x.shape[1:])} volume.",
+            )
+        total, count = SSIM._map_sum_over(x, y, mask, data_range, None)
+        return total / count
+
+    def _pairs(
+        self, output: torch.Tensor, targets: tuple[torch.Tensor, ...]
+    ) -> Iterator[tuple[torch.Tensor, torch.Tensor, torch.Tensor | None] | None]:
+        """Per batch item, the float pair and its bool mask; ``None`` for an item its mask empties."""
+        if len(targets) == 0:
+            raise ValueError("SSIM expects at least one target tensor.")
+        target = targets[0].to(device=output.device)
+        mask = self.get_mask(list(targets[1:]))
+        mask = None if mask is None else mask.to(device=output.device) == 1
+        for batch in range(output.shape[0]):
+            mask_b = None if mask is None else mask[batch, ...]
+            if mask_b is not None and not torch.any(mask_b):
+                yield None
+            else:
+                yield output[batch].float(), target[batch].float(), mask_b
 
     def forward(
         self,
         output: torch.Tensor,
         *targets: torch.Tensor,
     ) -> tuple[torch.Tensor, float]:
-        if len(targets) == 0:
-            raise ValueError("SSIM expects at least one target tensor.")
-        target = targets[0].to(device=output.device)
-        mask = self.get_mask(list(targets[1:]))
-        mask = None if mask is None else mask.to(device=output.device) == 1
-        values = []
-        for batch in range(output.shape[0]):
-            mask_b = None if mask is None else mask[batch, ...]
-            if mask_b is not None and not torch.any(mask_b):
-                continue
-            values.append(SSIM._ssim(output[batch].float(), target[batch].float(), mask_b, self._dynamic_range))
+        values = [SSIM._ssim(*pair, self._dynamic_range) for pair in self._pairs(output, targets) if pair is not None]
         if not values:
             return output.new_tensor(0.0), np.nan
         value = float(np.mean(values))
         return output.new_tensor(value), value
+
+    def partial_metric(
+        self, output: torch.Tensor, *targets: torch.Tensor, core: tuple[slice, ...] | None = None
+    ) -> Any:
+        """Each batch item's map sum and count over ``core`` (the whole patch when ``None``), in
+        the ``items`` form ``MaskedLoss.combine_metric`` finishes per item and averages."""
+        items = []
+        for pair in self._pairs(output, targets):
+            if pair is None:
+                items.append((0.0, 0, False))
+            else:
+                items.append((*SSIM._map_sum_over(*pair, self._dynamic_range, core), True))
+        return ("items", items)
+
+    def _finish(self, total: float, count: int) -> float:
+        if count == 0:
+            raise MeasureError(f"SSIM needs every spatial extent to be at least its {SSIM.window}-voxel window.")
+        return total / count
 
 
 class LPIPS(MaskedLoss):

--- a/tests/integration/test_konfai_streamed_evaluation.py
+++ b/tests/integration/test_konfai_streamed_evaluation.py
@@ -52,6 +52,8 @@ EVALUATION_TEMPLATE = """Evaluator:
               reduction: mean
             PSNR:
               dynamic_range: 2.0
+            SSIM:
+              dynamic_range: 2.0
             MAESaveMap:
               reduction: mean
               dataset: ./ErrorMaps:mha
@@ -92,7 +94,7 @@ def _create_paired_dataset(dataset_dir: Path, predictions_dir: Path) -> None:
     for idx in range(3):
         (dataset_dir / f"CASE_{idx:03d}").mkdir(parents=True)
         (predictions_dir / f"CASE_{idx:03d}").mkdir(parents=True)
-        ct = rng.normal(size=(5, 16, 16)).astype(np.float32)
+        ct = rng.normal(size=(12, 16, 16)).astype(np.float32)
         sct = (0.85 * ct + 0.1 * rng.normal(size=ct.shape) + 0.02 * idx).astype(np.float32)
         write_image(dataset_dir / f"CASE_{idx:03d}" / "CT.mha", ct, SimpleITK.sitkFloat32)
         write_image(predictions_dir / f"CASE_{idx:03d}" / "sCT.mha", sct, SimpleITK.sitkFloat32)
@@ -159,10 +161,12 @@ def test_streamed_evaluation_matches_whole_volume(tmp_path: Path) -> None:
     streamed_dir.mkdir()
 
     _run_evaluation(whole_dir, "None")
-    # A case here is 2 groups x 5x16x16 float32 ~= 10 KiB resident; 8000 bytes cannot hold it, so the
-    # run must patch. The log line is the proof the streamed path actually executed.
-    streamed_log = _run_evaluation(streamed_dir, "8000b")
+    # A case here is 2 groups x 12x16x16 float32 = 24 KiB resident; 40000 bytes cannot hold it at the
+    # sizing's 24 B/voxel, so the run must patch, every slot read with SSIM's halo of 3. The log line
+    # is the proof the streamed path actually executed.
+    streamed_log = _run_evaluation(streamed_dir, "40000b")
     assert "disjoint patches" in streamed_log, f"budget run did not take the patched path:\n{streamed_log}"
+    assert "read with a halo of 3" in streamed_log
 
     whole = _read_metrics(whole_dir)
     streamed = _read_metrics(streamed_dir)
@@ -182,7 +186,7 @@ def test_streamed_evaluation_matches_whole_volume(tmp_path: Path) -> None:
             else:
                 assert got == pytest.approx(value, rel=1e-4), f"{case}:{key}: whole={value} streamed={got}"
             compared += 1
-    assert compared >= 9  # 3 cases x 3 metrics: the comparison actually exercised the report
+    assert compared >= 12  # 3 cases x 4 metrics: the comparison actually exercised the report
 
     # The per-voxel error map streams region by region under the budget; being voxel-local over a
     # disjoint unpadded grid, it must land byte-identical to the whole-volume map.

--- a/tests/unit/test_auto_patching.py
+++ b/tests/unit/test_auto_patching.py
@@ -24,6 +24,8 @@ single patch spans.
 
 import numpy as np
 import pytest
+import torch
+from konfai.data.patching import DatasetPatch
 from konfai.utils.errors import ConfigError
 from konfai.utils.utils import (
     concretize_patch_size,
@@ -347,3 +349,53 @@ class TestMetricReductionContract:
 
         with pytest.raises(NotImplementedError, match="not reducible"):
             GradientImages().partial_metric(torch.rand(1, 1, 4, 4, 4))
+
+
+class TestHaloGrid:
+    """A grid patch read with a halo: the slot widened by the halo, clamped at the volume's faces,
+    and the slot's place within that read."""
+
+    @staticmethod
+    def _grid(halo: int) -> DatasetPatch:
+        patch = DatasetPatch(patch_size=[8, 8], overlap=0)
+        patch.pad_to_patch = False
+        patch.halo = halo
+        patch.load([20, 13], 0)
+        return patch
+
+    def test_reads_widen_by_the_halo_and_stop_at_the_faces(self):
+        patch = self._grid(3)
+        slots = patch.get_patch_slices(0)
+        assert slots[0] == (slice(0, 8), slice(0, 8)) and slots[-1] == (slice(16, 20), slice(8, 13))
+
+        assert patch.read_slices(0, 0, [20, 13]) == [slice(0, 11), slice(0, 11)]
+        assert patch.read_slices(0, slots.index((slice(8, 16), slice(0, 8))), [2, 20, 13]) == [
+            slice(5, 19),
+            slice(0, 11),
+        ]
+        assert patch.read_slices(0, len(slots) - 1, [20, 13]) == [slice(13, 20), slice(5, 13)]
+
+    def test_the_core_sits_a_halo_in_except_at_a_face(self):
+        patch = self._grid(3)
+        slots = patch.get_patch_slices(0)
+
+        assert patch.core_in_read(0, 0) == (slice(0, 8), slice(0, 8))
+        assert patch.core_in_read(0, slots.index((slice(8, 16), slice(8, 13)))) == (slice(3, 11), slice(3, 8))
+        assert patch.core_in_read(0, len(slots) - 1) == (slice(3, 7), slice(3, 8))
+
+    def test_the_read_plan_and_get_data_serve_the_widened_region(self):
+        patch = self._grid(2)
+        data = torch.arange(2 * 20 * 13, dtype=torch.float32).view(2, 20, 13)
+        index = patch.get_patch_slices(0).index((slice(8, 16), slice(8, 13)))
+
+        plan = patch.get_read_plan(data.shape, index, 0, is_input=True)
+        assert plan.data_slices == (slice(None), slice(6, 18), slice(6, 13))
+        torch.testing.assert_close(patch.get_data(data, index, 0, True), data[:, 6:18, 6:13])
+        core = patch.core_in_read(0, index)
+        torch.testing.assert_close(patch.get_data(data, index, 0, True)[(slice(None), *core)], data[:, 8:16, 8:13])
+
+    def test_without_a_halo_the_read_is_the_slot(self):
+        patch = self._grid(0)
+        for index, slot in enumerate(patch.get_patch_slices(0)):
+            assert patch.read_slices(0, index, [20, 13]) == list(slot)
+            assert patch.core_in_read(0, index) == tuple(slice(0, s.stop - s.start) for s in slot)

--- a/tests/unit/test_evaluator_update.py
+++ b/tests/unit/test_evaluator_update.py
@@ -20,12 +20,14 @@ An ``Evaluator`` is faked with the attributes ``__init__`` sets, no config or da
 paths run on in-memory batches.
 """
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 from konfai.data.data_manager import BatchDataItem
-from konfai.data.patching import SweepClock
+from konfai.data.patching import DatasetPatch, SweepClock
 from konfai.evaluator import Evaluator, Statistics
-from konfai.metric.measure import MAE, MSE
+from konfai.metric.measure import MAE, MSE, SSIM
 
 
 def _evaluator(metrics: dict[str, dict[str, dict[torch.nn.Module, None]]], streamed: bool = False) -> Evaluator:
@@ -34,6 +36,7 @@ def _evaluator(metrics: dict[str, dict[str, dict[torch.nn.Module, None]]], strea
     evaluator._device = torch.device("cpu")
     evaluator._clock = SweepClock()
     evaluator._streamed = streamed
+    evaluator._halo = 0
     evaluator._pending = {}
     evaluator._pending_name = None
     evaluator._last_result = {}
@@ -41,9 +44,9 @@ def _evaluator(metrics: dict[str, dict[str, dict[torch.nn.Module, None]]], strea
     return evaluator
 
 
-def _batch(name: str, **tensors: torch.Tensor) -> dict[str, BatchDataItem]:
+def _batch(name: str, p: int = 0, **tensors: torch.Tensor) -> dict[str, BatchDataItem]:
     return {
-        group: BatchDataItem(name=[name], tensor=tensor, attribute=[None], x=[0], a=[0], p=[0], is_input=False)
+        group: BatchDataItem(name=[name], tensor=tensor, attribute=[None], x=[0], a=[0], p=[p], is_input=False)
         for group, tensor in tensors.items()
     }
 
@@ -142,3 +145,61 @@ def test_streamed_update_moves_each_group_once_per_patch(monkeypatch, registrati
     whole = _evaluator(registration_metrics).update(_batch("case", **volumes), Statistics(None))
     for key, value in whole.items():
         assert statistics.measures["case"][key] == pytest.approx(value, rel=1e-6)
+
+
+class TestStreamedUpdateWithAHalo:
+    """A grid reading a halo: a metric that declared one is handed the read and its slot's place in
+    it, the others the slot alone, and each case ends on the whole-volume value."""
+
+    @staticmethod
+    def _grid(shape: list[int], halo: int) -> DatasetPatch:
+        patch = DatasetPatch(patch_size=[5, 6], overlap=0)
+        patch.pad_to_patch = False
+        patch.halo = halo
+        patch.load(shape, 0)
+        return patch
+
+    @classmethod
+    def _stream(cls, metrics, volumes: dict[str, torch.Tensor], halo: int) -> tuple[Statistics, list]:
+        """Feed every patch of the grid as the loader would read it, halo included; the MAE states."""
+        shape = list(next(iter(volumes.values())).shape[2:])
+        patch = cls._grid(shape, halo)
+        evaluator = _evaluator(metrics, streamed=True)
+        evaluator._halo = halo
+        evaluator._iter_dataset = SimpleNamespace(get_dataset_from_index=lambda group, x: SimpleNamespace(patch=patch))
+        statistics = Statistics(None)
+        states = []
+        for index in range(patch.get_size(0)):
+            read = patch.read_slices(0, index, shape)
+            evaluator.update(_batch("case", index, **{g: t[(..., *read)] for g, t in volumes.items()}), statistics)
+            states.append(next(iter(evaluator._pending.values()))[1][-1])
+        evaluator._flush_pending(statistics)
+        return statistics, states
+
+    @pytest.mark.parametrize("masked", [False, True])
+    def test_a_halo_metric_ends_on_the_whole_volume_value(self, masked):
+        torch.manual_seed(2)
+        volumes = {"CT": torch.rand(1, 1, 17, 23), "sCT": torch.rand(1, 1, 17, 23)}
+        target = "CT"
+        if masked:
+            volumes["MASK"] = (torch.rand(1, 1, 17, 23) > 0.3).to(torch.uint8)
+            target = "CT;MASK"
+        metrics = {"sCT": {target: {MAE(): None, SSIM(dynamic_range=1.0): None}}}
+
+        statistics, _ = self._stream(metrics, volumes, SSIM.halo)
+
+        whole = _evaluator(metrics).update(_batch("case", **volumes), Statistics(None))
+        assert statistics.measures["case"][f"sCT:{target}:SSIM"] == pytest.approx(whole[f"sCT:{target}:SSIM"], rel=1e-9)
+        assert statistics.measures["case"][f"sCT:{target}:MAE"] == pytest.approx(whole[f"sCT:{target}:MAE"], rel=1e-6)
+
+    def test_a_metric_without_a_halo_sees_the_slot_alone(self):
+        # MAE's partial states with the grid read with SSIM's halo are the states without it: the
+        # context past the slot never reaches a metric that did not ask for it.
+        torch.manual_seed(3)
+        volumes = {"CT": torch.rand(1, 1, 17, 23), "sCT": torch.rand(1, 1, 17, 23)}
+        metrics = {"sCT": {"CT": {MAE(): None, SSIM(dynamic_range=1.0): None}}}
+
+        _, with_halo = self._stream(metrics, volumes, SSIM.halo)
+        _, without = self._stream({"sCT": {"CT": {MAE(): None}}}, volumes, 0)
+
+        assert with_halo == without

--- a/tests/unit/test_evaluator_update.py
+++ b/tests/unit/test_evaluator_update.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""How :class:`Evaluator.update` feeds its metrics: the device moves and the values it records.
+
+An ``Evaluator`` is faked with the attributes ``__init__`` sets, no config or dataset, so the update
+paths run on in-memory batches.
+"""
+
+import pytest
+import torch
+from konfai.data.data_manager import BatchDataItem
+from konfai.data.patching import SweepClock
+from konfai.evaluator import Evaluator, Statistics
+from konfai.metric.measure import MAE, MSE
+
+
+def _evaluator(metrics: dict[str, dict[str, dict[torch.nn.Module, None]]], streamed: bool = False) -> Evaluator:
+    evaluator = object.__new__(Evaluator)
+    evaluator.metrics = metrics
+    evaluator._device = torch.device("cpu")
+    evaluator._clock = SweepClock()
+    evaluator._streamed = streamed
+    evaluator._pending = {}
+    evaluator._pending_name = None
+    evaluator._last_result = {}
+    evaluator._map_sinks = {}
+    return evaluator
+
+
+def _batch(name: str, **tensors: torch.Tensor) -> dict[str, BatchDataItem]:
+    return {
+        group: BatchDataItem(name=[name], tensor=tensor, attribute=[None], x=[0], a=[0], p=[0], is_input=False)
+        for group, tensor in tensors.items()
+    }
+
+
+@pytest.fixture
+def registration_metrics() -> dict[str, dict[str, dict[torch.nn.Module, None]]]:
+    # The shipped Registration evaluation: FIXED is the target of two outputs, and once more with a mask.
+    return {
+        "MOVED": {"FIXED": {MAE(): None, MSE(): None}},
+        "MOVING": {"FIXED": {MAE(): None}, "FIXED;MASK": {MAE(): None}},
+    }
+
+
+def test_a_group_named_by_several_specs_is_moved_once_per_update(monkeypatch, registration_metrics):
+    moves: list[str] = []
+    original = Evaluator._on
+
+    def counting(tensor, device):
+        moves.append(str(tensor.shape))
+        return original(tensor, device)
+
+    monkeypatch.setattr(Evaluator, "_on", staticmethod(counting))
+    batch = _batch("case", FIXED=torch.rand(1, 1, 4, 4), MOVED=torch.rand(1, 1, 4, 4), MOVING=torch.rand(1, 1, 4, 4))
+    batch["MASK"] = _batch("case", MASK=torch.ones(1, 1, 4, 4, dtype=torch.uint8))["MASK"]
+
+    moved = _evaluator(registration_metrics)._groups_on(batch)
+
+    assert set(moved) == {"FIXED", "MOVED", "MOVING", "MASK"}
+    assert len(moves) == 4  # FIXED once, not once per spec (three) nor per metric
+    assert moved["FIXED"] is batch["FIXED"].tensor  # already on the device: handed back, not copied
+
+
+def test_update_scores_every_spec_from_the_shared_tensors(registration_metrics):
+    torch.manual_seed(0)
+    fixed, moved, moving = torch.rand(1, 1, 4, 5), torch.rand(1, 1, 4, 5), torch.rand(1, 1, 4, 5)
+    mask = torch.zeros(1, 1, 4, 5, dtype=torch.uint8)
+    mask[..., :2, :] = 1
+    batch = _batch("case", FIXED=fixed, MOVED=moved, MOVING=moving, MASK=mask)
+    statistics = Statistics(None)
+
+    result = _evaluator(registration_metrics).update(batch, statistics)
+
+    assert result["MOVED:FIXED:MAE"] == pytest.approx((moved - fixed).abs().mean().item())
+    assert result["MOVED:FIXED:MSE"] == pytest.approx((moved - fixed).pow(2).mean().item())
+    assert result["MOVING:FIXED:MAE"] == pytest.approx((moving - fixed).abs().mean().item())
+    assert result["MOVING:FIXED;MASK:MAE"] == pytest.approx((moving - fixed).abs()[..., :2, :].mean().item())
+    assert statistics.measures["case"] == result
+    # A metric never writes into the tensors it is handed: sharing one upload is safe.
+    assert torch.equal(batch["FIXED"].tensor, fixed) and torch.equal(batch["MASK"].tensor, mask)
+
+
+class TestClockReport:
+    """Where a split's wall clock went: one line per split, in the sweep's format, above a second."""
+
+    def test_update_charges_the_move_and_each_metric_by_name(self, registration_metrics):
+        evaluator = _evaluator(registration_metrics)
+        batch = _batch("case", **{g: torch.rand(1, 1, 8, 8) for g in ("FIXED", "MOVED", "MOVING", "MASK")})
+
+        evaluator.update(batch, Statistics(None))
+
+        assert evaluator._clock.spent("h2d") > 0.0
+        assert evaluator._clock.spent("MAE") > 0.0 and evaluator._clock.spent("MSE") > 0.0
+        assert evaluator._clock.spent("map") == 0.0  # no SaveMap metric wrote anything
+
+    def test_report_is_silent_under_a_second_and_closes_on_other(self, registration_metrics):
+        evaluator = _evaluator(registration_metrics)
+        with evaluator._clock.phase("split"):
+            with evaluator._clock.phase("MAE"):
+                pass
+            with evaluator._clock.phase("wait(load)"):
+                pass
+
+        assert evaluator._clock_report("TRAIN") is None
+        report = evaluator._clock_report("TRAIN", min_seconds=0.0)
+
+        assert report.startswith("[KonfAI] evaluation TRAIN ")
+        assert " = wait(load) 0.0 + MAE 0.0 + other 0.0" in report  # MSE, h2d, map, flush: nothing to say
+        assert "MSE" not in report
+
+
+def test_streamed_update_moves_each_group_once_per_patch(monkeypatch, registration_metrics):
+    moves: list[str] = []
+    original = Evaluator._on
+    monkeypatch.setattr(Evaluator, "_on", staticmethod(lambda t, d: (moves.append("x"), original(t, d))[1]))
+    evaluator = _evaluator(registration_metrics, streamed=True)
+    torch.manual_seed(1)
+    volumes = {g: torch.rand(1, 1, 6, 5) for g in ("FIXED", "MOVED", "MOVING")}
+    volumes["MASK"] = (torch.rand(1, 1, 6, 5) > 0.3).to(torch.uint8)
+    statistics = Statistics(None)
+
+    for z in (0, 3):
+        evaluator.update(_batch("case", **{g: t[..., z : z + 3, :] for g, t in volumes.items()}), statistics)
+    evaluator._flush_pending(statistics)
+
+    assert len(moves) == 8  # four groups, two patches
+    whole = _evaluator(registration_metrics).update(_batch("case", **volumes), Statistics(None))
+    for key, value in whole.items():
+        assert statistics.measures["case"][key] == pytest.approx(value, rel=1e-6)

--- a/tests/unit/test_measure.py
+++ b/tests/unit/test_measure.py
@@ -20,6 +20,7 @@ PerceptualLoss plumbing, and optional-dependency errors)."""
 import numpy as np
 import pytest
 import torch
+import torch.nn.functional as F
 from konfai.metric.measure import SSIM, Dice, FocalLoss, KLDivergence, PerceptualLoss, Variance, _require_optional
 from konfai.network.network import CriterionsAttr
 from konfai.utils.errors import MeasureError
@@ -72,6 +73,35 @@ def test_a_criterion_accepts_the_integer_label_map_a_segmentation_target_is(crit
     loss = Dice()(output, target)[0] if criterion == "Dice" else FocalLoss()(output, target)
 
     assert torch.isfinite(loss).all()
+
+
+class TestOnGrid:
+    def test_a_target_on_the_output_grid_is_handed_back_as_is(self):
+        # No resample on the output's own grid: the integer label map keeps its dtype and its storage,
+        # where the unconditional float resample cost 3.7 s of copy plus float `unique` at 512^3.
+        output = torch.zeros(1, 3, 6, 5)
+        target = torch.randint(0, 3, (1, 1, 6, 5)).to(torch.uint8)
+
+        assert Dice.on_grid(output, target) is target
+
+    def test_a_target_on_another_grid_is_resampled_nearest(self):
+        output = torch.zeros(1, 3, 6, 4)
+        target = torch.tensor([[[[1, 2], [3, 4]]]], dtype=torch.uint8)
+
+        resampled = Dice.on_grid(output, target)
+
+        assert tuple(resampled.shape) == (1, 1, 6, 4)
+        assert set(resampled.unique().tolist()) == {1, 2, 3, 4}  # picked, never blended
+        assert torch.equal(resampled, F.interpolate(target.float(), (6, 4), mode="nearest"))
+
+    def test_focal_loss_takes_the_integer_target_on_its_own_grid(self):
+        output = torch.randn(1, 3, 4, 4)
+        target = torch.randint(0, 3, (1, 1, 4, 4)).to(torch.uint8)
+
+        loss = FocalLoss(alpha=[0.5, 2.0, 0.5])(output, target)
+
+        assert torch.isfinite(loss)
+        assert loss.item() == pytest.approx(FocalLoss(alpha=[0.5, 2.0, 0.5])(output, target.float()).item())
 
 
 class TestDice:
@@ -158,6 +188,249 @@ class TestDice:
         assert per_label[1] == pytest.approx(2 / 3, abs=1e-5)
 
 
+def _dice_per_label_oracle(labels, output, target, mask=None):
+    """The per-label spelling Dice scored hard labels with before the confusion matrix: one float
+    expansion and two sums per label, kept here as the oracle the bincount route is pinned against."""
+    if mask is not None:
+        mask = torch.where(mask == 1, 1, 0)
+        output, target = output * mask.to(output.dtype), target * mask.to(target.dtype)
+    result = {}
+    loss = torch.tensor(0, dtype=torch.float32)
+    if labels is None:
+        labels = [int(label) for label in torch.unique(target) if int(label) != 0]
+    count = 0
+    for label in labels:
+        tp = target == label
+        if tp.any().item():
+            pp = output[:, label].unsqueeze(1) if output.shape[1] > 1 else (output == label)
+            dice = Dice.dice_per_channel(pp.float(), tp.float())
+            loss += dice
+            count += 1
+            result[label] = dice.item()
+        else:
+            result[label] = np.nan
+    return (1 - loss / count if count else loss), result
+
+
+def _assert_same_scores(got, expected, abs_tol):
+    assert set(got[1]) == set(expected[1])
+    for label, value in expected[1].items():
+        if np.isnan(value):
+            assert np.isnan(got[1][label])
+        else:
+            assert got[1][label] == pytest.approx(value, abs=abs_tol)
+    assert got[0].item() == pytest.approx(expected[0].item(), abs=abs_tol)
+
+
+class TestDiceConfusionMatrix:
+    """Hard labels are scored from one confusion matrix; the per-label oracle above pins the values."""
+
+    @staticmethod
+    def _pair(structured: bool, dtype: torch.dtype):
+        rng = np.random.default_rng(7)
+        shape = (1, 1, 12, 13, 11)
+        if structured:
+            grid = np.stack(np.meshgrid(*[np.linspace(-1, 1, s) for s in shape[2:]], indexing="ij"))
+            target = np.clip((np.sqrt((grid**2).sum(0)) * 6).astype(np.int64), 0, 5)[None, None]
+            flips = rng.random(shape) < 0.15
+            output = np.where(flips, rng.integers(0, 6, size=shape), target)
+        else:
+            target = rng.integers(0, 6, size=shape)
+            output = rng.integers(0, 6, size=shape)
+        # Label 4 never predicted, label 5 never in the reference, label 9 in neither.
+        output[output == 4] = 0
+        target[target == 5] = 0
+        return torch.tensor(output).to(dtype), torch.tensor(target).to(dtype)
+
+    @pytest.mark.parametrize("labels", [None, [1, 2, 3], [-1, 2]])
+    def test_a_negative_label_and_a_nan_voxel_score_as_the_oracle_scores_them(self, labels):
+        """``bincount`` takes no negative index and no NaN: a label of -1 (an ignore convention) is
+        a label like any other, a NaN voxel is no label, as the per-label ``==`` always read them."""
+        output, target = self._pair(True, torch.int16)
+        output[output == 2] = -1
+        target[target == 3] = -1
+        _assert_same_scores(Dice(labels=labels)(output, target), _dice_per_label_oracle(labels, output, target), 1e-6)
+
+        output, target = self._pair(True, torch.float32)
+        output[output == 1] = float("nan")
+        target[target == 2] = float("nan")
+        # The oracle's own label discovery is torch.unique, which hands it the NaN: told the labels.
+        held = labels or sorted(int(v) for v in torch.unique(target[~target.isnan()]).tolist() if v != 0)
+        _assert_same_scores(Dice(labels=labels)(output, target), _dice_per_label_oracle(held, output, target), 1e-6)
+
+    @pytest.mark.parametrize("structured", [False, True])
+    @pytest.mark.parametrize("dtype", [torch.uint8, torch.float32])
+    @pytest.mark.parametrize("labels", [None, [1, 2, 3, 4, 5, 9]])
+    @pytest.mark.parametrize("masked", [False, True])
+    def test_matches_the_per_label_oracle(self, structured, dtype, labels, masked):
+        output, target = self._pair(structured, dtype)
+        mask = (torch.rand(output.shape) > 0.3).to(torch.uint8) if masked else None
+        args = (output, target, mask) if masked else (output, target)
+
+        got = Dice(labels=labels)(*args)
+        expected = _dice_per_label_oracle(labels, output, target, mask)
+
+        # Exact integer counts against float32 sums: the 1e-6 smooth term is the only rounding left.
+        _assert_same_scores(got, expected, abs_tol=1e-6)
+        if labels is not None:
+            assert np.isnan(got[1][9]) and np.isnan(got[1][5])  # absent from the reference
+            reference = int(((target == 4) & (mask == 1)).sum()) if masked else int((target == 4).sum())
+            assert got[1][4] == pytest.approx(1e-6 / (reference + 1e-6), abs=1e-9)  # never predicted
+
+    def test_soft_path_is_bit_identical_to_the_oracle(self):
+        torch.manual_seed(3)
+        output = torch.softmax(torch.randn(2, 5, 6, 7, 5), dim=1)
+        target = torch.randint(0, 5, (2, 1, 6, 7, 5))
+        target[target == 3] = 0
+
+        for labels in (None, [1, 2, 3, 4]):
+            got = Dice(labels=labels)(output, target)
+            expected = _dice_per_label_oracle(labels, output, target)
+            assert got[0].item() == expected[0].item()
+            _assert_same_scores(got, expected, abs_tol=0.0)
+
+    def test_soft_path_keeps_its_gradient(self):
+        output = torch.softmax(torch.randn(1, 3, 4, 4), dim=1).requires_grad_(True)
+        target = torch.randint(0, 3, (1, 1, 4, 4))
+
+        loss, _ = Dice()(output, target)
+        loss.backward()
+
+        assert output.grad is not None and torch.isfinite(output.grad).all()
+
+    def test_streamed_sums_carry_the_predicted_mass_of_a_label_the_patch_reference_lacks(self):
+        # labels=None: a patch predicting label 2 where its reference has none must still count
+        # that mass in the whole-case ratio; a state built from the patch's own label set dropped it.
+        target = torch.zeros(1, 1, 4, 4, dtype=torch.uint8)
+        target[..., :2, :] = 2  # label 2 in the first half only
+        output = torch.full((1, 1, 4, 4), 2, dtype=torch.uint8)  # predicted everywhere
+        metric = Dice(labels=None)
+
+        whole = metric(output, target)
+        states = [metric.partial_metric(output[..., :2, :], target[..., :2, :])]
+        states.append(metric.partial_metric(output[..., 2:, :], target[..., 2:, :]))
+        combined = metric.combine_metric(states)
+
+        assert whole[1][2] == pytest.approx(2 * 8 / (16 + 8), abs=1e-6)
+        assert combined[1][2] == pytest.approx(whole[1][2], abs=1e-9)
+        assert set(combined[1]) == {2}  # a label no reference holds is not reported
+
+    @pytest.mark.parametrize("soft", [False, True])
+    def test_combine_reproduces_the_oracle_from_the_same_patches(self, soft):
+        torch.manual_seed(5)
+        if soft:
+            output = torch.softmax(torch.randn(1, 6, 8, 9, 7), dim=1)
+        else:
+            output = torch.randint(0, 6, (1, 1, 8, 9, 7)).to(torch.uint8)
+        target = torch.randint(0, 6, (1, 1, 8, 9, 7)).to(torch.uint8)
+        target[target == 5] = 0
+        for labels in (None, [1, 2, 5, 9]):
+            metric = Dice(labels=labels)
+            states = [
+                metric.partial_metric(output[..., z : z + 3, :, :], target[..., z : z + 3, :, :]) for z in (0, 3, 6)
+            ]
+            _assert_same_scores(metric.combine_metric(states), _dice_per_label_oracle(labels, output, target), 1e-6)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="counts CUDA synchronisations")
+    def test_syncs_do_not_grow_with_the_label_count(self):
+        import warnings
+
+        output = torch.softmax(torch.randn(1, 41, 8, 8, 8, device="cuda"), dim=1)
+        target = torch.randint(0, 41, (1, 1, 8, 8, 8), device="cuda").to(torch.uint8)
+        hard = torch.randint(0, 41, (1, 1, 8, 8, 8), device="cuda").to(torch.uint8)
+        counts = {}
+        torch.cuda.set_sync_debug_mode("warn")
+        try:
+            for name, args in (("soft", (output, target)), ("hard", (hard, target))):
+                with warnings.catch_warnings(record=True) as caught:
+                    warnings.simplefilter("always")
+                    Dice()(*args)
+                    Dice().partial_metric(*args)
+                counts[name] = len(caught)
+        finally:
+            torch.cuda.set_sync_debug_mode("default")
+        # forward + partial_metric: bincount (one sync each) and one .tolist() each, never one per label.
+        assert counts["soft"] <= 8 and counts["hard"] <= 12, counts
+
+
+class TestSaveMaps:
+    """A SaveMap metric reads its scalar and its map off one difference buffer; the two-pass
+    spellings they replace are the oracles."""
+
+    @staticmethod
+    def _mae_oracle(reduction, output, target, mask=None):
+        from konfai.metric.measure import MAE
+
+        args = (output, target) if mask is None else (output, target, mask)
+        loss, value = MAE(reduction)(*args)
+        if mask is None:
+            map_ = torch.nn.L1Loss(reduction="none")(output.float(), target.float())
+        else:
+            mask64 = torch.where(mask == 1, 1, 0)
+            map_ = torch.nn.L1Loss(reduction="none")(output.float() * mask64, target.float() * mask64)
+        return loss, value, map_.to(output.dtype).cpu()
+
+    @pytest.mark.parametrize("reduction", ["mean", "sum"])
+    @pytest.mark.parametrize("masked", [False, True])
+    @pytest.mark.parametrize("batch", [1, 2])
+    def test_mae_scalar_and_map_are_bit_identical_to_the_two_pass_spelling(self, reduction, masked, batch):
+        from konfai.metric.measure import MAESaveMap
+
+        torch.manual_seed(11)
+        output = torch.rand(batch, 2, 7, 6, 5) * 4000 - 1000
+        target = output + torch.randn(batch, 2, 7, 6, 5) * 100
+        mask = (torch.rand(batch, 1, 7, 6, 5) > 0.4).to(torch.uint8) if masked else None
+        args = (output, target, mask) if masked else (output, target)
+
+        loss, value, map_ = MAESaveMap(reduction)(*args)
+        expected_loss, expected_value, expected_map = self._mae_oracle(reduction, output, target, mask)
+
+        assert value == expected_value
+        assert loss.item() == expected_loss.item()
+        assert torch.equal(map_, expected_map)
+        assert torch.equal(MAESaveMap(reduction).partial_map(*args), expected_map)
+
+    def test_mae_with_an_empty_mask_is_nan_and_its_map_zero(self):
+        from konfai.metric.measure import MAESaveMap
+
+        output, target = torch.rand(1, 1, 4, 4), torch.rand(1, 1, 4, 4)
+        mask = torch.zeros(1, 1, 4, 4, dtype=torch.uint8)
+
+        _, value, map_ = MAESaveMap()(output, target, mask)
+
+        assert np.isnan(value)
+        assert torch.equal(map_, torch.zeros(1, 1, 4, 4))
+
+    def test_dice_map_of_uint8_labels_does_not_wrap(self):
+        # |0 - 3| on uint8 labels is 3; the unmasked `output - target` wrapped to 253, and only the
+        # masked path's accidental int64 promotion got it right.
+        from konfai.metric.measure import DiceSaveMap
+
+        output = torch.tensor([[[[0, 3, 2]]]], dtype=torch.uint8)
+        target = torch.tensor([[[[3, 0, 2]]]], dtype=torch.uint8)
+
+        _, _, map_ = DiceSaveMap()(output, target)
+
+        assert map_.dtype == torch.uint8
+        assert map_.tolist() == [[[[3, 3, 0]]]]
+
+    @pytest.mark.parametrize("dtype", [torch.uint8, torch.float32])
+    def test_dice_masked_map_is_bit_identical_to_the_promoted_spelling(self, dtype):
+        from konfai.metric.measure import DiceSaveMap
+
+        torch.manual_seed(2)
+        output = torch.randint(0, 6, (1, 1, 6, 7, 5)).to(dtype)
+        target = torch.randint(0, 6, (1, 1, 6, 7, 5)).to(dtype)
+        mask = (torch.rand(1, 1, 6, 7, 5) > 0.3).to(torch.uint8)
+        mask64 = torch.where(mask == 1, 1, 0)
+        expected = torch.nn.L1Loss(reduction="none")(output * mask64, target * mask64).to(torch.uint8)
+
+        _, _, map_ = DiceSaveMap()(output, target, mask)
+
+        assert torch.equal(map_, expected)
+        assert torch.equal(DiceSaveMap().partial_map(output, target, mask), expected)
+
+
 class TestSSIM:
     dynamic_range = 4.0
 
@@ -197,12 +470,112 @@ class TestSSIM:
         assert value == pytest.approx(expected, abs=1e-5)
 
     def test_identical_volumes_give_one(self):
-        pytest.importorskip("skimage.metrics")
         x, _ = self._volumes()
 
         _, value = SSIM(dynamic_range=self.dynamic_range)(x, x.clone())
 
         assert value == pytest.approx(1.0, abs=1e-6)
+
+    # . The torch port against skimage, its oracle ----------------------------------------------
+    # skimage filters in float32 and means in float64; the port does the same, so the two agree to
+    # a few 1e-8 relative (measured max 4e-8 on 64x72x80 and 256^3 inputs): pinned at 1e-6 absolute.
+
+    @staticmethod
+    def _pair(kind: str, shape: tuple[int, ...]) -> tuple[np.ndarray, np.ndarray]:
+        rng = np.random.default_rng(0)
+        grid = np.stack(np.meshgrid(*[np.linspace(-1, 1, s) for s in shape], indexing="ij"))
+        if kind == "random":
+            x = rng.normal(size=shape).astype(np.float32) * 500
+            y = x + rng.normal(size=shape).astype(np.float32) * 100
+        elif kind == "smooth":
+            x = (np.sin(4 * grid[0]) * np.cos(3 * grid[1]) * 1000).astype(np.float32)
+            y = (x * 0.9 + 50 * np.cos(5 * grid[-1])).astype(np.float32)
+        elif kind == "masked":  # zeros outside a ball, what a body mask leaves
+            inside = (grid**2).sum(0) < 0.7
+            x = (rng.normal(size=shape).astype(np.float32) * 500) * inside
+            y = (x + rng.normal(size=shape).astype(np.float32) * 100) * inside
+        elif (
+            kind == "offset"
+        ):  # a constant 1000 against the same with a 5 HU step: the variance is nothing beside the mean
+            x = np.full(shape, 1000.0, dtype=np.float32)
+            y = x.copy()
+            y[tuple(slice(s // 2, None) for s in shape)] += 5.0
+        else:  # a CT-like field: a large mean, a little noise
+            x = (2500.0 + np.sin(4 * grid[0]) * 30 + rng.normal(size=shape) * 50).astype(np.float32)
+            y = (x + rng.normal(size=shape) * 20).astype(np.float32)
+        return x, y
+
+    @pytest.mark.parametrize("kind", ["random", "smooth", "masked", "offset", "hu"])
+    @pytest.mark.parametrize("shape", [(24, 27, 21), (40, 33)])
+    def test_matches_skimage(self, kind, shape):
+        structural_similarity = pytest.importorskip("skimage.metrics").structural_similarity
+        x, y = self._pair(kind, shape)
+        expected = float(structural_similarity(x.astype(np.float64), y.astype(np.float64), data_range=4095.0))
+
+        _, value = SSIM(dynamic_range=4095.0)(torch.tensor(x)[None, None], torch.tensor(y)[None, None])
+
+        assert value == pytest.approx(expected, abs=1e-6)
+
+    def test_channels_are_averaged_as_channel_axis_zero(self):
+        structural_similarity = pytest.importorskip("skimage.metrics").structural_similarity
+        x, y = self._pair("random", (3, 20, 22, 19))
+        expected = float(
+            structural_similarity(x.astype(np.float64), y.astype(np.float64), data_range=4095.0, channel_axis=0)
+        )
+
+        _, value = SSIM(dynamic_range=4095.0)(torch.tensor(x)[None], torch.tensor(y)[None])
+
+        assert value == pytest.approx(expected, abs=1e-6)
+
+    def test_a_mask_multiplies_the_pair_and_scores_the_whole_extent(self):
+        # The masked mode: both volumes are zeroed outside the mask and the mean still runs over the
+        # whole cropped extent, exactly what skimage sees when handed the masked volumes.
+        structural_similarity = pytest.importorskip("skimage.metrics").structural_similarity
+        x, y = self._pair("random", (18, 21, 17))
+        mask = (np.random.default_rng(1).random(x.shape) > 0.4).astype(np.uint8)
+        expected = float(structural_similarity(x * mask, y * mask, data_range=4095.0))
+
+        _, value = SSIM(dynamic_range=4095.0)(
+            torch.tensor(x)[None, None], torch.tensor(y)[None, None], torch.tensor(mask)[None, None]
+        )
+
+        assert value == pytest.approx(expected, abs=1e-6)
+
+    def test_batch_items_are_averaged_and_an_empty_mask_item_skipped(self):
+        x1, y1 = self._pair("random", (12, 14, 13))
+        x2, y2 = self._pair("smooth", (12, 14, 13))
+        x = torch.tensor(np.stack([x1, x2]))[:, None]
+        y = torch.tensor(np.stack([y1, y2]))[:, None]
+        metric = SSIM(dynamic_range=4095.0)
+        first = metric(x[:1], y[:1])[1]
+        second = metric(x[1:], y[1:])[1]
+
+        _, both = metric(x, y)
+        mask = torch.ones(2, 1, 12, 14, 13, dtype=torch.uint8)
+        mask[1] = 0
+        _, first_only = metric(x, y, mask)
+        _, none = metric(x, y, torch.zeros_like(mask))
+
+        assert both == pytest.approx((first + second) / 2, abs=1e-12)
+        assert first_only == pytest.approx(first, abs=1e-12)
+        assert np.isnan(none)
+
+    def test_slabs_reproduce_the_one_shot_map(self):
+        # The slab cut is a memory bound, not a value: every slab size gives the same map sum.
+        x, y = self._pair("random", (30, 16, 15))
+        xt, yt = torch.tensor(x)[None], torch.tensor(y)[None]
+        whole = SSIM._ssim(xt, yt, None, 4095.0)
+        original = SSIM.slab_bytes
+        try:
+            for slab_bytes in (1, 16 * 15 * 4 * 9, 16 * 15 * 4 * 13):
+                SSIM.slab_bytes = slab_bytes
+                assert SSIM._ssim(xt, yt, None, 4095.0) == pytest.approx(whole, rel=1e-7)
+        finally:
+            SSIM.slab_bytes = original
+
+    def test_an_extent_below_the_window_is_refused(self):
+        with pytest.raises(MeasureError, match="7-voxel window"):
+            SSIM(dynamic_range=1.0)(torch.rand(1, 1, 6, 9, 9), torch.rand(1, 1, 6, 9, 9))
 
 
 class TestVariance:

--- a/tests/unit/test_measure.py
+++ b/tests/unit/test_measure.py
@@ -851,3 +851,71 @@ def test_fid_builds_on_cpu_and_follows_the_input_device():
 
     metric = FID()
     assert next(metric.inception_model.parameters()).device.type == "cpu"
+
+
+class TestSSIMFromHaloPatches:
+    """SSIM is reducible from patches read with the window's radius of halo, each scoring the map
+    voxels centred in its own grid slot: the streamed sum equals the whole-volume sum to float64
+    summation order, including the slots at the volume's faces, where the halo is cut short and the
+    whole-volume map is cropped the same."""
+
+    @staticmethod
+    def _grid(shape: tuple[int, ...], patch: list[int]) -> list[tuple[slice, ...]]:
+        from konfai.utils.utils import get_patch_slices_from_shape
+
+        return get_patch_slices_from_shape(patch, list(shape), 0)[0]
+
+    @staticmethod
+    def _streamed(metric: SSIM, tensors: list[torch.Tensor], patch: list[int]) -> float:
+        shape = tuple(tensors[0].shape[2:])
+        states = []
+        for slot in TestSSIMFromHaloPatches._grid(shape, patch):
+            read = tuple(
+                slice(max(0, s.start - metric.halo), min(extent, s.stop + metric.halo))
+                for s, extent in zip(slot, shape, strict=True)
+            )
+            core = tuple(slice(s.start - r.start, s.stop - r.start) for s, r in zip(slot, read, strict=True))
+            states.append(metric.partial_metric(*[t[(slice(None), slice(None), *read)] for t in tensors], core=core))
+        return metric.combine_metric(states)[1]
+
+    def test_declares_its_window_radius_as_halo(self):
+        assert SSIM.reducible and SSIM.halo == 3
+
+    @pytest.mark.parametrize("masked", [False, True])
+    @pytest.mark.parametrize(
+        ("shape", "patch"), [((37, 29), [16, 13]), ((19, 23, 17), [8, 8, 8]), ((19, 23, 17), [5, 23, 7])]
+    )
+    def test_halo_patches_reproduce_the_whole_volume(self, shape, patch, masked):
+        # Every grid here leaves a partial slot on some axis; [5, 23, 7] also spans an axis whole.
+        rng = np.random.default_rng(2)
+        x = torch.tensor(rng.normal(size=(1, 2, *shape)).astype(np.float32) * 500)
+        y = x + torch.tensor(rng.normal(size=x.shape).astype(np.float32) * 100)
+        tensors = [x, y]
+        if masked:
+            tensors.append(torch.tensor((rng.random((1, 1, *shape)) > 0.4).astype(np.uint8)))
+        metric = SSIM(dynamic_range=4095.0)
+        whole = metric(*tensors)[1]
+
+        assert self._streamed(metric, tensors, patch) == pytest.approx(whole, rel=1e-9)
+
+    def test_a_slot_without_a_valid_centre_contributes_nothing(self):
+        # A read too thin for the window (a 2-wide slot at a face, read 5 wide) has no map voxel of
+        # its own: an empty state, never an error, the whole volume's map lies in the other slots.
+        x, y = torch.rand(1, 1, 12, 12), torch.rand(1, 1, 12, 12)
+        metric = SSIM(dynamic_range=1.0)
+        thin = metric.partial_metric(x[..., :5, :], y[..., :5, :], core=(slice(0, 2), slice(0, 12)))
+        rest = metric.partial_metric(x[..., 0:, :], y[..., 0:, :], core=(slice(2, 12), slice(0, 12)))
+
+        assert thin == ("items", [(0.0, 0, True)])
+        assert metric.combine_metric([thin, rest])[1] == pytest.approx(metric(x, y)[1], rel=1e-12)
+
+    def test_an_empty_mask_item_is_skipped_as_the_whole_volume_skips_it(self):
+        x, y = torch.rand(2, 1, 9, 9), torch.rand(2, 1, 9, 9)
+        mask = torch.ones(2, 1, 9, 9, dtype=torch.uint8)
+        mask[1] = 0
+        metric = SSIM(dynamic_range=1.0)
+        states = [metric.partial_metric(x[..., :7], y[..., :7], mask[..., :7], core=(slice(0, 9), slice(0, 4)))]
+        states.append(metric.partial_metric(x[..., 1:], y[..., 1:], mask[..., 1:], core=(slice(0, 9), slice(3, 8))))
+
+        assert metric.combine_metric(states)[1] == pytest.approx(metric(x, y, mask)[1], rel=1e-12)
+        assert np.isnan(metric.combine_metric([metric.partial_metric(x, y, torch.zeros_like(mask))])[1])

--- a/tests/unit/test_memory_budget.py
+++ b/tests/unit/test_memory_budget.py
@@ -363,6 +363,58 @@ def _metric_sizing_budget(
     return captured["budget"]
 
 
+def _metric_sizing(monkeypatch: pytest.MonkeyPatch, shape: list[int], budget_bytes: int, halo: int) -> DataMetric:
+    """Drive DataMetric._maybe_auto_patch over a fake two-group case of ``shape`` with a real
+    sizing, the metrics' widest halo declared."""
+    data = DataMetric(memory_budget=f"{budget_bytes}b")
+    data.datasets = {
+        "f": SimpleNamespace(
+            select_names=lambda group, requested: ["case"], get_infos=lambda group, name: (shape, None)
+        )
+    }
+    monkeypatch.setattr(
+        DataMetric,
+        "_resolve_dataset_sources",
+        lambda self, requested=None: {"CT": [("f", False)], "sCT": [("f", False)]},
+        raising=False,
+    )
+    data.patch_halo = halo
+    data._maybe_auto_patch()
+    return data
+
+
+def test_eval_sizing_reserves_the_metrics_halo_on_each_face(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Two float32 groups of 64^3 at 24 B/voxel sized (resident + 2x intermediates): the READ is
+    # what fits, and the slot is the read less a halo on each face, so every patch a metric is
+    # handed, halo included, stays within the sizing.
+    budget_bytes = 2 * 2**20
+    plain = _metric_sizing(monkeypatch, [1, 64, 64, 64], budget_bytes, 0)
+    haloed = _metric_sizing(monkeypatch, [1, 64, 64, 64], budget_bytes, 3)
+
+    assert plain.patch is not None and haloed.patch is not None
+    assert plain.patch.halo == 0 and haloed.patch.halo == 3
+    assert haloed.patch.patch_size == [size - 6 for size in plain.patch.patch_size]
+    read = [size + 6 for size in haloed.patch.patch_size]
+    assert 3 * 2 * 4 * read[0] * read[1] * read[2] <= budget_bytes * 0.8
+
+
+def test_eval_sizing_spans_an_axis_too_thin_for_its_halo(monkeypatch: pytest.MonkeyPatch) -> None:
+    # An isotropic cut leaves a 7-deep axis 5 or 6 deep: thinner than two halos of 3, so it is
+    # read whole and the other axes pay for it instead.
+    data = _metric_sizing(monkeypatch, [1, 7, 256, 256], 512 * 2**10, 3)
+
+    assert data.patch is not None
+    assert data.patch.patch_size[0] == 7
+    assert all(1 <= size < 256 - 6 for size in data.patch.patch_size[1:])
+
+
+def test_eval_sizing_refuses_a_budget_no_halo_patch_fits(monkeypatch: pytest.MonkeyPatch) -> None:
+    from konfai.utils.errors import DatasetManagerError
+
+    with pytest.raises(DatasetManagerError, match="halo"):
+        _metric_sizing(monkeypatch, [1, 64, 64, 64], 4096, 3)
+
+
 def test_eval_auto_budget_is_divided_by_the_local_ranks(monkeypatch: pytest.MonkeyPatch) -> None:
     # 4 ranks evaluating on one node share its RAM: each sizes its patch from a quarter of the
     # auto budget, or together they over-commit the host 4-fold.
@@ -558,6 +610,86 @@ def _build_predictor(root: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
     with strict_config("Predictor", refuse=False):
         return apply_config()(Predictor)()
+
+
+_HALO_EVALUATION = """Evaluator:
+  metrics:
+    sCT:
+      targets_criterions:
+        CT:
+          criterions_loader:
+            MAE:
+              reduction: mean
+            SSIM:
+              dynamic_range: 2.0
+  Dataset:
+    groups_src:
+      CT:
+        groups_dest:
+          CT:
+            transforms: None
+            patch_transforms: None
+            is_input: true
+      sCT:
+        groups_dest:
+          sCT:
+            transforms: None
+            patch_transforms: None
+            is_input: true
+    subset: None
+    validation: None
+    memory_budget: 40000b
+    dataset_filenames:
+      - __DATASET_DIR__:a:mha
+      - __PREDICTIONS_DATASET_DIR__:i:mha
+  train_name: HALO_01
+"""
+
+
+def test_a_halo_metric_no_longer_vetoes_the_patched_evaluation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """SSIM beside MAE under a budget the case exceeds: the run takes the patched path, reading
+    each slot with SSIM's halo, where SSIM once kept the whole run on the whole-volume path."""
+    pytest.importorskip("SimpleITK")
+    import numpy as np
+    from konfai.evaluator import Evaluator
+    from konfai.utils.config import apply_config, strict_config
+    from konfai.utils.dataset import Attribute, Dataset
+    from konfai.utils.runtime import State, configure_workflow_environment
+
+    for key in _WORKFLOW_ENV:
+        monkeypatch.setenv(key, "sentinel")
+        monkeypatch.delenv(key)
+    attributes = Attribute()
+    attributes["Origin"] = np.asarray([0.0, 0.0, 0.0])
+    attributes["Spacing"] = np.asarray([1.0, 1.0, 1.0])
+    attributes["Direction"] = np.eye(3, dtype=np.float64).reshape(-1)
+    volume = np.random.default_rng(0).random((1, 12, 16, 16)).astype(np.float32)
+    Dataset(tmp_path / "Dataset", "mha").write("CT", "CASE_000", volume, attributes)
+    Dataset(tmp_path / "Predictions", "mha").write("sCT", "CASE_000", volume, attributes)
+    config = tmp_path / "Evaluation.yml"
+    config.write_text(
+        _HALO_EVALUATION.replace("__DATASET_DIR__", str(tmp_path / "Dataset")).replace(
+            "__PREDICTIONS_DATASET_DIR__", str(tmp_path / "Predictions")
+        ),
+        encoding="utf-8",
+    )
+    configure_workflow_environment(
+        config_path=config,
+        root="Evaluator",
+        state=State.EVALUATION,
+        path_env={"KONFAI_EVALUATIONS_DIRECTORY": tmp_path / "Evaluations"},
+    )
+    os.environ["KONFAI_CONFIG_MODE"] = "Done"
+    with strict_config("Evaluator", refuse=False):
+        evaluator = apply_config()(Evaluator)()
+
+    assert evaluator.dataset.auto_patch_allowed
+    assert evaluator._streamed and evaluator._halo == 3
+    assert evaluator.dataset.patch is not None and evaluator.dataset.patch.halo == 3
+    # 2 groups x 12x16x16 float32 at 24 B/voxel against 32000 B: cut on every axis, the halo reserved.
+    assert all(
+        1 <= size < extent for size, extent in zip(evaluator.dataset.patch.patch_size, [12, 16, 16], strict=True)
+    )
 
 
 def test_a_declared_budget_bounds_the_chunk_cache_in_prediction_and_evaluation(


### PR DESCRIPTION

Two commits on the metric and evaluation side. `Dice` and `FocalLoss` resample a segmentation target only when its grid differs from the output's (`Dice.on_grid`). Hard-label Dice takes every label's counts from three `bincount` passes over the flat maps and one `.tolist()`, with the ratios in float64, a signed map shifted by its smallest label when that is below zero and a float map's NaN voxels dropped from every readout; the soft path keeps its differentiable spelling. `MAESaveMap` reads its scalar and its map off one `|output - target|`, and `DiceSaveMap` masks the pair once and takes its map as max - min. SSIM is computed in torch on the metric's device with skimage's definition and constants, slab by slab, its statistics in float64, and no scikit-image at runtime; it declares a halo of its window's radius and is reducible, so an evaluation with SSIM beside MAE and PSNR takes the patched path under `memory_budget` instead of the whole-volume one. `Patch.halo` widens a grid patch's read past its slot (`read_slices`, `core_in_read`, `pad_to_patch`); `DataMetric` sizes the read against the budget, cuts the slots narrower by the metrics' widest halo, spans an axis the cut leaves thinner than two halos, and refuses a budget no halo read fits with the number; the evaluator hands a halo metric the read and `core=`, the slot's place in it, and the others the slot alone. The evaluator moves each group the metrics name to the metric device once per update (`_groups_on`) and runs each split under a `SweepClock` that prints one line per split past a second. `evaluation.md` says which metrics stream, how a halo is served, and what the clock line reports.

## Measured

- Target resample guard, 512^3 uint8 label map, 12 threads (`.scratch/bench_guard.py`): interpolate + unique(float32) 3.67 s (spread 3.67-3.87) against on_grid + unique(uint8) 0.84 s (0.84-0.87); the resample alone is 0.10 s, the float unique 3.50 s against 0.79 s on uint8.
- Hard Dice, 512^3 uint8, 10 labels, 12 threads (`.scratch/bench_dice.py hard 512`): labels None 6.33 s -> 0.21 s, explicit 1..9 2.42 -> 0.21, masked 7.09 -> 0.84, float32 maps 8.11 -> 0.55, structured 6.78 -> 0.94 and masked 10.56 -> 1.32. Soft path on an idle RTX at 2x41x96^3: 163 CUDA syncs per forward to 4 (`torch.cuda.set_sync_debug_mode`), 65.9 -> 63.4 ms per forward+backward (spreads 65.9-109.0 / 63.4-86.0). A streamed 128^3 uint8 patch: 1.34 -> 0.31 ms and 56 -> 5 syncs.
- SaveMaps at 256^3, 12 threads (`.scratch/bench_dice.py maemap / map`): MAESaveMap unmasked 0.06 s -> 0.03 s, masked 0.53 s (spread 0.53-0.69) -> 0.22 s (0.22-0.26), bytes allocated by its ops on the masked call 2832 MiB -> 1085 MiB for a 128 MiB input pair (`torch.profiler`, `profile_memory`); DiceSaveMap unmasked 1.32 s -> 0.08 s, masked 1.95 s -> 0.16 s.
- SSIM per case, 12 threads / one RTX (`.scratch/bench_ssim_final.py`): 256^3 unmasked skimage 3.23 s -> 0.17 s CPU (spread 0.17-0.25), 0.009 s GPU; masked 2.89 s -> 0.20 s (0.20-0.22) / 0.009 s. 512^3 unmasked 39.7 s -> 1.28 s CPU (min of 4 at a load average of 13; 1.08 s idle) / 0.096 s GPU, masked 39.2 s -> 2.32 s / 0.096 s; the skimage route also paid 0.78 s of D2H for the operands at 512^3.
- Group upload (`.scratch/bench_h2d.py`): a 512^3 float32 volume (536.9 MB) takes 58 ms to upload from pageable memory (9.3 GB/s, spread 58-70 ms); the Registration evaluation paid that three times per case for FIXED and pays it once, the move count per update dropping from 6 to 4 on that config.
- Split clock, 4 synthetic 288^3 cases through the API with MAE, PSNR, MAESaveMap, and SSIM on the whole-volume runs (`.scratch/run_eval_report.py`): whole-volume CPU 4.0 s = wait(load) 0.6 + h2d 0.0 + MAE 0.2 + PSNR 0.1 + SSIM 2.5 + map 0.3 + flush 0.0 + other 0.1; whole-volume GPU 2.0 s; streamed 40MB CPU 2.4 s; streamed 40MB GPU 1.5 s.
- Halo evaluation, 4 synthetic 288^3 float32 cases, MAE + PSNR + SSIM, CPU, one process, 3 runs each (`.scratch/bench_halo_eval.py`, `/usr/bin/time -v`): whole volume peak RSS 1420 MiB, wall 4.6-5.7 s; 512 MiB budget 992 MiB, 4.1-4.7 s; 128 MiB budget 883 MiB, 3.5-4.3 s. The interpreter with torch and SimpleITK imported is 663 MiB of each. At 512 MiB the slots are 255^3, read as 258^3 (a halo of 3 at 288^3 reads 6.4% more bytes than the volume).

**Values:** `on_grid`, `_groups_on`, the clock and a halo of 0 do not move a value. Hard Dice moves by the float32 partial sums the old spelling rounded past 2^24: max |diff| 8.9e-8 on a label and 1.0e-7 on the loss on structured labels, 7.3e-9 / 0 on random labels; the soft path is bit-identical, loss and every label. With `labels: None` a streamed patch now reports every label either map holds, where a state built from the patch's own reference dropped the predicted mass of a label that patch lacked. A label of -1 is scored on the bincount route as the per-label `==` scored it. The unmasked Dice map of uint8 labels subtracted in uint8 and wrapped, |0 - 3| came out 253 (on a 256^3 random 10-label pair 7.5M of 16.7M voxels, max 255 against 9 now); MAE scalars and maps and the masked Dice map are bit-identical. SSIM against skimage: max |diff| 2.7e-8 (2.8e-8 relative) over random, smooth and masked inputs at 64x72x80, 256^3 and 512^3, the float32 rounding of a different summation order. The statistics are in float64: on a constant 1000 with a 5 HU step at 48x56x52, data_range 4095, a float32 route is 7.1e-6 (CPU) and 9.2e-6 (GPU) off a float64 reference (skimage's own float32 route 6.5e-8) with the devices disagreeing by 2.1e-6, where the float64 statistics are 1.3e-7 off on both, CPU and GPU agreeing to 3e-16. SSIM streamed against whole on the 4 cases: max |diff| 2.2e-16, float64 summation order; MAE and PSNR are what the streamed path gave before, 4.8e-9 and 1.1e-6 against the whole volume.

**Tests:** `test_auto_patching.py` TestHaloGrid (the widened reads, the clamp at the faces, the slot's place in the read, the read plan's data slices); `test_measure.py` TestOnGrid, TestDiceConfusionMatrix (the per-label oracle on structured and random maps, an int16 pair holding -1 and a float32 pair holding NaN, the soft path's value and gradient, the streamed sums and combine, the sync-count bound), TestSaveMaps, TestSSIM against the skimage oracle at 1e-6 (batch mean, `channel_axis=0`, masked mode, slab cut, float64 inputs, a constant with a step, a CT-like field; skipped without scikit-image) and TestSSIMFromHaloPatches on 2D and 3D grids with partial faces, masked and unmasked, to 1e-9 relative; `test_evaluator_update.py` (each group moved once per update on both paths, the recorded values against the per-spec computation, 6 -> 4 moves, TestClockReport, TestStreamedUpdateWithAHalo); `test_memory_budget.py` (the halo reserved within the budget, a thin axis spanned, an impossible budget refused, an Evaluator built with SSIM + MAE under a small budget takes the patched path); `tests/integration/test_konfai_streamed_evaluation.py` runs SSIM beside the sums and the error map.

**Stack:** Stacked on `pr/1.8.2-03-startup`; merge after it. Before deleting this branch, retarget the next PR of the stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added memory-bounded evaluation for halo-aware metrics, including streamed SSIM processing.
  * Improved Dice and Focal Loss support for varied label formats, resampled grids, masks, and streamed aggregation.
  * Added split evaluation timing reports for clearer performance insight.
* **Bug Fixes**
  * Improved handling of boundary patches, empty contributions, NaN values, and insufficient SSIM input sizes.
  * Ensured streamed and whole-volume metric results remain consistent.
* **Documentation**
  * Documented memory-bounded evaluation, custom metric settings, timing phases, and example logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->