### PR TITLE
Training: fewer syncs, a fused EMA, a threaded checkpoint, channels-last

### DIFF
--- a/docs/source/config_guide/prediction.md
+++ b/docs/source/config_guide/prediction.md
@@ -49,7 +49,8 @@ When multiple checkpoints are provided, the predictor combines them using the
 | `train_name` | string | `"name"` | Yes in practice | Names the prediction run and output folder. |
 | `manual_seed` | int or null | `None` | No | Optional seed. |
 | `gpu_checkpoints` | list or null | `None` | No | Module placement optimization. |
-| `autocast` | bool | `false` | No | Enables AMP during inference. |
+| `autocast` | bool | `false` | No | Enables AMP during inference. On the shipped Segmentation example: 4.2 s to 2.7 s, 11110 of 58.4 million label voxels change, at boundaries. |
+| `channels_last` | bool | `false` | No | Lays the convolution weights and inputs out channels-last (4-D and 5-D). With `autocast`, 2.7 s to 2.2 s on the same example and no further voxel changes; alone, no gain and 3199 voxels moved by the kernels cuDNN then picks. |
 | `data_log` | list or null | `None` | No | Optional TensorBoard logging. |
 
 ## `Predictor.Model`

--- a/docs/source/config_guide/training.md
+++ b/docs/source/config_guide/training.md
@@ -60,6 +60,7 @@ konfai TRAIN -y --config Config.yml \
 | `it_validation` | int or null | `None` | No | Validation and checkpoint interval in iterations. |
 | `it_lr_update` | int or null | `None` | No | Scheduler-step interval in iterations. `None` steps once per epoch (it resolves to the training dataloader's length). Every resolved config on disk carries this key. |
 | `autocast` | bool | `false` | No | Enables AMP during training. |
+| `channels_last` | bool | `false` | No | Lays the convolution weights and inputs out channels-last (4-D and 5-D). cuDNN picks its kernels by layout: with `autocast` the shipped Segmentation example predicts 1.25x faster; the kernels chosen differ, so labels can move at boundaries (3199 of 58.4 million voxels in fp32 on that example). |
 | `gradient_checkpoints` | list or null | `None` | No | Activates gradient checkpointing on selected modules. |
 | `gpu_checkpoints` | list or null | `None` | No | Pins selected modules to dedicated GPUs. |
 | `ema_decay` | float | `0` | No | Enables exponential moving average tracking when greater than zero. |

--- a/konfai/network/network.py
+++ b/konfai/network/network.py
@@ -634,6 +634,15 @@ def _flat_downsampling(module: torch.nn.Module, ndim: int) -> list[int]:
     return factor
 
 
+def _channels_last(tensor: torch.Tensor) -> torch.Tensor:
+    """``tensor`` in the channels-last layout of its rank, untouched when it has none (a vector, a plane)."""
+    if tensor.dim() == 4:
+        return tensor.contiguous(memory_format=torch.channels_last)
+    if tensor.dim() == 5:
+        return tensor.contiguous(memory_format=torch.channels_last_3d)
+    return tensor
+
+
 class ModuleArgsDict(torch.nn.Module, ABC):
     """Named module graph container supporting KonfAI branch routing metadata."""
 
@@ -665,6 +674,8 @@ class ModuleArgsDict(torch.nn.Module, ABC):
 
     def __init__(self) -> None:
         super().__init__()
+        #: Whether this graph's convolutions run channels-last: set by :meth:`Network.set_channels_last`.
+        self._channels_last = False
         self._modulesArgs: dict[str, ModuleArgsDict.ModuleArgs] = {}
         self._training = NetState.TRAIN
 
@@ -825,6 +836,10 @@ class ModuleArgsDict(torch.nn.Module, ABC):
         self, *inputs: torch.Tensor, attributes: list[list[Attribute]] | None = None
     ) -> Iterator[tuple[str, torch.Tensor]]:
         if len(inputs) > 0:
+            if self._channels_last:
+                # Once, as the graph is entered: cuDNN hands a channels-last input's output back in
+                # that layout, so converting again at every module only recopies what it kept.
+                inputs = tuple(_channels_last(tensor) for tensor in inputs)
             branchs: dict[str, torch.Tensor] = {}
             attribute_branchs: dict[str, list[Attribute]] = {}
             for i, sinput in enumerate(inputs):
@@ -1672,6 +1687,22 @@ class Network(ModuleArgsDict, ABC):
     @_function_network()
     def get_networks(self) -> Self:
         return self
+
+    @staticmethod
+    def set_channels_last(module: ModuleArgsDict) -> ModuleArgsDict:
+        """Lay the graph's convolution weights out channels-last, and its inputs as they enter.
+
+        cuDNN picks its kernels by layout: under autocast the shipped Segmentation example predicts
+        in 2.2 s against 2.7 s in the default layout (fp32: 4.1 against 4.2 s, where the kernels
+        chosen differ on 3199 of 58.4 million label voxels). Off by default, so the default layout
+        is what a run gets unless it asks.
+        """
+        for tensor in (*module.parameters(), *module.buffers()):
+            tensor.data = _channels_last(tensor.data)  # a 4-D and a 5-D weight each take their own layout
+        for submodule in module.modules():
+            if isinstance(submodule, ModuleArgsDict):
+                submodule._channels_last = True
+        return module
 
     @staticmethod
     def to(module: ModuleArgsDict, device: int, _counter: list[int] | None = None):

--- a/konfai/network/network.py
+++ b/konfai/network/network.py
@@ -18,14 +18,16 @@
 
 import importlib
 import inspect
+import math
 import os
 import warnings
 from abc import ABC
-from collections import OrderedDict
+from collections import OrderedDict, deque
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from contextlib import nullcontext
 from enum import Enum
 from functools import partial
+from itertools import islice
 from pathlib import Path
 from typing import Any
 
@@ -43,7 +45,7 @@ from torch.utils.checkpoint import checkpoint
 
 from konfai import konfai_root
 from konfai.data.data_manager import BatchSample
-from konfai.data.patching import Accumulator, ModelPatch
+from konfai.data.patching import Accumulator, ModelPatch, SweepClock
 from konfai.metric.schedulers import Scheduler
 from konfai.utils.config import apply_config, config
 from konfai.utils.errors import ConfigError, MeasureError, TrainerError
@@ -231,6 +233,30 @@ class TargetCriterionsLoader:
         return targets_criterions
 
 
+class _RunningNanMean:
+    """The nan-aware mean of everything added, in O(1) per value: what ``np.nanmean`` over the whole
+    history returns, up to summation order (measured at most 3.2e-14 relative over 5e5 values)."""
+
+    __slots__ = ("count", "total")
+
+    def __init__(self) -> None:
+        self.total = 0.0
+        self.count = 0
+
+    def add(self, value: float) -> None:
+        if not math.isnan(value):
+            self.total += value
+            self.count += 1
+
+    def mean(self) -> float:
+        return self.total / self.count if self.count else float("nan")
+
+
+def _tail(values: deque[float], n: int) -> list[float]:
+    """The last ``n`` values (``n > 0``)."""
+    return list(islice(values, max(0, len(values) - n), None))
+
+
 class Measure:
     """Collect, validate, and aggregate losses or metrics across model outputs."""
 
@@ -251,14 +277,49 @@ class Measure:
             self.target_group = target_group
             self.group = group
 
-            self._loss: list[torch.Tensor] = []
-            self._weight: list[float] = []
-            self._values: list[float] = []
+            # This iteration's (weight, loss) pairs: the gradient's, cleared by ``reset_loss``.
+            self._loss: list[tuple[float, torch.Tensor]] = []
+            # The logging windows, bounded by ``set_window`` to the widest window a consumer reads;
+            # the whole-history consumers read the running means instead, so nothing grows with the run.
+            self._weight: deque[float] = deque()
+            self._values: deque[float] = deque()
+            self._mean = _RunningNanMean()
+            self._mean_weight = _RunningNanMean()
+            self._recorded = 0
+            # Values recorded but not yet in ``_values``: a loss is kept as its 0-d tensor, because
+            # reading it inside the forward stalls the CPU on the whole graph before backward is
+            # enqueued. The consumers read them in one transfer per device (``Measure._materialize``).
+            self._unread: list[float | torch.Tensor] = []
 
         def reset_loss(self) -> None:
             self._loss.clear()
 
+        @property
+        def recorded(self) -> int:
+            """How many values this record has been given, read off their device or not."""
+            return self._recorded
+
+        def set_window(self, n: int) -> None:
+            """Keep at least the last ``n`` values and weights. Grows only; until it is called the
+            history is unbounded."""
+            if self._values.maxlen is not None and self._values.maxlen >= n:
+                return
+            self._values = deque(self._values, maxlen=n)
+            self._weight = deque(self._weight, maxlen=n)
+
+        def _record(self, value: float) -> None:
+            self._values.append(value)
+            self._mean.add(value)
+
+        def values_mean(self, n: int) -> float:
+            """The nan-mean of the last ``n`` values, of the whole history for ``n <= 0``."""
+            return float(np.nanmean(_tail(self._values, n))) if n > 0 else self._mean.mean()
+
+        def weights_mean(self, n: int) -> float:
+            return float(np.nanmean(_tail(self._weight, n))) if n > 0 else self._mean_weight.mean()
+
         def add(self, weight: float, value: torch.Tensor | tuple[torch.Tensor, float | dict[str, float]]) -> None:
+            true_value: float | torch.Tensor
             if isinstance(value, tuple):
                 loss_value, true_value = value
                 if isinstance(true_value, dict):
@@ -269,25 +330,24 @@ class Measure:
                     true_value = float(np.nanmean(numeric)) if numeric else float("nan")
             else:
                 loss_value = value
-                true_value = value.item()
+                true_value = value.detach()
 
-            self._loss.append(loss_value if self.is_loss else loss_value.detach())
-            self._values.append(true_value)
+            self._loss.append((weight, loss_value if self.is_loss else loss_value.detach()))
+            self._unread.append(true_value)
             self._weight.append(weight)
