### PR TITLE
Prediction and reductions

### DIFF
--- a/docs/source/config_guide/prediction.md
+++ b/docs/source/config_guide/prediction.md
@@ -165,6 +165,28 @@ device; only a transcendental-terminated float chain (Softmax/Sigmoid) can diffe
 GPU window and a CPU whole-volume run. Set `KONFAI_STREAMED_WRITES=0` to force the whole-volume path
 globally (ops/debug or exact bit-reproducibility against a CPU run).
 
+### Where the run's time went
+
+A run whose loop took more than a second closes with a line accounting for it, phase
+by phase, in the same shape as the transform workflow's sweep line:
+
+```text
+[KonfAI] prediction 84.2 s = fetch 3.1 + forward 41.5 + blend 22.0 + finalize(stream) 9.8 + finalize(case) 0.0 + drain 1.2 + other 6.6 | writer 30.4 s, waited on 8.9 s
+```
+
+The sum before the bar is the loop's own thread and it closes exactly: what the named
+phases do not account for is `other`. `fetch` is the wait for the loader's next batch,
+`forward` the model, `blend` a patch's inverses and its blend into the accumulator (the
+copy home included when the case accumulates on the host), the two `finalize` figures
+the slabs and the cases handed to the writer, and `drain` the writes still queued when
+the loop ends. On a GPU the loop only enqueues the forward and the blend, so the device's
+time is waited for where a result crosses to the host.
+
+After the bar is the writer: its own thread's time, and how long the loop stood waiting
+on it inside the finalize phases. The background writer overlaps the disk with the next
+forward only while its queue has room; `waited on` close to `writer` means the
+destination is the floor of the run, and the writer has become synchronous.
+
 ## Examples
 
 See:

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -1008,10 +1008,13 @@ class Accumulator:
         # of a 122-channel whole-body segmentation ≈ tens of GB) was the dominant reassembly RAM cost.
         self._result: torch.Tensor | None = None
         self._weighted: torch.Tensor | None = None
-        # Blend-weight geometry: fixed for the accumulator's life, so it survives _reset.
+        # Blend-weight geometry: fixed for the accumulator's life, so it survives _reset. The grid,
+        # the shares and the kept spans are all per (axis, start): sum(n_d) entries for a grid of
+        # prod(n_d) patches, and one dict lookup per patch and axis to find them.
         self._geometry: tuple[list[list[torch.Tensor]], list[torch.Tensor]] | None = None
+        self._grid: list[dict[int, int]] | None = None
         self._shares: dict[tuple[int, int, int, torch.dtype, torch.device], torch.Tensor] = {}
-        self._boxes: dict[tuple[int, ...], tuple[slice, ...]] = {}
+        self._kept: dict[tuple[int, int], slice] = {}
 
     def add_layer(self, index: int, layer: torch.Tensor) -> list[tuple[slice, torch.Tensor]]:
         """Blend one patch in; returns the slabs this completes (none for the whole-volume base)."""
@@ -1067,19 +1070,19 @@ class Accumulator:
     def _kept_box(self, patch_slice: tuple[slice, ...]) -> tuple[slice, ...]:
         """The sub-box a selection keeps of this patch: the run of ones in its window, per axis.
 
-        Pure geometry, so it is read once from the host-side windows and cached per grid position.
-        Deriving it from the share instead would read a device tensor: a host sync on every patch,
-        which costs more than the weighting it replaces.
+        Pure geometry, so it is read once from the host-side windows and cached per grid position
+        along each axis. Deriving it from the share instead would read a device tensor: a host sync
+        on every patch, which costs more than the weighting it replaces.
         """
-        key = tuple(s.start for s in patch_slice)
-        if key not in self._boxes:
+        return tuple(self._kept_span(dim, s.start) for dim, s in enumerate(patch_slice))
+
+    def _kept_span(self, dim: int, start: int) -> slice:
+        key = (dim, start)
+        if key not in self._kept:
             windows, _ = self._weight_geometry()
-            box = []
-            for dim, s in enumerate(patch_slice):
-                kept = windows[dim][self._starts(dim).index(s.start)].nonzero().flatten()
-                box.append(slice(int(kept[0]), int(kept[-1]) + 1))
-            self._boxes[key] = tuple(box)
-        return self._boxes[key]
+            kept = windows[dim][self._position(dim, start)].nonzero().flatten()
+            self._kept[key] = slice(int(kept[0]), int(kept[-1]) + 1)
+        return self._kept[key]
 
     def _weight_geometry(self) -> tuple[list[list[torch.Tensor]], list[torch.Tensor]]:
         """Per axis: the blend window, and its sum over the patch grid.
@@ -1099,7 +1102,7 @@ class Accumulator:
             combine = cast(PathCombine, self.patch_combine)
             windows, totals = [], []
             for dim, extent in enumerate(self.shape):
-                starts = self._starts(dim)
+                starts = list(self._positions()[dim])
                 length = self.patch_slices[0][dim].stop - self.patch_slices[0][dim].start
                 per_position, total = [], torch.zeros(extent)
                 for position, start in enumerate(starts):
@@ -1113,9 +1116,25 @@ class Accumulator:
             self._geometry = (windows, totals)
         return self._geometry
 
-    def _starts(self, dim: int) -> list[int]:
-        """The patch grid's positions along one axis, in order."""
-        return sorted({patch[dim].start for patch in self.patch_slices})
+    def _positions(self) -> list[dict[int, int]]:
+        """Per axis, the patch grid's starts in order, each mapped to its position along the axis.
+
+        One pass over the slices for the accumulator's life. Rebuilding the sorted starts per patch
+        made every lookup O(P): 0.07 ms per patch at P = 1331 and 15.6 s over a case of 18,000
+        thin 2.5D patches, against 16 ms for that case here.
+        """
+        if self._grid is None:
+            self._grid = [
+                {
+                    start: position
+                    for position, start in enumerate(sorted({patch[dim].start for patch in self.patch_slices}))
+                }
+                for dim in range(len(self.shape))
+            ]
+        return self._grid
+
+    def _position(self, dim: int, start: int) -> int:
+        return self._positions()[dim][start]
 
     def _share(self, dim: int, start: int, data: torch.Tensor) -> torch.Tensor:
         """This patch's fraction of the blend weight along one axis, ``w / sum_k w``, cached per axis."""
@@ -1123,7 +1142,7 @@ class Accumulator:
         key = (dim, start, extent, data.dtype, data.device)
         if key not in self._shares:
             windows, totals = self._weight_geometry()
-            window = windows[dim][self._starts(dim).index(start)]
+            window = windows[dim][self._position(dim, start)]
             share = window[:extent] / totals[dim][start : start + extent]
             self._shares[key] = share.to(device=data.device, dtype=data.dtype)
         return self._shares[key]
@@ -1663,16 +1682,7 @@ class Patch(ABC):
         if any(plan.reflect_padding):
             data_sliced = F.pad(data_sliced, plan.reflect_padding, "reflect")
         if any(plan.constant_padding):
-            data_sliced = F.pad(
-                data_sliced,
-                plan.constant_padding,
-                "constant",
-                (
-                    0
-                    if data_sliced.dtype == torch.uint8
-                    else (self.pad_value if self.pad_value is not None else float(data.min().item()))
-                ),
-            )
+            data_sliced = self._pad_constant(data_sliced, plan.constant_padding)
         if self.patch_size is not None and not all(p == 0 for p in self.patch_size):
             for d in [i for i, v in enumerate(reversed(self.patch_size)) if v == 1]:
                 data_sliced = torch.squeeze(data_sliced, dim=len(data_sliced.shape) - d - 1)
