### PR TITLE
Out-of-core: grids cut on the rank, declared patch reads, a folding chain that streams

### DIFF
--- a/docs/source/concepts/streaming.md
+++ b/docs/source/concepts/streaming.md
@@ -157,8 +157,8 @@ quarter turn are `ORIENTATION`; `ColorTransform` and its subclasses are
 `POINTWISE`, their field and their box being functions of the voxel's position in
 the whole volume. The `Mask` DRAW and `Elastix` load the volume (the draw's output grid is the
 mask's own, which is already resident); the `Mask` TRANSFORM above is pointwise and reads its
-mask by region, and declares those reads to the decoded-chunk cache ahead of a sweep, as the
-sweep declares its own.
+mask by region, and declares those reads to the decoded-chunk cache ahead of a sweep or of a
+case's patches, as the reader declares its own.
 
 The transforms that load the volume do so because their answer needs it:
 `Clip` and `Standardize` under a `mask` read a second full volume a patch cannot

--- a/docs/source/reference/api/extension-points.md
+++ b/docs/source/reference/api/extension-points.md
@@ -175,13 +175,14 @@ dtype its `inverse()` reads.
 A stage that reads a second volume beside its region (`Mask` reads its mask where
 the region sits) overrides `stream_region(name, tensor, context, cache_attribute)`:
 `context` says which part of the input the tensor covers and which part of the
-output is due. It may also override `plan_region_reads(name, contexts)`: a sweep
-calls it once, before its first region, with the contexts `stream_region` will
+output is due. It may also override `plan_region_reads(name, contexts)`: it is
+called once, before a case's first region, with the contexts `stream_region` will
 then be handed in that order, and the stage declares the windows it will read to
 the dataset holding them (`Dataset.plan_region_reads`), so a store that caches
-decoded chunks evicts by next use rather than by recency. A hint: neither what is
-read nor its values depend on it, and the patch route, whose order is the
-DataLoader's, never calls it.
+decoded chunks evicts by next use rather than by recency. A sweep declares its
+blocks; the patch route declares the case's patches in the DataLoader's own order,
+on the process that reads them. A hint: neither what is read nor its values depend
+on it.
 
 What a declaration costs you:
 

--- a/docs/source/reference/components/transforms.md
+++ b/docs/source/reference/components/transforms.md
@@ -147,7 +147,7 @@ stage that changes no grid refuses rather than pretend.
 | `Softmax` | `softmax(dim)`. | `dim=0` | no | no | **yes** at `dim=0`; no over a spatial axis (the reduction spans the extent) |
 | `FlatLabel` | Binarise selected labels (else `>0`) → 1. | `labels=None` | no | no | **yes** |
 | `SelectLabel` | Remap labels; entries are `"(old,new)"` strings. | `labels` | no | no | **yes** |
-| `Mask` | Set voxels where mask==0 to `value_outside`. | `path="./default.mha", value_outside=0` | no | no | **yes**: per voxel; the dispatcher tells it where its region sits (`stream_region`) and it reads that part of the mask, a dataset group or an `.mha`; a sweep is told those reads ahead (`plan_region_reads`), so the decoded-chunk cache keeps a dataset mask's chunks by their next use |
+| `Mask` | Set voxels where mask==0 to `value_outside`. | `path="./default.mha", value_outside=0` | no | no | **yes**: per voxel; the dispatcher tells it where its region sits (`stream_region`) and it reads that part of the mask, a dataset group or an `.mha`; a sweep, and a case's patches, are told those reads ahead (`plan_region_reads`), so the decoded-chunk cache keeps a dataset mask's chunks by their next use |
 | `Dilate` | Binary dilation via max-pool (2D/3D). | `dilate=1` | no | no | **yes**: halo of `dilate` voxels, within half the patch |
 | `Sum` | Sum over `dim` (merges multi-model label maps). | `dim=0` | no† | no | **yes** at `dim=0`; no over a spatial axis (the reduction spans the extent) |
 | `MergeLabels` | Merge the per-model `argmax` maps of a `combine: Concat` ensemble into one global label map (the correct alternative to `Sum` for disjoint-task ensembles, e.g. 5-task TotalSegmentator). |: | no | no | yes |

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -363,6 +363,60 @@ def _interleaved_case_entries(patches: list["DatasetPatch"], entries: list[tuple
     return sorted(entries, key=lambda entry: (order[entry], *entry))
 
 
+class PatchReadOrder:
+    """The epoch's patch order, published from where it is drawn to where the patches are read.
+
+    A store that caches decoded chunks decides what to keep from the sequence it is told is coming
+    (:meth:`~konfai.utils.dataset.Dataset.plan_region_reads`). On the patch route that sequence is
+    the sampler's, drawn at the epoch's start in the parent, while the reads happen in the
+    DataLoader's workers, each holding a cache of its own: a worker is forked before the draw, and a
+    persistent one is never forked again, so the order reaches it through shared memory or not at
+    all. Nothing but the order travels: neither what is read nor its values depend on this.
+
+    A worker is handed one batch in ``num_workers``, so what it declares for a case is the
+    subsequence of its own batches. Their stride is learnt from the first batch it is given, which
+    assumes only that the batches are dealt round-robin, not which worker opens the epoch.
+    """
+
+    def __init__(self, mapping: list[tuple[int, int, int]], batch_size: int) -> None:
+        self._mapping = mapping
+        self._batch_size = max(1, batch_size)
+        self._order = torch.zeros(len(mapping), dtype=torch.int64).share_memory_()
+        self._epoch = torch.zeros(1, dtype=torch.int64).share_memory_()
+        self._epoch_read = 0
+        self._entries: dict[int, list[tuple[int, int]]] = {}
+
+    def publish(self, order: torch.Tensor) -> None:
+        """The order the epoch is about to be walked in, from the sampler that drew it."""
+        self._order.copy_(order)
+        self._epoch += 1
+
+    def entering(self, index: int) -> list[tuple[int, int]] | None:
+        """The ``(copy, patch)`` entries of ``index``'s case this process still has to read, in the
+        order it will read them; ``None`` once the case has been entered this epoch, and while no
+        sampler has published an order at all."""
+        self._regroup(index)
+        return self._entries.pop(self._mapping[index][0], None)
+
+    def _regroup(self, index: int) -> None:
+        """Group this process's remaining reads by case, once per epoch, from the batch ``index``
+        opens: a batch is ``batch_size`` consecutive positions, and the next batch this process is
+        handed is ``num_workers`` batches on."""
+        epoch = int(self._epoch[0])
+        if epoch == self._epoch_read:
+            return
+        self._epoch_read = epoch
+        order = self._order.tolist()
+        worker = data.get_worker_info()
+        stride = self._batch_size * (worker.num_workers if worker is not None else 1)
+        entries: dict[int, list[tuple[int, int]]] = {}
+        for start in range(order.index(index), len(order), stride):
+            for position in range(start, min(start + self._batch_size, len(order))):
+                case, copy, patch = self._mapping[order[position]]
+                entries.setdefault(case, []).append((copy, patch))
+        self._entries = entries
+
+
 class WindowedCaseSampler(Sampler[int]):
     """Locality-aware training order: shuffle cases, window them, shuffle patches within each window.
 
@@ -386,9 +440,13 @@ class WindowedCaseSampler(Sampler[int]):
         window: int | None,
         batch_size: int,
         num_workers: int,
+        read_order: PatchReadOrder | None = None,
     ) -> None:
         self.mapping = mapping
         self.shuffle = shuffle
+        # Where the epoch's order is published for the processes that read the patches; a sampler
+        # asked for nothing but its order publishes nowhere.
+        self.read_order = read_order
         self.batch_size = max(1, batch_size)
         self.num_workers = max(1, num_workers)
         self.case_entries: dict[int, list[int]] = {}
@@ -456,10 +514,14 @@ class WindowedCaseSampler(Sampler[int]):
 
     def __iter__(self) -> Iterator[int]:
         if not self.shuffle:
-            return iter(range(len(self.mapping)))
-        if self.window is None:
-            return iter(torch.randperm(len(self.mapping)).tolist())
-        return iter(self._windowed_order())
+            order = torch.arange(len(self.mapping))
+        elif self.window is None:
+            order = torch.randperm(len(self.mapping))
+        else:
+            order = torch.as_tensor(self._windowed_order(), dtype=torch.int64)
+        if self.read_order is not None:
+            self.read_order.publish(order)
+        return iter(order.tolist())
 
     def __len__(self) -> int:
         # One epoch is one pass over the mapping: windowing chooses the ORDER, not the size. This is
@@ -541,6 +603,7 @@ class DatasetIter(data.Dataset):
         buffer_size: int,
         apply_augmentations: bool = True,
         use_cache=True,
+        batch_size: int = 1,
     ) -> None:
         self.rank = rank
         self.data = data
@@ -557,6 +620,7 @@ class DatasetIter(data.Dataset):
         self._index_cache_lookup: set[int] = set()
         self.inline_augmentations = inline_augmentations
         self.has_augmented_samples = self.apply_augmentations and any(a > 0 for _, a, _ in mapping)
+        self.read_order = PatchReadOrder(mapping, batch_size)
 
     def get_patch_config(self) -> tuple[list[int] | None, OverlapSpec]:
         return self.patch_size, self.overlap
@@ -682,6 +746,16 @@ class DatasetIter(data.Dataset):
     def unload_data(self, group_dest: str, index: int) -> None:
         return self.data[group_dest][index].unload()
 
+    def _declare_case_reads(self, index: int) -> None:
+        """Tell each group's store the patches this process will read of the case ``index`` enters,
+        in the order it will read them: once per case, at the first patch of it that arrives."""
+        entries = self.read_order.entering(index)
+        if entries is None:
+            return
+        case = self.mapping[index][0]
+        for _group_src, group_dest, chain in _chains(self.groups_src):
+            self.data[group_dest][case].plan_patch_reads(entries, chain.is_input, self.apply_augmentations)
+
     def __len__(self) -> int:
         return len(self.mapping)
 
@@ -696,6 +770,8 @@ class DatasetIter(data.Dataset):
             if len(self._index_cache) >= self.buffer_size and not self.use_cache:
                 self._unload_data(self._index_cache[0])
             self._load_data(x, a)
+
+        self._declare_case_reads(index)
 
         for _group_src, group_dest, chain in _chains(self.groups_src):
             dataset = self.data[group_dest][x]
@@ -1273,6 +1349,7 @@ class Data(DataSources):
             overlap=self.patch.overlap if self.patch is not None else None,
             buffer_size=self._buffer_size,
             use_cache=use_cache,
+            batch_size=self.batch_size,
         )
         resolved_num_workers = self._num_workers
         if self.requires_single_process_loading:
@@ -1702,23 +1779,25 @@ class Data(DataSources):
                 # (loader_index == 0). Validation is scored over the whole subset whatever the order,
                 # and ``None`` keeps it on the plain global one.
                 window = self.subset.shuffle_window if loader_index == 0 else None
+                dataset_iter = self.datasetIter(
+                    rank=i,
+                    data=dataset_items,
+                    mapping=mapping,
+                    data_augmentations_list=self._get_data_augmentations(
+                        loader_index == 0 or self.validation_augmentations
+                    ),
+                    apply_augmentations=loader_index == 0 or self.validation_augmentations,
+                )
                 data_loaders[i].append(
                     DataLoader(
-                        dataset=self.datasetIter(
-                            rank=i,
-                            data=dataset_items,
-                            mapping=mapping,
-                            data_augmentations_list=self._get_data_augmentations(
-                                loader_index == 0 or self.validation_augmentations
-                            ),
-                            apply_augmentations=loader_index == 0 or self.validation_augmentations,
-                        ),
+                        dataset=dataset_iter,
                         sampler=WindowedCaseSampler(
                             mapping,
                             self.subset.shuffle,
                             window,
                             self.batch_size,
                             self.resolved_num_workers,
+                            dataset_iter.read_order,
                         ),
                         batch_size=self.batch_size,
                         **self.dataLoader_args,

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -1546,9 +1546,8 @@ class Data(DataSources):
         The managers are rebuilt against the already-resolved sources and the SAME case lists --
         NOT through ``prepare()`` (its idempotence guard would skip the rebuild): so a later
         ``get_data`` shards cases identically across the restart: only the grids and the patch mapping change.
-        Each manager copies the shared ``DatasetPatch`` (with ``pad_to_patch``) at construction,
-        which is why the new sizes are written into that shared list IN PLACE: the loader factory
-        holds a reference to it too.
+        The new sizes are written into the shared ``patch_size`` list IN PLACE because the loader
+        factory holds a reference to it; each rebuilt manager then takes its own copy of them.
         """
         if self.patch is None or self._managers is None:
             raise DatasetManagerError(

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -53,7 +53,7 @@ from konfai.data.transform import (
     stat_seed_valid,
 )
 from konfai.utils.config import apply_config, config
-from konfai.utils.dataset import Attribute, Dataset, DataStream
+from konfai.utils.dataset import Attribute, Dataset, DataStream, as_channel_first
 from konfai.utils.errors import ConfigError, PatchError, TransformError
 from konfai.utils.runtime import preserved_rng, rank_cpu_share, seed_all
 from konfai.utils.utils import (
@@ -784,11 +784,14 @@ def _sweep_header(evolved: Attribute, scope: Attribute, keys_before: set[str]) -
     return attributes
 
 
-def _require_channel_first(block: np.ndarray, spatial: list[int], what: str) -> None:
-    """Refuse a block that lost the channel-first layout. Writing it anyway is the worst outcome
-    available: the header would take the block's first spatial extent for a channel count and
-    publish a store of that many "channels", raising nothing, while the whole-volume path
-    returns the right rank: the two would silently disagree."""
+def _channel_first_block(block: np.ndarray, spatial: list[int], header: Attribute, what: str) -> np.ndarray:
+    """The block a region write ships: channel-first, single-channel where the header says so
+    (:func:`as_channel_first`, the rule the whole-volume write applies), else refused.
+
+    Writing another rank anyway is the worst outcome available: the header would take the block's
+    first spatial extent for a channel count and publish a store of that many "channels", raising
+    nothing, while the whole-volume path returns the right rank: the two would silently disagree."""
+    block = as_channel_first(block, header)
     if block.ndim != len(spatial) + 1:
         raise PatchError(
             f"{what} returned a rank-{block.ndim} block where the channel-first layout needs rank"
@@ -797,6 +800,7 @@ def _require_channel_first(block: np.ndarray, spatial: list[int], what: str) -> 
             " stays C[Z]YX; only then does a region write mean the same thing as the"
             " whole-volume pass.",
         )
+    return block
 
 
 def _open_sweep_stream(
@@ -2354,25 +2358,29 @@ class DatasetManager:
     def _plan_read_stage(
         self, stage: Stage, loc: PatchLocality, shape: list[int], evolved: Attribute
     ) -> "_ReadStagePlan":
-        """One stage's slot in the composed plan: its shapes, its pull map, and (for a region stage)
-        the geometry it leaves for the stages after it (``write_stream_cache_attribute``)."""
+        """One stage's slot in the composed plan: its shapes, its pull map, and the case state it
+        leaves for the stages after it and for the header the sweep ships
+        (``write_stream_cache_attribute``, stated by every stage, region or not: a fold of the
+        channel axis consumes a key that describes an input the output no longer has)."""
         if not loc.kind.is_region:
-            return _ReadStagePlan(loc.kind, tuple(shape), tuple(shape), None)
-        if loc.kind is LocalityKind.HALO:
-            return _ReadStagePlan(
+            plan = _ReadStagePlan(loc.kind, tuple(shape), tuple(shape), None)
+        elif loc.kind is LocalityKind.HALO:
+            plan = _ReadStagePlan(
                 loc.kind, tuple(shape), tuple(shape), _HaloPull(_halo_radii(loc.halo, len(shape)), list(shape))
             )
-        # ORIENTATION / CROP / REGRID: the stage's own remap, on the state the stages before it left.
-        pull = _RemapPull(stage.stream_region_source, list(shape), Attribute(evolved), self.name)
-        measured = getattr(stage, "measured_region_source", None)
-        run_pull = (
-            _RemapPull(measured, list(shape), Attribute(evolved), self.name)
-            if measured is not None and getattr(stage, "measures_at_run", False)
-            else None
-        )
-        out = self._stage_out_shape(stage, shape, Attribute(evolved))
+        else:
+            # ORIENTATION / CROP / REGRID: the stage's own remap, on the state the stages before it left.
+            pull = _RemapPull(stage.stream_region_source, list(shape), Attribute(evolved), self.name)
+            measured = getattr(stage, "measured_region_source", None)
+            run_pull = (
+                _RemapPull(measured, list(shape), Attribute(evolved), self.name)
+                if measured is not None and getattr(stage, "measures_at_run", False)
+                else None
+            )
+            out = self._stage_out_shape(stage, shape, Attribute(evolved))
+            plan = _ReadStagePlan(loc.kind, tuple(shape), tuple(out), pull, run_pull)
         stage.write_stream_cache_attribute(evolved, list(shape), self.name)
-        return _ReadStagePlan(loc.kind, tuple(shape), tuple(out), pull, run_pull)
+        return plan
 
     def _stage_out_shape(self, stage: Stage, shape: list[int], attribute: Attribute) -> list[int]:
         """The spatial shape one stage folds ``shape`` to: a transform's map or a draw's own.
@@ -2900,11 +2908,14 @@ class DatasetManager:
                         # and this is where the run waits for it as well as for the copy home.
                         with SWEEP_CLOCK.phase("fetch"):
                             block = landing.take(member_tensor)
-                        _require_channel_first(
-                            block, spatial, f"A stage of the chain writing '{member.sweep.group}/{member.sweep.entry}'"
-                        )
                         if member.key not in headers:
                             headers[member.key] = _sweep_header(member.evolved, scope, keys_before)
+                        block = _channel_first_block(
+                            block,
+                            spatial,
+                            headers[member.key],
+                            f"A stage of the chain writing '{member.sweep.group}/{member.sweep.entry}'",
+                        )
                         with SWEEP_CLOCK.phase("wait(write)"):
                             write.write(
                                 member.key, (slice(0, int(block.shape[0])), *target), block, headers[member.key]

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -2849,17 +2849,7 @@ class DatasetManager:
         )
         ahead = depth if pulls else 0
         if pulls:
-            # The store is told the whole sequence, so a decoded block a later region asks for again
-            # outlives one none does. A hint: see Dataset.plan_region_reads.
-            lead = [slice(None)] * (len(source.shape) - len(spatial))
-            source.dataset.plan_region_reads(source.group, source.entry, [(*lead, *spans[0]) for spans in pulls])
-            # And each stage the regions it will be handed, in the same order, so one reading a
-            # companion volume beside them (Mask) declares those reads too.
-            for index, (stage, plan) in enumerate(zip(source.stages, source.stage_plans, strict=True)):
-                if plan.kind is LocalityKind.CROP:
-                    continue  # handed no region: its remap is its action
-                contexts = [plan.region_context(spans[index], spans[index + 1]) for spans in pulls]
-                stage.plan_region_reads(self.name, contexts)
+            self._declare_region_reads([(source, spans) for spans in pulls])
         # A member's tail reads on the landing, whose regions are the targets: known whether or not
         # the prefix folds its own pulls ahead.
         for member in members:
@@ -3156,6 +3146,63 @@ class DatasetManager:
         spans = self._region_spans(stream_source, target_slices)
         tensor, attributes = self._read_streamed_region(stream_source, spans)
         return self._apply_streamed_region(stream_source, spans, tensor, attributes, cache_attribute, case_attribute)
+
+    def plan_patch_reads(self, entries: Sequence[tuple[int, int]], is_input: bool, apply_augmentations: bool) -> None:
+        """Declare the store reads this case's patches will make, in the order one process will make
+        them: ``entries`` is its ``(copy, patch)`` sequence, from the loader's own order (see
+        :class:`~konfai.data.data_manager.PatchReadOrder`). Called once, as the case is entered.
+
+        The reads are named from the plans alone, so nothing is read here and no voxel of a patch
+        still to come is touched. A copy whose Save caches are not materialized yet is left out: the
+        sweep that materializes them declares its own reads, and what the patches then read is the
+        cache, not this source.
+        """
+        if self.loaded or not entries or not self._stream_ready(entries[0][0], apply_augmentations):
+            return
+        reads = []
+        for a, index in entries:
+            source = self._resolve_patch_stream_source(a, apply_augmentations)
+            if source is None or source.pending_sweeps:
+                continue
+            reads.append((source, self._patch_read_spans(source, index, a, is_input)))
+        self._declare_region_reads(reads)
+
+    def _patch_read_spans(
+        self, stream_source: _PatchStreamSource, index: int, a: int, is_input: bool
+    ) -> list[list[slice]]:
+        """The region each stage reads for patch ``index`` of copy ``a``, the first being the window
+        read from the store: what :meth:`_get_streamed_data` reads, without reading it. An exact-patch
+        chain hands every stage the patch itself, which is the region it reads."""
+        if stream_source.region_index is None:
+            plan = self.patch.get_read_plan(stream_source.shape, index, a, is_input)
+            region = plan.data_slices[len(plan.data_slices) - (len(stream_source.shape) - 1) :]
+            return [list(region) for _ in range(len(stream_source.stage_plans) + 1)]
+        return self._region_spans(stream_source, tuple(self.patch.read_slices(a, index, self.shapes[a])))
+
+    def _declare_region_reads(self, reads: Sequence[tuple[_PatchStreamSource, list[list[slice]]]]) -> None:
+        """Tell the stores, and the stages, the region reads about to happen in the order they will.
+
+        A store that caches decoded blocks then keeps what a later read asks for again and drops what
+        none does (:meth:`~konfai.utils.dataset.Dataset.plan_region_reads`), and a stage reading a
+        companion volume beside its region (:class:`~konfai.data.transform.Mask`) declares those reads
+        too. Grouped by the entry read and by the stage handed the region, so the copies of one case
+        interleaved over one store are declared as the single sequence that store will serve.
+        """
+        by_entry: dict[tuple[Dataset, str, str], list[tuple[slice, ...]]] = {}
+        by_stage: dict[int, tuple[Stage, list[RegionContext]]] = {}  # by identity: a Stage need not be hashable
+        for source, spans in reads:
+            lead = [slice(None)] * (len(source.shape) - len(spans[-1]))
+            by_entry.setdefault((source.dataset, source.group, source.entry), []).append((*lead, *spans[0]))
+            for index, (stage, plan) in enumerate(zip(source.stages, source.stage_plans, strict=True)):
+                if plan.kind is LocalityKind.CROP:
+                    continue  # handed no region: its remap is its action
+                by_stage.setdefault(id(stage), (stage, []))[1].append(
+                    plan.region_context(spans[index], spans[index + 1])
+                )
+        for (dataset, group, entry), windows in by_entry.items():
+            dataset.plan_region_reads(group, entry, windows)
+        for stage, contexts in by_stage.values():
+            stage.plan_region_reads(self.name, contexts)
 
     def _region_spans(self, stream_source: _PatchStreamSource, target_slices: tuple[slice, ...]) -> list[list[slice]]:
         """The region each stage of the chain reads for ``target_slices``, the last being the target

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -839,7 +839,6 @@ class PathCombine(ABC):
     """Base class for overlap-aware weighting schemes applied during patch assembly."""
 
     def __init__(self) -> None:
-        self.data: torch.Tensor
         self.windows_1d: list[torch.Tensor]
         self.overlap: int
         self.overlaps: list[int]
@@ -862,16 +861,25 @@ class PathCombine(ABC):
         # tapered weighting.
         if all(o <= 0 for o in overlaps):
             self.windows_1d = [torch.ones(size) for size in patch_size]
-            self.data = torch.ones(patch_size)
             return
         self.windows_1d = [
             self._window_1d(size, axis_overlap) if axis_overlap > 0 else torch.ones(size)
             for size, axis_overlap in zip(patch_size, overlaps, strict=True)
         ]
+
+    @property
+    def data(self) -> torch.Tensor:
+        """The per-voxel window: the outer product of the per-axis factors.
+
+        Derived, not stored: it is a patch of floats that ``Network.init`` builds before the spawn and
+        every rank then unpickles (a 128^3 ModelPatch at overlap 16 pickles to 8 391 775 bytes with it,
+        1355 without), while assembly goes through the factors themselves (see ``_weight_factors``).
+        :meth:`weight` caches what it builds per device and dtype.
+        """
         data = self.windows_1d[0]
         for window in self.windows_1d[1:]:
             data = data.unsqueeze(-1) * window
-        self.data = data
+        return data
 
     @property
     def selects(self) -> bool:
@@ -1654,7 +1662,7 @@ class Patch(ABC):
             # source of truth, because a grid emitted for one axis and reassembled along another hands out
             # regions that are not final, with nothing to report it.
             sweep_axis = best_sweep_axis(concretize_patch_size(self.patch_size, shape, self.free_axis_multiple), shape)
-            slices, _ = get_patch_slices_from_shape(
+            slices = get_patch_slices_from_shape(
                 self.patch_size,
                 shape,
                 self.overlap,
@@ -1910,7 +1918,9 @@ class DatasetManager:
 
         self.patch = (
             DatasetPatch(
-                patch_size=patch.patch_size,
+                # Its own list: the grid is cut lazily (``Patch._grid``), so sharing the source's list
+                # would let a later mutation of it move a grid already handed out.
+                patch_size=list(patch.patch_size) if patch.patch_size is not None else patch.patch_size,
                 overlap=patch.overlap,
                 pad_value=patch.pad_value,
                 extend_slice=patch.extend_slice,

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -35,7 +35,7 @@ from collections.abc import Callable, Iterable, Iterator, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from itertools import pairwise
-from typing import Any, Protocol, TypeGuard, cast
+from typing import Any, NamedTuple, Protocol, TypeGuard, cast
 
 import numpy as np
 import torch
@@ -1582,6 +1582,13 @@ class SlabAligner:
         return [(interval, rows)]
 
 
+class _PatchGrid(NamedTuple):
+    """One copy's cut: the axis the patches are ordered by, and the patches themselves."""
+
+    sweep_axis: int
+    slices: list[tuple[slice, ...]]
+
+
 class Patch(ABC):
     """Abstract base class for dataset-level and model-level patch definitions."""
 
@@ -1603,9 +1610,10 @@ class Patch(ABC):
         if isinstance(self.overlap, int):
             if self.overlap < 0:
                 self.overlap = None
-        self._patch_slices: dict[int, list[tuple[slice, ...]]] = {}
-        self._sweep_axis: dict[int, int] = {}
-        self._nb_patch_per_dim: dict[int, list[tuple[int, bool]]] = {}
+        #: The spatial shape each copy's grid is cut on, recorded by ``load``.
+        self._shapes: dict[int, list[int]] = {}
+        #: The cut itself, made on first use and left out of the pickle (``__getstate__``).
+        self._grids: dict[int, _PatchGrid] = {}
         self.pad_value = pad_value
         self.extend_slice = extend_slice
         # Models need every patch at the declared size, so the last patch of an axis is padded up to it.
@@ -1628,36 +1636,58 @@ class Patch(ABC):
         )
 
     def load(self, shape: list[int], a: int = 0) -> None:
-        # The grid decides its own sweep axis and the reassembly reads it back (get_sweep_axis): one
-        # source of truth, because a grid emitted for one axis and reassembled along another hands out
-        # regions that are not final, with nothing to report it.
-        self._sweep_axis[a] = best_sweep_axis(
-            concretize_patch_size(self.patch_size, shape, self.free_axis_multiple), shape
-        )
-        self._patch_slices[a], self._nb_patch_per_dim[a] = get_patch_slices_from_shape(
-            self.patch_size,
-            shape,
-            self.overlap,
-            self.free_axis_multiple,
-            self._declared_free_axis,
-            self._sweep_axis[a],
-        )
+        """Record the spatial shape copy ``a``'s grid is cut on; the cut itself waits for a consumer."""
+        self._shapes[a] = list(shape)
+        self._grids.pop(a, None)
+
+    def _grid(self, a: int) -> _PatchGrid:
+        """Copy ``a``'s cut, made once. A pure function of the recorded shape and this patch's own
+        configuration, so a rank rebuilds it instead of unpickling it (``__getstate__``)."""
+        grid = self._grids.get(a)
+        if grid is None:
+            shape = self._shapes[a]
+            # The grid decides its own sweep axis and the reassembly reads it back (get_sweep_axis): one
+            # source of truth, because a grid emitted for one axis and reassembled along another hands out
+            # regions that are not final, with nothing to report it.
+            sweep_axis = best_sweep_axis(concretize_patch_size(self.patch_size, shape, self.free_axis_multiple), shape)
+            slices, _ = get_patch_slices_from_shape(
+                self.patch_size,
+                shape,
+                self.overlap,
+                self.free_axis_multiple,
+                self._declared_free_axis,
+                sweep_axis,
+            )
+            grid = self._grids[a] = _PatchGrid(sweep_axis, slices)
+        return grid
+
+    def __getstate__(self) -> dict[str, Any]:
+        """The cuts stay out of the pickle: ``mp.spawn`` pickles the configured object once per
+        rank, and every manager's per-case grids dominated its bytes. Only the shapes travel, and
+        each rank cuts the same grids back from them on first use.
+
+        Cutting costs more than unpickling would have (100 cases of 2048 patches: 31 ms against 81
+        ms in process); it is the transfer, paid once per rank, that dominates. On a 2-rank CPU
+        spawn of 1000 such cases the payload goes from 35.2 to 0.44 MiB and the second rank holds
+        every grid 3.0 s after the launcher's stamp instead of 4.8 s.
+        """
+        return {**self.__dict__, "_grids": {}}
 
     def get_sweep_axis(self, a: int = 0) -> int:
         """The axis this grid is ordered by, and so the one reassembly must slide along."""
-        return self._sweep_axis[a]
+        return self._grid(a).sweep_axis
 
     @abstractmethod
     def init(self, key: str):
         pass
 
-    def get_patch_slices(self, a: int = 0):
-        return self._patch_slices[a]
+    def get_patch_slices(self, a: int = 0) -> list[tuple[slice, ...]]:
+        return self._grid(a).slices
 
     def read_slices(self, a: int, index: int, shape: Sequence[int]) -> list[slice]:
         """The region patch ``index`` of copy ``a`` reads: its grid slot, widened by the halo and
         clamped to the volume (``shape`` may carry leading non-spatial axes)."""
-        slot = self._patch_slices[a][index]
+        slot = self._grid(a).slices[index]
         if not self.halo:
             return list(slot)
         spatial = [int(extent) for extent in shape[len(shape) - len(slot) :]]
@@ -1668,7 +1698,7 @@ class Patch(ABC):
         where the volume's own face cut the halo short."""
         return tuple(
             slice(min(self.halo, s.start), min(self.halo, s.start) + s.stop - s.start)
-            for s in self._patch_slices[a][index]
+            for s in self._grid(a).slices[index]
         )
 
     def get_read_plan(
@@ -1761,7 +1791,7 @@ class Patch(ABC):
         return self.apply_read_plan(data_sliced, plan)
 
     def get_size(self, a: int = 0) -> int:
-        return len(self._patch_slices[a])
+        return len(self._grid(a).slices)
 
 
 @config("Patch")

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -2518,6 +2518,19 @@ class Dilate(Transform):
         return data.to(tensor.dtype)
 
 
+def _forget_model_channel_counts(cache_attribute: Attribute) -> None:
+    """Take ``number_of_channels_per_model`` off a case's state, as folding the model axis does.
+
+    The key describes the ensemble the fold consumed: once the models' channels are one map it
+    describes an input that no longer exists, and a later ``Sum`` or ``MergeLabels`` reading it off
+    the written store would take the ensemble branch on a one-channel map. The whole-volume pass
+    pops it from the live attribute it writes the header from; a streamed region pops it from a
+    scope that is thrown away, so the case-level state has to say it here.
+    """
+    if "number_of_channels_per_model" in cache_attribute:
+        cache_attribute.pop_tensor("number_of_channels_per_model")
+
+
 class Sum(Transform):
     def __init__(self, dim: int = 0) -> None:
         super().__init__()
@@ -2533,6 +2546,12 @@ class Sum(Transform):
             reason=f"dim {self.dim} reduces a spatial axis, which spans the whole extent; dim: 0"
             " reduces the channels and streams",
         )
+
+    def write_stream_cache_attribute(
+        self, cache_attribute: Attribute, source_spatial_shape: list[int], name: str = ""
+    ) -> None:
+        del source_spatial_shape, name
+        _forget_model_channel_counts(cache_attribute)
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         if "number_of_channels_per_model" in cache_attribute:
@@ -2567,6 +2586,12 @@ class MergeLabels(Transform):
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
         # Merges the leading model axis per voxel; spatial support is a single voxel.
         return PatchLocality(LocalityKind.POINTWISE)
+
+    def write_stream_cache_attribute(
+        self, cache_attribute: Attribute, source_spatial_shape: list[int], name: str = ""
+    ) -> None:
+        del source_spatial_shape, name
+        _forget_model_channel_counts(cache_attribute)
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         if "number_of_channels_per_model" not in cache_attribute:

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -659,6 +659,22 @@ def is_an_image(attributes: Attribute) -> bool:
     return "Origin" in attributes and "Spacing" in attributes and "Direction" in attributes
 
 
+def as_channel_first(data: np.ndarray, attributes: Attribute) -> np.ndarray:
+    """Give back its channel axis to a block that folded it away, where the header says it did.
+
+    A stage may hand back a volume without its channel axis (``Sum(dim=0)`` and ``MergeLabels`` fold
+    the leading axis, which in a TRANSFORM chain is the channel one). An array with as many axes as
+    the geometry has spatial axes IS a single-channel image: read as channel-first it would be a 2-D
+    image with a plane's worth of channels, refused by ITK or, worse, stored that way in silence.
+
+    The header is what declares the spatial rank, so a block that comes with none is handed back
+    untouched: only the caller knows whether it can be written as it is or must be refused.
+    """
+    if "Spacing" in attributes and data.ndim == len(attributes.get_np_array("Spacing")):
+        return data[None]
+    return data
+
+
 def data_to_image(data: np.ndarray, attributes: Attribute) -> sitk.Image:
     """Convert a NumPy array and KonfAI attributes into a SimpleITK image."""
     if isinstance(data, torch.Tensor):
@@ -3073,17 +3089,8 @@ class Dataset:
         attributes: Attribute | None = None,
     ) -> None:
         attributes = attributes if attributes is not None else Attribute()
-        # A stage may hand back a volume without its channel axis (``Sum(dim=0)`` and
-        # ``MergeLabels`` fold the leading axis, which in a TRANSFORM chain is the channel one).
-        # An array with as many axes as the geometry has spatial axes IS a single-channel image,
-        # and is written as one: read as channel-first it would be a 2-D image with a plane's worth
-        # of channels, refused by ITK or, worse, stored that way in silence.
-        if (
-            isinstance(data, np.ndarray)
-            and "Spacing" in attributes
-            and data.ndim == len(attributes.get_np_array("Spacing"))
-        ):
-            data = data[None]
+        if isinstance(data, np.ndarray):
+            data = as_channel_first(data, attributes)
         target, entry = self._write_target(group, name)
         with target as file:
             file.data_to_file(entry, data, attributes)

--- a/konfai/utils/utils.py
+++ b/konfai/utils/utils.py
@@ -98,33 +98,6 @@ def _sweep_first(slices: list[list[slice]], sweep_axis: int) -> list[tuple[slice
     return [tuple(chunk[position] for position in back) for chunk in itertools.product(*(slices[d] for d in order))]
 
 
-def get_patch_slices_from_nb_patch_per_dim(
-    patch_size_tmp: list[int],
-    nb_patch_per_dim: list[tuple[int, bool]],
-    overlap: int | None,
-    sweep_axis: int = 0,
-) -> list[tuple[slice, ...]]:
-    slices: list[list[slice]] = []
-    if overlap is None:
-        overlap = 0
-    patch_size = []
-    i = 0
-    for nb in nb_patch_per_dim:
-        if nb[1]:
-            patch_size.append(1)
-        else:
-            patch_size.append(patch_size_tmp[i])
-            i += 1
-
-    for dim, nb in enumerate(nb_patch_per_dim):
-        slices.append([])
-        for index in range(nb[0]):
-            start = (patch_size[dim] - overlap) * index
-            end = start + patch_size[dim]
-            slices[dim].append(slice(start, end))
-    return _sweep_first(slices, sweep_axis)
-
-
 #: Default overlap on tiled axes when a free-axis patch does not say otherwise: 20 % of the patch.
 DEFAULT_OVERLAP_FRACTION = 0.2
 
@@ -298,7 +271,7 @@ def get_patch_slices_from_shape(
     multiple: list[int] | None = None,
     declared_free_axis: bool | None = None,
     sweep_axis: int = 0,
-) -> tuple[list[tuple[slice, ...]], list[tuple[int, bool]]]:
+) -> list[tuple[slice, ...]]:
 
     # A free (``0``) axis concretizes to THIS case's extent, rounded up to the model's ``multiple`` so a
     # small case still reaches the network at a valid input size: the up-front worst-case sizing only
@@ -319,7 +292,6 @@ def get_patch_slices_from_shape(
             f"shape: {shape}",
             "Both must have the same number of dimensions (e.g., 3D patch for 3D volume).",
         )
-    nb_patch_per_dim = []
     slices: list[list[slice]] = []
     if overlap_tmp is None:
         if has_free_axis:
@@ -361,9 +333,8 @@ def get_patch_slices_from_shape(
                 break
             slices[dim].append(slice(start, end))
             index += 1
-        nb_patch_per_dim.append((index + 1, patch_size[dim] == 1))
 
-    return _sweep_first(slices, sweep_axis), nb_patch_per_dim
+    return _sweep_first(slices, sweep_axis)
 
 
 # Suffixes an entry can carry on disk: probed next to a case to find an entry whatever it was

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -173,7 +173,7 @@ def _drive_tta(
         volume = transform("CASE_000", volume, attribute)
     augmentations = _tta_augmentations(augmentation, shape=list(volume.shape[1:]), case_index=case_index)
     copies = [volume, augmentation.compute("CASE_000", case_index, 0, volume)]
-    patch_slices, _ = get_patch_slices_from_shape(_TTA_PATCH_SIZE, list(volume.shape[1:]), _TTA_OVERLAP)
+    patch_slices = get_patch_slices_from_shape(_TTA_PATCH_SIZE, list(volume.shape[1:]), _TTA_OVERLAP)
     patches = [_tta_make_patches(copy, patch_slices) for copy in copies]
 
     class DummyPatch:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -33,7 +33,8 @@ class StreamingDatasetStub:
     """In-memory dataset serving whole reads, region reads, and statistics, with identity geometry.
 
     The read counters (``full_reads``/``patch_reads``/``stats_reads``) let a test assert which
-    access path was taken.
+    access path was taken; ``regions`` and ``declared`` are the windows it was asked for and the
+    windows it was told to expect, in order, for a test that they are the same sequence.
     """
 
     def __init__(self, volume: np.ndarray) -> None:
@@ -41,6 +42,8 @@ class StreamingDatasetStub:
         self.full_reads = 0
         self.patch_reads = 0
         self.stats_reads = 0
+        self.regions: list[tuple[slice, ...]] = []
+        self.declared: list[tuple[slice, ...]] = []
 
     def _attributes(self) -> Attribute:
         spatial = self.volume.ndim - 1
@@ -59,7 +62,12 @@ class StreamingDatasetStub:
 
     def read_data_slice(self, group_src: str, name: str, slices: tuple[slice, ...]) -> tuple[np.ndarray, Attribute]:
         self.patch_reads += 1
+        self.regions.append(tuple(slices))
         return self.volume[slices].copy(), self._attributes()
+
+    def plan_region_reads(self, group_src: str, name: str, windows) -> None:
+        del group_src, name
+        self.declared.extend(tuple(window) for window in windows)
 
     def read_data_statistics(self, group_src: str, name: str, channels: list[int] | None = None) -> dict[str, float]:
         self.stats_reads += 1

--- a/tests/unit/test_auto_patching.py
+++ b/tests/unit/test_auto_patching.py
@@ -102,14 +102,13 @@ class TestResolveOverlap:
 class TestPatchGrid:
     def test_2d_slicing_grid(self):
         # [1,0,0] -> one full slice per Z index: exactly Z patches, each spanning Y and X.
-        slices, nb_per_dim = get_patch_slices_from_shape([1, 0, 0], [37, 41, 29], None)
+        slices = get_patch_slices_from_shape([1, 0, 0], [37, 41, 29], None)
         assert len(slices) == 37
         assert slices[0] == (slice(0, 1), slice(0, 41), slice(0, 29))
-        assert nb_per_dim[0] == (37, True)
 
     def test_free_axes_cover_the_volume_disjointly(self):
         # A fixed Z with free in-plane axes tiles Z only; the plane stays whole.
-        slices, _ = get_patch_slices_from_shape([16, 0, 0], [37, 41, 29], None)
+        slices = get_patch_slices_from_shape([16, 0, 0], [37, 41, 29], None)
         zs = sorted({(s[0].start, s[0].stop) for s in slices})
         assert all(s[1] == slice(0, 41) and s[2] == slice(0, 29) for s in slices)
         covered = set()
@@ -118,13 +117,13 @@ class TestPatchGrid:
         assert covered == set(range(37))
 
     def test_all_zero_is_the_whole_volume(self):
-        slices, _ = get_patch_slices_from_shape([0, 0, 0], [10, 20, 30], None)
+        slices = get_patch_slices_from_shape([0, 0, 0], [10, 20, 30], None)
         assert slices == [(slice(0, 10), slice(0, 20), slice(0, 30))]
 
     def test_fixed_patch_grid_stays_bit_identical(self):
         # A fully-fixed patch keeps the remainder-spreading overlap grid: every stored model was
         # trained and evaluated on it.
-        fixed, _ = get_patch_slices_from_shape([16, 16, 16], [37, 41, 29], None)
+        fixed = get_patch_slices_from_shape([16, 16, 16], [37, 41, 29], None)
         assert fixed[0] == (slice(0, 16), slice(0, 16), slice(0, 16))
         assert all(s[0].stop <= 37 and s[1].stop <= 41 and s[2].stop <= 29 for s in fixed)
 
@@ -137,9 +136,8 @@ class TestFreeAxisReachesTheModelAsAValidMultiple:
     def test_whole_volume_free_axis_stays_a_single_clamped_patch(self):
         # The grid is unchanged: one whole-volume patch whose slice is clamped to the extent. The
         # round-up to the multiple is a PADDING target, not extra patches.
-        slices, nb = get_patch_slices_from_shape([0, 0, 0], [122, 250, 250], None, [16, 16, 16])
+        slices = get_patch_slices_from_shape([0, 0, 0], [122, 250, 250], None, [16, 16, 16])
         assert slices == [(slice(0, 122), slice(0, 250), slice(0, 250))]
-        assert all(count == 1 for count, _ in nb)
 
     def test_small_case_is_padded_up_to_the_model_multiple(self):
         import torch
@@ -226,7 +224,7 @@ class TestPatchedReductionIdentity:
         rng = np.random.default_rng(0)
         out = rng.random((37, 41, 29))
         tgt = rng.random((37, 41, 29))
-        slices, _ = get_patch_slices_from_shape(patch, [37, 41, 29], 0)
+        slices = get_patch_slices_from_shape(patch, [37, 41, 29], 0)
 
         abs_sum, sq_sum, count = 0.0, 0.0, 0
         for sl in slices:
@@ -244,7 +242,7 @@ class TestMetricReductionContract:
 
     @staticmethod
     def _patches(shape, patch):
-        slices, _ = get_patch_slices_from_shape(patch, list(shape), 0)
+        slices = get_patch_slices_from_shape(patch, list(shape), 0)
         return [(slice(None), slice(None), *sl) for sl in slices]
 
     @staticmethod

--- a/tests/unit/test_channel_fold_streaming.py
+++ b/tests/unit/test_channel_fold_streaming.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""A stage that folds the channel axis away (``Sum(dim=0)``, ``MergeLabels``: the 5-task
+TotalSegmentator merge) hands back a block of the spatial rank. The whole-volume write reads that as
+a single-channel image; the region write reads it the same way, ships the same bytes and the same
+header, and refuses every rank the header does not name."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from konfai.data import patching
+from konfai.data.materialize import CaseMaterializer, Verdict
+from konfai.data.patching import DatasetManager
+from konfai.data.transform import LocalityKind, MergeLabels, PatchLocality, Save, Sum, Transform
+from konfai.utils.dataset import Attribute, Dataset
+
+#: One case, five models, disjoint label ranges: what a ``combine: Concat`` ensemble hands the fold.
+_MODEL_CHANNELS = [3, 4, 2, 5, 3]
+
+
+@pytest.fixture(autouse=True)
+def several_regions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two rows per region, so every case here is written in several pieces."""
+    monkeypatch.setattr(patching, "SWEEP_SLAB_ROWS", 2)
+
+
+class _ExtraAxis(Transform):
+    """A stage whose block keeps its spatial shape and gains an axis, a rank no rule covers."""
+
+    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
+        return PatchLocality(LocalityKind.POINTWISE)
+
+    def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
+        return shape
+
+    def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
+        return tensor.unsqueeze(0)
+
+
+def _source(tmp_path: Path, geometry: bool) -> Dataset:
+    """A five-model label stack, with or without the geometry that names its spatial rank."""
+    attributes = Attribute()
+    if geometry:
+        attributes["Origin"] = np.asarray([10.0, 20.0, 30.0])
+        attributes["Spacing"] = np.asarray([0.5, 1.5, 2.0])
+        attributes["Direction"] = np.eye(3, dtype=np.float64).reshape(-1)
+    attributes["number_of_channels_per_model"] = np.asarray(_MODEL_CHANNELS)
+    rng = np.random.default_rng(0)
+    volume = rng.integers(0, 5, size=(len(_MODEL_CHANNELS), 12, 10, 8)).astype(np.uint8)
+    dataset = Dataset(tmp_path / "source", "h5")
+    dataset.write("CT", "CASE_000", volume, attributes)
+    return dataset
+
+
+def _write(source: Dataset, transforms: list[Transform], out: Path, whole_volume: bool) -> Verdict:
+    manager = DatasetManager(
+        index=0,
+        group_src="CT",
+        group_dest="CT",
+        name="CASE_000",
+        dataset=source,
+        patch=None,
+        transforms=[*transforms, Save(f"{out}:h5")],
+        data_augmentations_list=[],
+    )
+    return CaseMaterializer(manager).materialize(prefer_whole=whole_volume)
+
+
+@pytest.mark.parametrize("fold", [Sum(dim=0), MergeLabels()], ids=["Sum", "MergeLabels"])
+def test_a_channel_fold_streams_the_store_the_whole_volume_pass_writes(tmp_path: Path, fold: Transform) -> None:
+    """Same bytes and same header keys on both routes."""
+    source = _source(tmp_path, geometry=True)
+
+    assert _write(source, [fold], tmp_path / "swept", whole_volume=False) is Verdict.STREAM
+    assert _write(source, [fold], tmp_path / "whole", whole_volume=True) is Verdict.LOAD
+
+    swept, swept_header = Dataset(tmp_path / "swept", "h5").read_data("CT", "CASE_000")
+    whole, whole_header = Dataset(tmp_path / "whole", "h5").read_data("CT", "CASE_000")
+    assert swept.shape == (1, 12, 10, 8)
+    assert swept.tobytes() == whole.tobytes()
+    assert sorted(swept_header.keys()) == sorted(whole_header.keys())
+    # The key describes the ensemble the fold consumed: an output holding one channel that still
+    # carried it would send a later fold down the ensemble branch.
+    assert not any(key.startswith("number_of_channels_per_model") for key in swept_header.keys())
+
+
+@pytest.mark.parametrize(
+    ("chain", "geometry"),
+    [([Sum(dim=0)], False), ([_ExtraAxis()], True)],
+    ids=["no-geometry-names-the-spatial-rank", "a-rank-above-channel-first"],
+)
+def test_a_block_of_an_unwritable_rank_refuses_and_falls_back(
+    tmp_path: Path, chain: list[Transform], geometry: bool
+) -> None:
+    """Written anyway, the header would take the block's first spatial extent for a channel count and
+    publish that many broadcast copies: a store whose rank disagrees with the whole-volume path, with
+    no exception raised."""
+    source = _source(tmp_path, geometry)
+
+    with pytest.warns(UserWarning, match="Falling back to the whole-volume path"):
+        assert _write(source, chain, tmp_path / "refused", whole_volume=False) is Verdict.WHOLE_VOLUME
+    assert _write(source, chain, tmp_path / "whole", whole_volume=True) is Verdict.LOAD
+
+    # The aborted sweep left no debris, and the fallback wrote the store the whole-volume route does.
+    assert not list((tmp_path / "refused").glob("**/*.tmp"))
+    refused, _ = Dataset(tmp_path / "refused", "h5").read_data("CT", "CASE_000")
+    whole, _ = Dataset(tmp_path / "whole", "h5").read_data("CT", "CASE_000")
+    assert refused.shape == whole.shape
+    assert refused.tobytes() == whole.tobytes()

--- a/tests/unit/test_data_manager.py
+++ b/tests/unit/test_data_manager.py
@@ -18,10 +18,12 @@
 subsets, DataLoader arguments, cache workers, and DatasetIter (streaming transforms, inline
 augmentations)."""
 
+import multiprocessing
 import os
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from typing import cast
 
 import numpy as np
@@ -36,13 +38,14 @@ from konfai.data.data_manager import (
     DataTrain,
     Group,
     GroupTransform,
+    PatchReadOrder,
     PredictionSubset,
     TrainSubset,
     WindowedCaseSampler,
     _cache_worker_count,
 )
 from konfai.data.patching import DatasetManager, DatasetPatch
-from konfai.data.transform import TensorCast, Transform, TransformLoader
+from konfai.data.transform import Gradient, TensorCast, Transform, TransformLoader
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.runtime import State, restart_startup_clock
 from konfai.utils.utils import split_path_spec
@@ -717,6 +720,128 @@ def test_windowed_sampler_shards_cases_across_workers_without_overlap() -> None:
         for a in range(num_workers):
             for b in range(a + 1, num_workers):
                 assert worker_cases[a].isdisjoint(worker_cases[b])
+
+
+# --------------------------------------------------------------------------------------
+# PatchReadOrder: the epoch's order, from where it is drawn to where the patches are read
+# --------------------------------------------------------------------------------------
+
+
+def _published(mapping: list[tuple[int, int, int]], order: list[int], batch_size: int = 1) -> PatchReadOrder:
+    read_order = PatchReadOrder(mapping, batch_size)
+    read_order.publish(torch.as_tensor(order, dtype=torch.int64))
+    return read_order
+
+
+def test_a_case_is_declared_once_per_epoch_in_the_order_its_patches_will_be_read() -> None:
+    """A schedule is followed only while the reads match it, so what a case declares must be the
+    sequence the loader is about to ask for, and only the part of it still to come."""
+    mapping = _case_major_mapping(2, 3)
+    order = [4, 0, 3, 2, 5, 1]
+
+    read_order = _published(mapping, order)
+
+    assert read_order.entering(4) == [(0, 1), (0, 0), (0, 2)], "case 1's patches, as they will come"
+    assert read_order.entering(0) == [(0, 0), (0, 2), (0, 1)], "case 0's, from where it is entered"
+    assert [read_order.entering(index) for index in order[2:]] == [None] * 4, "and never twice"
+
+
+def test_a_second_epoch_declares_the_order_it_was_published_and_not_the_first_one() -> None:
+    """A persistent worker outlives the epoch: an order it kept would declare the previous draw."""
+    mapping = _case_major_mapping(1, 2)
+    read_order = _published(mapping, [0, 1])
+    assert read_order.entering(0) == [(0, 0), (0, 1)]
+
+    read_order.publish(torch.as_tensor([1, 0], dtype=torch.int64))
+
+    assert read_order.entering(1) == [(0, 1), (0, 0)]
+
+
+def test_a_worker_declares_the_batches_it_is_handed_and_not_the_others(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A DataLoader deals one batch in num_workers to each worker, and each holds a cache of its
+    own: a worker declaring the whole epoch would deviate from its own first read."""
+    monkeypatch.setattr(torch.utils.data, "get_worker_info", lambda: SimpleNamespace(id=0, num_workers=2))
+    mapping = _case_major_mapping(4, 2)
+
+    read_order = _published(mapping, list(range(len(mapping))), batch_size=2)
+
+    assert read_order.entering(0) == [(0, 0), (0, 1)], "batch 0 is this worker's"
+    assert read_order.entering(4) == [(0, 0), (0, 1)], "and so is batch 2"
+    assert read_order.entering(2) is None, "batch 1 goes to the other worker"
+
+
+def _entering_at_each_draw(read_order: PatchReadOrder, draws, opening, answer) -> None:
+    for drawn in draws:
+        drawn.wait(30)
+        answer.put(read_order.entering(opening.get()))
+
+
+@pytest.mark.skipif("fork" not in multiprocessing.get_all_start_methods(), reason="no fork on this platform")
+def test_every_epoch_s_order_reaches_a_process_forked_before_the_first_draw() -> None:
+    """A DataLoader forks its workers before the sampler draws the epoch's order and, when they are
+    persistent, never forks them again: an order held in ordinary memory would reach neither the
+    first epoch nor the ones after it."""
+    mapping = _case_major_mapping(1, 6)
+    read_order = PatchReadOrder(mapping, batch_size=1)
+    sampler = WindowedCaseSampler(mapping, True, None, 1, 1, read_order)
+    context = multiprocessing.get_context("fork")
+    draws = [context.Event(), context.Event()]
+    opening, answer = context.SimpleQueue(), context.SimpleQueue()
+    child = context.Process(target=_entering_at_each_draw, args=(read_order, draws, opening, answer))
+    child.start()
+
+    drawn: list[list[int]] = []
+    declared: list[list[tuple[int, int]]] = []
+    for epoch, event in enumerate(draws):
+        torch.manual_seed(epoch)
+        drawn.append(list(iter(sampler)))
+        opening.put(drawn[-1][0])
+        event.set()
+        declared.append(answer.get())
+    child.join(60)
+
+    assert child.exitcode == 0
+    assert drawn[0] != drawn[1], "the two epochs drew the same order: the test would prove nothing"
+    assert declared == [[mapping[index][1:] for index in order] for order in drawn]
+
+
+@pytest.mark.parametrize("transforms", [[], [Gradient()]], ids=["exact-patch", "halo"])
+def test_the_windows_declared_are_the_windows_the_patch_route_then_reads(
+    streaming_dataset_stub, transforms: list[Transform]
+) -> None:
+    """The declaration is named from the plans and the read from the run: a window that misses what
+    the read asks for deviates the schedule at its first step and buys nothing, in silence."""
+    dataset_stub = streaming_dataset_stub(np.arange(1 * 8 * 8, dtype=np.float32).reshape(1, 8, 8))
+    manager = DatasetManager(
+        index=0,
+        group_src="CT",
+        group_dest="CT",
+        name="CASE_000",
+        dataset=cast(Dataset, dataset_stub),
+        patch=DatasetPatch([4, 4]),
+        transforms=transforms,
+        data_augmentations_list=[],
+    )
+    mapping = [(0, 0, index) for index in range(manager.get_size(0))]
+    dataset_iter = DatasetIter(
+        rank=0,
+        data={"CT": [manager]},
+        mapping=mapping,
+        groups_src={"CT": Group(groups_dest={"CT": GroupTransform(transforms=None, patch_transforms=None)})},
+        inline_augmentations=False,
+        data_augmentations_list=[],
+        patch_size=[4, 4],
+        overlap=None,
+        buffer_size=1,
+        use_cache=False,
+    )
+    sampler = WindowedCaseSampler(mapping, False, None, 1, 1, dataset_iter.read_order)
+
+    for index in sampler:
+        dataset_iter[index]
+
+    assert dataset_stub.declared, "the case declared nothing"
+    assert dataset_stub.regions == dataset_stub.declared
 
 
 class _WholeVolumeDataset:

--- a/tests/unit/test_data_manager.py
+++ b/tests/unit/test_data_manager.py
@@ -408,6 +408,25 @@ def test_streaming_tensorcast_persists_source_dtype_for_inverse(streaming_datase
     assert restored.dtype == torch.int16
 
 
+def test_manager_patch_copy_owns_its_patch_size(streaming_dataset_stub) -> None:
+    """The copy's grid is cut lazily, so it must not read a list its source can still change."""
+    shared = DatasetPatch([4, 4])
+    manager = DatasetManager(
+        index=0,
+        group_src="CT",
+        group_dest="CT",
+        name="CASE_000",
+        dataset=cast(Dataset, streaming_dataset_stub(np.arange(1 * 8 * 8, dtype=np.float32).reshape(1, 8, 8))),
+        patch=shared,
+        transforms=[],
+        data_augmentations_list=[],
+    )
+    shared.patch_size[:] = [8, 8]  # before any cut: nothing has read the copy's sizes yet
+
+    assert manager.patch.patch_size == [4, 4]
+    assert len(manager.patch.get_patch_slices(0)) == 4  # 8x8 in 4x4 patches, not one whole-volume patch
+
+
 # --------------------------------------------------------------------------------------
 # DatasetIter: inline augmentations and per-case state draws
 # --------------------------------------------------------------------------------------

--- a/tests/unit/test_measure.py
+++ b/tests/unit/test_measure.py
@@ -863,7 +863,7 @@ class TestSSIMFromHaloPatches:
     def _grid(shape: tuple[int, ...], patch: list[int]) -> list[tuple[slice, ...]]:
         from konfai.utils.utils import get_patch_slices_from_shape
 
-        return get_patch_slices_from_shape(patch, list(shape), 0)[0]
+        return get_patch_slices_from_shape(patch, list(shape), 0)
 
     @staticmethod
     def _streamed(metric: SSIM, tensors: list[torch.Tensor], patch: list[int]) -> float:

--- a/tests/unit/test_ome_zarr_data_surface.py
+++ b/tests/unit/test_ome_zarr_data_surface.py
@@ -19,6 +19,8 @@
 These cover what a hand-rolled store reader gets wrong, which is never the happy path: a big-endian
 source, a pyramid level that does not exist, and a downsampling default that changes the pixels."""
 
+import contextlib
+from collections.abc import Iterator
 from pathlib import Path, PureWindowsPath
 
 import numpy as np
@@ -34,6 +36,7 @@ from konfai.data import (
     read_ome_zarr_data_slice,
     write_ome_zarr,
 )
+from konfai.data.transform import Transform
 from konfai.utils.dataset import Attribute, Dataset, _store_chunks
 from konfai.utils.errors import DatasetManagerError
 
@@ -440,10 +443,10 @@ def test_an_empty_declared_read_still_advances_its_schedule(tmp_path: Path) -> N
 
 
 class _CountingArray:
-    """A zarr array whose reads count the chunks they decode."""
+    """A zarr array whose reads add the chunks they decode to ``decoded[group]``."""
 
-    def __init__(self, array, decoded: list[int]) -> None:
-        self._array, self._decoded = array, decoded
+    def __init__(self, array, decoded: dict[str, int], group: str) -> None:
+        self._array, self._decoded, self._group = array, decoded, group
         self.shape, self.chunks, self.dtype = array.shape, array.chunks, array.dtype
 
     def __getitem__(self, index):
@@ -451,7 +454,7 @@ class _CountingArray:
         for item, chunk, extent in zip(index, self.chunks, self.shape, strict=True):
             lo, hi, _ = item.indices(extent) if isinstance(item, slice) else (item, item + 1, 1)
             touched *= max(0, -(-hi // chunk) - lo // chunk)
-        self._decoded[0] += touched
+        self._decoded[self._group] += touched
         return self._array[index]
 
 
@@ -478,24 +481,58 @@ def _two_stores(root: Path) -> None:
     Dataset(root / "ref", "h5").write("GRID", "TARGET", np.zeros((1, *landing), np.float32), rotated)
 
 
-def _sweep_with_a_mask_companion(
-    root: Path, monkeypatch: pytest.MonkeyPatch, *, declared: str, capacity_chunks: int, label: str
-) -> dict[str, int]:
-    """One sweep of CT through a Mask (reading Labels beside it) and a rotated resample over the
-    stores of :func:`_two_stores`, one thread (the cache sees the read's own order), the
-    decoded-chunk cache holding ``capacity_chunks``; the chunks decoded per store. ``declared``
-    is what tells the cache its future: ``"nothing"`` (LRU), ``"source"`` (the sweep's own reads,
-    the mask ranked by recency) or ``"both"`` (the mask's reads too)."""
-    from konfai.data import patching as patching_module
-    from konfai.data.materialize import CaseMaterializer, Verdict
-    from konfai.data.patching import DatasetManager, DatasetPatch
-    from konfai.data.transform import Mask, Resample, Save
+@contextlib.contextmanager
+def _counting_decodes(patched: pytest.MonkeyPatch, capacity_chunks: int) -> Iterator[dict[str, int]]:
+    """The chunks each store of :func:`_two_stores` decodes while the block runs, with the
+    decoded-chunk cache holding ``capacity_chunks`` of them. The dict fills as the block runs."""
     from konfai.utils import ome_zarr
+
+    decoded = {"CT": 0, "Labels": 0}
+    level_array = ome_zarr._level_array
+    level_array.cache_clear()
+
+    def counting(store_path: str, level_path: str):
+        group = next(group for group in decoded if f"/{group}." in store_path)
+        return _CountingArray(level_array(store_path, level_path), decoded, group)
+
+    patched.setenv("OMP_NUM_THREADS", "1")  # one thread: the cache sees the read's own order
+    patched.setattr(ome_zarr, "_level_array", counting)
+    cache = ome_zarr._chunk_cache()
+    previous = cache.capacity
+    cache.forget()
+    cache.set_capacity(capacity_chunks * 16 * 32 * 32 * 4)
+    try:
+        yield decoded
+    finally:
+        cache.set_capacity(previous)
+        cache.forget()
+
+
+def _masked_resample(root: Path) -> tuple[Dataset, list[Transform]]:
+    """The store of :func:`_two_stores` and the chain both engines are measured on: a Mask reading
+    Labels at every region beside the CT, then a 20-degree rotated resample whose blocks pull each
+    chunk of both stores from several regions."""
+    from konfai.data.transform import Mask, Resample
 
     source = Dataset(root / "src", "omezarr")
     mask = Mask(path="Labels", value_outside=-7)
     mask.set_datasets([source])
     resample = Resample(reference="TARGET", reference_group="GRID", reference_dataset=f"{root / 'ref'}:h5")
+    return source, [mask, resample]
+
+
+def _sweep_with_a_mask_companion(
+    root: Path, monkeypatch: pytest.MonkeyPatch, *, declared: str, capacity_chunks: int, label: str
+) -> dict[str, int]:
+    """One sweep of :func:`_masked_resample`; the chunks decoded per store. ``declared`` is what
+    tells the cache its future: ``"nothing"`` (LRU), ``"source"`` (the sweep's own reads, the mask
+    ranked by recency) or ``"both"`` (the mask's reads too)."""
+    from konfai.data import patching as patching_module
+    from konfai.data.materialize import CaseMaterializer, Verdict
+    from konfai.data.patching import DatasetManager, DatasetPatch
+    from konfai.data.transform import Mask, Save
+
+    source, chain = _masked_resample(root)
     manager = DatasetManager(
         index=0,
         group_src="CT",
@@ -503,36 +540,61 @@ def _sweep_with_a_mask_companion(
         name="CASE_000",
         dataset=source,
         patch=DatasetPatch([4, 5, 4]),
-        transforms=[mask, resample, Save(f"{root / f'out_{label}'}:h5")],
+        transforms=[*chain, Save(f"{root / f'out_{label}'}:h5")],
         data_augmentations_list=[],
     )
-    decoded: dict[str, list[int]] = {"CT": [0], "Labels": [0]}
-    level_array = ome_zarr._level_array
-    level_array.cache_clear()
-
-    def counting(store_path: str, level_path: str):
-        group = next(group for group in decoded if f"/{group}." in store_path)
-        return _CountingArray(level_array(store_path, level_path), decoded[group])
-
-    with monkeypatch.context() as patched:
-        patched.setenv("OMP_NUM_THREADS", "1")
+    with monkeypatch.context() as patched, _counting_decodes(patched, capacity_chunks) as decoded:
         patched.setattr(patching_module, "SWEEP_SLAB_ROWS", 12)
         patched.setattr(patching_module, "_sweep_pipeline_depth", lambda: 0)
-        patched.setattr(ome_zarr, "_level_array", counting)
         if declared == "nothing":
             patched.setattr(Dataset, "plan_region_reads", lambda self, groups, name, windows: None)
         elif declared == "source":
             patched.setattr(Mask, "plan_region_reads", lambda self, name, contexts: None)
-        cache = ome_zarr._chunk_cache()
-        previous = cache.capacity
-        cache.forget()
-        cache.set_capacity(capacity_chunks * 16 * 32 * 32 * 4)
-        try:
-            assert CaseMaterializer(manager).materialize() is Verdict.STREAM
-        finally:
-            cache.set_capacity(previous)
-            cache.forget()
-    return {group: count[0] for group, count in decoded.items()}
+        assert CaseMaterializer(manager).materialize() is Verdict.STREAM
+    return decoded
+
+
+def _patch_epoch_with_a_mask_companion(
+    root: Path, monkeypatch: pytest.MonkeyPatch, *, declared: bool, shuffle: bool, capacity_chunks: int
+) -> dict[str, int]:
+    """One pass over a case's patches through :func:`_masked_resample`, read in the loader's own
+    order (the grid's, or a shuffled epoch's) on one process; the chunks decoded per store.
+    ``declared`` is whether the sampler publishes that order for the reads to declare."""
+    import torch
+    from konfai.data.data_manager import DatasetIter, Group, GroupTransform, WindowedCaseSampler
+    from konfai.data.patching import DatasetManager, DatasetPatch
+
+    source, chain = _masked_resample(root)
+    patch = [16, 64, 64]
+    manager = DatasetManager(
+        index=0,
+        group_src="CT",
+        group_dest="CT",
+        name="CASE_000",
+        dataset=source,
+        patch=DatasetPatch(patch),
+        transforms=chain,
+        data_augmentations_list=[],
+    )
+    mapping = [(0, 0, index) for index in range(manager.get_size(0))]
+    dataset_iter = DatasetIter(
+        rank=0,
+        data={"CT": [manager]},
+        mapping=mapping,
+        groups_src={"CT": Group(groups_dest={"CT": GroupTransform(transforms=None, patch_transforms=None)})},
+        inline_augmentations=False,
+        data_augmentations_list=[],
+        patch_size=patch,
+        overlap=None,
+        buffer_size=1,
+        use_cache=False,
+    )
+    sampler = WindowedCaseSampler(mapping, shuffle, None, 1, 1, dataset_iter.read_order if declared else None)
+    with monkeypatch.context() as patched, _counting_decodes(patched, capacity_chunks) as decoded:
+        torch.manual_seed(7)
+        for index in sampler:
+            dataset_iter[index]
+    return decoded
 
 
 def test_a_mask_companion_of_a_declared_sweep_is_decoded_once_where_lru_decodes_it_again(
@@ -599,3 +661,25 @@ def test_a_declared_companion_shares_a_tight_cache_with_the_source_it_is_read_be
     assert both["Labels"] <= lru["Labels"], "and decoded no more than under LRU"
     if beats_lru:
         assert sum(both.values()) < sum(lru.values()), f"{both} against LRU's {lru}"
+
+
+@pytest.mark.parametrize("shuffle", [False, True], ids=["grid-order", "shuffled-epoch"])
+@pytest.mark.parametrize("capacity_chunks", [39, 24])
+def test_a_declared_patch_epoch_decodes_fewer_chunks_than_recency_alone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capacity_chunks: int, shuffle: bool
+) -> None:
+    """The patch route reads a case in a known order nobody declared: the grid's for PREDICTION and
+    EVALUATION, the sampler's for a TRAIN epoch. Told it, the cache evicts by the next declared use
+    and the mask read beside every patch is ranked against the same future. Decodes over the two
+    stores together at 39 and 24 of the 96 chunks they hold, LRU -> declared: 312 -> 212 and
+    384 -> 336 in the grid's order, 247 -> 217 and 344 -> 309 over a shuffled epoch."""
+    _two_stores(tmp_path)
+
+    def epoch(declared: bool) -> dict[str, int]:
+        return _patch_epoch_with_a_mask_companion(
+            tmp_path, monkeypatch, declared=declared, shuffle=shuffle, capacity_chunks=capacity_chunks
+        )
+
+    lru, planned = epoch(False), epoch(True)
+
+    assert sum(planned.values()) < sum(lru.values()), f"{planned} against LRU's {lru}"

--- a/tests/unit/test_patching.py
+++ b/tests/unit/test_patching.py
@@ -19,6 +19,7 @@ DatasetManager patch grids."""
 
 import itertools
 import math
+import pickle
 from typing import cast
 
 import numpy as np
@@ -856,3 +857,108 @@ def test_chain_device_lives_only_for_the_materialize_call(streaming_dataset_stub
     CaseMaterializer(manager).materialize(rewrite=True, device=torch.device("cuda", 0))
     assert seen == [torch.device("cuda", 0)]
     assert manager._chain_device is None
+
+
+# --------------------------------------------------------------------------------------
+# Patch pickling: a rank cuts the grids, it is not shipped them
+# --------------------------------------------------------------------------------------
+
+
+def _multi_copy_patch(patch_size: list[int], shapes: list[list[int]]) -> DatasetPatch:
+    """A patch loaded for one copy per shape, carrying the flags its cut and its reads depend on."""
+    patch = DatasetPatch(patch_size=list(patch_size))
+    patch.pad_to_patch = False
+    patch.halo = 3
+    patch.free_axis_multiple = [8, 8, 8]
+    for a, shape in enumerate(shapes):
+        patch.load(shape, a)
+    return patch
+
+
+def test_a_pickled_patch_does_not_carry_its_grids() -> None:
+    """mp.spawn pickles the configured object with every manager's patch, and the per-case grids
+    dominated those bytes: 100 synthetic cases of 2048 patches shipped 3.69 MB, 47 kB once the cuts
+    stay home (32 patches each: 139 kB -> 47 kB)."""
+    patch = _multi_copy_patch([16, 16, 16], [[64, 64, 64]])
+
+    assert len(pickle.dumps(patch)) < len(pickle.dumps(patch.get_patch_slices(0)))
+
+
+@pytest.mark.parametrize(
+    "patch_size, pinned",
+    [
+        ([16, 16, 16], None),
+        ([0, 16, 16], None),
+        ([1, 8, 8], None),
+        ([0, 16, 16], [40, 16, 16]),  # an OOM re-plan pinned the declared free axis in place
+    ],
+)
+def test_an_unpickled_patch_cuts_back_the_same_grids(patch_size, pinned) -> None:
+    """The rebuilt grid is the shipped grid: same slices in the same order, same sweep axis, same
+    reads. The cut is a pure function of the recorded shape and the configuration, so every input
+    it reads must survive the pickle: the halo and ``pad_to_patch`` a reducing consumer sets, the
+    model's free-axis multiple, and the DECLARED free axis a restart's concretization erases from
+    ``patch_size`` (without it the axis falls back to the fixed-patch remainder overlap)."""
+    shapes = [[40, 48, 56], [48, 40, 56], [56, 48, 40]]
+    patch = _multi_copy_patch(patch_size, shapes)
+    if pinned is not None:
+        patch.patch_size[:] = pinned
+        for a, shape in enumerate(shapes):
+            patch.load(shape, a)
+    reference = {a: (patch.get_sweep_axis(a), patch.get_patch_slices(a)) for a in range(len(shapes))}
+
+    restored = pickle.loads(pickle.dumps(patch))
+
+    assert restored._grids == {}, "the cuts must not travel"
+    assert (restored.pad_to_patch, restored.halo, restored.free_axis_multiple) == (False, 3, [8, 8, 8])
+    assert restored._declared_free_axis == patch._declared_free_axis
+    for a, shape in enumerate(shapes):
+        assert (restored.get_sweep_axis(a), restored.get_patch_slices(a)) == reference[a]
+        assert restored.get_size(a) == patch.get_size(a)
+        indices = range(patch.get_size(a))
+        assert [restored.read_slices(a, i, shape) for i in indices] == [patch.read_slices(a, i, shape) for i in indices]
+        assert [restored.core_in_read(a, i) for i in indices] == [patch.core_in_read(a, i) for i in indices]
+
+
+def test_reloading_a_copy_recuts_its_grid() -> None:
+    """``load`` is the only thing that changes a copy's grid, so a second call must not hand back
+    the first one's cut (a model patch re-loads per forward, on the shape it is given)."""
+    patch = _multi_copy_patch([16, 16, 16], [[64, 64, 64]])
+    first = patch.get_patch_slices(0)
+
+    patch.load([32, 32, 32], 0)
+
+    assert patch.get_patch_slices(0) != first
+    assert patch.get_patch_slices(0) == _multi_copy_patch([16, 16, 16], [[32, 32, 32]]).get_patch_slices(0)
+
+
+def test_a_pickled_manager_hands_every_copy_the_grid_it_was_counted_on(streaming_dataset_stub) -> None:
+    """The loader mapping shipped to a rank is ``(case, copy, patch)`` triples counted on the
+    parent's grids: a rank that cut different ones would index patches that are not there.
+
+    A quarter ``Rotate`` transposes per-copy extents, so the copies are cut on three different
+    grids and a shape confused between them shows up at once.
+    """
+    torch.manual_seed(0)
+    augmentations = DataAugmentationsList(nb=2, data_augmentations={})
+    rotate = Rotate(is_quarter=True)
+    rotate.load(1.0)
+    augmentations.data_augmentations = [rotate]
+    manager = DatasetManager(
+        index=0,
+        group_src="CT",
+        group_dest="CT",
+        name="CASE_000",
+        dataset=cast(Dataset, streaming_dataset_stub(np.zeros((1, 6, 8, 10), dtype=np.float32))),
+        patch=DatasetPatch([4, 4, 4]),
+        transforms=[],
+        data_augmentations_list=[augmentations],
+    )
+    copies = range(len(manager.shapes))
+    reference = {a: (manager.patch.get_sweep_axis(a), manager.patch.get_patch_slices(a)) for a in copies}
+
+    restored = pickle.loads(pickle.dumps(manager))
+
+    assert restored.shapes == manager.shapes
+    for a in copies:
+        assert (restored.patch.get_sweep_axis(a), restored.patch.get_patch_slices(a)) == reference[a]

--- a/tests/unit/test_patching.py
+++ b/tests/unit/test_patching.py
@@ -45,7 +45,7 @@ from konfai.utils.utils import best_sweep_axis, get_patch_slices_from_shape, res
 
 def _tile_2d(full: torch.Tensor, patch_size: list[int], overlap: int):
     """Return (patch_slices, patches) tiling the spatial dims of *full* ([B, C, H, W])."""
-    patch_slices, _ = get_patch_slices_from_shape(patch_size, list(full.shape[2:]), overlap)
+    patch_slices = get_patch_slices_from_shape(patch_size, list(full.shape[2:]), overlap)
     patches = [full[:, :, sl[0], sl[1]].clone() for sl in patch_slices]
     return patch_slices, patches
 
@@ -165,7 +165,7 @@ def test_free_axis_reassembles_like_its_concrete_extent(free_axis, combine_cls):
     concrete_overlap[free_axis] = 0
 
     def assemble(patch_size: list[int], overlap: int | list[int]) -> torch.Tensor:
-        slices, _ = get_patch_slices_from_shape(patch_size, spatial, overlap)
+        slices = get_patch_slices_from_shape(patch_size, spatial, overlap)
         combine = None
         if combine_cls is not None:
             combine = combine_cls()
@@ -199,14 +199,14 @@ def test_declared_free_axis_keeps_the_fraction_overlap_after_restart_concretizat
     concrete = [64, 128, 128]  # what the restart pins it to
 
     # Baseline: passing the declared flag explicitly must not change the non-restart result.
-    declared_slices, _ = get_patch_slices_from_shape(declared, shape, None, None, True)
-    derived_slices, _ = get_patch_slices_from_shape(declared, shape, None)
+    declared_slices = get_patch_slices_from_shape(declared, shape, None, None, True)
+    derived_slices = get_patch_slices_from_shape(declared, shape, None)
     assert _axis_overlaps(declared_slices, [512, 128, 128]) == _axis_overlaps(derived_slices, [512, 128, 128])
 
     # Regression: on the concretized grid the derived flag is False (no ``0`` left) and would take the
     # remainder branch; carrying declared_free_axis=True restores the exact fraction default on the tiled axes.
-    remainder, _ = get_patch_slices_from_shape(concrete, shape, None, None, False)
-    fixed, _ = get_patch_slices_from_shape(concrete, shape, None, None, True)
+    remainder = get_patch_slices_from_shape(concrete, shape, None, None, False)
+    fixed = get_patch_slices_from_shape(concrete, shape, None, None, True)
     assert _axis_overlaps(remainder, concrete) == [0, 0, 0]
     assert _axis_overlaps(fixed, concrete) == list(resolve_overlap(None, concrete, shape))
 
@@ -386,7 +386,7 @@ def _padded_patches(full: torch.Tensor, patch_slices, patch_size: list[int]) -> 
 def test_streaming_accumulator_slabs_match_assemble(combine_cls, dtype, shape, patch_size, overlap):
     torch.manual_seed(0)
     full = torch.randn(shape, dtype=dtype)
-    patch_slices, _ = get_patch_slices_from_shape(patch_size, list(shape[1:]), overlap)
+    patch_slices = get_patch_slices_from_shape(patch_size, list(shape[1:]), overlap)
     patches = _padded_patches(full, patch_slices, patch_size)
 
     def _combine():
@@ -429,7 +429,7 @@ def test_streaming_accumulator_refuses_whole_volume_assemble():
 
 def test_streaming_accumulator_is_reusable_after_finalize():
     full = torch.arange(2 * 8, dtype=torch.float32).reshape(1, 2, 8)
-    patch_slices, _ = get_patch_slices_from_shape([1, 8], [2, 8], 0)
+    patch_slices = get_patch_slices_from_shape([1, 8], [2, 8], 0)
     streaming = StreamingAccumulator(patch_slices, [1, 8], patch_combine=None, batch=False)
     for _ in range(2):
         slabs = []
@@ -443,7 +443,7 @@ def test_streaming_accumulator_rejects_out_of_order_arrival():
     # Correctness needs patches to ARRIVE in non-decreasing first-axis-start order, not just the slice
     # list to be sorted. Arriving 0, 2, 3 then the skipped 1 flushes the window past start=2 before
     # patch 1 (start=2) shows up; without the guard its window offset goes negative -> silent misplace.
-    patch_slices, _ = get_patch_slices_from_shape([4, 8], [10, 8], 2)  # starts 0, 2, 4, 6; window 4
+    patch_slices = get_patch_slices_from_shape([4, 8], [10, 8], 2)  # starts 0, 2, 4, 6; window 4
     starts = [sl[0].start for sl in patch_slices]
     assert starts == [0, 2, 4, 6]
     streaming = StreamingAccumulator(patch_slices, [4, 8], patch_combine=None, batch=False)
@@ -466,7 +466,7 @@ def test_blend_weight_factorises_into_one_vector_per_axis(combine_cls):
     spatial-sized weight buffer.
     """
     shape, patch, overlap = [10, 12, 14], [6, 6, 6], 2
-    slices, _ = get_patch_slices_from_shape(patch, shape, overlap)
+    slices = get_patch_slices_from_shape(patch, shape, overlap)
     combine = combine_cls()
     combine.set_patch_config(patch, overlap)
     accumulator = Accumulator(slices, patch, patch_combine=combine, batch=False)
@@ -493,7 +493,7 @@ def test_blend_recovers_the_source_in_low_precision(combine_cls):
     """
     shape, patch, overlap = [10, 12, 14], [6, 6, 6], 2
     full = torch.rand(2, *shape)
-    slices, _ = get_patch_slices_from_shape(patch, shape, overlap)
+    slices = get_patch_slices_from_shape(patch, shape, overlap)
     combine = combine_cls()
     combine.set_patch_config(patch, overlap)
     accumulator = Accumulator(slices, patch, patch_combine=combine, batch=False)
@@ -515,7 +515,7 @@ def test_anisotropic_overlap_reassembles_exactly(combine_cls):
     # 12=2x6, 14=6+8, 16=4+4+8: every patch is full patch_size (the model emits full-size patches)
     shape, patch, overlap = [12, 14, 16], [6, 8, 8], [0, 2, 4]
     full = torch.rand(2, *shape)
-    slices, _ = get_patch_slices_from_shape(patch, shape, overlap)
+    slices = get_patch_slices_from_shape(patch, shape, overlap)
     combine = combine_cls()
     combine.set_patch_config(patch, overlap)
     accumulator = Accumulator(slices, patch, patch_combine=combine, batch=False)
@@ -533,7 +533,7 @@ def test_blend_does_not_depend_on_patch_arrival_order(combine_cls):
     """
     shape, patch, overlap = [10, 10, 14], [6, 6, 6], 2  # exact tiling at step 4
     full = torch.rand(2, *shape)
-    slices, _ = get_patch_slices_from_shape(patch, shape, overlap)
+    slices = get_patch_slices_from_shape(patch, shape, overlap)
 
     def assemble(order: list[int]) -> torch.Tensor:
         combine = combine_cls()
@@ -554,7 +554,7 @@ def test_unweighted_overlap_is_last_write_wins():
     own border, with no context behind it, which is what shows up as a seam.
     """
     shape, patch, overlap = [8], [4], 2
-    slices, _ = get_patch_slices_from_shape(patch, shape, overlap)
+    slices = get_patch_slices_from_shape(patch, shape, overlap)
     accumulator = Accumulator(slices, patch, patch_combine=None, batch=False)
     for index, _ in enumerate(slices):
         accumulator.add_layer(index, torch.full((1, 4), float(index)))
@@ -570,7 +570,7 @@ def test_trim_selects_the_most_central_patch():
     the axis, the first and last open to the edge, and every interior voxel sits at least one row
     inside the patch it came from. Compare test_unweighted_overlap_is_last_write_wins.
     """
-    slices, _ = get_patch_slices_from_shape([4], [8], 2)
+    slices = get_patch_slices_from_shape([4], [8], 2)
     combine = Trim()
     combine.set_patch_config([4], 2)
     accumulator = Accumulator(slices, [4], patch_combine=combine, batch=False)
@@ -594,7 +594,7 @@ def test_trim_reassembles_exactly_and_keeps_values_discrete(shape, patch, overla
     coverage gap only darkens a voxel, where a 0/1 selection leaves it unwritten.
     """
     labels = torch.randint(0, 5, (2, *shape)).float()
-    slices, _ = get_patch_slices_from_shape(patch, shape, overlap)
+    slices = get_patch_slices_from_shape(patch, shape, overlap)
     combine = Trim()
     combine.set_patch_config(patch, overlap)
     accumulator = Accumulator(slices, patch, patch_combine=combine, batch=False)
@@ -624,7 +624,7 @@ def test_trim_kept_boxes_partition_the_volume(shape, patch, overlap):
     This is the property the selection path rests on: if the kept boxes tiled imperfectly, assembly
     would leave holes (never written) or race (written twice), and neither shows up as an error.
     """
-    slices, _ = get_patch_slices_from_shape(patch, shape, overlap)
+    slices = get_patch_slices_from_shape(patch, shape, overlap)
     combine = Trim()
     combine.set_patch_config(patch, overlap)
     accumulator = Accumulator(slices, patch, patch_combine=combine, batch=False)
@@ -649,7 +649,7 @@ def test_trim_kept_boxes_are_cached_per_axis_position_not_per_patch():
     reads the windows position by position.
     """
     shape, patch, overlap = [20, 22, 24], [8, 8, 8], 4
-    slices, _ = get_patch_slices_from_shape(patch, shape, overlap)
+    slices = get_patch_slices_from_shape(patch, shape, overlap)
     combine = Trim()
     combine.set_patch_config(patch, overlap)
     accumulator = Accumulator(slices, patch, patch_combine=combine, batch=False)
@@ -714,7 +714,7 @@ def test_streaming_accumulator_sweeps_any_axis(sweep_axis):
     """
     shape, patch, overlap = [10, 10, 14], [6, 6, 6], 2
     full = torch.rand(2, *shape)
-    slices, _ = get_patch_slices_from_shape(patch, shape, overlap)
+    slices = get_patch_slices_from_shape(patch, shape, overlap)
     # The grid is emitted with axis 0 outermost; a sweep along another axis needs that axis outermost.
     rest = [axis for axis in range(3) if axis != sweep_axis]
     ordered = sorted(slices, key=lambda sl: tuple(sl[axis].start for axis in (sweep_axis, *rest)))
@@ -746,8 +746,8 @@ def test_patch_grid_orders_by_the_sweep_axis(sweep_axis):
     is why the set is asserted and not just the ordering.
     """
     shape, patch, overlap = [10, 12, 14], [6, 6, 6], 2
-    reference, _ = get_patch_slices_from_shape(patch, shape, overlap)
-    ordered, _ = get_patch_slices_from_shape(patch, shape, overlap, sweep_axis=sweep_axis)
+    reference = get_patch_slices_from_shape(patch, shape, overlap)
+    ordered = get_patch_slices_from_shape(patch, shape, overlap, sweep_axis=sweep_axis)
 
     assert sorted(map(str, ordered)) == sorted(map(str, reference)), "the grid itself must not change"
     starts = [patch_slice[sweep_axis].start for patch_slice in ordered]

--- a/tests/unit/test_predictor_reduction_device.py
+++ b/tests/unit/test_predictor_reduction_device.py
@@ -151,7 +151,7 @@ def test_accumulate_device_budgets_the_streaming_window_not_the_whole_volume(mon
     patch = torch.zeros(64, 8, dtype=torch.float16, device="cuda")
     # The whole volume's accumulator (~3.4 GiB) overflows 3 x 0.9; the window (one patch extent,
     # ~0.13 GiB) fits easily.
-    patch_slices, _ = get_patch_slices_from_shape([16, 256, 256], [400, 256, 256], 0)
+    patch_slices = get_patch_slices_from_shape([16, 256, 256], [400, 256, 256], 0)
     combine = Cosinus()
     combine.set_patch_config([16, 256, 256], 0)
     whole = _FakeAccumulator([400, 256, 256])

--- a/tests/unit/test_save_streaming.py
+++ b/tests/unit/test_save_streaming.py
@@ -24,7 +24,6 @@ from pathlib import Path
 import numpy as np
 import pytest
 import torch
-from konfai.data.materialize import CaseMaterializer, Verdict
 from konfai.data.patching import DatasetManager, DatasetPatch
 from konfai.data.transform import Clip, Permute, Save, Standardize, Transform
 from konfai.utils.dataset import Attribute, Dataset
@@ -276,40 +275,6 @@ def test_an_interrupted_sweep_aborts_its_stream_and_does_not_fall_back(
     assert not manager._sweep_failed
     assert not list((tmp_path / "cache").glob("**/*.tmp"))
     assert not Dataset(tmp_path / "cache", "mha").is_dataset_exist("CT", "CASE_000")
-
-
-def test_a_rank_dropping_stage_refuses_instead_of_writing_a_broadcast_store(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """`Sum(dim=0)` drops the leading axis, so its slab is no longer C[Z]YX.
-
-    Written anyway, the header takes the slab's first spatial extent for a channel count and
-    publishes that many broadcast copies: a store whose rank disagrees with the whole-volume path,
-    with no exception raised. It must refuse and fall back instead."""
-    from konfai.data import patching as patching_module
-    from konfai.data.transform import Sum
-
-    monkeypatch.setattr(patching_module, "SWEEP_SLAB_ROWS", 2)
-    rng = np.random.default_rng(0)
-    volume = rng.random((5, 12, 10, 8)).astype(np.float32)
-    source = Dataset(tmp_path / "source", "h5")
-    source.write("CT", "CASE_000", volume, Attribute())
-
-    manager = DatasetManager(
-        index=0,
-        group_src="CT",
-        group_dest="CT",
-        name="CASE_000",
-        dataset=source,
-        patch=None,
-        transforms=[Sum(dim=0), Save(f"{tmp_path / 'out'}:h5")],
-        data_augmentations_list=[],
-    )
-    with pytest.warns(UserWarning, match="Falling back to the whole-volume path"):
-        assert CaseMaterializer(manager).materialize() is Verdict.WHOLE_VOLUME
-
-    written, _ = Dataset(tmp_path / "out", "h5").read_data("CT", "CASE_000")
-    np.testing.assert_allclose(written, volume.sum(axis=0), rtol=1e-6)
 
 
 def test_kill_switch_keeps_the_whole_volume_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_streamed_oracle.py
+++ b/tests/unit/test_streamed_oracle.py
@@ -63,11 +63,9 @@ from konfai.data.transform import (
     Flip,
     Gradient,
     Mask,
-    MergeLabels,
     Reduce,
     Resample,
     Save,
-    Sum,
     Transform,
     Write,
 )
@@ -99,11 +97,6 @@ GEOMETRIES = {
 }
 #: The one the tests that vary something OTHER than the geometry run on.
 MAIN = "rank3-seed11"
-
-#: Two POINTWISE stages no sweep can honour: both fold the leading model axis and hand back a volume
-#: without it, so their block is no longer C[Z]YX. They leave the matrix (there is no streamed store
-#: to compare) and their refusal is pinned on its own below.
-_RANK_DROPPING = ("Sum", "MergeLabels")
 
 
 @dataclass(frozen=True)
@@ -218,18 +211,13 @@ def _assert_same(got: Written, want: Written, atol: float, rtol: float = 0.0) ->
 # ---------------------------------------------------------------- the cases the matrix runs
 
 
-def _sweepable_cases(geometry: str) -> list[StageCase]:
-    """What a sweep can be asked for on this geometry: what the read side streams, less the two
-    stages whose block is not channel-first, which are pinned as a refusal of their own below."""
-    return [
-        case for case in streamable_cases(GEOMETRIES[geometry]) if type(case.transform).__name__ not in _RANK_DROPPING
-    ]
-
-
 def _matrix() -> list[tuple[str, StageCase, Route]]:
     """Every (geometry, built-in, decomposition) the property is proven on."""
     return [
-        (geometry, case, route) for geometry in GEOMETRIES for case in _sweepable_cases(geometry) for route in ROUTES
+        (geometry, case, route)
+        for geometry in GEOMETRIES
+        for case in streamable_cases(GEOMETRIES[geometry])
+        for route in ROUTES
     ]
 
 
@@ -298,29 +286,6 @@ def test_a_swept_case_equals_the_whole_volume_case(
     # would pass on a sweep that never decomposed anything.
     assert streamed.regions >= (2 if route.height == 0.0 else 1)
     _assert_same(streamed, whole, case.atol, case.rtol)
-
-
-def test_every_read_streamable_builtin_is_in_the_matrix() -> None:
-    """The matrix follows the DECLARATIONS, so a newly streamable built-in joins it the day it lands
-    and one that quietly retreats to WHOLE_VOLUME leaves a hole this states rather than hides."""
-    for name, geometry in GEOMETRIES.items():
-        swept = {type(case.transform).__name__ for case in _sweepable_cases(name)}
-        declared = {type(case.transform).__name__ for case in streamable_cases(geometry)}
-        assert swept == declared - set(_RANK_DROPPING) and swept
-
-
-@pytest.mark.parametrize("stage", [MergeLabels(), Sum(0)], ids=_RANK_DROPPING)
-def test_a_rank_dropping_pointwise_stage_refuses_the_sweep_and_says_why(
-    stage: Transform, cases: dict[str, Dataset], tmp_path: Path
-) -> None:
-    """Both declare POINTWISE and hand back a volume without its leading axis, so no region write
-    can mean what the whole-volume write means. The sweep must refuse with the layout it needed and
-    fall back, not publish a store whose rank disagrees with the other route's."""
-    manager = _manager(cases[MAIN], "Ensemble", [stage, Save(f"{tmp_path / 'out'}:h5")])
-    with pytest.warns(UserWarning, match="Falling back to the whole-volume path"):
-        assert CaseMaterializer(manager).materialize() is Verdict.WHOLE_VOLUME
-    assert manager._sweep_failure is not None
-    assert "channel-first" in manager._sweep_failure and "rank 4" in manager._sweep_failure
 
 
 # ---------------------------------------------------------------- the dtypes a store holds


### PR DESCRIPTION
Four changes on the out-of-core path. A case's patch grid is now cut on the rank instead of before the spawn: `load` records the shape only, `__getstate__` leaves the cuts out, and the accessors (`get_patch_slices`, `get_sweep_axis`, `read_slices`, `core_in_read`, `get_size`) cut on first use, so the spawn no longer ships them. The blend window `PathCombine` stored beside the per-axis factors it is the outer product of is derived on demand and cached per device and dtype, `get_patch_slices_from_shape` returns the slice list alone (its count had no reader left, and all 42 call sites spelled `x, _ = ...`), `get_patch_slices_from_nb_patch_per_dim` had no caller anywhere in core, apps, mcp, studio, tests or docs and is dropped, and the manager's patch copy gets its own `patch_size` list so a mutation of the source cannot move a grid the copy has not cut yet. The single-channel block rule moves into `as_channel_first(data, attributes)` and the region write applies it, so `Sum(dim=0)` and `MergeLabels`, whose PREDICTION contract is `[M, C, ...] -> [C, ...]` without keepdim, stream instead of falling to the whole-volume route the plan did not announce; `write_stream_cache_attribute` is now stated by every stage and the two folds drop `number_of_channels_per_model` there, so a merged output no longer ships the key describing the ensemble it consumed. Finally the patch route declares its reads to the decoded-chunk cache in the order the process will read them, the grid's for PREDICTION and EVALUATION and the sampler's for a TRAIN epoch, carried to the DataLoader's workers through shared memory by `PatchReadOrder`, with one declaration site (`DatasetManager._declare_region_reads`) now serving both engines.

## Measured

Pickle size and the in-process unpickle-and-cut of 100 synthetic cases on a headers-only dataset, one patch, one copy, min of 5 (`CUDA_VISIBLE_DEVICES= python .scratch/measure_pickle.py`):

| patches/case | bytes | unpickle and cut |
|---|---|---|
| 32 | 138 669 -> 46 849 B | 2.1 -> 4.1 ms |
| 256 | 565 526 -> 46 849 B | 6.5 -> 13.1 ms |
| 2048 | 3 686 530 -> 46 849 B | 31.0 -> 80.9 ms |

Cutting costs more than unpickling; the transfer, paid once per rank, is what dominates. A 2-rank CPU spawn of 1000 cases at 2048 patches (`.scratch/measure_launch.py`, 3 runs, host load ~8) carries 35.22 MiB instead of 0.44 and reaches "every grid available on the rank" at rank 0 in 2.25-2.53 s -> 1.98-2.15 s and rank 1 in 4.60-5.08 s -> 2.87-3.13 s. A 128^3 `ModelPatch` at overlap 16 pickled to 8 391 775 bytes, 2649 with the window derived on demand.

Decodes on a synthetic OME-Zarr case read patch by patch on one process (48x128x128 over 48 chunks of 16x32x32, chain `Resample` onto a 20-degree rotated grid, the source alone declared), undeclared -> declared:

| patch | order | cache 64 | cache 39 | cache 24 |
|---|---|---|---|---|
| 16x32x32 | grid | 44/44 | 44/44 | 82/69 |
| 16x32x32 | shuffled epoch | 45/45 | 61/46 | 145/96 |
| 8x32x32 | grid | 44/44 | 45/44 | 185/109 |
| 8x32x32 | shuffled epoch | 52/52 | 67/54 | 276/185 |

At 64 the store fits and neither policy evicts. Over the 96 chunks the CT and its `Labels` mask hold, at 39 and 24 of them, LRU -> declared is 312 -> 212 and 384 -> 336 in the grid's order, 247 -> 217 and 344 -> 309 over a shuffled epoch.

Streamed write of a synthetic [5, 512, 512, 512] uint8 case, `MergeLabels` + `Save(:h5)`, one process, CPU, host at load 4-5, three interleaved runs each: whole-volume 3.72 / 3.89 / 3.80 s at 4551 MiB peak RSS, streamed 4.91 / 4.75 / 4.99 s at 1535 MiB peak RSS, so +26 % of wall clock for -66 % of peak RSS.

## Values

Nothing moves. The cut is a pure function of the recorded shape and the patch's configuration, the derived window is the product the constructor computed and the all-flat case is `ones()` either way, the epoch's order is unchanged (`torch.arange` and `torch.randperm` draw as before), and for the streamed fold the two stores are equal by `np.array_equal` and by `tobytes()` with headers carrying the same keys.

## Tests

Pickle-crossing tests compare every copy's slices, sweep axis, reads and cores over a fixed patch, a free axis, a singleton axis and a free axis a restart already concretized; five declaration contracts, each failing on the base tree, pin the per-epoch order, a second epoch's own draw, a worker's own batches, delivery to a process forked before the first draw, and that the windows declared are the windows the route reads on both the exact-patch and the region branch; the copy's own `patch_size` is pinned by mutating the source after construction (it fails on the shared list, [8, 8] instead of [4, 4], one whole-volume patch instead of four); `Sum(dim=0)` and `MergeLabels` join the streamed oracle matrix (3 geometries x 3 decompositions each, streamed byte-equal to whole-volume) as `_RANK_DROPPING` is retired, with the rest in `tests/unit/test_channel_fold_streaming.py`.

## Stack

Stacked on `pr/1.8.2-11-chain-check`; merge after it. Before deleting this branch, retarget the next PR of the stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved streaming cache planning for sweeps and patch-based workflows.
  * Added support for channel-first normalization of spatial-only NumPy image data.
  * Enabled streamed outputs for channel-folding transforms, with fallback handling for unsupported layouts.
  * Improved patch-grid rebuilding after serialization and reload.

* **Bug Fixes**
  * Improved patch read ordering and region declarations for more efficient streamed data access.
  * Corrected streamed writes for incompatible array ranks and channel metadata.

* **Documentation**
  * Clarified streaming cache behavior and region-read planning across processing routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->