### PR TITLE
Correctness: four defects no error named

### DIFF
--- a/docs/source/usage/large-images.md
+++ b/docs/source/usage/large-images.md
@@ -89,7 +89,13 @@ The generator only calls `get_infos()` and `read_data_slice()`, never
    forward passes.
 5. `num_workers` up until storage or CPU preprocessing saturates.
 6. `pin_memory: true` then measure; it locks host memory and is not always
-   faster.
+   faster. It buys the upload a real DMA: a 32 MiB `int64` target reaches the
+   device in 1.1 ms instead of 2.9 ms of compute-stream time. The epoch rarely
+   follows, because the step is bound by the device, not by the copy. On eight
+   `256³` cases, `128³` patches, batch 2, streamed over four workers, the median
+   epoch went 5.2 s to 5.1 s, inside a 4.9 to 5.5 s spread, for 430 MiB more
+   resident and page-locked; with the dataset cached in RAM the loader pins
+   inline and the epoch did not move at all (4.2 s either way).
 7. `prefetch_factor` only with worker processes, and count the extra batches in
    RAM.
 

--- a/konfai/api.py
+++ b/konfai/api.py
@@ -394,10 +394,13 @@ def evaluate(
     )
     groups_src: dict[str, object] = {}
     for group in groups:
-        destination: dict[str, object] = {"is_input": True}
-        if transforms is not None and group in transforms:
-            destination["transforms"] = _chain_tree(transforms[group], _STAGE_MODULES, f"transforms.{group}")
-        groups_src[group] = {"groups_dest": {group: destination}}
+        # An undeclared chain is spelled None, never left out: the binder materializes its own
+        # default (Normalize) for an absent key, and each group rescaled to [-1, 1] by its own
+        # extrema erases the very difference the metrics measure (MAE 1.9e-8 instead of 0.025 on a
+        # pair related by 0.9x + 0.05). ``transforms`` is the only key GroupTransformMetric reads.
+        declared = None if transforms is None else transforms.get(group)
+        chain: object = "None" if declared is None else _chain_tree(declared, _STAGE_MODULES, f"transforms.{group}")
+        groups_src[group] = {"groups_dest": {group: {"transforms": chain}}}
     metrics_tree = {
         str(output): {
             "targets_criterions": {

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -1889,8 +1889,9 @@ class DataMetric(Data):
                 template[d] = extent[d]
         if all(template):
             raise DatasetManagerError(
-                f"The memory budget cannot hold a patch of '{worst}' ({channels_by_name[worst]}ch x {extent}) "
-                f"with the {halo}-voxel halo its metrics read past each face.",
+                f"The memory budget ({format_bytes(budget)}) cannot hold a patch of '{worst}' "
+                f"({channels_by_name[worst]}ch x {extent}) with the {halo}-voxel halo its metrics read "
+                "past each face.",
                 "Raise 'memory_budget'.",
             )
         if sized == extent:

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -25,7 +25,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import partial
 from pathlib import Path
 from typing import TypeAlias, cast
@@ -493,6 +493,15 @@ class BatchDataItem:
     a: list[int]
     p: list[int]
     is_input: bool
+
+    def pin_memory(self) -> "BatchDataItem":
+        """The batch with its tensor in page-locked memory, so the upload is a real DMA.
+
+        ``torch``'s pinner walks tensors, mappings and sequences and hands anything else back
+        untouched: without this method ``pin_memory: true`` reaches nothing and every upload
+        stays a pageable copy the host has to wait for.
+        """
+        return replace(self, tensor=self.tensor.pin_memory())
 
 
 Sample: TypeAlias = dict[str, DataItem]

--- a/konfai/data/materialize.py
+++ b/konfai/data/materialize.py
@@ -62,6 +62,7 @@ from konfai.data.patching import (
     _SweepMember,
 )
 from konfai.data.transform import LocalityKind, Reduce, Resample, Save, Transform
+from konfai.utils.budget import format_bytes
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import PatchError
 
@@ -195,7 +196,8 @@ class CaseMaterializer:
         if case_bytes > fallback_budget_bytes:
             raise PatchError(
                 f"Case '{self.manager.name}' fell back to the whole-volume path at run time and its"
-                f" working set (~{case_bytes / 2**30:.2f} GiB) exceeds the per-rank budget.",
+                f" working set (~{format_bytes(case_bytes)}) exceeds the per-rank budget"
+                f" ({format_bytes(fallback_budget_bytes)}).",
                 "Nothing was written for this case. Raise 'memory_budget' or make the chain streamable.",
             )
 

--- a/konfai/data/materialize.py
+++ b/konfai/data/materialize.py
@@ -30,7 +30,7 @@ reason live on the manager, because a streamed read of a pending ``Save`` sweeps
 import contextlib
 import sys
 import warnings
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from typing import NamedTuple
 
@@ -54,12 +54,12 @@ from konfai.data.patching import (
     FALLBACK_INFLIGHT_FACTOR,
     AugmentedStage,
     DatasetManager,
-    Stage,
     _PendingSweep,
     _ReadStagePlan,
     _stage_failures_explained,
     _stage_name,
     _sweep_targets,
+    _SweepMember,
 )
 from konfai.data.transform import LocalityKind, Reduce, Resample, Save, Transform
 from konfai.utils.dataset import Attribute, Dataset
@@ -307,7 +307,7 @@ class CaseMaterializer:
                 routes[a] = CopyRoute(Regime.SOLO, reason)
             elif not per_copy:
                 routes[a] = CopyRoute(Regime.SOLO)  # nothing left to write: its own path writes nothing
-            elif len(per_copy) == 1 and self._pointwise_tail(per_copy[0]):
+            elif len(per_copy) == 1 and self._pointwise_tail(per_copy[0].tail_plans):
                 routes[a] = CopyRoute(Regime.SHARED, sweep=per_copy[0])
             else:
                 routes[a] = CopyRoute(Regime.SOLO, self._solo_reason(per_copy))
@@ -318,11 +318,11 @@ class CaseMaterializer:
         return routes
 
     @staticmethod
-    def _pointwise_tail(sweep: _PendingSweep) -> bool:
-        """Whether everything per-copy in this sweep is a pure value map on its slab: a pointwise
-        tail pulls exactly the slab the shared prefix landed on, so every such copy can consume one
-        read; a region draw pulls its own geometry and a GLOBAL_STAT reads a statistic of ITS input."""
-        return all(plan.kind is LocalityKind.POINTWISE for plan in sweep.stage_plans[sweep.copy_stage_start :])
+    def _pointwise_tail(plans: Sequence[_ReadStagePlan]) -> bool:
+        """Whether a copy's per-copy stages are pure value maps on their slab: a pointwise tail pulls
+        exactly the slab the shared prefix landed on, so every such copy can consume one read; a
+        region draw pulls its own geometry and a GLOBAL_STAT reads a statistic of ITS input."""
+        return all(plan.kind is LocalityKind.POINTWISE for plan in plans)
 
     @staticmethod
     def _solo_reason(per_copy: list[_PendingSweep]) -> str:
@@ -330,9 +330,7 @@ class CaseMaterializer:
         if len(per_copy) > 1:
             return "the copy's chain crosses more than one per-copy Save, so it sweeps its own passes."
         sweep = per_copy[0]
-        for stage, plan in zip(
-            sweep.stages[sweep.copy_stage_start :], sweep.stage_plans[sweep.copy_stage_start :], strict=False
-        ):
+        for stage, plan in zip(sweep.tail_stages, sweep.tail_plans, strict=False):
             if plan.kind is not LocalityKind.POINTWISE:
                 return (
                     f"stage '{_stage_name(stage)}' of this copy declares {plan.kind.name},"
@@ -369,11 +367,17 @@ class CaseMaterializer:
         )
         if source is None:
             return set()
-        members: list[tuple[int, _PendingSweep, list[Stage], Attribute]] = []
+        members: list[_SweepMember] = []
         for a, sweep in shared:
             planned, evolved, _reason = manager._replan_sweep(sweep)
-            if planned is not None:
-                members.append((a, sweep, list(sweep.stages[sweep.copy_stage_start :]), evolved))
+            if planned is None:
+                continue
+            tail_plans = planned.stage_plans[sweep.copy_stage_start :]
+            # Re-planned against the materialized source, so re-checked here: the shared block is a
+            # tail stage's region only while every one of them is pointwise. A copy left out takes
+            # its own pass, where its tail reads its own geometry.
+            if self._pointwise_tail(tail_plans):
+                members.append(_SweepMember(a, sweep, evolved, sweep.tail_stages, tail_plans))
         if not members:
             return set()
         written, failure = manager._sweep(source, reference, prefix_evolved, members)

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -432,6 +432,38 @@ class _PendingSweep:
     copy_stage_start: int = 0
     stage_plans: tuple[_ReadStagePlan, ...] = ()
 
+    @property
+    def tail_stages(self) -> tuple[Stage, ...]:
+        """The per-copy part of the segment: what a copy applies to a block the copies share."""
+        return tuple(self.stages[self.copy_stage_start :])
+
+    @property
+    def tail_plans(self) -> tuple[_ReadStagePlan, ...]:
+        """The probe-time plans of :attr:`tail_stages`."""
+        return self.stage_plans[self.copy_stage_start :]
+
+
+@dataclass(frozen=True)
+class _SweepMember:
+    """One stream a sweep writes: the key it is reported under, the :class:`Save` it lands in, the
+    case state its plan leaves (its header), and the per-copy tail it applies to each block.
+
+    ``stages``/``stage_plans`` name the tail in the same shape as a :class:`_PatchStreamSource`'s
+    chain, so the block dispatch is the one the stages before the marker take. Every tail plan is
+    POINTWISE (``CaseMaterializer._pointwise_tail``): the block a member is handed IS its region,
+    which is what lets the copies share one read pass."""
+
+    key: Any
+    sweep: _PendingSweep
+    evolved: Attribute = field(repr=False)
+    stages: tuple[Stage, ...] = ()
+    stage_plans: tuple[_ReadStagePlan, ...] = ()
+
+    def region_spans(self, target: tuple[slice, ...]) -> list[list[slice]]:
+        """The region each tail stage reads for a block of the landing: the block itself, for all of
+        them, a pointwise stage pulling exactly what it is handed."""
+        return [list(target) for _ in range(len(self.stages) + 1)]
+
 
 def _sweep_targets(spatial: list[int], tile: Sequence[int]) -> Iterator[tuple[slice, ...]]:
     """The sweep's regions: ``tile``-sized blocks of the landing, innermost axis fastest.
@@ -2719,7 +2751,7 @@ class DatasetManager:
             return self._sweep_failed_because(
                 sweep, refusal or "the segment feeding it no longer plans against its materialized source."
             )
-        _written, failure = self._sweep(source, sweep, evolved, [(None, sweep, [], evolved)])
+        _written, failure = self._sweep(source, sweep, evolved, [_SweepMember(None, sweep, evolved)])
         if failure is not None:
             return self._sweep_failed_because(sweep, failure)
         return True
@@ -2758,20 +2790,20 @@ class DatasetManager:
         source: _PatchStreamSource,
         reference: _PendingSweep,
         evolved: Attribute,
-        members: list[tuple[Any, _PendingSweep, list[Stage], Attribute]],
+        members: list[_SweepMember],
     ) -> tuple[set[Any], str | None]:
         """The block loop every sweep runs: each block of REFERENCE's landing is read once through
         SOURCE (its first block against EVOLVED, so a region stage recording geometry nowhere the
-        case can read refuses here, as the patch path does), then every member ``(key, sweep, tail,
-        evolved)`` applies its tail to the block and region-writes it into its own stream, opened on
-        the first block with the header the whole-volume pass would leave. Returns the keys written
-        and, when the pass failed, why: every stream is then aborted; an interrupt is re-raised."""
+        case can read refuses here, as the patch path does), then every :class:`_SweepMember`
+        applies its tail to the block and region-writes it into its own stream, opened on the first
+        block with the header the whole-volume pass would leave. Returns the keys written and, when
+        the pass failed, why: every stream is then aborted; an interrupt is re-raised."""
         spatial = list(reference.out_spatial)
         channels = int(reference.source_shape[0])
         tile = self._sweep_tile(spatial, channels, source.stage_plans)
         targets = list(_sweep_targets(spatial, tile))
         depth = self._sweep_depth(spatial, channels, source.stage_plans, tile)
-        if any(_shares_h5_file(source.dataset, sweep.destination) for _key, sweep, _tail, _evolved in members):
+        if any(_shares_h5_file(source.dataset, member.sweep.destination) for member in members):
             # The h5 backend holds a per-file lock for a stream's whole life, on the thread that
             # opened it: a read of that file from any other thread waits for the close that the
             # read itself stands in the way of. One thread, where the lock re-enters.
@@ -2798,7 +2830,12 @@ class DatasetManager:
                     continue  # handed no region: its remap is its action
                 contexts = [plan.region_context(spans[index], spans[index + 1]) for spans in pulls]
                 stage.plan_region_reads(self.name, contexts)
-        sweeps = {key: sweep for key, sweep, _tail, _evolved in members}
+        # A member's tail reads on the landing, whose regions are the targets: known whether or not
+        # the prefix folds its own pulls ahead.
+        for member in members:
+            for stage, plan in zip(member.stages, member.stage_plans, strict=True):
+                stage.plan_region_reads(self.name, [plan.region_context(target, target) for target in targets])
+        sweeps = {member.key: member.sweep for member in members}
         headers: dict[Any, Attribute] = {}
         writer = RegionWriter(lambda key, block, header: _open_sweep_stream(sweeps[key], block, spatial, tile, header))
 
@@ -2823,23 +2860,35 @@ class DatasetManager:
                             Attribute(reference.base_attributes),
                             Attribute(evolved) if index == 0 else None,
                         )
-                    for key, sweep, tail, member_evolved in members:
+                    for member in members:
                         with SWEEP_CLOCK.phase("chain"):
                             member_tensor = tensor.clone() if len(members) > 1 else tensor
                             scope = Attribute(region_attribute)
-                            for stage in tail:
-                                member_tensor = stage(self.name, member_tensor, scope)
+                            # Dispatched exactly as the stages before the marker are, so a tail stage
+                            # reading a companion volume (Mask) or drawing from the voxel's place
+                            # (Noise, CutOUT) is told where its block sits instead of taking it for
+                            # the whole volume.
+                            member_tensor = self._run_streamed_stages(
+                                member.stages,
+                                member.stage_plans,
+                                member.region_spans(target),
+                                member_tensor,
+                                scope,
+                                None,
+                            )
                         # Its own phase, not the chain's: on a device the chain only ENQUEUES,
                         # and this is where the run waits for it as well as for the copy home.
                         with SWEEP_CLOCK.phase("fetch"):
                             block = landing.take(member_tensor)
                         _require_channel_first(
-                            block, spatial, f"A stage of the chain writing '{sweep.group}/{sweep.entry}'"
+                            block, spatial, f"A stage of the chain writing '{member.sweep.group}/{member.sweep.entry}'"
                         )
-                        if key not in headers:
-                            headers[key] = _sweep_header(member_evolved, scope, keys_before)
+                        if member.key not in headers:
+                            headers[member.key] = _sweep_header(member.evolved, scope, keys_before)
                         with SWEEP_CLOCK.phase("wait(write)"):
-                            write.write(key, (slice(0, int(block.shape[0])), *target), block, headers[key])
+                            write.write(
+                                member.key, (slice(0, int(block.shape[0])), *target), block, headers[member.key]
+                            )
                 # The publish is a write too (an OME-Zarr pyramid is derived here), and it is waited for.
                 with SWEEP_CLOCK.phase("wait(write)"):
                     written = write.close()
@@ -3110,20 +3159,40 @@ class DatasetManager:
         cache_attribute: Attribute,
         case_attribute: Attribute | None,
     ) -> tuple[torch.Tensor, Attribute, set[str]]:
-        """The chain forward over a region already read, each stage on the region pair the fold
-        computed for it: HALO reads the enlarged region and is cropped back, ORIENTATION remaps what
-        it read, a CROP's remap is its action (not re-applied), REGRID interpolates to its target
-        extent, a per-voxel stage is told where its region sits. ``cache_attribute`` is the region's
-        scope, evolved by the chain; ``case_attribute``, when given, receives each region stage's
-        case-level geometry (from the full shape). Returns the tensor, the evolved scope, and the
-        keys the scope held before (what the chain added is what the caller may persist).
+        """The chain forward over a region already read: the region's scope is seeded from what the
+        read returned, then :meth:`_run_streamed_stages` walks the stages over it.
+
+        ``cache_attribute`` is the region's scope, evolved by the chain; ``case_attribute``, when
+        given, receives each region stage's case-level geometry (from the full shape). Returns the
+        tensor, the evolved scope, and the keys the scope held before (what the chain added is what
+        the caller may persist).
         """
         cache_attribute.update(attributes)
         cache_attribute["StatisticsSeeded"] = 1.0  # same contract as the pointwise route above
         keys_before = set(cache_attribute.keys())
+        tensor = self._run_streamed_stages(
+            stream_source.stages, stream_source.stage_plans, spans, tensor, cache_attribute, case_attribute
+        )
+        return tensor, cache_attribute, keys_before
 
-        plans = stream_source.stage_plans
-        for stage, plan, source, target in zip(stream_source.stages, plans, spans[:-1], spans[1:], strict=True):
+    def _run_streamed_stages(
+        self,
+        stages: Sequence[Stage],
+        plans: Sequence["_ReadStagePlan"],
+        spans: list[list[slice]],
+        tensor: torch.Tensor,
+        cache_attribute: Attribute,
+        case_attribute: Attribute | None,
+    ) -> torch.Tensor:
+        """Walk STAGES over a region already read, each on the region pair the fold computed for it:
+        HALO reads the enlarged region and is cropped back, ORIENTATION remaps what it read, a
+        CROP's remap is its action (not re-applied), REGRID interpolates to its target extent, a
+        per-voxel stage is told where its region sits.
+
+        The one dispatch: a chain read through the store and a member's per-copy tail (which reads
+        on the landing, so its regions are the blocks themselves) both come here.
+        """
+        for stage, plan, source, target in zip(stages, plans, spans[:-1], spans[1:], strict=True):
             if not plan.kind.is_region:
                 # The span is handed over rather than dropped: a stage reading a second aligned
                 # volume needs to know WHICH part of it lines up with this region, and the
@@ -3146,7 +3215,7 @@ class DatasetManager:
                 stage.write_stream_cache_attribute(case_attribute, list(plan.in_shape), self.name)
                 self._check_region_geometry_reaches_the_case(stage, scoped, cache_attribute)
 
-        return tensor, cache_attribute, keys_before
+        return tensor
 
     def _check_region_geometry_reaches_the_case(
         self, region_stage: Stage, scoped: Attribute, cache_attribute: Attribute

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -2900,6 +2900,11 @@ class DatasetManager:
             write.abort(exception)
             if not isinstance(exception, Exception):
                 raise  # an interrupt is not a sweep failure: no fallback, and no .tmp left behind
+            if isinstance(exception, MemoryError | torch.cuda.OutOfMemoryError):
+                # The fallback answers a failed region with the WHOLE case: a larger allocation than
+                # the one that just failed, on the same device. Running out of memory is the one
+                # failure it cannot repair, so it propagates instead.
+                raise
             return set(), _stage_failure(exception)
         finally:
             write.shutdown()

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -31,7 +31,7 @@ sitk = pytest.importorskip("SimpleITK")
 from konfai import api  # noqa: E402
 from konfai.data.reduction import Std  # noqa: E402
 from konfai.data.transform import Clip, Magnitude, Resample, Save, Write  # noqa: E402
-from konfai.metric.measure import Dice  # noqa: E402
+from konfai.metric.measure import MAE, Dice  # noqa: E402
 from konfai.utils.errors import ConfigError, KonfAIError  # noqa: E402
 
 # --------------------------------------------------------------------------- recording and trees
@@ -230,6 +230,32 @@ def test_the_reference_follows_the_case(cohort: Path, monkeypatch: pytest.Monkey
         assert moved.GetSpacing() == pytest.approx(spacing)
         assert moved.GetOrigin() == pytest.approx(origin)
         assert moved.GetSize() == (7, 6, 5)
+
+
+def test_evaluate_scores_the_stored_values_when_no_chain_is_declared(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An absent ``transforms`` key is not an absent chain: the binder materializes its own default
+    (``Normalize``), and two groups each rescaled to [-1, 1] by their own extrema no longer differ
+    where they did. On a pair related by ``0.9 x + 0.05`` that reported MAE 1.9e-8 for 0.025."""
+    monkeypatch.chdir(tmp_path)
+    truth = np.linspace(0.0, 1.0, 6 * 7 * 8, dtype=np.float32).reshape(6, 7, 8)
+    prediction = (0.9 * truth + 0.05).astype(np.float32)
+    _write_case(tmp_path / "Raw" / "P000" / "CT.mha", truth)
+    _write_case(tmp_path / "Raw" / "P000" / "sCT.mha", prediction)
+
+    result = api.evaluate(
+        "STORED_VALUES",
+        "./Raw:mha",
+        {"sCT": {"CT": [MAE()]}},
+        evaluations_dir=tmp_path / "Evaluations",
+        quiet=True,
+        overwrite=True,
+    )
+
+    assert result.metrics["TRAIN"]["case"]["sCT:CT:MAE"]["P000"] == pytest.approx(
+        float(np.abs(prediction - truth).mean()), rel=1e-5
+    )
 
 
 # --------------------------------------------------------------------------- uncertainty vocabulary