+            self._mean_weight.add(weight)
+            self._recorded += 1
 
         def get_last_loss(self) -> torch.Tensor:
-            return self._loss[-1] * self._weight[-1] if len(self._loss) else torch.zeros(1, requires_grad=True)
+            if not len(self._loss):
+                return torch.zeros(1, requires_grad=True)
+            weight, loss_value = self._loss[-1]
+            return loss_value * weight
 
         def get_loss(self) -> torch.Tensor:
             if not len(self._loss):
                 return torch.zeros(1, requires_grad=True)
-            # ``_weight`` accumulates across iterations for the logging windows while ``_loss`` is
-            # reset every iteration; align the current losses with their own (trailing) weights so a
-            # loss-weight scheduler drives the gradient instead of the first weight ever recorded.
-            weights = self._weight[-len(self._loss) :]
-            return torch.stack(
-                [w * loss_value for w, loss_value in zip(weights, self._loss, strict=False)], dim=0
-            ).mean(dim=0)
+            return torch.stack([weight * loss_value for weight, loss_value in self._loss], dim=0).mean(dim=0)
 
         def __len__(self) -> int:
             return len(self._loss)
@@ -305,6 +365,20 @@ class Measure:
             )
         self._loss: dict[int, dict[str, Measure.Loss]] = {}
         self.scaler: torch.amp.GradScaler | None = None
+        # One forward's targets on the outputs' device, keyed by (group, device) and checked against
+        # the source tensor: a group feeding several outputs (two heads, deep supervision) is
+        # uploaded once. Released at the end of the forward (``Network.forward``).
+        self._targets: dict[tuple[str, torch.device], tuple[torch.Tensor, torch.Tensor]] = {}
+
+    def _target(self, group: str, tensor: torch.Tensor, device: torch.device) -> torch.Tensor:
+        moved = self._targets.get((group, device))
+        if moved is None or moved[0] is not tensor:
+            moved = (tensor, tensor.to(device).detach())
+            self._targets[(group, device)] = moved
+        return moved[1]
+
+    def release_targets(self) -> None:
+        self._targets.clear()
 
     def init(self, model: torch.nn.Module, group_dest: list[str]) -> None:
         outputs_group_rename = {}
@@ -372,16 +446,8 @@ class Measure:
         training: bool,
     ) -> None:
         for target_group in self.outputs_criterions[output_group]:
-            target_data = [
-                batch_data_with_attribute[group][0].to(output[0].device).detach()
-                for group in target_group.split(";")
-                if group in batch_data_with_attribute
-            ]
-            target_attribute = [
-                batch_data_with_attribute[group][1]
-                for group in target_group.split(";")
-                if group in batch_data_with_attribute
-            ]
+            groups = [group for group in target_group.split(";") if group in batch_data_with_attribute]
+            target_attribute = [batch_data_with_attribute[group][1] for group in groups]
 
             for criterion, criterions_attr in self.outputs_criterions[output_group][target_group].items():
                 if it >= criterions_attr.start and (criterions_attr.stop is None or it <= criterions_attr.stop):
@@ -392,6 +458,10 @@ class Measure:
                         criterion.to(output.device)
                         setattr(criterion, "_konfai_device", output.device)  # noqa: B010 -- Module.__setattr__ is Tensor-typed
                     scheduler = self.update_scheduler(criterions_attr.schedulers, it)
+                    # Below the window gate: a criterion outside its start/stop uploads nothing.
+                    target_data = [
+                        self._target(group, batch_data_with_attribute[group][0], output.device) for group in groups
+                    ]
                     if getattr(criterion, "accepts_attributes", False):
                         loss = criterion(output, *target_data, attributes=target_attribute)
                     else:
@@ -446,40 +516,51 @@ class Measure:
             for v in self._loss[group].values():
                 v.reset_loss()
 
+    def _records(self) -> Iterator[tuple[str, "Measure.Loss"]]:
+        for group in self._loss.values():
+            yield from group.items()
+
+    def _materialize(self) -> None:
+        """Append every unread value to its record's window, in the order recorded, reading the
+        tensors off their device in one transfer per device."""
+        records = [record for _, record in self._records() if record._unread]
+        tensors: dict[torch.device, list[torch.Tensor]] = {}
+        for record in records:
+            for value in record._unread:
+                if isinstance(value, torch.Tensor):
+                    tensors.setdefault(value.device, []).append(value.reshape(()))
+        read = {device: iter(torch.stack(batch).tolist()) for device, batch in tensors.items()}
+        for record in records:
+            for value in record._unread:
+                record._record(next(read[value.device]) if isinstance(value, torch.Tensor) else value)
+            record._unread.clear()
+
+    def set_window(self, n: int) -> None:
+        """Keep at least the last ``n`` values and weights per criterion: the widest window a consumer
+        will read. Grows only; without a call the history is unbounded."""
+        for _, record in self._records():
+            record.set_window(n)
+
+    def _read(self, n: int) -> Iterator[tuple[str, "Measure.Loss"]]:
+        """The records given at least ``n`` values, every value read off its device, and the window
+        at least ``n`` wide from now on: a consumer's first read declares what it will keep reading."""
+        self._materialize()
+        if n > 0:
+            self.set_window(n)
+        return ((name, record) for name, record in self._records() if record.recorded >= n)
+
     def get_last_values(self, n: int = 1) -> dict[str, float]:
-        result = {}
-        for group in self._loss.keys():
-            result.update(
-                {
-                    name: np.nanmean(value._values[-n:] if n > 0 else value._values)
-                    for name, value in self._loss[group].items()
-                    if n < 0 or len(value._values) >= n
-                }
-            )
-        return result
+        return {name: record.values_mean(n) for name, record in self._read(n)}
 
     def get_last_weights(self, n: int = 1) -> dict[str, float]:
-        result = {}
-        for group in self._loss.keys():
-            result.update(
-                {
-                    name: np.nanmean(value._weight[-n:] if n > 0 else value._weight)
-                    for name, value in self._loss[group].items()
-                    if n < 0 or len(value._values) >= n
-                }
-            )
-        return result
+        return {name: record.weights_mean(n) for name, record in self._read(n)}
 
     def format_loss(self, is_loss: bool, n: int) -> dict[str, tuple[float, float]]:
-        result = {}
-        for group in self._loss.keys():
-            for name, loss in self._loss[group].items():
-                if loss.is_loss == is_loss and len(loss._values) >= n:
-                    result[name] = (
-                        np.nanmean(loss._weight[-n:]),
-                        np.nanmean(loss._values[-n:]),
-                    )
-        return result
+        return {
+            name: (record.weights_mean(n), record.values_mean(n))
+            for name, record in self._read(n)
+            if record.is_loss == is_loss
+        }
 
     def update_scheduler(self, schedulers: dict[Scheduler, int], it: int) -> Scheduler:
         if not schedulers:
@@ -1445,11 +1526,22 @@ class Network(ModuleArgsDict, ABC):
         self,
         batch_sample: BatchSample,
         output_layers: list[str] = [],
+        clock: SweepClock | None = None,
     ) -> list[tuple[str, torch.Tensor]]:
+        """The graph walk over ``batch_sample``, its criteria evaluated as their output groups complete.
+        ``clock`` charges the criteria to its ``criteria`` phase, apart from the walk."""
         if not len(self.outputsGroup) and not len(output_layers):
             return []
 
         self.reset_loss()
+        try:
+            return self._forward(batch_sample, output_layers, clock)
+        finally:
+            self.release_targets()
+
+    def _forward(
+        self, batch_sample: BatchSample, output_layers: list[str], clock: SweepClock | None
+    ) -> list[tuple[str, torch.Tensor]]:
         results = []
         measure_output_layers = set()
         for _outputs_group in self.outputsGroup:
@@ -1492,14 +1584,15 @@ class Network(ModuleArgsDict, ABC):
                                 if k != output_group[0]
                             }
                         )
-                        output_group.measure.update(
-                            output_group[0],
-                            output_group.layers[output_group[0]],
-                            batch_data_with_attribute,
-                            output_group.network._it,
-                            nb,
-                            self.training,
-                        )
+                        with clock.phase("criteria") if clock is not None else nullcontext():
+                            output_group.measure.update(
+                                output_group[0],
+                                output_group.layers[output_group[0]],
+                                batch_data_with_attribute,
+                                output_group.network._it,
+                                nb,
+                                self.training,
+                            )
                         output_group.clear()
             if name in output_layers:
                 results.append((name, layer))
@@ -1509,6 +1602,11 @@ class Network(ModuleArgsDict, ABC):
     def reset_loss(self):
         if self.measure:
             self.measure.reset_loss()
+
+    @_function_network()
+    def release_targets(self):
+        if self.measure:
+            self.measure.release_targets()
 
     @_function_network()
     def backward(self, model: Any):
@@ -1783,5 +1881,9 @@ class Model:
         self,
         batch_sample: BatchSample,
         output_layers: list[str] = [],
+        clock: SweepClock | None = None,
     ) -> Any:
-        return self.module(batch_sample, output_layers)
+        # Passed only when given: the predictor's ModelComposite has a forward of its own, without it.
+        if clock is None:
+            return self.module(batch_sample, output_layers)
+        return self.module(batch_sample, output_layers, clock=clock)

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -2008,6 +2008,7 @@ class Predictor(DistributedObject):
         manual_seed: int | None = None,
         gpu_checkpoints: list[str] | None = None,
         autocast: bool = False,
+        channels_last: bool = False,
         outputs_dataset: dict[str, OutputDatasetLoader] | None = {"default|Default": OutputDatasetLoader()},
         data_log: list[str] | None = None,
     ) -> None:
@@ -2034,6 +2035,7 @@ class Predictor(DistributedObject):
             self.combine = apply_config(f"{konfai_root()}.{combine}")(getattr(module, name))()
 
         self.autocast = autocast
+        self.channels_last = channels_last
         with startup_clock().phase("model"):
             self.model = model.get_model(train=False)
         self.it = 0