@@ -1681,6 +1691,29 @@ class Patch(ABC):
             if plan.concatenate_extend_slice
             else data_sliced
         )
+
+    def _pad_constant(self, data: torch.Tensor, padding: tuple[int, ...]) -> torch.Tensor:
+        """``data`` padded (``F.pad`` pair order) with the configured value, a uint8 map with zero,
+        and anything else with its own minimum when no value is configured.
+
+        That minimum never leaves the device: the bands are filled from the 0-d tensor after a zero
+        pad. Reading it back through ``.item()`` drained the CUDA stream once per padded patch (37
+        of the 64 patches of a 100^3 case at 32^3, measured), each a wait for every kernel queued
+        before it.
+        """
+        if data.dtype == torch.uint8:
+            return F.pad(data, padding, "constant", 0)
+        if self.pad_value is not None:
+            return F.pad(data, padding, "constant", self.pad_value)
+        padded = F.pad(data, padding, "constant", 0)
+        lowest = data.min()
+        for pair, (before, after) in enumerate(zip(padding[::2], padding[1::2], strict=True)):
+            dim = padded.dim() - 1 - pair
+            if before:
+                padded.narrow(dim, 0, before).copy_(lowest)
+            if after:
+                padded.narrow(dim, padded.shape[dim] - after, after).copy_(lowest)
+        return padded
 
     def get_data(self, data: torch.Tensor, index: int, a: int, is_input: bool) -> list[torch.Tensor]:
         plan = self.get_read_plan(list(data.shape), index, a, is_input)

--- a/konfai/data/reduction.py
+++ b/konfai/data/reduction.py
@@ -123,7 +123,13 @@ class Mean(Reduction):
         if self._total is None:
             self._total, self._dtype = tensor.to(torch.float32, copy=True), tensor.dtype
         else:
-            self._total.add_(tensor.float())
+            # Promoted inside the add kernel, whose cast to float32 is the one float() made: the
+            # same bits, without the float32 copy of the member that float() put beside the total
+            # (64 MiB per 32 MiB fp16 member: one allocation per member on CUDA, none here,
+            # measured; the CPU iterator casts into a temporary either way). A member wider than
+            # float32 would be added at its own width and rounded after, so it is narrowed first.
+            promoted = torch.promote_types(torch.float32, tensor.dtype) is torch.float32
+            self._total.add_(tensor if promoted else tensor.float())
         self._count += 1
 
     def finalize(self) -> torch.Tensor:
@@ -255,27 +261,52 @@ class Vote(Reduction):
     """
 
     voxel_local = True
-    # The sorted copy of the stack, and one stack-sized mask beside it.
+    # What the running best holds beside the members: two counts, the best label, the mask
+    # deciding it and the comparisons behind it, 2 x itemsize + 6 bytes per voxel (measured 6 to
+    # 9 on uint8 and int16 members, at two and at six members). A fixed set of planes, so as a
+    # share of the cohort it shrinks with the count: 16 bytes over the plan's 4 per member, and
+    # the attribute is the two-member fold, the worst case.
     working_multiple = 2.0
+
+    def working_multiple_for(self, cases: int) -> float:
+        return 4.0 / cases if cases > 1 else 0.0
 
     def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
         if len(tensors) == 1:
             return tensors[0]
         # NOT torch.mode: its tie-break is the smallest label on CPU and the LARGEST on CUDA
-        # (measured: 19% of a six-member fold differed by device), so a --gpu reduce and a CPU
-        # reduce wrote different label maps under one provenance. Sorted along the case axis and
-        # counted member by member, the first count that is not beaten IS the smallest label with
-        # the most votes, on every device. Per voxel this is cases^2 comparisons over the stack and
-        # nothing else: no unique over the volume (a sort of every voxel, 31 s per 512^3 on a
-        # CPU where this takes 2 s), no per-label count planes.
-        ranked = torch.stack(tensors, dim=0).sort(dim=0).values
-        best, best_count = ranked[0], (ranked == ranked[0]).sum(dim=0, dtype=torch.int16)
-        for member in ranked[1:]:
-            count = (ranked == member).sum(dim=0, dtype=torch.int16)
-            better = count > best_count
+        # (measured: 16% of a six-member fold differed by device), so a --gpu reduce and a CPU
+        # reduce wrote different label maps under one provenance. Every member is a candidate
+        # counted against the others, and the running best keeps a strictly larger count or the
+        # same count on a smaller label: the smallest label with the most votes, on every device
+        # and whatever the members' order. Per voxel this is cases^2 comparisons and nothing else:
+        # no stack sorted along the case axis (whose int64 indices alone were 8 bytes per voxel and
+        # member: a 128-row slab of six 512x512 uint8 members peaked 1920 MiB sorted, 256 MiB
+        # here, 64 -> 11 ms on CUDA, measured), no unique over the volume, no per-label planes.
+        best, best_votes = tensors[0], self._votes_for(0, tensors)
+        for index in range(1, len(tensors)):
+            member, votes = tensors[index], self._votes_for(index, tensors)
+            better = (votes > best_votes) | ((votes == best_votes) & (member < best))
             best = torch.where(better, member, best)
-            best_count = torch.where(better, count, best_count)
+            best_votes = torch.where(better, votes, best_votes)
         return best
+
+    @staticmethod
+    def _votes_for(index: int, tensors: list[torch.Tensor]) -> torch.Tensor:
+        """How many members hold member ``index``'s label, per voxel: its own vote and every
+        equal one.
+
+        Counted in uint8 from the mask viewed as uint8 (a bool is one byte holding 0 or 1): the
+        same dtype on both sides of the add, so the CPU iterator adds in place where a bool into
+        a wider count went through a cast temporary (1156 -> 784 ms per six-member int16 slab on
+        the host, 29 -> 21 ms on CUDA, measured). int16 past 255 members, where uint8 would wrap.
+        """
+        member = tensors[index]
+        votes = torch.ones_like(member, dtype=torch.uint8 if len(tensors) < 256 else torch.int16)
+        for other_index, other in enumerate(tensors):
+            if other_index != index:
+                votes.add_((other == member).view(torch.uint8))
+        return votes
 
 
 class Concat(Reduction):

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -54,6 +54,7 @@ from konfai.data.patching import (
     SlabAligner,
     SlabRegionStream,
     StreamingAccumulator,
+    SweepClock,
     _halo_radii,
     _HaloPull,
     _RemapPull,
@@ -93,6 +94,14 @@ from konfai.utils.runtime import (
 from konfai.utils.utils import concretize_patch_size, env_flag, get_module, size_free_axes, split_path_spec
 from konfai.utils.vram import next_patch_candidate, usable_vram
 
+#: This rank's prediction loop, phase by phase, summed over the cases it ran: the unit the line
+#: at the end of a run accounts for (see ``_prediction_report``).
+PREDICTION_CLOCK = SweepClock()
+
+#: Batches between two refreshes of the progress bar's status. The status is an NVML query, two
+#: psutil calls and a forced redraw (95 us per batch, measured) that no batch needs to be current.
+_DESCRIPTION_EVERY = 10
+
 
 class _AsyncWriter:
     """A background thread owning one output dataset's disk writes, in submission order.