--- a/tests/unit/test_case_expansion.py
+++ b/tests/unit/test_case_expansion.py
@@ -28,10 +28,11 @@ from pathlib import Path
 import numpy as np
 import pytest
 import torch
+from konfai.data import patching as patching_module
 from konfai.data.augmentation import Brightness, CutOUT, Flip, Noise, Permute, Rotate, Scale
 from konfai.data.materialize import CaseMaterializer, Regime, Verdict
 from konfai.data.patching import DatasetManager
-from konfai.data.transform import Clip, Expand, Resample, Save, TensorCast, Transform, Write, split_expand
+from konfai.data.transform import Clip, Expand, Mask, Resample, Save, TensorCast, Transform, Write, split_expand
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import PatchError, TransformError
 
@@ -354,6 +355,68 @@ def test_the_shared_pass_reads_the_source_once_for_every_copy(tmp_path: Path) ->
     assert len(source_reads) == 1, f"the copies did not share the read pass: {len(source_reads)} reads"
 
 
+def test_a_companion_read_in_a_copys_tail_reads_the_block_and_not_the_volume(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stage after the marker is dispatched as a region, like the stages before it.
+
+    A ``Mask`` there reads a second volume beside the block: handed the whole volume's job on a
+    block, it reads the whole mask per block, so the peak the plan priced is one mask larger than
+    it says. Its windows are declared before the first read (the store's chunk cache evicts by next
+    use) and are the blocks' own; and the copies still equal the whole-volume ones.
+    """
+    monkeypatch.setattr(patching_module, "SWEEP_SLAB_ROWS", 3)  # 12 rows: four blocks
+    source = _source(tmp_path)
+    mask = (np.arange(12 * 10 * 8).reshape(1, 12, 10, 8) % 3 > 0).astype(np.uint8)
+    source.write("MASK", "CASE_000", mask, _image_attributes())
+    declared: list[tuple] = []
+    windows: list[tuple] = []
+    whole: list[tuple] = []
+    read_slice, read_whole = Dataset.read_data_slice, Dataset.read_data
+    monkeypatch.setattr(
+        Dataset, "plan_region_reads", lambda self, group, name, w: declared.append((group, name, list(w)))
+    )
+    monkeypatch.setattr(
+        Dataset,
+        "read_data_slice",
+        lambda self, group, name, s: (windows.append((group, name, tuple(s))), read_slice(self, group, name, s))[1],
+    )
+    monkeypatch.setattr(
+        Dataset, "read_data", lambda self, group, name: (whole.append((group, name)), read_whole(self, group, name))[1]
+    )
+
+    def chain(store: str) -> list:
+        mask = Mask(path="MASK")
+        mask.set_datasets([source])
+        return [
+            Clip(0.0, 50.0),
+            Expand(nb=2, pattern="{name}_r{a:02d}"),
+            _draw(Brightness(b_std=0.3)),
+            mask,
+            Write(f"{tmp_path / store}:h5"),
+        ]
+
+    streamed = _manager(source, chain("streamed"))
+    assert CaseMaterializer(streamed).materialize_copies([1, 2]) == {
+        1: (Verdict.STREAM, Regime.SHARED),
+        2: (Verdict.STREAM, Regime.SHARED),
+    }
+    mask_windows = [window for group, _name, window in windows if group == "MASK"]
+    blocks = [(slice(None), slice(row, row + 3), slice(0, 10), slice(0, 8)) for row in (0, 3, 6, 9)]
+    assert mask_windows == sorted(blocks * 2, key=lambda window: window[1].start), "one region per block per copy"
+    assert not [entry for entry in whole if entry[0] == "MASK"], "the whole mask was read beside a block"
+    assert [(group, name) for group, name, _w in declared].count(("MASK", "CASE_000")) == 2, "once per copy"
+    assert all(window in blocks for _g, _n, w in declared for window in w)
+
+    classic = _manager(source, chain("classic"))
+    for a in (1, 2):
+        CaseMaterializer(classic)._assemble_and_write(a)
+    for a in (1, 2):
+        entry = f"CASE_000_r{a:02d}"
+        got = Dataset(tmp_path / "streamed", "h5").read_data("CT", entry)[0]
+        np.testing.assert_array_equal(got, Dataset(tmp_path / "classic", "h5").read_data("CT", entry)[0])
+
+
 def test_a_region_draw_takes_its_own_pass_and_the_plan_names_the_draw(tmp_path: Path) -> None:
     """A draw reading elsewhere than its target slab cannot ride the shared slab, and says so."""
     source = _source(tmp_path)
@@ -417,11 +480,18 @@ def test_a_solo_copy_sweeps_on_the_requested_device(tmp_path: Path, monkeypatch:
     ],
     ids=["Noise", "CutOUT", "Rotate", "Scale"],
 )
-def test_the_geometric_and_field_draws_stream_their_copies(tmp_path: Path, draw, regime: str, atol: float) -> None:
+@pytest.mark.parametrize("rows", [64, 3], ids=["one-block", "four-blocks"])
+def test_the_geometric_and_field_draws_stream_their_copies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, draw, regime: str, atol: float, rows: int
+) -> None:
     """The offline-augmentation case: 4 copies of a free rotation were 4 whole-volume passes and 5x
     the volume in RSS. A rotation or a scale now pulls the source box each region maps to (its own
     pass, bounded); a noise field or a cutout is a function of the voxel's position, so their copies
-    share one read pass. Streamed copies equal the whole-volume ones."""
+    share one read pass. Streamed copies equal the whole-volume ones.
+
+    Over both decompositions: how many blocks the landing is swept in is not a value, and a draw
+    parameterised by the voxel's PLACE is exactly the one that can disagree across them."""
+    monkeypatch.setattr(patching_module, "SWEEP_SLAB_ROWS", rows)
     source = _source(tmp_path)
     augmentation = draw()
     streamed = _manager(

--- a/tests/unit/test_data_manager.py
+++ b/tests/unit/test_data_manager.py
@@ -29,6 +29,7 @@ import pytest
 import torch
 from konfai.data.augmentation import DataAugmentation, DataAugmentationsList
 from konfai.data.data_manager import (
+    BatchDataItem,
     Data,
     DataPrediction,
     DatasetIter,
@@ -45,6 +46,7 @@ from konfai.data.transform import TensorCast, Transform, TransformLoader
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.runtime import State, restart_startup_clock
 from konfai.utils.utils import split_path_spec
+from torch.utils.data._utils.pin_memory import pin_memory as torch_pin_memory
 
 # --------------------------------------------------------------------------------------
 # Data._split. TRAIN/RESUME shards must be equal length to avoid a DDP hang
@@ -939,6 +941,34 @@ def test_data_prediction_disables_workers_for_konfai_inference_transforms() -> N
     assert dataset.dataLoader_args["num_workers"] == 0
     assert "prefetch_factor" not in dataset.dataLoader_args
     assert "persistent_workers" not in dataset.dataLoader_args
+
+
+def test_pin_memory_reaches_the_batch_tensor() -> None:
+    # ``torch_pin_memory`` is what both DataLoader iterators call on a collated batch; it hands
+    # back untouched anything that is neither a tensor, a mapping nor a sequence. A recording
+    # subclass stands in for the pinned tensor so the contract holds without a CUDA device.
+    pinned: list[torch.Tensor] = []
+
+    class Recording(torch.Tensor):
+        def pin_memory(self, *args: object, **kwargs: object) -> "Recording":
+            pinned.append(self)
+            return self
+
+    item = BatchDataItem(
+        name=["case"],
+        tensor=torch.zeros(1, 2, 2).as_subclass(Recording),
+        attribute=[Attribute()],
+        x=[0],
+        a=[0],
+        p=[0],
+        is_input=True,
+    )
+
+    batch = torch_pin_memory({"CT": item})
+
+    assert pinned, "pin_memory: true never reached the batch's tensor"
+    assert batch["CT"].name == ["case"]
+    assert batch["CT"].is_input is True
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/unit/test_memory_budget.py
+++ b/tests/unit/test_memory_budget.py
@@ -681,7 +681,7 @@ def test_a_halo_metric_no_longer_vetoes_the_patched_evaluation(tmp_path: Path, m
         state=State.EVALUATION,
         path_env={"KONFAI_EVALUATIONS_DIRECTORY": tmp_path / "Evaluations"},
     )
-    os.environ["KONFAI_CONFIG_MODE"] = "Done"
+    monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
     with strict_config("Evaluator", refuse=False):
         evaluator = apply_config()(Evaluator)()
 

--- a/tests/unit/test_memory_budget.py
+++ b/tests/unit/test_memory_budget.py
@@ -409,9 +409,11 @@ def test_eval_sizing_spans_an_axis_too_thin_for_its_halo(monkeypatch: pytest.Mon
 
 
 def test_eval_sizing_refuses_a_budget_no_halo_patch_fits(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Its remedy is "raise memory_budget", so the refusal names the budget it broke, not only the
+    # case it could not hold: without the figure the reader has to go and find what it was.
     from konfai.utils.errors import DatasetManagerError
 
-    with pytest.raises(DatasetManagerError, match="halo"):
+    with pytest.raises(DatasetManagerError, match=r"budget \(4\.00 KiB\).+halo"):
         _metric_sizing(monkeypatch, [1, 64, 64, 64], 4096, 3)
 
 

--- a/tests/unit/test_sweep_pipeline.py
+++ b/tests/unit/test_sweep_pipeline.py
@@ -351,6 +351,34 @@ def test_a_uint16_case_through_a_chain_torch_cannot_run_says_so(
         CaseMaterializer(manager).materialize()
 
 
+class _OutOfMemoryOnRegions(Transform):
+    """Fails on a region the way a read under a tight cap fails, and succeeds on the whole volume."""
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        return PatchLocality(LocalityKind.POINTWISE)
+
+    def stream_region(self, name: str, tensor, context: RegionContext, cache_attribute: Attribute):
+        raise MemoryError("Unable to allocate 30.5 MiB for an array with shape (78, 320, 320)")
+
+    def __call__(self, name: str, tensor, cache_attribute: Attribute):
+        return tensor
+
+
+def test_a_sweep_that_runs_out_of_memory_does_not_answer_with_the_whole_case(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole-volume fallback holds the WHOLE case, a larger allocation than the region that just
+    failed and on the same device: it repairs a stage that cannot serve a region, never a shortage
+    of memory. So an out-of-memory propagates where every other failure falls back."""
+    monkeypatch.setattr(patching_module, "SWEEP_SLAB_ROWS", 3)
+    source = Dataset(tmp_path / "src", "mha")
+    source.write("CT", "CASE_000", np.ones((1, 14, 10, 8), np.float32), _attributes())
+    chain = [_OutOfMemoryOnRegions(), Save(f"{tmp_path / 'out'}:h5")]
+
+    with pytest.raises(MemoryError):
+        CaseMaterializer(_manager(source, chain, tmp_path)).materialize()
+
+
 def test_a_serial_sweep_charges_its_writes_where_a_pipelined_one_does(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_transformer_workflow.py
+++ b/tests/unit/test_transformer_workflow.py
@@ -1036,6 +1036,29 @@ def test_on_fallback_error_holds_at_run_time_too(tmp_path: Path, monkeypatch: py
     assert not Dataset(tmp_path / "out", "h5").is_dataset_exist("CT_out", "CASE_000")
 
 
+def test_a_run_time_fallback_refusal_names_the_budget_it_broke(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Its remedy is 'raise memory_budget', so the refusal must say what the case needs AND what
+    the budget grants: with only the first figure the reader has to go and find the second."""
+    from konfai.data.patching import DatasetManager
+
+    _write_source(tmp_path)
+    config_path = _write_config(tmp_path, _STREAMABLE.format(out=tmp_path / "out"))
+    config_path.write_text(config_path.read_text().replace("memory_budget: auto", "memory_budget: 1KiB"))
+    workflow = _build(tmp_path)
+    workflow.setup(1)
+    monkeypatch.setattr(
+        DatasetManager,
+        "_materialize_save",
+        lambda self, sweep: self._sweep_failed_because(sweep, "OSError: no space left on device"),
+    )
+
+    with (
+        pytest.raises(TransformerError, match=r"exceeds the per-rank budget \(1.00 KiB\)"),
+        pytest.warns(UserWarning),
+    ):
+        workflow.run_process(1, 0, 0, [])
+
+
 def test_a_failing_case_does_not_stop_the_shard_and_is_listed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """One unreadable case among three: the other two are written, the rank finishes its shard, and
     it exits non-zero naming the failed case. Before, the rank died at the broken case and every


### PR DESCRIPTION
Four defects that ran without an error naming them. `pin_memory: true` pinned nothing, because `BatchDataItem` is a frozen dataclass and torch's pinner hands anything that is not a tensor, mapping or sequence back untouched, so every host upload stayed a pageable copy; the batch item now takes part in the pin and the copies become a DMA. A sweep that raised `MemoryError` or `torch.OutOfMemoryError` was recorded as a stage failure and the case fell back to the whole-volume path, which assembles the whole case on the same device; those two now propagate and every other failure keeps its fallback, and the two refusals that break on `memory_budget` now name the budget through `format_bytes`. `konfai.evaluate` left `transforms` out of the tree for a group with no declared chain, so the binder materialized its default `Normalize` and rescaled both sides of every metric independently; an undeclared chain is now spelled `None`, as the shipped YAML configs spell it, and `is_input` goes with it. Stages after an `Expand` marker ran through `__call__` on each block of the shared read pass, so a stage that needs to know where its block sits took the block for the whole volume; the tail now goes through the same dispatcher the pre-marker stages take.

## Measured

| What | Before | After |
| --- | --- | --- |
| 4 MiB int64 target, compute-stream time (`konfai TRAIN -c Config.yml --gpu 0 -y`, Segmentation example, autocast + channels_last, one RTX PRO 5000, three mid-epoch steps) | 226 us | 148 us |
| 3D case, 128^3 patches, batch 2: 32 MiB target / 16 MiB input | 2.94 ms / 1.52 ms | 1.10 ms / 0.52 ms |
| Segmentation example, 325 steps | 9.4 / 9.3 / 9.4 s | 9.4 / 9.3 / 9.3 s |
| Eight 256^3 cases, 128^3 patches, batch 2, cached in RAM (no worker, the loader pins inline) | 4.2 s, wait(data) 0.3 s | 4.2 s, wait(data) 0.4 s |
| The same streamed over four workers: median epoch, peak RSS | 5.2 s, 2.53 GiB | 5.1 s (4.9 to 5.5 s spread), 2.95 GiB, the 430 MiB being page-locked |
| Streamed TRANSFORM (Resample -> Gradient -> Write), 200x320x320 float32, RLIMIT_AS = interpreter floor + 192 MiB, `memory_budget` 128MiB | warns "Falling back to the whole-volume path", stopped only by the whole-volume check (0.38 GiB vs 128 MiB) | the out-of-memory propagates |
| `CUDA_VISIBLE_DEVICES= konfai.evaluate` with MAE + SSIM, 200x320x320 float32, pair related by `0.9 x + 0.05` | MAE 1.9e-8, SSIM 1.0 | MAE 0.025, SSIM 0.9945 |
| 12x10x8 case swept in 4 blocks (`SWEEP_SLAB_ROWS=3`), streamed copy against the whole-volume copy: Noise / CutOUT max\|diff\| | 4.85 / 50.0 | 0 / 0 |
| Same case, dataset Mask after the marker, two copies: source block reads / whole-mask reads / mask region reads | 8 / 1 (960 voxels per block) / 12 | 4 / 0 / 8, each of the block's own 240 voxels |

The step is bound by the device (busy 87 % of the step's wall in 2D, 95 % in 3D), so the epoch does not follow the stream time the DMA saves, and `pin_memory` keeps its default of false.

## Values

Two of the four move values. `konfai.evaluate` with no declared chain now scores the stored values: MAE 0.025 instead of 1.9e-8, SSIM 0.9945 instead of 1.0 on the pair above. A streamed copy's tail past an `Expand` marker now matches the whole-volume copy: Noise max|diff| 4.85 -> 0, CutOUT 50.0 -> 0, both already 0 when the landing fits in one block. Every stage that inherits `stream_region`, which delegates to `__call__`, is bit-identical; the affected built-ins are transform `Mask` and the `PlacedDraw` draws `Noise` and `CutOUT`. `pin_memory` moves nothing: a seeded epoch each way leaves the weights bit-identical (0 of 1 934 299 differ; a before/before pair is also 0).

## Tests

`test_sweep_pipeline.py::test_a_sweep_that_runs_out_of_memory_does_not_answer_with_the_whole_case` (completed as WHOLE_VOLUME before), `test_memory_budget.py::test_eval_sizing_refuses_a_budget_no_halo_patch_fits` (now matching "budget (4.00 KiB)"), `test_transformer_workflow.py::test_a_run_time_fallback_refusal_names_the_budget_it_broke`, `test_api.py::test_evaluate_scores_the_stored_values_when_no_chain_is_declared` (reported 9.2e-09 for 0.0250746 before), and in `test_case_expansion.py` the values oracle over both block decompositions (`SWEEP_SLAB_ROWS` 64 and 3 on a 12-row case) plus the read contract counted on a dataset Mask after the marker.

## Stack

Stacked on `pr/1.8.2-08-companion`; merge after it. Before deleting this branch, retarget the next PR of the stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pinned-memory support for batch tensors to improve data transfer workflows.
  * Evaluation results now consistently report the configured transform chain, including groups without transforms.
  * Improved streamed processing for copied data and companion masks.

* **Bug Fixes**
  * Memory and CUDA out-of-memory errors are now reported instead of triggering whole-case fallback.
  * Memory-budget errors now include the configured budget for clearer troubleshooting.

* **Documentation**
  * Expanded guidance on `pin_memory` with benchmark data covering transfer time, epoch impact, and memory usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->