@@ -2210,6 +2212,8 @@ class Predictor(DistributedObject):
             if len(cuda_visible_devices())
             else self.model_composite
         )
+        if self.channels_last:
+            Network.set_channels_last(model_composite)
         if len(cuda_visible_devices()):
             # Co-locate the output writers with the model so their reduction/transforms know the GPU.
             for output_dataset in self.outputs_dataset.values():

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -888,6 +888,7 @@ class Trainer(DistributedObject):
         it_validation: int | None = None,
         it_lr_update: int | None = None,
         autocast: bool = False,
+        channels_last: bool = False,
         gradient_checkpoints: list[str] | None = None,
         gpu_checkpoints: list[str] | None = None,
         ema_decay: float = 0,
@@ -911,6 +912,7 @@ class Trainer(DistributedObject):
         self._vram_patch_candidate: list[int] | None = None
         self._downsampling_factor: list[int] | None = None
         self.autocast = autocast
+        self.channels_last = channels_last
         self.epochs = epochs
         self.epoch = 0
         self.override_lr: float | None = None
@@ -1073,6 +1075,8 @@ class Trainer(DistributedObject):
             dataloaders (list[DataLoader]): Training and validation dataloaders.
         """
         model = Network.to(self.model, local_rank * self.size) if len(cuda_visible_devices()) else self.model
+        if self.channels_last:
+            Network.set_channels_last(model)
         if dist.is_initialized():
             ddp_kwargs: dict[str, object] = {"static_graph": True}
             if len(cuda_visible_devices()) and self.size == 1:
@@ -1082,6 +1086,8 @@ class Trainer(DistributedObject):
             model = Model(model)
         if self.model_ema is not None:
             self.model_ema.module = Network.to(self.model_ema.module, local_rank * self.size)
+            if self.channels_last:
+                Network.set_channels_last(self.model_ema.module)
         device = local_rank * self.size if len(cuda_visible_devices()) else None
         # Round a free patch axis up to the model's valid input multiple before the first step, so the
         # network's skips align instead of crashing on a non-divisible extent; every rank rounds the

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -20,6 +20,7 @@ import math
 import os
 import shutil
 import signal
+import threading
 from collections.abc import Callable
 from contextlib import suppress
 from pathlib import Path
@@ -47,6 +48,7 @@ from konfai import (
     statistics_directory,
 )
 from konfai.data.data_manager import BatchSample, DataTrain
+from konfai.data.patching import SweepClock
 from konfai.network.network import Model, ModelLoader, NetState, Network
 from konfai.utils.config import apply_config, config, strict_config
 from konfai.utils.errors import ConfigError, TrainerError
@@ -170,6 +172,52 @@ class EarlyStopping(EarlyStoppingBase):
         return self.early_stop
 
 
+def _on_host(value: Any) -> Any:
+    """``value`` with every tensor copied into host memory: a snapshot the writer serialises while the
+    training thread moves on. Containers keep their type and attributes (a state dict is an
+    OrderedDict, possibly carrying ``_metadata``), so the file's layout is the one torch.save of the
+    live objects would write."""
+    if isinstance(value, torch.Tensor):
+        return value.detach().to("cpu", copy=True)
+    if isinstance(value, dict):
+        copy = value.__class__((key, _on_host(item)) for key, item in value.items())
+        for name, attribute in getattr(value, "__dict__", {}).items():
+            setattr(copy, name, attribute)
+        return copy
+    if isinstance(value, list | tuple):
+        return value.__class__(_on_host(item) for item in value)
+    return value
+
+
+class _CheckpointWriter:
+    """Serialises one checkpoint at a time on a thread of its own. ``submit`` first joins the previous
+    write, so at most one is in flight; a failure on the thread is raised by the next ``join``, on the
+    training thread, never lost."""
+
+    def __init__(self) -> None:
+        self._thread: threading.Thread | None = None
+        self._error: BaseException | None = None
+
+    def submit(self, work: Callable[[], None]) -> None:
+        self.join()
+        self._thread = threading.Thread(target=self._run, args=(work,), name="konfai-checkpoint")
+        self._thread.start()
+
+    def _run(self, work: Callable[[], None]) -> None:
+        try:
+            work()
+        except BaseException as error:  # carried to the training thread by join()
+            self._error = error
+
+    def join(self) -> None:
+        if self._thread is not None:
+            self._thread.join()
+            self._thread = None
+        if self._error is not None:
+            error, self._error = self._error, None
+            raise error
+
+
 class _Trainer:
     """
     Internal class for managing the training loop in a distributed or standalone setting.
@@ -186,7 +234,9 @@ class _Trainer:
     (`with _Trainer(...) as trainer:`)  inside the public `Trainer` class.
     """
 
-    # Rank-aligned poll cadence (iterations) shared by the validation-request and live-tunable pollers.
+    # Rank-aligned poll cadence (iterations) shared by the validation-request and live-tunable pollers,
+    # and the cadence of the progress bar's description (an NVML query, two psutil queries and the
+    # last values of every criterion; refreshed on the bar's own schedule, not once per batch).
     _LIVE_POLL_INTERVAL = 20
 
     def __init__(
@@ -230,6 +280,7 @@ class _Trainer:
         self.it_validation = len(dataloader_training) if it_validation is None else it_validation
         self.it_lr_update = len(dataloader_training) if it_lr_update is None else it_lr_update
         self.it = it
+        self._declare_measure_window()
         # Live steering: an external steerer (MCP/Studio) drops control.json in the run dir; the loop applies
         # each new revision at a DDP poll boundary and records the change into the run's config snapshot.
         self._config_snapshot = config_snapshot
@@ -242,6 +293,7 @@ class _Trainer:
         self.tb = SummaryWriter(log_dir=statistics_directory() / self.train_name / "tb")
         self._best_checkpoint_path: Path | None = None
         self._best_checkpoint_loss: float | None = None
+        self._checkpoint_writer = _CheckpointWriter()
         self._loss_keys: set[str] = set()
         if self.global_rank == 0 and self.save_checkpoint_mode == "BEST":
             self._initialize_best_checkpoint_state()
@@ -261,6 +313,17 @@ class _Trainer:
         if self.tb is not None:
             self.tb.close()
         self.checkpoint_save(None)
+        self._checkpoint_writer.join()
+
+    def _declare_measure_window(self) -> None:
+        """The widest window the logs read from a criterion's history: the training window or the
+        validation pass. Everything older is only read as a running mean (ReduceLROnPlateau)."""
+        validation = len(self.dataloader_validation) if self.dataloader_validation is not None else 0
+        models = [self.model.module] + ([self.model_ema.module] if self.model_ema is not None else [])
+        for model in models:
+            for network in model.get_networks().values():
+                if network.measure is not None:
+                    network.measure.set_window(max(self.it_validation, validation))
 
     def _initialize_best_checkpoint_state(self) -> None:
         """Bootstrap BEST-checkpoint tracking once, including resume scenarios."""
@@ -308,7 +371,7 @@ class _Trainer:
         Triggers early stopping and resets data augmentations between epochs.
         """
         # SIGUSR1 requests an on-demand validation pass (KonfAI Studio's "Validate now"); the handler only
-        # flips a flag: the loop consumes it at a poll boundary, DDP-safe (see _requested_validation).
+        # flips a flag: the loop consumes it at a poll boundary, DDP-safe (see _poll_live_requests).
         sigusr1 = getattr(signal, "SIGUSR1", None)  # absent on Windows
         if sigusr1 is not None:
             with suppress(ValueError, OSError):  # signals only install on the main thread
@@ -347,34 +410,46 @@ class _Trainer:
             self.model_ema.eval()
             self.model_ema.module.set_state(NetState.TRAIN)
 
-        with tqdm.tqdm(
-            iterable=enumerate(self.dataloader_training),
-            desc=f"Training : {description(self.model, self.model_ema)}",
-            total=len(self.dataloader_training),
-            leave=False,
-            ncols=0,
-        ) as batch_iter:
+        clock = SweepClock()
+        with (
+            clock.phase("epoch"),
+            tqdm.tqdm(
+                iterable=clock.waiting("wait(data)", enumerate(self.dataloader_training)),
+                desc=f"Training : {description(self.model, self.model_ema)}",
+                total=len(self.dataloader_training),
+                leave=False,
+                ncols=0,
+            ) as batch_iter,
+        ):
             for _, batch_sample in batch_iter:
                 with torch.amp.autocast("cuda", enabled=self.autocast):
-                    self.model(batch_sample)
-                    self.model.module.backward(self.model)
+                    with clock.phase("forward"):
+                        self.model(batch_sample, clock=clock)
+                    with clock.phase("backward+step"):
+                        self.model.module.backward(self.model)
                     if self.model_ema is not None:
-                        self.model_ema.update_parameters(self.model)
+                        with clock.phase("ema"):
+                            self.model_ema.update_parameters(self.model)
                     self.it += 1
 
-                    self._apply_live_tunables()  # before update_lr, so a fresh LR anchors the next step
+                    validate_now, pending = self._poll_live_requests()
+                    if pending:
+                        self._apply_live_tunables(pending)  # before update_lr, so a fresh LR anchors the next step
 
                     if (self.it) % self.it_lr_update == 0:
                         self.model.module.update_lr()
 
-                    if self.dataloader_validation is not None and self._requested_validation():
-                        self._validate()  # on-demand (SIGUSR1): metrics only, no checkpoint / early-stopping
+                    if self.dataloader_validation is not None and validate_now:
+                        with clock.phase("validation"):
+                            self._validate()  # on-demand (SIGUSR1): metrics only, no checkpoint / early-stopping
 
                     if (self.it) % self.it_validation == 0:
-                        loss = self._train_log(batch_sample)
+                        with clock.phase("telemetry"):
+                            loss = self._train_log(batch_sample)
 
                         if self.dataloader_validation is not None:
-                            loss = self._validate()
+                            with clock.phase("validation"):
+                                loss = self._validate()
 
                         stop = False
                         if self.global_rank == 0:
@@ -387,7 +462,8 @@ class _Trainer:
                                 score = self.early_stopping.get_score(
                                     {key: loss[key] for key in self._loss_keys if key in loss}
                                 )
-                            self.checkpoint_save(score)
+                            with clock.phase("checkpoint"):
+                                self.checkpoint_save(score)
                             stop = self.early_stopping(score)
 
                             # Stop once the schedulers have decayed the learning rate to zero:
@@ -401,7 +477,28 @@ class _Trainer:
                             self.early_stopping.stop()
                             break
 
-                batch_iter.set_description(f"Training : {description(self.model, self.model_ema)}")
+                if self.it % self._LIVE_POLL_INTERVAL == 0:
+                    with clock.phase("telemetry"):
+                        batch_iter.set_description(
+                            f"Training : {description(self.model, self.model_ema)}", refresh=False
+                        )
+        report = self._epoch_report(clock)
+        if self.global_rank == 0 and report is not None:
+            tqdm.tqdm.write(report)
+
+    @staticmethod
+    def _epoch_report(clock: SweepClock, min_seconds: float = 1.0) -> str | None:
+        """One line accounting for the epoch's wall clock, in the sweep report's format, or ``None``
+        below ``min_seconds``. ``forward`` is the graph walk alone, the criteria being timed inside it;
+        what no phase names is ``other``, so the sum closes on the wall clock."""
+        wall = clock.spent("epoch")
+        if wall < min_seconds:
+            return None
+        phases = ("wait(data)", "forward", "criteria", "backward+step", "ema", "telemetry", "validation", "checkpoint")
+        named = {phase: clock.spent(phase) for phase in phases}
+        named["forward"] -= named["criteria"]
+        parts = " + ".join(f"{phase} {value:.1f}" for phase, value in named.items())
+        return f"[KonfAI] epoch {wall:.1f} s = {parts} + other {wall - sum(named.values()):.1f}"
 
     @torch.no_grad()
     def _validate(self) -> float:
@@ -427,12 +524,13 @@ class _Trainer:
             leave=False,
             ncols=0,
         ) as batch_iter:
-            for _, batch_sample in batch_iter:
+            for i, batch_sample in batch_iter:
                 self.model(batch_sample)
                 if self.model_ema is not None:
                     self.model_ema.module(batch_sample)
 
-                batch_iter.set_description(f"Validation : {description(self.model, self.model_ema)}")
+                if i % self._LIVE_POLL_INTERVAL == 0:
+                    batch_iter.set_description(f"Validation : {description(self.model, self.model_ema)}", refresh=False)
         self.dataloader_validation.dataset.reset_augmentation("Validation")
         if dist.is_initialized():
             dist.barrier()
@@ -443,14 +541,16 @@ class _Trainer:
         return self._validation_log(batch_sample)
 
     def _broadcast_from_master(self, value: Any) -> Any:
-        """Share rank 0's value with every rank, so the loop stays synchronized under DDP. Any picklable
-        object rides through (synchronize_data uses all_gather_object): callers cast as they need."""
-        outputs = synchronize_data(
-            self.world_size,
-            self.local_rank * self.size + self.size - 1,
-            value,
-        )
-        return outputs[0]
+        """Rank 0's value on every rank, so the loop stays synchronized under DDP: one broadcast of a
+        pickled object, where an all_gather would ship every rank's copy for a rank-0 payload. Any
+        picklable object rides through; callers cast as they need."""
+        if not dist.is_initialized():
+            return value
+        payload = [value if self.global_rank == 0 else None]
+        if torch.cuda.is_available():
+            torch.cuda.set_device(self.local_rank * self.size + self.size - 1)
+        dist.broadcast_object_list(payload, src=0)
+        return payload[0]
 
     def _broadcast_stop(self, stop: bool) -> bool:
         """
@@ -470,26 +570,20 @@ class _Trainer:
             value = self._broadcast_from_master(value)
         return value
 
-    def _requested_validation(self) -> bool:
-        """Whether an on-demand validation (SIGUSR1) is pending. Polled at a modest cadence so the DDP
-        broadcast stays rare; rank 0's flag is authoritative, so every rank validates on the same
-        iteration. Single-process runs skip the collective entirely."""
-        if self.it % self._LIVE_POLL_INTERVAL != 0:  # bound the on-demand latency while keeping the poll cheap
-            return False
-        requested = bool(self._poll_from_rank0(lambda: self._validate_now))
+    def _poll_live_requests(self) -> tuple[bool, dict[str, Any] | None]:
+        """What rank 0 has pending, at the poll cadence: an on-demand validation (SIGUSR1) and the
+        control file's new tunables, in one broadcast. Rank 0's state is authoritative, so every rank
+        acts on the same pair at the same iteration; the cadence bounds the latency while keeping the
+        collective rare, and single-process runs skip it entirely."""
+        if self.it % self._LIVE_POLL_INTERVAL != 0:
+            return False, None
+        requested, pending = self._poll_from_rank0(lambda: (self._validate_now, self._live_control.take()))
         if requested:
             self._validate_now = False
-        return requested
+        return bool(requested), pending
 
-    def _apply_live_tunables(self) -> None:
-        """Poll the run's control file at the same coarse, rank-aligned cadence as the validation poll and
-        apply any new tunables. Rank 0 reads and broadcasts, so every rank applies the same change on the
-        same iteration; rank 0 also records it into the run's config snapshot. No control file → a no-op."""
-        if self.it % self._LIVE_POLL_INTERVAL != 0:
-            return
-        pending = self._poll_from_rank0(lambda: self._live_control.take())
-        if not pending:
-            return
+    def _apply_live_tunables(self, pending: dict[str, Any]) -> None:
+        """Apply the tunables rank 0 polled; rank 0 also records them into the run's config snapshot."""
         applied = self._apply_tunables(pending)
         if self.global_rank == 0 and applied:
             self._interventions.extend(applied)
@@ -505,6 +599,7 @@ class _Trainer:
         if "it_validation" in pending:
             old = self.it_validation
             self.it_validation = max(1, int(pending["it_validation"]))
+            self._declare_measure_window()
             applied.append({"it": self.it, "key": "it_validation", "from": old, "to": self.it_validation})
         return applied
 
@@ -541,11 +636,16 @@ class _Trainer:
         """
         Saves model and optimizer states. Keeps either all checkpoints or only the best one.
 
+        The training thread copies the states into host memory and returns; the serialisation, the
+        publish and the BEST-mode pruning run on the writer's thread, joined before the next save and
+        at exit.
+
         Args:
             loss (float): Current loss used for best checkpoint selection.
         """
         if self.global_rank != 0:
             return
+        self._checkpoint_writer.join()  # the previous file is on disk before this one's name is chosen
 
         path = checkpoints_directory() / self.train_name
         path.mkdir(parents=True, exist_ok=True)
@@ -560,7 +660,7 @@ class _Trainer:
         # An unscored checkpoint (the final save at close) carries the worst possible score so
         # `_update_best_checkpoint` retires it in BEST mode instead of leaving it beside the real best.
         checkpoint_loss = loss if loss is not None else self.early_stopping.worst_score
-        save_dict = {
+        save_dict: dict[str, Any] = {
             "epoch": self.epoch,
             "it": self.it,
             "loss": checkpoint_loss,
@@ -593,15 +693,19 @@ class _Trainer:
             }
         )
 
-        # Staged and renamed, the invariant the dataset writers hold: a multi-GB torch.save takes
-        # seconds, and a kill mid-write left a truncated .pt under a plausible name that RESUME
-        # then died on with an opaque unpickling error.
-        staging = save_path.with_name(f"{save_path.name}.{os.getpid()}.tmp")
-        torch.save(save_dict, staging)
-        os.replace(staging, save_path)
+        snapshot = _on_host(save_dict)
 
-        if self.save_checkpoint_mode == "BEST":
-            self._update_best_checkpoint(save_path, checkpoint_loss)
+        def publish() -> None:
+            # Staged and renamed, the invariant the dataset writers hold: a multi-GB torch.save takes
+            # seconds, and a kill mid-write left a truncated .pt under a plausible name that RESUME
+            # then died on with an opaque unpickling error.
+            staging = save_path.with_name(f"{save_path.name}.{os.getpid()}.tmp")
+            torch.save(snapshot, staging)
+            os.replace(staging, save_path)
+            if self.save_checkpoint_mode == "BEST":
+                self._update_best_checkpoint(save_path, checkpoint_loss)
+
+        self._checkpoint_writer.submit(publish)
 
     @torch.no_grad()
     def _log(
@@ -883,7 +987,7 @@ class Trainer(DistributedObject):
                 state_dict = self._load()
             self.model.load(state_dict, init=True, ema=False, override_lr=self.override_lr)
         if self.ema_decay > 0:
-            self.model_ema = AveragedModel(self.model, avg_fn=self._avg_fn)
+            self.model_ema = AveragedModel(self.model, **self._ema_update())
             if state_dict is not None:
                 self.model_ema.module.load(state_dict, init=False, ema=True)
                 if "Model_EMA_n_averaged" in state_dict:
@@ -936,6 +1040,15 @@ class Trainer(DistributedObject):
                 self.config_namefile,
                 self.config_namefile.parent / new_name,
             )
+
+    def _ema_update(self) -> dict[str, Callable]:
+        """The EMA rule for AveragedModel: torch's fused ``multi_avg_fn`` (one ``_foreach_lerp_`` per
+        device and dtype) where it exists, the per-tensor ``avg_fn`` otherwise."""
+        try:
+            from torch.optim.swa_utils import get_ema_multi_avg_fn
+        except ImportError:
+            return {"avg_fn": self._avg_fn}
+        return {"multi_avg_fn": get_ema_multi_avg_fn(self.ema_decay)}
 
     def _avg_fn(self, averaged_model_parameter: float, model_parameter, num_averaged):
         """EMA update (AveragedModel avg_fn): ``ema_decay * averaged + (1 - ema_decay) * model``."""

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -29,7 +29,7 @@ import pytest
 import torch
 from konfai.metric.schedulers import Constant, PolyLRScheduler
 from konfai.network.blocks import Add