@@ -119,7 +128,8 @@ class _AsyncWriter:
                 if operation is None:
                     return
                 if self._error is None:
-                    operation()
+                    with PREDICTION_CLOCK.phase("write"):
+                        operation()
             except BaseException as error:  # kept and re-raised on the loop thread
                 self._error = error
             finally:
@@ -232,15 +242,21 @@ class OutputDataset(Dataset, NeedDevice, ABC):
         return torch.device("cuda", self.device) if isinstance(self.device, int) else self.device
 
     def _submit_write(self, operation: Callable[[], None]) -> None:
-        """Run ``operation`` on the background writer, or inline when the destination must stay serial."""
+        """Run ``operation`` on the background writer, or inline when the destination must stay serial.
+
+        Charged to ``wait(write)`` either way: inline, the write IS the wait, and a submission
+        blocks once the writer's queue is full, which is where a slow destination turns the
+        background writer synchronous with nothing else to show it.
+        """
         if self._async_writes is None:
             self._async_writes = self._torch_device().type == "cuda"
-        if not self._async_writes:
-            operation()
-            return
-        if self._writer is None:
-            self._writer = _AsyncWriter()
-        self._writer.submit(operation)
+        with PREDICTION_CLOCK.phase("wait(write)"):
+            if not self._async_writes:
+                operation()
+                return
+            if self._writer is None:
+                self._writer = _AsyncWriter()
+            self._writer.submit(operation)
 
     def finalize_writes(self) -> None:
         """Drain and stop the background writer; every submitted write is on disk when this returns."""
@@ -568,23 +584,21 @@ class OutSameAsGroupDataset(OutputDataset):
         attribute: Attribute | None = None,
         number_of_channels_per_model: list[int] | None = None,
     ):
-        self._ensure_case_state(
-            index_dataset, index_augmentation, layer, dataset, attribute, number_of_channels_per_model
-        )
-        for transform in reversed(dataset.groups_src[self.group_src][self.group_dest].patch_transforms):
-            if isinstance(transform, TransformInverse) and transform.apply_inverse:
-                layer = transform.inverse(
-                    self.names[index_dataset],
-                    layer,
-                    self.attributes[index_dataset][index_augmentation][index_patch],
-                )
-        accumulator = self.output_layer_accumulator[index_dataset][index_augmentation]
-        slabs = self._blend_patch(index_dataset, index_patch, layer, accumulator)
+        with PREDICTION_CLOCK.phase("blend"):
+            self._ensure_case_state(
+                index_dataset, index_augmentation, layer, dataset, attribute, number_of_channels_per_model
+            )
+            attributes = self.attributes[index_dataset][index_augmentation]
+            for transform in self._patch_inverses(dataset):
+                layer = transform.inverse(self.names[index_dataset], layer, attributes[index_patch])
+            accumulator = self.output_layer_accumulator[index_dataset][index_augmentation]
+            slabs = self._blend_patch(index_dataset, index_patch, layer, accumulator)
         if not self._stream_plans.get(index_dataset):
             return
