### PR TITLE
The training step: a fused optimizer, a folded soft Dice

### DIFF
--- a/docs/source/config_guide/prediction.md
+++ b/docs/source/config_guide/prediction.md
@@ -49,8 +49,8 @@ When multiple checkpoints are provided, the predictor combines them using the
 | `train_name` | string | `"name"` | Yes in practice | Names the prediction run and output folder. |
 | `manual_seed` | int or null | `None` | No | Optional seed. |
 | `gpu_checkpoints` | list or null | `None` | No | Module placement optimization. |
-| `autocast` | bool | `false` | No | Enables AMP during inference. On the shipped Segmentation example: 4.2 s to 2.7 s, 11110 of 58.4 million label voxels change, at boundaries. |
-| `channels_last` | bool | `false` | No | Lays the convolution weights and inputs out channels-last (4-D and 5-D). With `autocast`, 2.7 s to 2.2 s on the same example and no further voxel changes; alone, no gain and 3199 voxels moved by the kernels cuDNN then picks. |
+| `autocast` | bool | `false` | No | Enables AMP during inference. On the shipped Segmentation example: 4.2 s to 2.7 s, 11110 of 58.4 million label voxels change, at boundaries. On a 3D UNet (five levels to 256 channels, 96 cubed patches, batch 2, twenty 128 cubed cases): 4.8 s to 2.9 s. |
+| `channels_last` | bool | `false` | No | Lays the convolution weights and inputs out channels-last (4-D and 5-D). With `autocast`, 2.7 s to 2.2 s on the same example and no further voxel changes, and 2.9 s to 2.4 s on the 3D UNet above; alone, no gain and 3199 voxels moved by the kernels cuDNN then picks. |
 | `data_log` | list or null | `None` | No | Optional TensorBoard logging. |
 | `check_training_transforms` | bool | `true` | No | Warns when a model input is not preprocessed the way its checkpoint trained on it. See [The training-chain check](#the-training-chain-check). |
 

--- a/docs/source/config_guide/training.md
+++ b/docs/source/config_guide/training.md
@@ -59,8 +59,8 @@ konfai TRAIN -y --config Config.yml \
 | `epochs` | int | `100` | No | Number of training epochs. |
 | `it_validation` | int or null | `None` | No | Validation and checkpoint interval in iterations. |
 | `it_lr_update` | int or null | `None` | No | Scheduler-step interval in iterations. `None` steps once per epoch (it resolves to the training dataloader's length). Every resolved config on disk carries this key. |
-| `autocast` | bool | `false` | No | Enables AMP during training. |
-| `channels_last` | bool | `false` | No | Lays the convolution weights and inputs out channels-last (4-D and 5-D). cuDNN picks its kernels by layout: with `autocast` the shipped Segmentation example predicts 1.25x faster; the kernels chosen differ, so labels can move at boundaries (3199 of 58.4 million voxels in fp32 on that example). |
+| `autocast` | bool | `false` | No | Enables AMP during training. On a 3D UNet (five levels to 256 channels, 96 cubed patches, batch 2, twenty 128 cubed cases, one RTX PRO 5000) an epoch runs 11.7 s against 27.0 s in fp32. |
+| `channels_last` | bool | `false` | No | Lays the convolution weights and inputs out channels-last (4-D and 5-D). cuDNN picks its kernels by layout: with `autocast` the shipped Segmentation example predicts 1.25x faster, and the 3D UNet above trains an epoch in 10.0 s against 11.7 s; the kernels chosen differ, so labels can move at boundaries (3199 of 58.4 million voxels in fp32 on that example). |
 | `gradient_checkpoints` | list or null | `None` | No | Activates gradient checkpointing on selected modules. |
 | `gpu_checkpoints` | list or null | `None` | No | Pins selected modules to dedicated GPUs. |
 | `ema_decay` | float | `0` | No | Enables exponential moving average tracking when greater than zero. |
@@ -93,6 +93,21 @@ Common nested fields used by built-in and local models:
 | `outputs_criterions` | mapping | Usually | Declares losses and metrics attached to specific model outputs. |
 | `ModelPatch` | mapping or null | Optional | Enables a second, model-level patch inside the network (a config key named `ModelPatch`, distinct from `Dataset.Patch`). |
 | `dim` | int | Model-dependent | Declares whether the network operates in 2D or 3D. |
+
+### `optimizer`
+
+`name` selects a class from `torch.optim`; the rest of the section is that
+class's own signature, so a resolved config carries every one of its keys.
+
+`fused` and `foreach` both left at `None` ask for the widest batched step the
+optimizer implements: fused where torch has one, foreach otherwise. The run
+decides, not the parameters: a run that places the graph on a GPU takes the
+batched step, a CPU run keeps torch's own default. On the Segmentation example
+(1.93 M parameters in 40 tensors, one RTX PRO 5000) an AdamW step costs
+0.059 ms of host time fused against 0.188 ms foreach, in two kernels against
+eight. A fused step sums in another order, so its parameters drift from the
+foreach ones: 3.7e-05 after 100 steps, 8.3e-06 of their own scale. Write
+`fused: false` to pin the foreach step.
 
 ### `outputs_criterions`
 

--- a/konfai/metric/measure.py
+++ b/konfai/metric/measure.py
@@ -628,16 +628,6 @@ class Dice(Criterion):
     maximize = True  # reported value is the Dice coefficient (higher-is-better); DiceSaveMap inherits it
 
     @staticmethod
-    def flatten(tensor: torch.Tensor) -> torch.Tensor:
-        return tensor.permute((1, 0, *tuple(range(2, tensor.dim())))).contiguous().view(tensor.size(1), -1)
-
-    @staticmethod
-    def dice_per_channel(tensor: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
-        tensor = Dice.flatten(tensor)
-        target = Dice.flatten(target)
-        return (2.0 * (tensor * target).sum() + 1e-6) / (tensor.sum() + target.sum() + 1e-6)
-
-    @staticmethod
     def on_grid(output: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         """A label map on the output's spatial grid.
 
@@ -746,7 +736,15 @@ class Dice(Criterion):
     def _soft_sums(output: torch.Tensor, target: torch.Tensor, labels: list[int] | None) -> LabelSums:
         """The sums of a probability map against a label map, per channel: the intersection is
         taken only where the reference holds the label (it is zero elsewhere), and one
-        ``.tolist()`` brings every sum back."""
+        ``.tolist()`` brings every sum back.
+
+        A label at a time, where the loss batches them: this route carries no gradient, so its peak
+        is one channel and never the label count. Batched it read 1050 MiB instead of 346 and took
+        4.44 ms instead of 1.95 on a ``[1, 41, 128, 128, 128]`` patch of 40 labels.
+
+        With ``labels=None`` every label either map holds gets its sums, so a patch's predicted mass
+        for a label its reference lacks still reaches the whole-case ratio in ``combine_metric``.
+        """
         scored = labels if labels is not None else list(range(1, output.shape[1]))
         _, reference = Dice._reference_counts(target, scored)
         sums: list[torch.Tensor] = []
@@ -756,7 +754,8 @@ class Dice(Criterion):
                 continue
             predicted = output[:, label].unsqueeze(1).float()
             sums.append(predicted.sum())
-            sums.append((predicted * (target == label).float()).sum() if count else predicted.new_zeros(()))
+            # A bool mask multiplies in the probability's own dtype: no float copy of the reference.
+            sums.append((predicted * (target == label)).sum() if count else predicted.new_zeros(()))
         values = torch.stack(sums).tolist() if sums else []
         return {
             label: (values[2 * index + 1], values[2 * index], float(count), count > 0)
@@ -785,21 +784,44 @@ class Dice(Criterion):
         labels: list[int] | None, output: torch.Tensor, target: torch.Tensor
     ) -> tuple[torch.Tensor, dict[int, float]]:
         """The differentiable soft Dice over a probability map's channels, one per label the
-        reference holds. The readouts come back in one ``.tolist()`` after the loop: a ``.item()``
-        per label drained the CUDA queue mid-loss, twice per label."""
+        reference holds, every label in one expression: their channels gathered in one slice, the
+        reference one comparison against the label vector on an axis of its own, and each sum one
+        reduction. That axis sits before the target's channels, so a reference of any channel count
+        broadcasts against a gathered channel exactly as a per-label ``target == label`` did.
+
+        A slice per label cost a gradient write into the whole logits tensor each: 22.7 ``add_`` and
+        28.7 ``fill_`` per step, 10.2 ms of the 28.2 ms of GPU time of a training step of
+        ``examples/Segmentation`` (batch 8, 41 channels, 256x256, autocast + channels_last).
+        Backward held a float copy of both operands per label already, so training peaks lower
+        (242 -> 180 MiB on that batch); with no gradient to build it is the label count that peaks
+        where the loop peaked at one channel (6 -> 180 MiB), and ``_soft_sums`` is the frugal route.
+
+        The reference's own mass is the voxel count ``_reference_counts`` already holds, the exact
+        integer the metric route's ``_score`` divides by. The readouts come back in one
+        ``.tolist()``: a ``.item()`` per label drained the CUDA queue mid-loss, twice per label.
+        """
         labels, reference = Dice._reference_counts(target, labels)
-        loss = torch.tensor(0, dtype=torch.float32).to(output.device)
-        dices: list[torch.Tensor] = []
-        for label, count in zip(labels, reference, strict=True):
-            if count:
-                dice = Dice.dice_per_channel(output[:, label].unsqueeze(1).float(), (target == label).float())
-                loss += dice
-                dices.append(dice)
-        values = iter(torch.stack(dices).tolist() if dices else [])
+        held = [label for label, count in zip(labels, reference, strict=True) if count]
+        held_counts = [count for count in reference if count]
+        if not held:
+            return torch.tensor(0, dtype=torch.float32).to(output.device), dict.fromkeys(labels, np.nan)
+        channels = output.shape[1]
+        if min(held) < -channels or max(held) >= channels:
+            raise MeasureError(
+                f"Dice was asked to score labels {held} of a probability map of {channels} channels",
+                "the reference holds a label the prediction has no channel for",
+                "Give the criterion the `labels:` it should score, or predict one channel per label.",
+            )
+        label_vector = torch.tensor(held, device=output.device)
+        probabilities = output[:, label_vector].float().unsqueeze(2)
+        on_reference = target.unsqueeze(1) == label_vector.view(1, -1, *(1,) * (target.dim() - 1))
+        summed = (0, 2, *range(3, probabilities.dim()))
+        intersection = (probabilities * on_reference).sum(summed)
+        reference_mass = torch.tensor(held_counts, dtype=torch.float32, device=output.device)
+        dices = (2.0 * intersection + 1e-6) / (probabilities.sum(summed) + reference_mass + 1e-6)
+        values = iter(dices.tolist())
         result = {label: next(values) if count else np.nan for label, count in zip(labels, reference, strict=True)}
-        if not dices:
-            return loss, result
-        return 1 - loss / len(dices), result
+        return 1 - dices.mean(), result
 
     @staticmethod
     def _loss(

--- a/konfai/metric/measure.py
+++ b/konfai/metric/measure.py
@@ -21,7 +21,7 @@ import importlib
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator
-from functools import partial
+from functools import partial, reduce
 from types import ModuleType
 from typing import Any
 
@@ -663,7 +663,10 @@ class Dice(Criterion):
                 index = index.masked_fill_(nan_mask, 0)  # a whole number, so the minimum below is a label's
             indices.append(index)
         signed = [index for index, tensor in zip(indices, maps, strict=True) if Dice._may_hold_a_negative(tensor)]
-        lowest = int(torch.stack([index.min() for index in signed]).min()) if signed else 0
+        # One reduction per map and nothing more: stacking the minima to reduce them again adds a
+        # kernel and a device copy, 0.0967 -> 0.1040 ms for the counts of a [8, 1, 256, 256] int64
+        # map (CUDA events).
+        lowest = int(reduce(torch.minimum, (index.min() for index in signed))) if signed else 0
         nan_bin = int(any(nan_mask is not None for nan_mask in nan_masks))
         offset = min(0, lowest, *(labels or [0])) - nan_bin
         if offset:

--- a/konfai/network/network.py
+++ b/konfai/network/network.py
@@ -511,31 +511,22 @@ class Measure:
                     self._loss[criterions_attr.group][
                         f"{output_group}:{target_group}:{criterion.__class__.__name__}"
                     ].add(scheduler.get_value(), loss)
-                    if (
-                        training
-                        and len(
-                            np.unique(
-                                [
-                                    len(loss_value)
-                                    for loss_value in self._loss[criterions_attr.group].values()
-                                    if loss_value.accumulation and loss_value.is_loss
-                                ]
-                            )
-                        )
-                        == 1
-                    ):
-                        # Only the accumulation loss that completes the group's per-patch set may fire the
-                        # accumulated backward. Without the `accumulation` guard, a plain (non-accumulation)
-                        # loss added later in the SAME numeric group re-satisfies the uniform-count test and
-                        # re-runs backward over the already-freed accumulation graph (double gradient / crash).
-                        if criterions_attr.accumulation and criterions_attr.is_loss:
+                    # Only the accumulation loss that completes the group's per-patch set may fire the
+                    # accumulated backward: a plain (non-accumulation) loss added later in the SAME
+                    # numeric group must not re-satisfy the uniform-count test and re-run backward over
+                    # the already-freed accumulation graph (double gradient / crash). The criterion's own
+                    # flags are the cheap half of that test and gate it: 0.02 us a call against 2.94 for
+                    # the count over the group (timeit, 20000 calls).
+                    if training and criterions_attr.accumulation and criterions_attr.is_loss:
+                        accumulated = [
+                            record
+                            for record in self._loss[criterions_attr.group].values()
+                            if record.accumulation and record.is_loss
+                        ]
+                        if len({len(record) for record in accumulated}) == 1:
                             loss = torch.zeros(1, requires_grad=True)
-                            for v in [
-                                loss_value
-                                for loss_value in self._loss[criterions_attr.group].values()
-                                if loss_value.accumulation and loss_value.is_loss
-                            ]:
-                                loss_value = v.get_last_loss()
+                            for record in accumulated:
+                                loss_value = record.get_last_loss()
                                 loss = loss.to(loss_value.device) + loss_value
                             loss = loss / nb_patch
                             if self.scaler is not None:

--- a/konfai/network/network.py
+++ b/konfai/network/network.py
@@ -43,7 +43,7 @@ import torch
 from torch._jit_internal import _copy_to_script_wrapper
 from torch.utils.checkpoint import checkpoint
 
-from konfai import konfai_root
+from konfai import cuda_visible_devices, konfai_root
 from konfai.data.data_manager import BatchSample
 from konfai.data.patching import Accumulator, ModelPatch, SweepClock
 from konfai.metric.schedulers import Scheduler
@@ -71,6 +71,45 @@ class PatchIndexed:
         return len(self.patch.get_patch_slices(0)) == self.index
 
 
+def batched_step(
+    optimizer_class: type[torch.optim.Optimizer], parameters: list[torch.nn.parameter.Parameter]
+) -> Callable[..., torch.optim.Optimizer]:
+    """``optimizer_class``, its step batched over ``parameters`` when the config leaves the choice open.
+
+    ``fused`` and ``foreach`` both unset ask for the widest batched step the optimizer implements: fused
+    when it has one, foreach when it only has that. The device is the one the run will place the graph on,
+    not the one the parameters sit on here, because an optimizer is built on the launcher and ``Network.to``
+    moves the graph afterwards. Off CUDA torch's own default stands (forcing foreach there costs 526 ms a
+    step against 2.0 ms, over the 40 tensors of the Segmentation example); an explicit value in the config
+    is passed through either way.
+
+    One RTX PRO 5000, those 40 tensors / 1.93 M parameters: an AdamW step costs 0.059 ms of host time fused
+    against 0.188 ms foreach, in two kernels against eight, and a fused step is the only one that applies the
+    AMP scale itself, so ``GradScaler.step`` stops reading ``found_inf`` back to the host once a step. Fused
+    sums in another order: after 100 steps its parameters sit 3.7e-05 from the foreach ones, 8.3e-06 of their
+    own scale.
+    """
+    signature = inspect.signature(optimizer_class)
+    on_cuda = len(cuda_visible_devices()) > 0
+
+    def build(params: Any, **kwargs: Any) -> torch.optim.Optimizer:
+        batchable = (
+            on_cuda
+            and not kwargs.get("differentiable", False)
+            and all(parameter.is_floating_point() for parameter in parameters)
+        )
+        if batchable and kwargs.get("fused") is None and kwargs.get("foreach") is None:
+            for name in ("fused", "foreach"):
+                if name in signature.parameters:
+                    kwargs[name] = True
+                    break
+        return optimizer_class(params, **kwargs)
+
+    # The binder reads this signature: the optimizer's own keys, so the config keeps exactly them.
+    build.__signature__ = signature  # type: ignore[attr-defined]
+    return build
+
+
 @config("optimizer")
 class OptimizerLoader:
     """Configuration-aware factory for PyTorch optimizers."""
@@ -79,9 +118,11 @@ class OptimizerLoader:
         self.name = name
 
     def get_optimizer(self, key: str, parameter: Iterator[torch.nn.parameter.Parameter]) -> torch.optim.Optimizer:
-        return apply_config(f"{konfai_root()}.Model.{key}.optimizer")(
-            getattr(importlib.import_module("torch.optim"), self.name)
-        )(parameter)
+        parameters = list(parameter)
+        optimizer_class = getattr(importlib.import_module("torch.optim"), self.name)
+        return apply_config(f"{konfai_root()}.Model.{key}.optimizer")(batched_step(optimizer_class, parameters))(
+            parameters
+        )
 
 
 class LRSchedulersLoader:

--- a/tests/unit/test_measure.py
+++ b/tests/unit/test_measure.py
@@ -75,6 +75,18 @@ def test_a_criterion_accepts_the_integer_label_map_a_segmentation_target_is(crit
     assert torch.isfinite(loss).all()
 
 
+def test_the_lowest_label_of_a_pair_of_maps_is_the_lowest_of_both() -> None:
+    """``bincount`` takes no negative index, so the bins are offset by the smallest label ANY map
+    holds: reducing each map's own minimum must keep the smaller of the two."""
+    predicted = torch.tensor([[[-1, 0, 2]]])
+    reference = torch.tensor([[[-3, 0, 2]]])
+
+    (_, _), offset, nan_bin, _ = Dice._bins([predicted, reference], None)
+
+    assert (offset, nan_bin) == (-3, 0)
+    assert Dice._bins([reference, predicted], None)[1] == -3
+
+
 class TestOnGrid:
     def test_a_target_on_the_output_grid_is_handed_back_as_is(self):
         # No resample on the output's own grid: the integer label map keeps its dtype and its storage,

--- a/tests/unit/test_measure.py
+++ b/tests/unit/test_measure.py
@@ -189,8 +189,8 @@ class TestDice:
 
 
 def _dice_per_label_oracle(labels, output, target, mask=None):
-    """The per-label spelling Dice scored hard labels with before the confusion matrix: one float
-    expansion and two sums per label, kept here as the oracle the bincount route is pinned against."""
+    """The per-label spelling Dice was scored with before the batched one: one float expansion and
+    two sums per label, kept here as the oracle both routes are pinned against."""
     if mask is not None:
         mask = torch.where(mask == 1, 1, 0)
         output, target = output * mask.to(output.dtype), target * mask.to(target.dtype)
@@ -200,10 +200,10 @@ def _dice_per_label_oracle(labels, output, target, mask=None):
         labels = [int(label) for label in torch.unique(target) if int(label) != 0]
     count = 0
     for label in labels:
-        tp = target == label
+        tp = (target == label).float()
         if tp.any().item():
-            pp = output[:, label].unsqueeze(1) if output.shape[1] > 1 else (output == label)
-            dice = Dice.dice_per_channel(pp.float(), tp.float())
+            pp = (output[:, label].unsqueeze(1) if output.shape[1] > 1 else (output == label)).float()
+            dice = (2.0 * (pp * tp).sum() + 1e-6) / (pp.sum() + tp.sum() + 1e-6)
             loss += dice
             count += 1
             result[label] = dice.item()
@@ -277,8 +277,12 @@ class TestDiceConfusionMatrix:
             reference = int(((target == 4) & (mask == 1)).sum()) if masked else int((target == 4).sum())
             assert got[1][4] == pytest.approx(1e-6 / (reference + 1e-6), abs=1e-9)  # never predicted
 
-    def test_soft_path_is_bit_identical_to_the_oracle(self):
-        torch.manual_seed(3)
+    @pytest.mark.parametrize("seed", range(4))
+    def test_soft_path_matches_the_oracle_to_the_last_float32_bits(self, seed):
+        """One reduction per label over the whole batch instead of a sum accumulated label by
+        label: the reduction order moves, the values do not beyond float32 rounding (measured
+        max |diff| 6e-8 on the loss over these seeds, 7.5e-9 per label)."""
+        torch.manual_seed(seed)
         output = torch.softmax(torch.randn(2, 5, 6, 7, 5), dim=1)
         target = torch.randint(0, 5, (2, 1, 6, 7, 5))
         target[target == 3] = 0
@@ -286,17 +290,37 @@ class TestDiceConfusionMatrix:
         for labels in (None, [1, 2, 3, 4]):
             got = Dice(labels=labels)(output, target)
             expected = _dice_per_label_oracle(labels, output, target)
-            assert got[0].item() == expected[0].item()
-            _assert_same_scores(got, expected, abs_tol=0.0)
+            _assert_same_scores(got, expected, abs_tol=1e-7)
 
-    def test_soft_path_keeps_its_gradient(self):
-        output = torch.softmax(torch.randn(1, 3, 4, 4), dim=1).requires_grad_(True)
-        target = torch.randint(0, 3, (1, 1, 4, 4))
+    def test_soft_path_keeps_the_gradient_the_per_label_oracle_gives(self):
+        torch.manual_seed(11)
+        probabilities = torch.softmax(torch.randn(2, 6, 5, 5), dim=1)
+        target = torch.randint(0, 6, (2, 1, 5, 5))
 
-        loss, _ = Dice()(output, target)
-        loss.backward()
+        gradients = []
+        for score in (lambda o, t: Dice()(o, t), lambda o, t: _dice_per_label_oracle(None, o, t)):
+            output = probabilities.clone().requires_grad_(True)
+            gradients.append(torch.autograd.grad(score(output, target)[0], output)[0])
 
-        assert output.grad is not None and torch.isfinite(output.grad).all()
+        assert torch.isfinite(gradients[0]).all()
+        assert (gradients[0] - gradients[1]).abs().max() < 1e-7 * gradients[1].abs().max()
+
+    def test_soft_loss_refuses_a_reference_label_the_probability_map_has_no_channel(self):
+        """The channels are gathered in one slice: an out-of-range label would be a device-side
+        assert on CUDA, so it is refused on the spot."""
+        output = torch.softmax(torch.randn(1, 3, 4, 4), dim=1)
+        target = torch.full((1, 1, 4, 4), 7)
+
+        with pytest.raises(MeasureError, match="no channel for"):
+            Dice()(output, target)
+
+    def test_soft_loss_of_a_reference_holding_no_label_scores_nothing(self):
+        output = torch.softmax(torch.randn(1, 3, 4, 4), dim=1)
+        target = torch.zeros(1, 1, 4, 4, dtype=torch.int64)
+
+        loss, per_label = Dice()(output, target)
+        assert loss.item() == 0.0 and per_label == {}
+        assert np.isnan(Dice(labels=[1, 2])(output, target)[1][2])
 
     def test_streamed_sums_carry_the_predicted_mass_of_a_label_the_patch_reference_lacks(self):
         # labels=None: a patch predicting label 2 where its reference has none must still count

--- a/tests/unit/test_network_step.py
+++ b/tests/unit/test_network_step.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for how one training step is built: which optimizer implementation the config asks for."""
+
+from pathlib import Path
+
+import pytest
+import torch
+from konfai.network.network import OptimizerLoader, batched_step
+
+
+@pytest.fixture
+def on_gpu(monkeypatch: pytest.MonkeyPatch):
+    """The run places the graph on a GPU. The parameters stay on the host: an optimizer is built on
+    the launcher, before ``Network.to`` moves them, which is why the choice reads the run, not them."""
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
+
+
+@pytest.fixture
+def on_cpu(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+
+
+def _parameters() -> list[torch.nn.parameter.Parameter]:
+    torch.manual_seed(0)
+    return [torch.nn.Parameter(torch.randn(4, 3)), torch.nn.Parameter(torch.randn(5))]
+
+
+def _steps(optimizer: torch.optim.Optimizer, parameters: list[torch.nn.parameter.Parameter]) -> list[torch.Tensor]:
+    generator = torch.Generator().manual_seed(7)
+    for _ in range(100):
+        for parameter in parameters:
+            parameter.grad = torch.randn(parameter.shape, generator=generator)
+        optimizer.step()
+    return [parameter.detach().clone() for parameter in parameters]
+
+
+def test_a_run_without_a_gpu_keeps_the_default_step(on_cpu) -> None:
+    """Off CUDA nothing is forced: torch's own default stands, foreach costing 526 ms a step there
+    against 2.0 ms single-tensor over the Segmentation example's 40 tensors."""
+    optimizer = batched_step(torch.optim.AdamW, _parameters())(_parameters())
+
+    assert optimizer.defaults["fused"] is None
+    assert optimizer.defaults["foreach"] is None
+
+
+def test_the_default_step_is_bit_identical_to_the_plain_class(on_cpu) -> None:
+    """The wrapper only chooses an implementation: over 100 steps it moves no parameter bit."""
+    plain, wrapped = _parameters(), _parameters()
+
+    expected = _steps(torch.optim.AdamW(plain, lr=1e-3), plain)
+    obtained = _steps(batched_step(torch.optim.AdamW, wrapped)(wrapped, lr=1e-3), wrapped)
+
+    for reference, value in zip(expected, obtained, strict=True):
+        assert torch.equal(reference, value)
+
+
+def test_a_gpu_run_takes_the_fused_step_when_the_optimizer_has_one(on_gpu) -> None:
+    parameters = _parameters()
+
+    assert batched_step(torch.optim.AdamW, parameters)(parameters).defaults["fused"] is True
+
+
+def test_a_gpu_run_falls_back_to_foreach_without_a_fused_step(on_gpu) -> None:
+    parameters = _parameters()
+    optimizer = batched_step(torch.optim.Adadelta, parameters)(parameters)
+
+    assert "fused" not in optimizer.defaults
+    assert optimizer.defaults["foreach"] is True
+
+
+def test_an_integer_parameter_keeps_the_default_step(on_gpu) -> None:
+    """A batched step reads floating-point tensors only."""
+    parameters = [*_parameters(), torch.nn.Parameter(torch.zeros(3, dtype=torch.int64), requires_grad=False)]
+
+    assert batched_step(torch.optim.AdamW, parameters)(parameters).defaults["fused"] is None
+
+
+@pytest.mark.parametrize("asked", [{"fused": False}, {"foreach": True}, {"differentiable": True}])
+def test_the_config_wins_over_the_chosen_step(on_gpu, asked: dict[str, bool]) -> None:
+    """A value written in the config is passed through: only an unset pair is decided here."""
+    parameters = _parameters()
+    optimizer = batched_step(torch.optim.AdamW, parameters)(parameters, **asked)
+
+    assert optimizer.defaults["fused"] is not True or asked.get("fused") is True
+    for name, value in asked.items():
+        assert optimizer.defaults[name] == value
+
+
+def test_the_optimizer_keeps_its_own_config_keys(on_cpu, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The binder reads the optimizer class's signature, so the YAML keeps exactly its keys: the
+    implementation is chosen under ``fused``/``foreach``, never beside them."""
+    config = tmp_path / "Config.yml"
+    config.write_text("Trainer:\n  Model:\n    UNet:\n      optimizer:\n        lr: 0.002\n", encoding="utf-8")
+    monkeypatch.setenv("KONFAI_config_file", str(config))
+    monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
+    monkeypatch.setenv("KONFAI_ROOT", "Trainer")
+
+    optimizer = OptimizerLoader().get_optimizer("UNet", iter(_parameters()))
+
+    assert optimizer.defaults["lr"] == 0.002
+    written = config.read_text(encoding="utf-8")
+    assert "fused: None" in written and "foreach: None" in written


### PR DESCRIPTION
TITLE: The training step: a fused optimizer, a folded soft Dice

BODY:
Three changes to the per-step cost of training. `fused` and `foreach` both unset now ask for the widest batched optimizer step the optimizer implements: fused where torch has one, foreach otherwise, torch's own default off CUDA, and the device read is the one the run will place the graph on, not the one the parameters sit on when the optimizer is built on the launcher. Only a fused optimizer applies the AMP scale itself, so `GradScaler.step` stops reading `found_inf` back to the host and the host enqueues the next forward while the GPU finishes the backward. The soft Dice's per-label loop becomes one expression: the labels' channels gathered in one slice, the reference one comparison against the label vector on an axis of its own, each sum one reduction, dividing by the reference's exact voxel count the integer `_score` already divides by. The metric route keeps its loop, because it carries no gradient and its peak stays one channel, and it now masks its sums in the probability's own dtype instead of expanding the reference to float32. Alongside them, the group's accumulated backward is gated on the criterion's own two flags rather than a `np.unique` over the group's accumulation losses, Dice reads its lowest label in one reduction per map, and the `autocast` and `channels_last` config-guide rows, which carried the shipped 2D example only, gain their 3D numbers.

## Measured

`examples/Segmentation`, autocast + channels_last, one RTX PRO 5000, 325 steps per epoch (`Config_cl.yml`, gpu 0, run in-process), soft Dice folded:

| | before | after |
|---|---|---|
| epoch, median of 9 alternating pairs | 12.95 s (12.73-13.37) | 9.67 s (9.38-10.16) |
| criteria phase | 22.6 ms/step | 14.8 ms/step |
| cudaLaunchKernel (torch.profiler, 3 mid-epoch steps) | 802.0 per step | 307.0 per step |
| CUDA kernels | 1073.0 per step | 468.3 per step |
| `aten::add_` | 63.3 calls, 8.450 ms | 21.0 calls, 1.006 ms |
| `aten::fill_` | 67.7 calls, 2.519 ms | 47.0 calls, 0.240 ms |
| criteria device time | 2.407 ms/step | 1.732 ms/step |

Peak CUDA allocation of the call, `labels=None` over 41 channels: `[8, 41, 256, 256]` 242 -> 180 MiB with gradient, 6 -> 180 MiB under `no_grad`; `[1, 41, 128, 128, 128]` 968 -> 720 MiB with gradient, 18 -> 720 MiB under `no_grad`. Training peaks lower: the backward held a float copy of both operands per label already. A whole soft volume scored in one call with no gradient to build peaks at the label count where the loop peaked at one channel.

Fused optimizer, `konfai TRAIN -c Config_cl.yml --gpu 0 -y` alternated with the same config at `fused: false`. On a quiet host (load 2.3-4.2), three pairs: epoch 13.0 s median (12.9-13.2) fused against 13.7 s (13.5-13.9) foreach, forward + criteria + backward+step 10.1 s against 11.1 s, 31.1 ms a step against 34.2. Twelve more pairs at load 5-29: compute phases 10.1 s median (8.7-10.7) against 11.6 s (11.2-11.8). torch.profiler: 9 `cudaStreamSynchronize` a step against 10; the step's own host time 0.474 ms -> 0.193 ms, its kernels 8 -> 2. Off CUDA nothing is forced; forcing foreach there would cost 526 ms a step against 2.0 ms.

Metric-route masking, five calls each, `labels=None` over 41 channels: `[8, 41, 256, 256]` 1.22 -> 0.98 ms, peak 86.5 -> 85.0 MiB; `[1, 41, 128, 128, 128]` 1.92 -> 1.76 ms, peak 346 -> 340 MiB; `[1, 41, 64, 64, 64]` 1.09 -> 0.97 ms, peak 43.3 -> 42.5 MiB. Dice's lowest label: 0.1040 -> 0.0967 ms for the counts of a `[8, 1, 256, 256]` int64 map (CUDA events). The accumulation gate: 2.94 us per call (timeit, 20000 calls) against 0.02 us.

Docs numbers, 3D UNet of the same shape as the shipped example (five levels to 256 channels, `dim: 3`), 96 cubed patches, batch 2, twenty synthetic 128 cubed cases, three alternating passes each. Training epoch (`konfai TRAIN --gpu 0 -y`), median of nine: fp32 27.0 s (25.5-27.9), autocast 11.7 s (10.9-13.2), autocast + `channels_last` 10.0 s (9.8-10.9). Prediction sweep (`konfai PREDICTION --gpu 0 -y`), the run's own accounting: fp32 4.8 s, autocast 2.9 s, autocast + `channels_last` 2.4 s; whole process 6.8, 4.8 and 4.5 s.

## Values

Two reductions change order on CUDA. The folded soft Dice is not bit-identity: over 5 seeded batches of the example's shape (24 held labels of 41 channels), max |diff| 0 on the loss, 7.5e-9 on a per-label value, 4.5e-13 on the logits gradient, 1.9e-7 of its scale; 0 in fp16, and the same on a 3D `[2, 41, 64, 64, 64]` batch. The fused kernel sums in another order, so after 100 AdamW steps over those 1.93 M parameters the weights sit 3.7e-05 from the foreach ones, 8.3e-06 of their own scale (foreach against single-tensor, same run: 2.4e-07); off CUDA the 100 steps stay bit-identical. Neither reaches the labels: one seeded epoch each way then the 5 cases predicted gives 0 differing voxels of 58 446 992 for the soft Dice, the same count a before/before pair gives, and the two checkpoints of the same seeded epoch predict the 5 cases identically, 0 of 58 446 992 voxels differ, for the optimizer. The accumulation gate, the lowest-label reduction and the metric-route masking are unchanged, the last bit-identical with max |diff| 0 on every sum of the three shapes.

## Tests

`tests/unit/test_network_step.py` pins the off-CUDA bit-identity of the 100 steps and the accumulation contract stays pinned by `test_accumulation_backward_not_refired_by_plain_loss_in_same_group`; `tests/unit/test_measure.py` spells the soft Dice formula out in its oracle, and a reference label the probability map has no channel for is refused with a `MeasureError` instead of raising `IndexError` from the Python slice or hitting a CUDA device-side assert. `flatten` and `dice_per_channel` had no caller left and are gone.

## Stack

Stacked on `pr/1.8.2-12-out-of-core`; merge after it. Before deleting this branch, retarget the next PR of the stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Optimizer execution now automatically selects optimized GPU settings while respecting explicit configuration.
  - Training configuration documentation adds optimizer guidance and performance details.

- **Bug Fixes**
  - Improved gradient accumulation behavior for mixed loss groups.
  - Enhanced Dice metric handling for batched inputs, labels, validation, and empty references.

- **Documentation**
  - Added benchmark results for mixed-precision and channels-last settings in training and inference scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->