-from konfai.network.network import Measure, ModuleArgsDict, Network
+from konfai.network.network import Measure, ModuleArgsDict, Network, _channels_last
 from konfai.utils.dataset import Attribute
 from konfai.utils.errors import ConfigError, MeasureError
 
@@ -960,3 +960,46 @@ def test_measure_update_moves_the_criterion_onto_the_outputs_device_once() -> No
     measure.update("Head", output, batch, it=1, nb_patch=1, training=True)
 
     assert moved_to == [output.device], "one move onto the output's device, not one per step"
+
+
+def test_channels_last_lays_out_every_weight_and_every_input_of_its_rank() -> None:
+    """The layout reaches the nested graph's 4-D and 5-D weights and the inputs as they enter a
+    module (a CPU conv may hand its output back contiguous: the input is what the graph owes);
+    a tensor with no such layout (a vector) is handed on as it is."""
+
+    class _Probe(torch.nn.Module):
+        def __init__(self, memory_format: torch.memory_format) -> None:
+            super().__init__()
+            self.memory_format, self.seen = memory_format, []
+
+        def forward(self, tensor: torch.Tensor) -> torch.Tensor:
+            self.seen.append(tensor.is_contiguous(memory_format=self.memory_format))
+            return tensor
+
+    class _Inner3d(ModuleArgsDict):
+        def __init__(self) -> None:
+            super().__init__()
+            self.add_module("Probe", _Probe(torch.channels_last_3d))
+            self.add_module("Conv3", torch.nn.Conv3d(2, 2, 3, padding=1))
+
+    class _Graph(ModuleArgsDict):
+        def __init__(self) -> None:
+            super().__init__()
+            self.add_module("Probe", _Probe(torch.channels_last), in_branch=[0], out_branch=[0])
+            self.add_module("Conv2", torch.nn.Conv2d(2, 2, 3, padding=1), in_branch=[0], out_branch=[0])
+            self.add_module("Deep", _Inner3d(), in_branch=[1], out_branch=[1])
+
+    graph = _Graph()
+    plane, volume = torch.randn(1, 2, 8, 8), torch.randn(1, 2, 4, 8, 8)
+    before = dict(graph.named_forward(plane, volume))
+    assert graph["Probe"].seen == [False] and graph["Deep"]["Probe"].seen == [False]
+    Network.set_channels_last(graph)
+
+    assert graph["Conv2"].weight.is_contiguous(memory_format=torch.channels_last)
+    assert graph["Deep"]["Conv3"].weight.is_contiguous(memory_format=torch.channels_last_3d)
+    assert graph._channels_last and graph["Deep"]._channels_last
+    after = dict(graph.named_forward(plane, volume))
+    assert graph["Probe"].seen == [False, True] and graph["Deep"]["Probe"].seen == [False, True]
+    for name in before:
+        torch.testing.assert_close(after[name], before[name], rtol=1e-5, atol=1e-6)
+    assert _channels_last(torch.zeros(3)).dim() == 1

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -239,16 +239,111 @@ def test_loss_add_summarises_dict_metric_payload() -> None:
     record.add(1.0, (torch.tensor([0.7]), {"1": 0.6, "2": 0.8, "3": float("nan")}))
 
     # The dict is summarised to a scalar (nan-mean of 0.6 and 0.8), and the logging mean is safe.
-    assert isinstance(record._values[-1], float)
-    assert record._values[-1] == pytest.approx(0.7)
-    assert np.nanmean(record._values) == pytest.approx(0.7)
+    assert isinstance(record._unread[-1], float)
+    assert record._unread[-1] == pytest.approx(0.7)
+    assert _measure_of(record).get_last_values() == {"Dice": pytest.approx(0.7)}
 
 
 def test_loss_add_keeps_plain_scalar_metric() -> None:
     # A regular (tensor, float) metric is unchanged.
     record = Measure.Loss("MSE", "out", "tgt", 0, is_loss=False, accumulation=False)
     record.add(1.0, (torch.tensor([0.5]), 0.5))
-    assert record._values[-1] == pytest.approx(0.5)
+    assert record._unread[-1] == pytest.approx(0.5)
+
+
+def _measure_of(*records: Measure.Loss) -> Measure:
+    measure = Measure.__new__(Measure)
+    measure._loss = {0: {record.name: record for record in records}}
+    return measure
+
+
+def test_loss_add_does_not_read_a_loss_off_its_device() -> None:
+    # `.item()` inside the forward stalls the CPU on the whole graph before backward is enqueued:
+    # the loss is kept as a detached tensor and read when a consumer asks for the value.
+    record = _loss_record()
+    record.add(1.0, torch.tensor([3.0], requires_grad=True))
+
+    kept = record._unread[-1]
+    assert isinstance(kept, torch.Tensor) and not kept.requires_grad
+    assert len(record._values) == 0 and record.recorded == 1
+
+    assert _measure_of(record).get_last_values() == {"l": 3.0}
+    assert list(record._values) == [3.0] and record._unread == []
+
+
+def test_measure_reads_every_unread_value_in_one_transfer(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Two criteria over three batches, one of them handing a float in the middle: one stack per
+    # device reads the lot, each record keeps the order it recorded, and the floats equal `.item()`.
+    loss = Measure.Loss("l", "out", "tgt", 0, is_loss=True, accumulation=False)
+    metric = Measure.Loss("m", "out", "tgt", 0, is_loss=False, accumulation=False)
+    for i in range(3):
+        loss.add(1.0, torch.tensor(float(i)))
+        metric.add(1.0, (torch.tensor([11.0]), 11.5) if i == 1 else torch.tensor([10.0 + i]))
+    stacked: list[int] = []
+    original_stack = torch.stack
+
+    def counting_stack(tensors, *args, **kwargs):
+        stacked.append(len(tensors))
+        return original_stack(tensors, *args, **kwargs)
+
+    monkeypatch.setattr(torch, "stack", counting_stack)
+    measure = _measure_of(loss, metric)
+
+    assert measure.format_loss(True, 3) == {"l": (1.0, 1.0)}
+    assert stacked == [5]
+    assert list(loss._values) == [0.0, 1.0, 2.0]
+    assert list(metric._values) == [10.0, 11.5, 12.0]
+    assert measure.get_last_values(3) == {"l": 1.0, "m": pytest.approx(33.5 / 3)}
+    assert stacked == [5]  # nothing was left unread: no second transfer
+
+
+def test_whole_history_mean_is_a_running_mean_and_the_window_is_bounded() -> None:
+    # The lists grew for the run and get_last_values(0) (ReduceLROnPlateau) converted the whole
+    # history every LR update. The history is a bounded window plus a running nan-mean.
+    record = _loss_record()
+    measure = _measure_of(record)
+    measure.set_window(3)
+    values = [1.0, float("nan"), 2.0, 4.0, float("nan"), 8.0, 16.0]
+    for i, value in enumerate(values):
+        record.add(float(i), torch.tensor(value))
+
+    assert measure.get_last_values(3) == {"l": pytest.approx(np.nanmean(values[-3:]))}
+    assert measure.get_last_weights(3) == {"l": 5.0}
+    assert measure.get_last_values(0) == {"l": pytest.approx(np.nanmean(values))}
+    assert measure.get_last_weights(0) == {"l": 3.0}
+    assert len(record._values) == 3 and len(record._weight) == 3 and record.recorded == 7
+    assert measure.format_loss(True, 2) == {"l": (5.5, 12.0)}
+    assert measure.format_loss(True, 8) == {}  # fewer than 8 recorded, exactly as before
+
+
+def test_a_consumer_asking_for_a_wider_window_gets_it_from_then_on() -> None:
+    # The trainer declares the widest window it reads; a consumer of its own (diffusionGan reads 4)
+    # widens the window at its first read, so its later reads see every value it asks for.
+    record = _loss_record()
+    measure = _measure_of(record)
+    measure.set_window(2)
+    for value in (1.0, 2.0, 3.0):
+        record.add(1.0, torch.tensor(value))
+    assert measure.get_last_values(4) == {}  # 3 recorded: not reported, as before
+    assert record._values.maxlen == 4
+    for value in (4.0, 5.0):
+        record.add(1.0, torch.tensor(value))
+    assert measure.get_last_values(4) == {"l": pytest.approx(3.5)}
+    measure.set_window(2)  # a narrower declaration never shrinks it
+    assert record._values.maxlen == 4
+
+
+def test_get_loss_pairs_every_accumulated_loss_with_its_own_weight_under_a_narrow_window() -> None:
+    # The gradient's weights ride with their losses, so the logging window can be one entry wide
+    # while an accumulation iteration holds several (weight, loss) pairs.
+    record = _loss_record()
+    record.set_window(1)
+    record.add(0.5, torch.tensor([2.0]))
+    record.add(2.0, torch.tensor([4.0]))
+    record.add(1.0, torch.tensor([6.0]))
+
+    assert record.get_loss().item() == pytest.approx((1.0 + 8.0 + 6.0) / 3)
+    assert record.get_last_loss().item() == 6.0
 
 
 # --------------------------------------------------------------------------------------
@@ -273,6 +368,7 @@ def _make_accumulating_measure(scaler) -> tuple[Measure, torch.Tensor]:
     key = f"out:tgt:{criterion.__class__.__name__}"
     measure.outputs_criterions = {"out": {"tgt": {criterion: _CriterionAttr()}}}
     measure._loss = {0: {key: Measure.Loss(criterion.__class__.__name__, "out", "tgt", 0, True, True)}}
+    measure._targets = {}
     measure.scaler = scaler
     output = torch.zeros(1, 1, 2, 2, requires_grad=True)
     return measure, output
@@ -327,6 +423,7 @@ def test_accumulation_backward_not_refired_by_plain_loss_in_same_group() -> None
             f"out:tgt:{plain_crit.__class__.__name__}": Measure.Loss("L1Loss", "out", "tgt", 0, True, False),
         }
     }