-        self._advance_stream(
-            index_dataset, index_augmentation, accumulator, slabs, number_of_channels_per_model, dataset
-        )
+        with PREDICTION_CLOCK.phase("finalize(stream)"):
+            self._advance_stream(
+                index_dataset, index_augmentation, accumulator, slabs, number_of_channels_per_model, dataset
+            )
 
     def _ensure_case_state(
         self,
@@ -638,7 +652,14 @@ class OutSameAsGroupDataset(OutputDataset):
                 # large case pays it: say so, once per distinct path.
                 path = "whole-volume" if plan is None else "buffered (the prefix streams, the tail runs whole-volume)"
                 self._report_once(path, f"streaming: case '{input_dataset.name}' takes the {path} path.")
-        self.attributes[index_dataset][index_augmentation] = {}
+        # Everything past this point reads the header at index 0; a patch-level inverse reads one
+        # per patch, each undone on a copy of its own taken before any inverse ran. Only then are
+        # the copies made: on a grid of 18,000 thin 2.5D patches with nothing to undo they cost
+        # 473 ms and as many dicts held per (case, augmentation), measured.
+        attributes = self.attributes[index_dataset][index_augmentation] = {0: source_attribute}
+        if self._patch_inverses(dataset):
+            for i in range(1, len(input_dataset.patch.get_patch_slices(index_augmentation))):
+                attributes[i] = Attribute(source_attribute)
 
         accumulator_type = StreamingAccumulator if self._stream_plans[index_dataset] else Accumulator
         self.output_layer_accumulator[index_dataset][index_augmentation] = accumulator_type(
@@ -649,8 +670,14 @@ class OutSameAsGroupDataset(OutputDataset):
             sweep_axis=input_dataset.patch.get_sweep_axis(index_augmentation),
         )
 
-        for i in range(len(input_dataset.patch.get_patch_slices(index_augmentation))):
-            self.attributes[index_dataset][index_augmentation][i] = Attribute(source_attribute)
+    def _patch_inverses(self, dataset: DatasetIter) -> list[TransformInverse]:
+        """The patch-level transforms of the mirrored group that each patch is passed back through,
+        last applied first."""
+        return [
+            transform
+            for transform in reversed(dataset.groups_src[self.group_src][self.group_dest].patch_transforms)
+            if isinstance(transform, TransformInverse) and transform.apply_inverse
+        ]
 
     def _blend_patch(
         self, index_dataset: int, index_patch: int, layer: torch.Tensor, accumulator: Accumulator
@@ -1334,7 +1361,11 @@ class OutSameAsGroupDataset(OutputDataset):
             # gate) whether the whole finalize chain stays on the GPU or moves back to the host.
             results.append(layer)
 
-        # Mean, Median -> [1, C, ...] | Concat -> [M, C, ...]
+        # Mean, Median -> [1, C, ...] | Concat -> [M, C, ...]. A lone chunk stacks as a view: the copy
+        # torch.stack made was the assembled volume, 448 MiB and 54 ms for a [14, 256^3] fp16 case
+        # (measured), once per augmentation. No reduction writes into what it is handed.
+        if len(results) == 1:
+            return results[0].unsqueeze(0)
         return torch.stack(results, dim=0)
 
     def _reduction_device(self, chunk: torch.Tensor, nb_chunks: int = 1) -> torch.device:
@@ -1477,6 +1508,35 @@ class OutputDatasetLoader:
         )()
 
 
+def _prediction_report(clock: SweepClock, min_seconds: float = 1.0) -> str | None:
+    """One line accounting for the prediction loop's wall clock, in the sweep report's shape, or
+    ``None`` below ``min_seconds``.
+
+    The sum before the bar is the loop's own thread and closes exactly: what its phases do not
+    name (the logging, the progress bar, the bookkeeping between them) is ``other``. ``fetch`` is
+    the wait for the loader's next batch, ``blend`` a patch's inverses and its blend into the
+    accumulator (the copy home included on the host route), the two ``finalize`` the slabs and the
+    cases handed to the writer, ``drain`` the writes still queued when the loop ends. On a GPU the
+    loop only enqueues the forward and the blend; the device's time is waited for where a result
+    crosses to the host.
+
+    After the bar is the writer: its own thread's time, and how long the loop stood waiting on it
+    inside the finalize phases (a full queue, or the write itself when the destination keeps it
+    inline). A slow destination shows there, as the wait that turns the background writer
+    synchronous, which nothing reported before.
+    """
+    wall = clock.spent("prediction")
+    if wall < min_seconds:
+        return None
+    phases = ("fetch", "forward", "blend", "finalize(stream)", "finalize(case)", "drain")
+    named = {phase: clock.spent(phase) for phase in phases}
+    parts = " + ".join(f"{phase} {value:.1f}" for phase, value in named.items())
+    return (
+        f"[KonfAI] prediction {wall:.1f} s = {parts} + other {wall - sum(named.values()):.1f}"
+        f" | writer {clock.spent('write'):.1f} s, waited on {clock.spent('wait(write)'):.1f} s"
+    )
+
+
 class _Predictor:
     """
     Internal class that runs distributed inference over a dataset using a composite model.
@@ -1581,17 +1641,24 @@ class _Predictor:
         self.model_composite.eval()
         self.model_composite.module.set_state(NetState.PREDICTION)
         self.dataloader_prediction.dataset.load("Prediction")
+        PREDICTION_CLOCK.reset()
         try:
-            self._run_batches()
+            with PREDICTION_CLOCK.phase("prediction"):
+                self._run_batches()
         finally:
             # Every submitted write must be on disk before the run returns: including on the error
             # path, where the drain also closes the sinks the abort operations enqueued.
-            for output_dataset in self.outputs_dataset.values():
-                output_dataset.finalize_writes()
+            with PREDICTION_CLOCK.phase("prediction"), PREDICTION_CLOCK.phase("drain"):
+                for output_dataset in self.outputs_dataset.values():
+                    output_dataset.finalize_writes()
+        if self.global_rank == 0:
+            clock = _prediction_report(PREDICTION_CLOCK)
+            if clock is not None:
+                print(clock)
 
     def _run_batches(self) -> None:
         with tqdm.tqdm(
-            iterable=enumerate(self.dataloader_prediction),
+            iterable=enumerate(PREDICTION_CLOCK.waiting("fetch", self.dataloader_prediction)),
             leave=True,
             desc=f"Prediction : {description(self.model_composite)}",
             total=len(self.dataloader_prediction),
@@ -1599,11 +1666,12 @@ class _Predictor:
         ) as batch_iter:
             with torch.inference_mode():
                 with torch.amp.autocast("cuda", enabled=self.autocast):
-                    for _, batch_sample in batch_iter:
-                        outputs = self.model_composite(
-                            batch_sample,
-                            list(self.outputs_dataset.keys()),
-                        )
+                    for batch_index, batch_sample in batch_iter:
+                        with PREDICTION_CLOCK.phase("forward"):
+                            outputs = self.model_composite(
+                                batch_sample,
+                                list(self.outputs_dataset.keys()),
+                            )
                         self._predict_log(batch_sample)
                         for name, number_of_channels_per_model, output in outputs:
                             output_dataset = self.outputs_dataset[name]
@@ -1629,13 +1697,20 @@ class _Predictor:
                                     number_of_channels_per_model,
                                 )
                                 if output_dataset.is_done(index):
-                                    output_dataset.write_prediction(
-                                        index,
-                                        batch_sample[group].name[i],
-                                        output_dataset.get_output(index, number_of_channels_per_model, self.dataset),
-                                    )
+                                    with PREDICTION_CLOCK.phase("finalize(case)"):
+                                        output_dataset.write_prediction(
+                                            index,
+                                            batch_sample[group].name[i],
+                                            output_dataset.get_output(
+                                                index, number_of_channels_per_model, self.dataset
+                                            ),
+                                        )
 
-                        batch_iter.set_description(f"Prediction : {description(self.model_composite)}")
+                        if batch_index % _DESCRIPTION_EVERY == 0:
+                            # The bar redraws on its own clock; the status only has to be there by then.
+                            batch_iter.set_description(
+                                f"Prediction : {description(self.model_composite)}", refresh=False
+                            )
                         self.it += 1
 
     def _predict_log(
@@ -1884,7 +1959,10 @@ class ModelComposite(Network):
                         sum_acc[key].add_(tensor)
                     count[key] += 1
             for key, acc in sum_acc.items():
-                final_outputs.append((key, channels[key], (acc / count[key])))
+                # The sum was folded in place into the first model's output; a lone model's is the
+                # answer as it stands. Dividing by one copied the batch output (56 MiB per
+                # [1, 14, 128^3] fp16 patch, 512 MiB at 122 channels), on every single-model run.
+                final_outputs.append((key, channels[key], acc if count[key] == 1 else acc.div_(count[key])))
         else:
             aggregated = defaultdict(list)
             for model_index in range(n_replicas):

--- a/tests/unit/test_case_reduction.py
+++ b/tests/unit/test_case_reduction.py
@@ -501,7 +501,7 @@ def test_a_single_case_is_its_own_vote() -> None:
     [
         (Mean(), 1, 2, "one running accumulator and the region coming into it"),
         (Median(), 1, int(3.5 * CASES) + 1, "the cohort, what the four-member network holds beside it, the output"),
-        (Vote(), 1, 3 * CASES + 1, "same shape of work: a mode sorts a copy of the stack too"),
+        (Vote(), 1, CASES + 5, "the cohort, the fixed planes the running best holds beside it, the output"),
         (Concat(), CASES, 2 * CASES, "the cohort, and the concatenation that IS the output"),
     ],
     ids=["mean", "median", "vote", "concat"],
@@ -549,6 +549,35 @@ def test_median_selects_the_middle_instead_of_sorting_the_stack(cases: int) -> N
     assert Median().working_multiple_for(cases) == {1: 1.0, 2: 1.5, 3: 1.0, 4: 2.5, 5: 1.5}.get(cases, 4.0)
 
 
+@pytest.mark.parametrize(
+    "dtype", [torch.float16, torch.bfloat16, torch.uint8, torch.int16, torch.int32, torch.int64, torch.float64]
+)
+def test_mean_promotes_each_member_inside_the_add(dtype: torch.dtype) -> None:
+    """A member is added at its own dtype and the kernel casts it to float32 on the way: the
+    float() that ran first materialised a float32 copy of the member beside the total (64 MiB per
+    32 MiB fp16 member; one allocation per member on CUDA, none now, measured). That spelling is
+    the oracle here, dtype by dtype: the same bits, float64 included, which the fold still narrows
+    first because the kernel would otherwise add at 64 bits and round after.
+    """
+    torch.manual_seed(0)
+    if dtype.is_floating_point:
+        members = [(torch.randn(1, 1, 3, 5, 7, dtype=torch.float64) * 1e3).to(dtype) for _ in range(4)]
+    else:
+        bound = min(torch.iinfo(dtype).max, 2**30)
+        members = [
+            torch.randint(max(torch.iinfo(dtype).min, -bound), bound, (1, 1, 3, 5, 7), dtype=dtype) for _ in range(4)
+        ]
+
+    total = members[0].to(torch.float32, copy=True)
+    for member in members[1:]:
+        total.add_(member.float())
+    oracle = total.div_(len(members)).to(dtype if dtype.is_floating_point else torch.float32)
+
+    folded = Mean()(members)
+    assert folded.dtype is oracle.dtype
+    assert torch.equal(folded, oracle)
+
+
 def test_a_vote_tie_goes_to_the_smallest_label_whatever_the_cohort_order() -> None:
     """The reproducibility half of Vote's contract, which its docstring promises out loud.
 
@@ -564,6 +593,38 @@ def test_a_vote_tie_goes_to_the_smallest_label_whatever_the_cohort_order() -> No
     # A majority still beats the smallest label: the tie rule is a tie-breaker, not a preference.
     counted = [torch.full((1, 1, 2, 2), value, dtype=torch.uint8) for value in (9, 2, 9)]
     assert int(Vote()(counted).flatten()[0]) == 9
+
+
+def _vote_by_sorting(tensors: list[torch.Tensor]) -> torch.Tensor:
+    """The stack sorted along the case axis and counted member by member: the spelling Vote
+    shipped with, kept as the oracle of its labels and its tie rule."""
+    ranked = torch.stack(tensors, dim=0).sort(dim=0).values
+    best, best_count = ranked[0], (ranked == ranked[0]).sum(dim=0, dtype=torch.int16)
+    for member in ranked[1:]:
+        count = (ranked == member).sum(dim=0, dtype=torch.int16)
+        better = count > best_count
+        best = torch.where(better, member, best)
+        best_count = torch.where(better, count, best_count)
+    return best
+
+
+@pytest.mark.parametrize("cases", [2, 3, 4, 6, 7])
+@pytest.mark.parametrize("dtype", [torch.uint8, torch.int16, torch.int32, torch.float32])
+def test_vote_counts_every_candidate_instead_of_sorting_the_stack(cases: int, dtype: torch.dtype) -> None:
+    """The label with the most votes, the smallest on a tie, found by a running best over each
+    member's count: no stack and no sort, whose int64 indices alone were 8 bytes per voxel and
+    member. Measured on a 128-row slab of six 512x512 uint8 members on CUDA: 1920 MiB and 64 ms
+    sorted, 256 MiB and 11 ms here; on the host, 351 -> 127 ms at two members. The sorted
+    spelling is the oracle: the same labels to the bit on cohorts drawn from four labels, where
+    most voxels tie.
+    """
+    torch.manual_seed(cases)
+    members = [torch.randint(0, 4, (1, 1, 5, 6, 7)).to(dtype) for _ in range(cases)]
+    voted = Vote()(members)
+    assert voted.dtype is dtype
+    assert torch.equal(voted, _vote_by_sorting(members))
+    assert Vote().working_multiple_for(cases) == 4.0 / cases
+    assert Vote().working_multiple_for(1) == 0.0
 
 
 def test_a_budget_with_room_folds_the_whole_volume(tmp_path: Path) -> None:

--- a/tests/unit/test_patching.py
+++ b/tests/unit/test_patching.py
@@ -638,6 +638,34 @@ def test_trim_kept_boxes_partition_the_volume(shape, patch, overlap):
     assert int(hits.max()) == 1, f"{int((hits > 1).sum())} voxel(s) written by more than one patch"
 
 
+def test_trim_kept_boxes_are_cached_per_axis_position_not_per_patch():
+    """A kept box is the product of one span per axis, so the cache holds one span per (axis,
+    start): sum(n_d) entries for prod(n_d) patches, and the grid's starts are read off the slices
+    once. Keyed per patch, every patch missed and each miss re-sorted the starts of every patch:
+    O(P^2) over a case (15.6 s for 18,000 thin 2.5D patches, 16 ms here, measured).
+
+    The boxes themselves come from the same window nonzero run, checked against a derivation that
+    reads the windows position by position.
+    """
+    shape, patch, overlap = [20, 22, 24], [8, 8, 8], 4
+    slices, _ = get_patch_slices_from_shape(patch, shape, overlap)
+    combine = Trim()
+    combine.set_patch_config(patch, overlap)
+    accumulator = Accumulator(slices, patch, patch_combine=combine, batch=False)
+
+    starts = [sorted({s[dim].start for s in accumulator.patch_slices}) for dim in range(len(shape))]
+    expected = {}
+    for dim, axis_starts in enumerate(starts):
+        for position, start in enumerate(axis_starts):
+            ones = combine.window(dim, position, len(axis_starts)).nonzero().flatten()
+            expected[dim, start] = slice(int(ones[0]), int(ones[-1]) + 1)
+    boxes = [accumulator._kept_box(patch_slice) for patch_slice in accumulator.patch_slices]
+
+    assert boxes == [tuple(expected[dim, s.start] for dim, s in enumerate(p)) for p in accumulator.patch_slices]
+    assert len(accumulator._kept) == sum(len(axis_starts) for axis_starts in starts) < len(slices)
+    assert [list(positions) for positions in accumulator._positions()] == starts
+
+
 def test_trim_keeps_the_patch_whole_when_there_is_nothing_to_trim():
     """An overlap at least as wide as the patch leaves no central band; keep the patch instead.
 
@@ -646,6 +674,33 @@ def test_trim_keeps_the_patch_whole_when_there_is_nothing_to_trim():
     """
     for size, overlap in ((4, 4), (3, 4), (1, 2), (2, 3)):
         assert torch.equal(Trim()._window_1d(size, overlap), torch.ones(size)), (size, overlap)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.int16, torch.uint8])