+    measure._targets = {}
     measure.scaler = scaler
     output = torch.zeros(1, 1, 2, 2, requires_grad=True)
     target = torch.ones(1, 1, 2, 2)
@@ -559,6 +656,7 @@ def test_checkpoint_save_round_trip_restores_nested_network_state(tmp_path: Path
     )
 
     trainer.checkpoint_save(1.0)
+    trainer._checkpoint_writer.join()
 
     state_dict = torch.load(tmp_path / "Checkpoints" / "RUN" / "ckpt.pt", map_location="cpu", weights_only=False)
     target = with_optimizers(Root())
@@ -726,6 +824,103 @@ def test_composite_criteria_are_scheduled_on_the_owning_networks_counter() -> No
 
     assert seen_its == [0, 1, 2], f"criteria must see the owner's advancing counter, got {seen_its}"
     assert root._it == 0  # the composite root still owns no optimizer and never steps
+
+
+def test_a_target_group_is_moved_once_per_forward_and_not_for_a_criterion_outside_its_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Measure.update ran once per completed output group and moved the group's target each time: the
+    shipped Segmentation config uploaded SEG twice per step, a deep-supervision config once per head,
+    and a criterion outside its start/stop window still paid for the upload it never read."""
+    from konfai.metric.schedulers import Constant
+    from konfai.network.network import CriterionsAttr, Measure
+
+    class Net(Network):
+        def __init__(self) -> None:
+            super().__init__(in_channels=1, dim=2)
+            self.add_module("Logits", torch.nn.Conv2d(1, 3, 1))
+            self.add_module("Softmax", torch.nn.Softmax(dim=1))
+
+    def attr(start: int = 0) -> CriterionsAttr:
+        attributes = CriterionsAttr(start=start)
+        attributes.schedulers = {Constant(): None}
+        return attributes
+
+    model = Net()
+    measure = Measure("Net", {})
+    measure.outputs_criterions = {
+        "Logits": {"SEG": {torch.nn.CrossEntropyLoss(): attr(), torch.nn.MSELoss(): attr(start=5)}},
+        "Softmax": {"SEG": {torch.nn.L1Loss(): attr()}},
+    }
+    measure.init(model, ["SEG"])
+    model.measure = measure
+    model.init_outputs_group()
+
+    seg = torch.randn(2, 3, 4, 4)
+    moved: list[torch.Tensor] = []
+    original_to = torch.Tensor.to
+
+    def counting_to(self: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:
+        if self is seg:
+            moved.append(self)
+        return original_to(self, *args, **kwargs)
+
+    monkeypatch.setattr(torch.Tensor, "to", counting_to)
+
+    class _BatchItem:
+        def __init__(self, tensor: torch.Tensor, is_input: bool) -> None:
+            self.tensor = tensor
+            self.is_input = is_input
+            self.attribute = [Attribute()]
+
+    batch = {"CT": _BatchItem(torch.randn(2, 1, 4, 4), True), "SEG": _BatchItem(seg, False)}
+    model.forward(batch)
+    assert len(moved) == 1, "one upload for the two output groups reading SEG"
+    assert measure._targets == {}, "released with the forward, not held through backward"
+
+    model._it = 5
+    model.forward(batch)
+    assert len(moved) == 2, "the next forward uploads again (a new batch in the run)"
+
+    measure.outputs_criterions["Logits"]["SEG"] = {torch.nn.MSELoss(): attr(start=50)}
+    measure.outputs_criterions["Softmax"]["SEG"] = {torch.nn.L1Loss(): attr(start=50)}
+    model.forward(batch)
+    assert len(moved) == 2, "every criterion outside its window: nothing uploaded"
+
+
+def test_forward_charges_the_criteria_to_the_clock_apart_from_the_walk() -> None:
+    from konfai.data.patching import SweepClock
+    from konfai.metric.schedulers import Constant
+    from konfai.network.network import CriterionsAttr, Measure
+
+    class Net(Network):
+        def __init__(self) -> None:
+            super().__init__(in_channels=1, dim=2)
+            self.add_module("Head", torch.nn.Conv2d(1, 1, 1))
+
+    model = Net()
+    measure = Measure("Net", {})
+    attr = CriterionsAttr()
+    attr.schedulers = {Constant(): None}
+    measure.outputs_criterions = {"Head": {"CT": {torch.nn.L1Loss(): attr}}}
+    measure.init(model, ["CT"])
+    model.measure = measure
+    model.init_outputs_group()
+
+    class _BatchItem:
+        def __init__(self, tensor: torch.Tensor, is_input: bool) -> None:
+            self.tensor = tensor
+            self.is_input = is_input
+            self.attribute = [Attribute()]
+
+    batch = {"CT": _BatchItem(torch.ones(1, 1, 4, 4), True)}
+    clock = SweepClock()
+    model.forward(batch, clock=clock)
+    timed = measure.get_last_values()
+    model.forward(batch)
+    assert measure.get_last_values() == timed  # the clock changes nothing but the account
+    assert clock.spent("criteria") > 0.0
+    assert clock.spent("forward") == 0.0  # the walk is the caller's phase, not the network's
 
 
 def test_measure_update_moves_the_criterion_onto_the_outputs_device_once() -> None:

--- a/tests/unit/test_trainer.py
+++ b/tests/unit/test_trainer.py
@@ -17,6 +17,7 @@
 """Tests for konfai.trainer: checkpoint save/bootstrap, early stopping, EMA, and RESUME
 learning-rate/checkpoint handling."""
 
+import threading
 from collections.abc import Iterator
 from pathlib import Path
 from types import SimpleNamespace
@@ -65,7 +66,15 @@ def _date_sequence(values: list[str]) -> Iterator[str]:
         yield values[-1]
 
 
-def _build_trainer(tmp_path: Path, monkeypatch, date_values: list[str], early_stopping=None) -> _Trainer:
+def _build_trainer(
+    tmp_path: Path,
+    monkeypatch,
+    date_values: list[str],
+    early_stopping=None,
+    model: Any = None,
+    it_validation: int = 1,
+    dataloader_validation: Any = None,
+) -> _Trainer:
     checkpoints_dir = tmp_path / "Checkpoints"
     statistics_dir = tmp_path / "Statistics"
     date_iter = _date_sequence(date_values)
@@ -87,15 +96,21 @@ def _build_trainer(tmp_path: Path, monkeypatch, date_values: list[str], early_st
         epochs=1,
         epoch=0,
         autocast=False,
-        it_validation=1,
+        it_validation=it_validation,
         it_lr_update=1,
         it=0,
-        model=cast(Any, _DummyModel()),
+        model=cast(Any, _DummyModel() if model is None else model),
         model_ema=None,
         config_snapshot=tmp_path / "Config.yml",
         dataloader_training=[object()],
-        dataloader_validation=None,
+        dataloader_validation=dataloader_validation,
     )
+
+
+def _save(trainer: _Trainer, loss: float | None) -> None:
+    """A save and its landing on disk: what the loop guarantees before the next save and at exit."""
+    trainer.checkpoint_save(loss)
+    trainer._checkpoint_writer.join()
 
 
 def test_best_checkpoint_save_keeps_only_best_without_rescanning(tmp_path: Path, monkeypatch) -> None:
@@ -107,9 +122,9 @@ def test_best_checkpoint_save_keeps_only_best_without_rescanning(tmp_path: Path,
 
     monkeypatch.setattr(trainer_module.torch, "load", fail_if_reloaded)
 
-    trainer.checkpoint_save(2.0)
-    trainer.checkpoint_save(1.0)
-    trainer.checkpoint_save(3.0)
+    _save(trainer, 2.0)
+    _save(trainer, 1.0)
+    _save(trainer, 3.0)
 
     checkpoints = sorted((tmp_path / "Checkpoints" / "RUN").glob("*.pt"))
     assert [path.name for path in checkpoints] == ["ckpt_b.pt"]
@@ -126,9 +141,9 @@ def test_best_checkpoint_keeps_highest_score_when_mode_is_max(tmp_path: Path, mo
         early_stopping=EarlyStopping(monitor=["Dice"], mode="max"),
     )
 
-    trainer.checkpoint_save(0.60)
-    trainer.checkpoint_save(0.85)  # best (highest)
-    trainer.checkpoint_save(0.70)
+    _save(trainer, 0.60)
+    _save(trainer, 0.85)  # best (highest)
+    _save(trainer, 0.70)
 
     checkpoints = sorted((tmp_path / "Checkpoints" / "RUN").glob("*.pt"))
     assert [path.name for path in checkpoints] == ["ckpt_b.pt"]
@@ -158,8 +173,8 @@ def test_best_checkpoint_bootstrap_scans_existing_files_once_and_prunes_stale_on
     assert [path.name for path in sorted(checkpoint_dir.glob("*.pt"))] == ["old_b.pt"]
     assert [path.name for path in load_calls] == ["old_a.pt", "old_b.pt"]
 
-    trainer.checkpoint_save(4.0)
-    trainer.checkpoint_save(2.0)
+    _save(trainer, 4.0)
+    _save(trainer, 2.0)
 
     assert [path.name for path in load_calls] == ["old_a.pt", "old_b.pt"]
     checkpoints = sorted(checkpoint_dir.glob("*.pt"))
@@ -170,8 +185,8 @@ def test_best_checkpoint_bootstrap_scans_existing_files_once_and_prunes_stale_on
 def test_best_checkpoint_survives_same_second_collision(tmp_path: Path, monkeypatch) -> None:
     trainer = _build_trainer(tmp_path, monkeypatch, ["same_stamp", "same_stamp"])
 
-    trainer.checkpoint_save(1.0)  # best
-    trainer.checkpoint_save(2.0)  # worse, produced within the same timestamp
+    _save(trainer, 1.0)  # best
+    _save(trainer, 2.0)  # worse, produced within the same timestamp
 
     checkpoints = sorted((tmp_path / "Checkpoints" / "RUN").glob("*.pt"))
     assert len(checkpoints) == 1
@@ -181,7 +196,7 @@ def test_best_checkpoint_survives_same_second_collision(tmp_path: Path, monkeypa
 def test_exit_checkpoint_loss_does_not_poison_best(tmp_path: Path, monkeypatch) -> None:
     trainer = _build_trainer(tmp_path, monkeypatch, ["exit_stamp"])
 
-    trainer.checkpoint_save(None)  # the save emitted on context exit
+    _save(trainer, None)  # the save emitted on context exit
 
     saved = torch.load(
         tmp_path / "Checkpoints" / "RUN" / "exit_stamp.pt",
@@ -212,7 +227,7 @@ def test_checkpoint_persists_ema_n_averaged(tmp_path: Path, monkeypatch) -> None
     trainer = _build_trainer(tmp_path, monkeypatch, ["ema_stamp"])
     trainer.model_ema = cast(Any, ema)
 
-    trainer.checkpoint_save(1.0)
+    _save(trainer, 1.0)
 
     saved = torch.load(
         tmp_path / "Checkpoints" / "RUN" / "ema_stamp.pt",
@@ -223,6 +238,78 @@ def test_checkpoint_persists_ema_n_averaged(tmp_path: Path, monkeypatch) -> None
     assert saved["Model_EMA_n_averaged"] == int(ema.n_averaged) == 2
 
 
+def test_checkpoint_save_returns_before_the_file_lands_and_the_file_equals_the_live_state(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # The training thread pays the host copy only; the serialisation and the publish run on the
+    # writer's thread. What lands is what torch.save of the live states writes.
+    net = nn.Linear(3, 2)
+    optimizer = torch.optim.AdamW(net.parameters())
+    net(torch.ones(1, 3)).sum().backward()
+    optimizer.step()
+    network = SimpleNamespace(optimizer=optimizer, _it=4, _nb_lr_update=2, measure=None)
+    module = SimpleNamespace(state_dict=net.state_dict, get_networks=lambda: {"Net": network})
+    trainer = _build_trainer(tmp_path, monkeypatch, ["stamp"], model=SimpleNamespace(module=module))
+
+    gate = threading.Event()
+    real_save = torch.save
+
+    def gated_save(*args, **kwargs):
+        gate.wait(5)
+        real_save(*args, **kwargs)
+
+    monkeypatch.setattr(trainer_module.torch, "save", gated_save)
+    trainer.checkpoint_save(0.5)
+    assert not list((tmp_path / "Checkpoints" / "RUN").glob("*.pt")), "returned before the write"
+    gate.set()
+    trainer._checkpoint_writer.join()
+
+    reference = tmp_path / "reference.pt"
+    real_save(
+        {
+            "epoch": 0,
+            "it": 0,
+            "loss": 0.5,
+            "Model": net.state_dict(),
+            "Net_optimizer_state_dict": optimizer.state_dict(),
+            "Net_it": 4,
+            "Net_nb_lr_update": 2,
+        },
+        reference,
+    )
+    saved = torch.load(tmp_path / "Checkpoints" / "RUN" / "stamp.pt", map_location="cpu", weights_only=False)
+    expected = torch.load(reference, map_location="cpu", weights_only=False)
+
+    def flatten(value: Any, prefix: str = "") -> dict[str, Any]:
+        if isinstance(value, dict):
+            return {k: v for key, item in value.items() for k, v in flatten(item, f"{prefix}{key}.").items()}
+        if isinstance(value, list | tuple):
+            return {k: v for i, item in enumerate(value) for k, v in flatten(item, f"{prefix}{i}.").items()}
+        return {prefix: value}
+
+    flat_saved, flat_expected = flatten(saved), flatten(expected)
+    assert flat_saved.keys() == flat_expected.keys()
+    for key, value in flat_expected.items():
+        if isinstance(value, torch.Tensor):
+            assert torch.equal(flat_saved[key], value), key
+        else:
+            assert flat_saved[key] == value, key
+
+
+def test_a_failed_checkpoint_write_is_raised_at_the_next_save(tmp_path: Path, monkeypatch) -> None:
+    trainer = _build_trainer(tmp_path, monkeypatch, ["one", "two"])
+
+    def failing_save(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(trainer_module.torch, "save", failing_save)
+    trainer.checkpoint_save(1.0)  # returns: the failure sits on the writer's thread
+    with pytest.raises(OSError, match="disk full"):
+        trainer.checkpoint_save(2.0)  # joins the failed write before choosing a name
+    trainer._checkpoint_writer.join()  # nothing in flight: the second save never got submitted
+    assert not list((tmp_path / "Checkpoints" / "RUN").glob("*.pt"))
+
+
 def test_broadcast_stop_returns_local_value_without_distributed(tmp_path: Path, monkeypatch) -> None:
     trainer = _build_trainer(tmp_path, monkeypatch, ["stamp"])
 
@@ -230,14 +317,81 @@ def test_broadcast_stop_returns_local_value_without_distributed(tmp_path: Path, 
     assert trainer._broadcast_stop(False) is False
 
 
+class _FakeGroup:
+    """A process group of one broadcast: rank 0's payload lands on the caller, whatever it offered."""
+
+    def __init__(self, monkeypatch, rank0_value: Any) -> None:
+        self.calls = 0
+        self.rank0_value = rank0_value
+        monkeypatch.setattr(trainer_module.dist, "is_initialized", lambda: True)
+        monkeypatch.setattr(trainer_module.torch.cuda, "is_available", lambda: False)
+        monkeypatch.setattr(trainer_module.dist, "broadcast_object_list", self.broadcast)
+
+    def broadcast(self, payload: list, src: int = 0) -> None:
+        assert src == 0
+        self.calls += 1
+        payload[0] = self.rank0_value
+
+
 def test_broadcast_stop_adopts_rank_zero_decision(tmp_path: Path, monkeypatch) -> None:
     trainer = _build_trainer(tmp_path, monkeypatch, ["stamp"])
+    trainer.global_rank = 1
 
-    monkeypatch.setattr(trainer_module, "synchronize_data", lambda *_args, **_kwargs: [True, False, False])
+    _FakeGroup(monkeypatch, True)
     assert trainer._broadcast_stop(False) is True  # a non-zero rank still stops when rank 0 does
 
-    monkeypatch.setattr(trainer_module, "synchronize_data", lambda *_args, **_kwargs: [False, True])
+    _FakeGroup(monkeypatch, False)
     assert trainer._broadcast_stop(True) is False  # a non-zero rank keeps going when rank 0 does
+
+
+def test_validation_request_and_live_tunables_ride_one_broadcast(tmp_path: Path, monkeypatch) -> None:
+    # Rank 0 polls its SIGUSR1 flag and the control file once per cadence; every rank receives the
+    # pair in one broadcast instead of two all_gathers, and acts on it at the same iteration.
+    trainer = _build_trainer(tmp_path, monkeypatch, ["stamp"])
+    trainer.world_size = 2
+    trainer.it = trainer._LIVE_POLL_INTERVAL
+    trainer._validate_now = True
+    monkeypatch.setattr(trainer._live_control, "take", lambda: {"lr": 0.5})
+    group = _FakeGroup(monkeypatch, (True, {"lr": 0.5}))
+
+    assert trainer._poll_live_requests() == (True, {"lr": 0.5})
+    assert group.calls == 1
+    assert trainer._validate_now is False  # consumed
+
+    trainer.global_rank = 1
+    trainer._validate_now = False
+    monkeypatch.setattr(trainer._live_control, "take", lambda: pytest.fail("only rank 0 reads the control file"))
+    assert trainer._poll_live_requests() == (True, {"lr": 0.5})  # rank 0's pair, not its own
+    assert group.calls == 2
+
+    trainer.it += 1
+    assert trainer._poll_live_requests() == (False, None)  # off the cadence: no collective
+    assert group.calls == 2
+
+
+# ---- Epoch wall-clock account ----
+
+
+def test_epoch_report_closes_on_the_wall_clock_with_the_criteria_apart_from_the_forward() -> None:
+    from konfai.data.patching import SweepClock
+
+    clock = SweepClock()
+    clock._spent = {
+        "epoch": 10.0,
+        "wait(data)": 1.0,
+        "forward": 5.0,  # the graph walk and, inside it, the criteria
+        "criteria": 1.0,
+        "backward+step": 2.0,
+        "telemetry": 0.5,
+        "validation": 0.5,
+        "checkpoint": 0.5,
+    }
+    assert _Trainer._epoch_report(clock) == (
+        "[KonfAI] epoch 10.0 s = wait(data) 1.0 + forward 4.0 + criteria 1.0 + backward+step 2.0 + ema 0.0"
+        " + telemetry 0.5 + validation 0.5 + checkpoint 0.5 + other 0.5"
+    )
+    clock._spent = {"epoch": 0.4}
+    assert _Trainer._epoch_report(clock) is None  # an epoch this short has nothing to account for
 
 
 # ---- OOM shrink rendezvous agreement ----
@@ -329,6 +483,29 @@ def test_avg_fn_high_decay_keeps_running_average_dominant() -> None:
     result = Trainer._avg_fn(stub, averaged, model, 5)
 
     assert result.item() == pytest.approx(9.99)
+
+
+def test_ema_runs_torchs_fused_rule_and_matches_the_per_tensor_one(monkeypatch) -> None:
+    # avg_fn forces AveragedModel's per-tensor path (n_averaged.to(device), three kernels and a copy
+    # per parameter); multi_avg_fn is the same formula as one _foreach_lerp_ per device and dtype.
+    stub = SimpleNamespace(ema_decay=0.9, _avg_fn=lambda a, m, n: Trainer._avg_fn(stub, a, m, n))
+    rule = Trainer._ema_update(cast(Any, stub))
+    assert set(rule) == {"multi_avg_fn"}
+
+    net = nn.Linear(4, 4)
+    fused, per_tensor = AveragedModel(net, **rule), AveragedModel(net, avg_fn=stub._avg_fn)
+    for _ in range(3):
+        with torch.no_grad():
+            for param in net.parameters():
+                param.add_(torch.randn_like(param))
+        fused.update_parameters(net)
+        per_tensor.update_parameters(net)
+    for a, b in zip(fused.parameters(), per_tensor.parameters(), strict=True):
+        torch.testing.assert_close(a, b, rtol=0, atol=1e-6)
+    assert int(fused.n_averaged) == int(per_tensor.n_averaged) == 3
+
+    monkeypatch.delattr(torch.optim.swa_utils, "get_ema_multi_avg_fn")  # a torch without the fused rule
+    assert Trainer._ema_update(cast(Any, stub)) == {"avg_fn": stub._avg_fn}
 
 
 # ---- RESUME LR override ----