+def test_border_patches_pad_with_the_patch_minimum_kept_on_the_device(dtype):
+    """Under ``pad_value=None`` a border patch pads with its own minimum (a uint8 map with zero).
+
+    The minimum is filled from the 0-d device tensor, never read back through ``.item()``, which
+    drained the CUDA stream once per padded patch: 37 of the 64 patches of a 100^3 case at 32^3,
+    measured, and none now. The values are those of the ``.item()`` spelling to the bit, which is
+    the oracle here (a padded patch keeps every band, on every axis that pads).
+    """
+    torch.manual_seed(0)
+    shape = [7, 9, 10]
+    data = (torch.randn(2, *shape) * 40).to(dtype)
+    patch = DatasetPatch(patch_size=[4, 4, 4], overlap=0)
+    assert patch.pad_value is None
+    patch.load(shape)
+
+    padded = 0
+    for index in range(patch.get_size()):
+        plan = patch.get_read_plan(list(data.shape), index, 0, True)
+        window = data[plan.data_slices]
+        pad_with = 0 if dtype is torch.uint8 else float(window.min().item())
+        oracle = torch.nn.functional.pad(window, plan.constant_padding, "constant", pad_with)
+        padded += any(plan.constant_padding)
+        assert torch.equal(patch.get_data(data, index, 0, True), oracle)
+    assert padded > 0
 
 
 @pytest.mark.parametrize("sweep_axis", [0, 1, 2])