@@ -434,6 +611,23 @@ def test_apply_tunables_changes_it_validation_and_audits(tmp_path: Path, monkeyp
     assert applied == [{"it": 40, "key": "it_validation", "from": 1, "to": 5}]
 
 
+def test_trainer_bounds_each_criterions_history_to_the_widest_window_it_reads(tmp_path: Path, monkeypatch) -> None:
+    from konfai.network.network import Measure
+
+    record = Measure.Loss("l", "out", "tgt", 0, is_loss=True, accumulation=False)
+    measure = Measure.__new__(Measure)
+    measure._loss = {0: {"l": record}}
+    model = SimpleNamespace(module=SimpleNamespace(get_networks=lambda: {"Net": SimpleNamespace(measure=measure)}))
+
+    trainer = _build_trainer(
+        tmp_path, monkeypatch, ["stamp"], model=model, it_validation=7, dataloader_validation=[object()] * 3
+    )
+    assert record._values.maxlen == 7  # max(it_validation, validation batches)
+
+    trainer._apply_tunables({"it_validation": 12})
+    assert record._values.maxlen == 12
+
+
 def test_apply_tunables_clamps_it_validation_to_at_least_one(tmp_path: Path, monkeypatch) -> None:
     trainer = _build_trainer(tmp_path, monkeypatch, ["run"])
 
@@ -504,7 +698,7 @@ def test_a_saved_checkpoint_with_no_score_loses_to_one_with_a_score(tmp_path: Pa
     # finite score, so BEST freezes on the last unscored epoch and no later one can take it.
     early_stopping = EarlyStopping(monitor=None, mode=mode)
     trainer = _build_trainer(tmp_path, monkeypatch, ["ckpt_a", "ckpt_b"], early_stopping=early_stopping)
-    trainer.checkpoint_save(None)
+    _save(trainer, None)
     saved = sorted((tmp_path / "RUN" / "Checkpoints").glob("*.pt")) if (tmp_path / "RUN").exists() else []
     if not saved:
         saved = sorted(tmp_path.rglob("*.pt"))


### PR DESCRIPTION

The training loop paid for work it did not need per step. `Measure.Loss.add` called `.item()` on every loss inside `Network.forward`, one CUDA sync per criterion taken before backward was enqueued; the record now keeps the detached 0-d tensor and the consumers (`get_last_values`, `format_loss`) read every unread value in one transfer per device, after backward. A criterion's history kept every value of the run and `ReduceLROnPlateau` nan-meaned the whole list at each LR update; the windows are now deques bounded to the widest window a consumer reads (the trainer declares `max(it_validation, validation batches)`, a consumer's own wider read widens it from then on) and the whole-history consumers read a running nan-aware `(sum, count)`. `Measure.update` moved its target group to the device on every call, before the criterion's start/stop gate; the move is memoised per (group, device) for one forward and sits below the gate. The EMA takes torch's fused rule, `multi_avg_fn=get_ema_multi_avg_fn(decay)`, one `_foreach_lerp_` per device and dtype, with the per-tensor `avg_fn` kept as the fallback. The progress bar's description (an NVML query, two `psutil.virtual_memory()`, every criterion's last value) is rebuilt every `_LIVE_POLL_INTERVAL` (20) batches with `refresh=False` instead of a forced redraw per batch into the SLURM log. `checkpoint_save` copies the states to host memory on the training thread and hands `torch.save`, the staged publish and the BEST-mode pruning to a writer thread, joined before the next save and at exit, a failure raised by that join. The validation request and the live tunables ride one `broadcast_object_list` from rank 0 instead of two `all_gather_object` polls, effects in the same order. Two additions: rank 0 prints one wall-clock line per epoch, phase by phase, on the `SweepClock` from `konfai.data.patching` (`Network.forward` takes the clock as an argument to charge the criteria apart from the walk; an epoch under a second prints nothing), and a `channels_last` key on the trainer and the predictor lays every 4-D and 5-D weight out channels-last at placement and the inputs once at the graph's entry, off by default and documented as `autocast`'s companion.

## Measured

| Change | Setup | Before | After |
|---|---|---|---|
| Loss read after backward | `torch.cuda.set_sync_debug_mode('warn')`, two-criterion 2D net (4x1x64x64 batch, CrossEntropyLoss + MSELoss, RTX PRO 5000) | 6 syncs inside forward+backward | 4, plus 1 at the consumer's read |
| Bounded history | one record over 5e5 adds, `reset_loss` per add, window 100 | 19.4 MiB held; `get_last_values(0)` 10.4-11.0 ms | 0.2 MiB; 0.001-0.003 ms |
| Target uploaded once | `torch.profiler`, two-head 2D net (4x1x64x64 batch, CrossEntropyLoss + MSELoss on SEG, RTX PRO 5000) | Memcpy HtoD per step 4; syncs inside forward+backward 4 | 3; 3 |
| Fused EMA | CPU, 64-layer Conv2d(16, 16, 3) stack (128 parameter tensors, 148480 values), `torch.profiler` over one `update_parameters` and the wall clock of 200, three runs | 2313 aten ops per update; 200 updates 191-193 ms | 523; 62-63 ms |
| Progress bar | 500 batches of a 2-criterion Conv2d(1, 3, 1) net through `_Trainer.train()` on CPU, stderr to a file, three epochs per run, two runs each, load average 21-35 | 0.722-0.729 / 1.403-1.462 ms per batch; 99313 / 100278 bytes of stderr per epoch | 0.440-0.445 / 1.012-1.967 ms; 789 / 1516 bytes |
| Threaded checkpoint, CPU | 50M-parameter model (two Linear(5000, 5000)) with AdamW state, 572 MiB file, torch at 8 threads, two runs of four saves, load average 12-18 | training thread blocked 266-315 ms; file on disk after 266-315 ms | 41-47 ms; 361-411 ms |
| Threaded checkpoint, CUDA | same | training thread blocked 577-659 ms; file on disk after 577-659 ms | 235-309 ms; 568-658 ms |
| One broadcast | 2-rank gloo group, rank 0, three runs of 500 polls, a bool and a one-key dict as the payload | two `all_gather_object` polls 709-4029 us per poll | one `broadcast_object_list` 150-199 us per poll |
| Epoch clock | one epoch of examples/Segmentation on CPU, the demo dataset's 5 cases, 325 batches of 8, load average 16-25 | | `epoch 1177.1 s = wait(data) 3.9 + forward 258.1 + criteria 48.2 + backward+step 708.1 + ema 0.0 + telemetry 0.1 + validation 158.6 + checkpoint 0.0 + other 0.1` |
| `channels_last`, `konfai TRAIN` | examples/Segmentation copied to scratch, one RTX, GPU alone, one epoch, four quiet runs | fp32 27.6 s; autocast alone 26.8 s (backward+step 15.5 s) | autocast + channels_last 13.3-14.3 s (backward+step 7.4-7.5 s) |
| `channels_last`, `konfai PREDICTION` | shipped checkpoint, 5 cases, four runs | fp32 4.2 s; autocast 2.7 s | autocast + channels_last 2.2-2.3 s |

The inputs are converted once at the graph's entry because cuDNN hands a channels-last input's output back in that layout: converting again at every module measured a forward of 2.0 s against 1.4-1.6 s per prediction under a test gate's load. The NVML handle is not cached: `nvmlDeviceGetHandleByIndex` measures 0.9 us against 9.6 us for the memory query and 21.5 us per `psutil.virtual_memory()`.

**Values.** The loss read, the target upload, the progress bar, the checkpoint, the broadcast and the epoch clock move nothing: `torch.stack(...).tolist()` of the same 0-d tensors gives the floats `.item()` gave, the same tensor reaches every criterion, and the checkpoint file's contents are what `torch.save` of the live states wrote (one extra host copy of the states in RAM while the write is in flight, 572 MiB here). Windowed loss values are the same floats through the same `np.nanmean`; the whole-history mean moves by summation order only, relative |diff| 2.7e-14 on the 5e5-add sequence and at most 3.2e-14 over 20 random sequences of 5e5 values with 1 % NaN. The EMA moves at the last ulp: after 100 updates at decay 0.999 with the parameters perturbed by N(0, 0.01) each step, max |diff| over the 148480 values is 2.5e-7 (largest |weight| 0.124). `channels_last` is off by default and the default layout is byte-identical to before; with `autocast` it moves no label voxel beyond the 11110 of 58.4 million `autocast` moves against fp32; alone in fp32 it moves 3199 (the kernels chosen differ) for no gain.

**Tests.** The unit tests pin the fused EMA within 1e-6 of the per-tensor rule over three updates, and compare every tensor and scalar of the checkpoint file with the live states.

**Stack.** Stacked on `pr/1.8.2-05-prediction`; merge after it. Before deleting this branch, retarget the next PR of the stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional channels-last tensor support for training, prediction, and nested model graphs.
  - Added configurable timing, progress, validation, and metric-window handling.
  - Improved checkpoint saving with asynchronous processing and clearer error reporting.
  - Added support for loading catalog YAML models and resized model weights.
  - Added improved routing validation and legacy model-path warnings.

- **Documentation**
  - Documented channels-last configuration, supported tensor dimensions, performance, and numerical behavior.

- **Bug Fixes**
  - Improved target handling, device transfers, model loading, and checkpoint reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->