--- a/tests/unit/test_predictor.py
+++ b/tests/unit/test_predictor.py
@@ -23,12 +23,25 @@ re-raised), but only when the destination serves disjoint files per entry
 ever written from two threads. Pure ``threading``/``queue``, no fork and no signals, so the behaviour
 is the same on Linux, macOS and Windows."""
 
+import time
+
 import pytest
 import torch
 from konfai.data.augmentation import Flip
-from konfai.predictor import _AsyncWriter
+from konfai.predictor import PREDICTION_CLOCK, _AsyncWriter
 from konfai.utils.dataset import Dataset
 from konfai.utils.errors import PredictorError
+
+
+def test_async_writer_charges_its_writes_to_the_writer_s_own_phase() -> None:
+    """The writer thread is the one thread charging ``write``, so the report can set the writer's
+    time beside how long the loop waited on it: a submission into a queue with room is no wait."""
+    PREDICTION_CLOCK.reset()
+    writer = _AsyncWriter()
+    writer.submit(lambda: time.sleep(0.05))
+    writer.close()
+    assert PREDICTION_CLOCK.spent("write") >= 0.05
+    assert PREDICTION_CLOCK.spent("wait(write)") == 0.0
 
 
 def test_async_writer_runs_in_order_and_surfaces_failures() -> None:

--- a/tests/unit/test_predictor_memory.py
+++ b/tests/unit/test_predictor_memory.py
@@ -19,9 +19,20 @@ from typing import Any, ClassVar, cast
 import numpy as np
 import pytest
 import torch
+import tqdm
 from konfai.data.data_manager import BatchDataItem, DatasetIter
+from konfai.data.patching import SweepClock
+from konfai.data.transform import TransformInverse
 from konfai.network.network import Network
-from konfai.predictor import Mean, ModelComposite, OutSameAsGroupDataset, _colocate_loaded_modules, _Predictor
+from konfai.predictor import (
+    PREDICTION_CLOCK,
+    Mean,
+    ModelComposite,
+    OutSameAsGroupDataset,
+    _colocate_loaded_modules,
+    _prediction_report,
+    _Predictor,
+)
 from konfai.utils.dataset import Attribute
 
 
@@ -70,6 +81,44 @@ def test_model_composite_streams_ensemble_through_a_single_loaded_model() -> Non
     assert isinstance(streamed_model, DummyPredictNetwork)
     assert streamed_model.load_history == [1.0, 3.0]
     assert streamed_model.load_name_history == ["DummyPredictNetwork", "DummyPredictNetwork"]
+
+
+def test_model_composite_hands_over_a_lone_model_output_and_folds_an_ensemble_in_place() -> None:
+    """A single-model run hands the model's own output on: dividing it by one copied every batch
+    output (56 MiB per [1, 14, 128^3] fp16 patch; 2 allocations per forward measured against 1).
+    An ensemble's mean is folded into the first output in place, the same values as the
+    out-of-place quotient to the bit.
+    """
+
+    class RecordingNetwork(DummyPredictNetwork):
+        def forward(self, batch_sample, output_layers=[]):  # type: ignore[override]
+            self.last = next(iter(batch_sample.values())).tensor * self.scale
+            return [("out", self.last)]
+
+    def batch() -> dict[str, BatchDataItem]:
+        torch.manual_seed(0)
+        return {
+            "input": BatchDataItem(
+                name=["CASE_000"],
+                tensor=torch.randn(1, 1, 4, 4, dtype=torch.float16),
+                attribute=[Attribute()],
+                x=[0],
+                a=[0],
+                p=[0],
+                is_input=True,
+            )
+        }
+
+    composite = ModelComposite(RecordingNetwork(), Mean())
+    composite.load([{"scale": 3.0}])
+    output = composite(batch(), ["out"])[0][2]
+    assert output is cast(RecordingNetwork, composite["Model_0"]).last
+
+    composite = ModelComposite(RecordingNetwork(), Mean())
+    composite.load([{"scale": 1.0}, {"scale": 3.0}, {"scale": 5.0}])
+    folded = composite(batch(), ["out"])[0][2]
+    outputs = [batch()["input"].tensor * scale for scale in (1.0, 3.0, 5.0)]
+    assert torch.equal(folded, (outputs[0] + outputs[1] + outputs[2]) / 3)
 
 
 def test_model_composite_runs_a_weightless_model_without_a_checkpoint() -> None:
@@ -256,6 +305,153 @@ def test_output_dataset_offloads_patch_predictions_to_cpu_before_accumulating() 
     assert accumulator._result.device.type == "cpu"
 
 
+def _single_patch_dataset_iter() -> DatasetIter:
+    """A dataset double whose one case is one 2x2 patch, swept along axis 0, with no patch transform."""
+
+    class DummyPatch:
+        patch_size: ClassVar[list[int]] = [2, 2]
+
+        @staticmethod
+        def get_patch_slices(index_augmentation: int):
+            del index_augmentation
+            return [(slice(0, 2), slice(0, 2))]
+
+        @staticmethod
+        def get_sweep_axis(index_augmentation: int) -> int:
+            del index_augmentation
+            return 0
+
+    class DummyManager:
+        name = "CASE_000"
+        patch = DummyPatch()
+        cache_attributes: ClassVar[list[Attribute]] = [Attribute({"Origin": [0.0, 0.0]})]
+
+    class DummyGroupTransform:
+        patch_transforms: ClassVar[list[object]] = []
+
+    class DummyDatasetIter:
+        groups_src: ClassVar[dict[str, dict[str, object]]] = {"src": {"dest": DummyGroupTransform()}}
+
+        @staticmethod
+        def get_dataset_from_index(group_dest: str, index: int):
+            assert group_dest == "dest"
+            assert index == 0
+            return DummyManager()
+
+    return cast(DatasetIter, DummyDatasetIter())
+
+
+def _three_patch_dataset_iter(patch_transforms: list[object]) -> DatasetIter:
+    """A dataset double whose one case is three 2x2 patches down axis 0, mirroring ``patch_transforms``."""
+
+    class DummyPatch:
+        patch_size: ClassVar[list[int]] = [2, 2]
+
+        @staticmethod
+        def get_patch_slices(index_augmentation: int):
+            del index_augmentation
+            return [(slice(row, row + 2), slice(0, 2)) for row in (0, 2, 4)]
+
+        @staticmethod
+        def get_sweep_axis(index_augmentation: int) -> int:
+            del index_augmentation
+            return 0
+
+    class DummyManager:
+        name = "CASE_000"
+        patch = DummyPatch()
+        cache_attributes: ClassVar[list[Attribute]] = [Attribute({"Origin": [0.0, 0.0]})]
+
+    class DummyGroupTransform:
+        pass
+
+    group = DummyGroupTransform()
+    group.patch_transforms = patch_transforms  # type: ignore[attr-defined]
+
+    class DummyDatasetIter:
+        groups_src: ClassVar[dict[str, dict[str, object]]] = {"src": {"dest": group}}
+
+        @staticmethod
+        def get_dataset_from_index(group_dest: str, index: int):
+            assert group_dest == "dest"
+            assert index == 0
+            return DummyManager()
+
+    return cast(DatasetIter, DummyDatasetIter())
+
+
+def test_patch_headers_are_copied_only_for_a_patch_inverse_to_undo_on() -> None:
+    """One header per (case, augmentation), at index 0, unless a patch-level inverse reads one per
+    patch: then every patch gets a copy of its own, taken before any inverse ran, so what one
+    inverse pushes never reaches the next patch's. On a grid of 18,000 thin 2.5D patches with
+    nothing to undo the copies cost 473 ms and 18,000 dicts held per (case, augmentation),
+    measured; 17 ms and one header now.
+    """
+
+    class Undo(TransformInverse):
+        def __init__(self) -> None:
+            super().__init__(inverse=True)
+            self.undone_on: list[Attribute] = []
+
+        def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
+            return tensor
+
+        def inverse(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
+            cache_attribute["Undone"] = 1
+            self.undone_on.append(cache_attribute)
+            return tensor
+
+    def output_dataset() -> OutSameAsGroupDataset:
+        return OutSameAsGroupDataset(
+            same_as_group="src:dest",
+            dataset_filename="./Output:mha",
+            group="out",
+            patch_combine=None,
+            reduction="Mean",
+        )
+
+    plain = output_dataset()
+    for index_patch in range(3):
+        plain.add_layer(0, 0, index_patch, torch.zeros(1, 2, 2), _three_patch_dataset_iter([]), Attribute())
+    assert list(plain.attributes[0][0]) == [0]
+
+    undo = Undo()
+    inverted = output_dataset()
+    for index_patch in range(3):
+        inverted.add_layer(0, 0, index_patch, torch.zeros(1, 2, 2), _three_patch_dataset_iter([undo]), Attribute())
+    headers = inverted.attributes[0][0]
+    assert list(headers) == [0, 1, 2]
+    assert [undone is headers[index_patch] for index_patch, undone in enumerate(undo.undone_on)] == [True] * 3
+    assert all("Undone_0" in header and "Undone_1" not in header for header in headers.values())
+
+
+def test_get_output_hands_the_assembled_volume_on_as_a_view() -> None:
+    """One model chunk: the assembled volume reaches the reduction without a copy.
+
+    Stacking a lone chunk copied it: 448 MiB and 54 ms per copy of a [14, 256^3] fp16 case,
+    measured, once per augmentation. No reduction writes into what it is handed (a Mean of one is
+    the member itself, a fold of several copies first, Median/Vote/Concat build a new tensor), so
+    the accumulator's own buffer, which assemble() has already let go of, can be the answer.
+    """
+    output_dataset = OutSameAsGroupDataset(
+        same_as_group="src:dest",
+        dataset_filename="./Output:mha",
+        group="out",
+        patch_combine=None,
+        reduction="Mean",
+    )
+    dataset = _single_patch_dataset_iter()
+    output_dataset.add_layer(0, 0, 0, torch.arange(12, dtype=torch.float32).reshape(3, 2, 2), dataset, Attribute())
+    assembled = output_dataset.output_layer_accumulator[0][0]._result
+    assert assembled is not None
+
+    stacked = output_dataset._get_output(0, 0, [3], dataset)
+
+    assert stacked.shape == (1, 3, 2, 2)
+    assert stacked.data_ptr() == assembled.data_ptr()
+    assert torch.equal(stacked[0], torch.arange(12, dtype=torch.float32).reshape(3, 2, 2))
+
+
 def test_predict_log_skips_measure_sync_when_tensorboard_is_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     predictor = _Predictor.__new__(_Predictor)
     predictor_any = cast(Any, predictor)
@@ -274,9 +470,10 @@ def test_predict_log_skips_measure_sync_when_tensorboard_is_disabled(monkeypatch
     predictor._predict_log({})
 
 
-def test_predictor_runs_prediction_logging_once_per_batch_even_with_multiple_outputs(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def _loop_doubles(batches: int) -> tuple[_Predictor, Any, dict[str, Any], Any]:
+    """A ``_Predictor`` over ``batches`` identical one-patch batches of one case, two outputs done at
+    every batch, no TensorBoard: the doubles the loop tests drive."""
+
     class DummyPredictionDataset:
         def __init__(self) -> None:
             self.labels: list[str] = []
@@ -360,7 +557,7 @@ def test_predictor_runs_prediction_logging_once_per_batch_even_with_multiple_out
             is_input=True,
         )
     }
-    loader = DummyPredictionLoader([batch], dataset)
+    loader = DummyPredictionLoader([batch] * batches, dataset)
     outputs_dataset = {"out_a": DummyOutputDataset(), "out_b": DummyOutputDataset()}
     model_composite = DummyComposite()
 
@@ -376,6 +573,13 @@ def test_predictor_runs_prediction_logging_once_per_batch_even_with_multiple_out
     predictor_any.it = 0
     predictor_any.dataset = dataset
     predictor_any.tb = None
+    return predictor, dataset, outputs_dataset, model_composite
+
+
+def test_predictor_runs_prediction_logging_once_per_batch_even_with_multiple_outputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    predictor, dataset, outputs_dataset, model_composite = _loop_doubles(batches=1)
 
     log_calls: list[int] = []
     monkeypatch.setattr(predictor, "_predict_log", lambda batch_sample: log_calls.append(len(batch_sample)))
@@ -388,6 +592,63 @@ def test_predictor_runs_prediction_logging_once_per_batch_even_with_multiple_out
     assert model_composite.eval_calls == 1
     assert outputs_dataset["out_a"].writes == 1
     assert outputs_dataset["out_b"].writes == 1
+
+
+def test_prediction_loop_refreshes_its_status_every_tenth_batch_and_clocks_its_phases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bar's status (an NVML query, two psutil calls and a forced redraw: 95 us per batch,
+    measured) is set every ``_DESCRIPTION_EVERY`` batches without a redraw; the bar redraws on its
+    own clock. The loop charges ``PREDICTION_CLOCK``: the fetch of each batch, the forward, the
+    case finalize, and the run's wall, which bounds their sum; a run under a second reports nothing.
+    """
+    predictor, _dataset, outputs_dataset, _model_composite = _loop_doubles(batches=25)
+    monkeypatch.setattr(predictor, "_predict_log", lambda batch_sample: None)
+    described: list[str] = []
+    monkeypatch.setattr("konfai.predictor.description", lambda model: described.append("status") or "status")
+    refreshes: list[bool] = []
+    set_description = tqdm.tqdm.set_description
+
+    def recording(self, desc=None, refresh=True):
+        refreshes.append(refresh)
+        return set_description(self, desc, refresh)
+
+    monkeypatch.setattr(tqdm.tqdm, "set_description", recording)
+
+    predictor.run()
+
+    assert outputs_dataset["out_a"].writes == 25
+    assert len(described) == 1 + 3, "the bar's own description, then batches 0, 10 and 20"
+    assert refreshes == [False] * 3
+    clock = PREDICTION_CLOCK
+    assert clock.spent("fetch") > 0 and clock.spent("forward") > 0 and clock.spent("finalize(case)") > 0
+    assert clock.spent("prediction") >= clock.spent("fetch") + clock.spent("forward") + clock.spent("finalize(case)")
+    assert _prediction_report(clock) is None
+
+
+def test_prediction_report_closes_on_the_loop_s_own_thread() -> None:
+    """The sum before the bar is the loop's thread and closes exactly (what no phase names is
+    ``other``); after it, the writer's own time and how long the loop waited on it."""
+    clock = SweepClock()
+    spent = {
+        "prediction": 10.0,
+        "fetch": 1.0,
+        "forward": 5.0,
+        "blend": 2.0,
+        "finalize(stream)": 0.6,
+        "finalize(case)": 0.2,
+        "drain": 0.2,
+        "write": 3.0,
+        "wait(write)": 0.5,
+    }
+    clock._spent = dict(spent)
+
+    assert _prediction_report(clock) == (
+        "[KonfAI] prediction 10.0 s = fetch 1.0 + forward 5.0 + blend 2.0 + finalize(stream) 0.6"
+        " + finalize(case) 0.2 + drain 0.2 + other 1.0 | writer 3.0 s, waited on 0.5 s"
+    )
+    clock._spent = {"prediction": 0.9}
+    assert _prediction_report(clock) is None
 
 
 def test_gate_approved_blend_falls_back_to_cpu_when_the_allocation_fails() -> None:


### PR DESCRIPTION

## Summary

Eight performance changes on the prediction path and the reductions it shares with `Reduce`, folded into `perf(predictor): fold an ensemble in place, and clock the loop`. Trim's kept spans are cached per (axis, start) instead of being re-sorted per patch; `ModelComposite` hands a lone model's output on as it stands and divides an ensemble's sum in place; a lone model chunk reaches the reduction as a view rather than a `torch.stack` copy; `Mean.accumulate` adds each member at its own dtype and lets the kernel promote it; `Vote` counts each candidate's votes instead of sorting the stack (no int64 index tensor), and its `working_multiple_for` is now the planes the fold holds (`4 / cases`, the attribute being the two-member worst case); `_ensure_case_state` copies a patch's header only when a patch-level inverse will read it; a border patch under `pad_value=None` pads from the 0-d minimum on the device, with no host sync; the progress bar's status is set every ten batches with `refresh=False`, and the loop charges its phases (`fetch`, `forward`, `blend`, `finalize(stream)`, `finalize(case)`, `drain`, and the writer's own `write` with `wait(write)`) to a `SweepClock` of its own, `PREDICTION_CLOCK`, printed by rank 0 in the sweep report's shape for a loop over a second. The prediction config guide documents that line.

## Measured

| Change | Script | Before -> after |
|---|---|---|
| Trim kept spans, every patch of a grid, best of 3 | `.scratch/bench_kept_box.py` | P=1,331 (544^3 at 64^3, overlap 16): 95.6 ms -> 1.0 ms; P=18,000 (720x512x512 at 1x128x128, ov 32): 15.55 s -> 16 ms; P=79,507 (2048^3 at 64^3, overlap 16): killed at 900 s -> 46 ms |
| `ModelComposite` divide, per forward on CUDA, [1, 14, 128^3] fp16 | `.scratch/bench_composite_div.py` | 1 model: 2 allocations, 112 MiB, peak 112 MiB above resident -> 1, 56 MiB, 56 MiB; 2 models: 3 allocations, 168 MiB, peak 168 MiB -> 2, 112 MiB, 112 MiB |
| Lone chunk to the reduction, [14, 256^3] fp16, 448 MiB | `.scratch/bench_stack_lone.py` | `torch.stack([x])` 53.8 ms best of 5 (53.8 to 91.2), a new storage -> `x.unsqueeze(0)` 0.0 ms, the same storage |
| `Mean.accumulate`, 32 MiB member into a float32 total | `.scratch/bench_mean_accumulate.py` | CUDA fp16/uint8/int16/int32: 1 allocation, 64 MiB above resident -> 0 allocations, 0 MiB; CPU: a 64 MiB temporary either way, wall clock the same (fp16 23 vs 27 ms best of 7, int16 19 vs 19) |
| `Vote`, 128-row slab of 512x512 members, best of 3, peak above the members | `.scratch/bench_vote.py`, `bench_vote_after.py` | CUDA uint8 K=2: 640 MiB, 13 allocations, 34 ms -> 192 MiB, 11, 2.0 ms; K=6: 1920 MiB, 37, 63 ms -> 256 MiB, 71, 16 ms. CUDA int16 K=2: 768 MiB, 13, 36 ms -> 192 MiB, 11, 2.6 ms; K=6: 2304 MiB, 37, 70 ms -> 288 MiB, 71, 16 ms. CPU uint8 K=2: 438 -> 232 ms, K=6: 1803 -> 1190 ms; int16 K=2: 438 -> 266 ms, K=6: 1900 -> 1184 ms (load average 38 to 48 at the time) |
| `_ensure_case_state`, 18,000 thin 2.5D patches, no patch transform, 8 keys per header, best of 5 | `.scratch/bench_case_state.py` | 473 ms, 18,000 headers held -> 17 ms, 1 header held (the 17 ms is the accumulator reading its 18,000 slices) |
| Border-patch padding, 100^3 fp16 case at 32^3, 64 patches, 37 padded, `torch.cuda.set_sync_debug_mode` | `.scratch/bench_read_plan_sync.py` | 37 host syncs during the reads -> 0 |
| Progress-bar status, per call | `.scratch/bench_description.py` | `gpu_info` 46 us, `get_memory_info` 40 us, `set_description(refresh=True)` 8 us against 0 us deferred: ~95 us per batch -> ~10 us per batch |

`torch.mode` was measured and stays out of `Vote`: its tie-break differs by device, 4501 of 28672 voxels of a six-member fold on CUDA against the CPU's smallest label.

**Values:** nothing moves. The Trim boxes are the same window nonzero run, and the sha256 of every box of the first two grids is equal before and after. `torch.equal` pins the arithmetic against the previous spelling kept as the oracle: a three-model ensemble against the out-of-place quotient; the `Mean` sum for every dtype float32 promotes over (fp16, bf16, every integer width; a float64 member is still narrowed first, as before); `Vote` for two to nine members of uint8, int16, int32 and float32 labels on CPU and CUDA, against the sorted spelling; the padded patches on float32, fp16, int16 and uint8, against the `.item()` spelling. The lone chunk handed on is the assembled volume itself, and nothing else holds the buffer; a case with a patch inverse gets the same per-patch header copies of the same source, each patch undone on its own copy. The clock adds two `perf_counter` calls per phase and touches nothing in the data path.

**Tests:** `tests/unit/test_patching.py` (`test_trim_kept_boxes_are_cached_per_axis_position_not_per_patch`, `test_border_patches_pad_with_the_patch_minimum_kept_on_the_device`), `tests/unit/test_case_reduction.py` (`test_mean_promotes_each_member_inside_the_add`, `test_vote_counts_every_candidate_instead_of_sorting_the_stack`), `tests/unit/test_predictor_memory.py` (`test_model_composite_hands_over_a_lone_model_output_and_folds_an_ensemble_in_place`, `test_patch_headers_are_copied_only_for_a_patch_inverse_to_undo_on`, `test_get_output_hands_the_assembled_volume_on_as_a_view`, `test_predictor_runs_prediction_logging_once_per_batch_even_with_multiple_outputs`, `test_prediction_loop_refreshes_its_status_every_tenth_batch_and_clocks_its_phases`, `test_prediction_report_closes_on_the_loop_s_own_thread`), `tests/unit/test_predictor.py` (`test_async_writer_charges_its_writes_to_the_writer_s_own_phase`).

**Stack:** Stacked on `pr/1.8.2-04-metrics`; merge after it. Before deleting this branch, retarget the next PR of the stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prediction timing reports covering fetching, processing, blending, writing, queue waits, and GPU synchronization.
  * Progress descriptions now update periodically during prediction runs.

* **Performance Improvements**
  * Reduced memory use and unnecessary copying during prediction and result aggregation.
  * Improved patch blending, ensemble reduction, and vote processing efficiency.
  * Optimized asynchronous output writing and finalization.

* **Bug Fixes**
  * Preserved configured padding behavior while improving border-patch handling across data types.

* **Documentation**
  * Documented prediction timing output and the conditions under which it is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->