### PR TITLE
Blending and reads: a blend that could not run, a header printed once

### DIFF
--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -1336,9 +1336,9 @@ class Data(DataSources):
     def _configure_data_loading(self, use_cache: bool) -> None:
         """Build the loader from the cache regime: the DatasetIter factory and the worker settings.
 
-        Called once from ``__init__`` with the declared ``use_cache`` and, when a ``memory_budget``
-        overrides it, again from ``get_data`` with the derived value. Caching preloads every case up
-        front, so it defaults to zero DataLoader workers; the streaming/buffer path spins workers up.
+        Called once from ``__init__`` with the declared ``use_cache``, again from ``prepare`` once
+        the managers say how each case is read, and, when a ``memory_budget`` overrides it, again
+        from ``get_data`` with the derived value.
         """
         self.use_cache = use_cache
         self.datasetIter = partial(
@@ -1355,7 +1355,7 @@ class Data(DataSources):
         if self.requires_single_process_loading:
             resolved_num_workers = 0
         elif resolved_num_workers is None:
-            resolved_num_workers = max(1, min(os.cpu_count() or 1, 4)) if not use_cache else 0
+            resolved_num_workers = self._default_num_workers(use_cache)
         self.resolved_num_workers: int = resolved_num_workers
         self.dataLoader_args: dict[str, object] = {
             "num_workers": resolved_num_workers,
@@ -1375,6 +1375,50 @@ class Data(DataSources):
             else:
                 persistent_workers = True
             self.dataLoader_args["persistent_workers"] = persistent_workers
+
+    def _default_num_workers(self, use_cache: bool) -> int:
+        """The worker count when the config names none.
+
+        A cache preloads every case up front and leaves the loader nothing to do. A one-pass
+        workflow walks each case once in grid order, and shipping a batch through shared memory
+        costs more than reading it in place. Workers pay for themselves in one place, where a
+        patch read decodes more than the patch it asks for, and the decodes then run in parallel.
+
+        Measured on a quiet 24-core host, three cases, whole PREDICTION runs, best of two
+        (``CUDA_VISIBLE_DEVICES=``), zero workers against four:
+        patches streaming off an uncompressed MetaImage 0.24 s / 0.34 s (2.5-D, patch
+        [1, 192, 192]), 0.14 s / 0.27 s (3-D, [32, 32, 32]), and 4.26 s / 4.89 s on the 2.5-D grid
+        with a five-layer convolutional net; the case buffered whole 0.17 s / 0.44 s; and, where
+        every patch decodes the volume, 18.1 s / 5.7 s.
+        """
+        if use_cache:
+            return 0
+        if self._reads_each_case_once and not self._patch_read_decodes_the_volume():
+            return 0
+        return max(1, min(os.cpu_count() or 1, 4))
+
+    def _patch_read_decodes_the_volume(self) -> bool:
+        """Whether reading one patch costs a whole-volume decode, on any case of any group.
+
+        Only where the patches are read from the store one by one AND the store cannot serve a
+        region (a compressed MetaImage, an NRRD, a gzipped NIfTI). A chain that cannot stream is
+        not that: it reads the case once into the loader's buffer and cuts its patches from RAM.
+
+        ``False`` before ``prepare``, where no manager can answer yet: only the worker default
+        reads this, and only ``get_data`` reads the default.
+        """
+        if self._managers is None:
+            return False
+        return any(
+            manager.can_stream_patch(0) and not manager.dataset.bounded_region_reads(manager.group_src, manager.name)
+            for managers in self._managers.values()
+            for manager in managers
+        )
+
+    def prepare(self) -> None:
+        super().prepare()
+        # The managers are what says how each case is read, which is what the worker default turns on.
+        self._configure_data_loading(self.use_cache)
 
     def _estimate_cached_bytes(self) -> int:
         """Raw in-RAM size of the whole prepared dataset, from headers alone (no voxel read).
@@ -1400,10 +1444,11 @@ class Data(DataSources):
                     total += int(np.prod(manager.base_shape, dtype=np.int64)) * _CACHE_ELEMENT_BYTES * copies
         return total
 
-    #: Whether a ``memory_budget`` that fits may choose the cache. True for training (epochs
-    #: re-read every case); overridden False by the one-pass workflows, where a cache is never
-    #: re-read and the regime is always stream/buffer.
-    _budget_caches_when_fit = True
+    #: Whether the workflow reads each case exactly once. False for training, whose epochs
+    #: re-read every case; True for prediction and evaluation. A one-pass workflow never re-reads
+    #: a cache, so a fitting ``memory_budget`` does not choose one, and its loader has one region
+    #: read per patch to do, which costs less in place than through a worker.
+    _reads_each_case_once = False
 
     def _resolve_cache_regime(self, world_size: int) -> None:
         """Derive ``use_cache`` from ``memory_budget``. ``None`` means ``"auto"``.
@@ -1415,7 +1460,7 @@ class Data(DataSources):
         and the test reduces to "does the whole dataset fit the node". The decision is logged once
         here: ``get_data`` runs on the launcher alone, before any worker is spawned.
         """
-        if not self._budget_caches_when_fit:
+        if self._reads_each_case_once:
             # One-pass workflows (prediction, evaluation) read each case exactly once: a cache is
             # never re-read, so the regime is always stream/buffer and there is nothing to derive.
             return
@@ -1863,8 +1908,7 @@ class DataTrain(Data):
 class DataPrediction(Data):
     """Dataset configuration used by the prediction workflow."""
 
-    # One pass: each case is read once, a cache is never re-read, always stream/buffer.
-    _budget_caches_when_fit = False
+    _reads_each_case_once = True
 
     def __init__(
         self,
@@ -1911,8 +1955,7 @@ class DataMetric(Data):
     that needs the whole volume always gets it.
     """
 
-    # One pass: each case is read once, a cache is never re-read, always stream/buffer.
-    _budget_caches_when_fit = False
+    _reads_each_case_once = True
 
     #: Working copies a metric makes of the patch pair (float casts, the difference, a masked select):
     #: measured ~<= 2x the resident tensors; the sizing keeps this conservative and the 0.8 safety

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -1077,7 +1077,7 @@ class Accumulator:
         # prod(n_d) patches, and one dict lookup per patch and axis to find them.
         self._geometry: tuple[list[list[torch.Tensor]], list[torch.Tensor]] | None = None
         self._grid: list[dict[int, int]] | None = None
-        self._shares: dict[tuple[int, int, int, torch.dtype, torch.device], torch.Tensor] = {}
+        self._shares: dict[tuple[int, int, int, torch.dtype, torch.device], torch.Tensor | None] = {}
         self._kept: dict[tuple[int, int], slice] = {}
 
     def add_layer(self, index: int, layer: torch.Tensor) -> list[tuple[slice, torch.Tensor]]:
@@ -1200,15 +1200,22 @@ class Accumulator:
     def _position(self, dim: int, start: int) -> int:
         return self._positions()[dim][start]
 
-    def _share(self, dim: int, start: int, data: torch.Tensor) -> torch.Tensor:
-        """This patch's fraction of the blend weight along one axis, ``w / sum_k w``, cached per axis."""
+    def _share(self, dim: int, start: int, data: torch.Tensor) -> torch.Tensor | None:
+        """This patch's fraction of the blend weight along one axis, ``w / sum_k w``, cached per axis.
+
+        ``None`` where that fraction is exactly one on every voxel of the axis, which is what an axis
+        holding a single grid position gives (the patch is the whole of the weight there, so the total
+        IS its own window): the blend then skips a full pass over the patch, bit for bit the same
+        values. A patch grid that tiles one axis and spans the other two is that case twice over.
+        """
         extent = data.shape[self._n + dim]
         key = (dim, start, extent, data.dtype, data.device)
         if key not in self._shares:
             windows, totals = self._weight_geometry()
             window = windows[dim][self._position(dim, start)]
             share = window[:extent] / totals[dim][start : start + extent]
-            self._shares[key] = share.to(device=data.device, dtype=data.dtype)
+            share = share.to(device=data.device, dtype=data.dtype)
+            self._shares[key] = None if torch.equal(share, torch.ones_like(share)) else share
         return self._shares[key]
 
     def _weighted_patch(self, data: torch.Tensor, patch_slice: tuple[slice, ...]) -> torch.Tensor:
@@ -1220,10 +1227,21 @@ class Accumulator:
         stays exact, and each factor is a ratio of comparable quantities, so it lives in [0, 1] where
         the raw product underflows fp16 and needed a floor.
 
-        Into a staging buffer the patches share, one patch-sized allocation per accumulator instead of
-        per blend, and out of place: the caller's tensor is never touched, so the OOM retry (which
-        re-blends the same patch on the CPU) never re-weights it.
+        Only the axes whose share is not identically one are applied (see ``_share``), each one pass
+        over the patch: a grid tiled along one axis and spanning the other two hands the patch back
+        untouched. Into a staging buffer the patches share otherwise, one patch-sized allocation per
+        accumulator instead of per blend, and out of place: the caller's tensor is never touched, so
+        the OOM retry (which re-blends the same patch on the CPU) never re-weights it.
         """
+        shares = []
+        for dim, s in enumerate(patch_slice):
+            share = self._share(dim, s.start, data)
+            if share is not None:
+                view = [1] * data.ndim
+                view[self._n + dim] = -1
+                shares.append(share.view(view))
+        if not shares:
+            return data
         if (
             self._weighted is None
             or self._weighted.shape != data.shape
@@ -1231,14 +1249,9 @@ class Accumulator:
             or self._weighted.device != data.device
         ):
             self._weighted = torch.empty_like(data)
-        for dim, s in enumerate(patch_slice):
-            view = [1] * data.ndim
-            view[self._n + dim] = -1
-            share = self._share(dim, s.start, data).view(view)
-            if dim == 0:
-                torch.mul(data, share, out=self._weighted)
-            else:
-                self._weighted.mul_(share)
+        torch.mul(data, shares[0], out=self._weighted)
+        for share in shares[1:]:
+            self._weighted.mul_(share)
         return self._weighted
 
     def _along_sweep(self, span: slice, lead: int) -> tuple[slice, ...]:

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -928,6 +928,17 @@ class PathCombine(ABC):
         """Return the 1-D blend weight along one axis (length ``size``, ``overlap`` voxels tapered per side)."""
 
 
+def blend_axes(patch_size: list[int]) -> list[int]:
+    """The blend window's axes for a ``patch_size``: every axis kept, a free (0) or singleton (1) axis
+    as a single broadcast entry.
+
+    ``Accumulator`` reads one window per spatial axis of the volume, and the window has to broadcast
+    against the patch at any axis position. Dropping the untiled axes shortens the list, so the
+    window is looked up on the wrong axis (or not at all).
+    """
+    return [size if size > 1 else 1 for size in patch_size]
+
+
 def blend_overlap(overlap: "int | float | str | list[int | float | str]", patch_size: list[int]) -> list[int]:
     """Per-axis blend overlap for a concrete ``patch_size`` (int broadcast, ``%``/fraction resolved).
 
@@ -1845,10 +1856,7 @@ class ModelPatch(Patch):
             self.patch_combine = apply_config(key)(getattr(module, name))()
         if self.patch_size is not None and self.overlap is not None:
             if self.patch_combine is not None:
-                # Keep every axis so the weight broadcasts against the patch whatever the axis position
-                # (dropping trailing axes misaligns the broadcast); a singleton (1) or free (0) axis
-                # carries a uniform weight, a >1 axis its tapered window.
-                kept = [i if i > 1 else 1 for i in self.patch_size]
+                kept = blend_axes(self.patch_size)
                 self.patch_combine.set_patch_config(kept, blend_overlap(self.overlap, kept))
         else:
             self.patch_combine = None

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -58,6 +58,7 @@ from konfai.data.patching import (
     _halo_radii,
     _HaloPull,
     _RemapPull,
+    blend_axes,
     blend_overlap,
 )
 
@@ -350,12 +351,13 @@ class OutputDataset(Dataset, NeedDevice, ABC):
         overlap: int | float | str | list[int | float | str] | None,
         nb_data_augmentation: int,
     ) -> None:
-        # EMPTY, not just missing: the caller drops the axes of extent 1, so a case with nothing tiled
-        # arrives as []. That is a single patch covering the volume: no combine applies, and a blend
-        # window built on no axis leaves max() nothing to take.
-        if patch_size and overlap is not None:
+        # Nothing tiled (no axis longer than one voxel) is a single patch covering the volume: no combine
+        # applies. Anything else keeps EVERY axis, the untiled ones as a single broadcast entry, because
+        # the accumulator reads one window per spatial axis (see blend_axes).
+        if patch_size and any(size > 1 for size in patch_size) and overlap is not None:
             if self.patch_combine is not None:
-                self.patch_combine.set_patch_config(patch_size, blend_overlap(overlap, patch_size))
+                axes = blend_axes(patch_size)
+                self.patch_combine.set_patch_config(axes, blend_overlap(overlap, axes))
         else:
             self.patch_combine = None
         self.nb_data_augmentation = nb_data_augmentation
@@ -1585,7 +1587,7 @@ class _Predictor:
         patch_size, overlap = self.dataset.get_patch_config()
         for output_dataset in self.outputs_dataset.values():
             output_dataset.set_patch_config(
-                [size for size in patch_size if size > 1] if patch_size else None,
+                patch_size,
                 overlap,
                 np.max(
                     [

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -1461,6 +1461,10 @@ class _PixelBlock(NamedTuple):
     shape: tuple[int, ...]  # channel-first
     metadata: Attribute  # the header's own keys, as image_to_data imports them
     probe: Any  # a one-voxel sitk.Image carrying the header's geometry: ITK's own index-to-world arithmetic
+    # Origin / Spacing / Direction as an attribute holds them, printed once for the file: every region
+    # of a volume records the same spacing and direction, and printing a float array costs 24 us for
+    # three elements and 30 us for nine (measured), against 0.04 us to hand text through the same door.
+    geometry_text: dict[str, str]
 
     @property
     def origin(self) -> np.ndarray:
@@ -1574,7 +1578,12 @@ def _pixel_block_at(path: str, stamp: tuple[int, int]) -> _PixelBlock | None:
     for key in probe.GetMetaDataKeys():
         if not key.startswith("ITK_"):  # the reader's own bookkeeping, as image_to_data drops it
             metadata[key] = probe.GetMetaData(key)
-    return _PixelBlock(offset, dtype, interleaved, shape, metadata, probe)
+    geometry_text = {
+        "Origin": _attribute_text(np.asarray(probe.GetOrigin())),
+        "Spacing": _attribute_text(np.asarray(probe.GetSpacing())),
+        "Direction": _attribute_text(np.asarray(probe.GetDirection())),
+    }
+    return _PixelBlock(offset, dtype, interleaved, shape, metadata, probe, geometry_text)
 
 
 def _pixel_block(path: str) -> _PixelBlock | None:
@@ -1607,11 +1616,11 @@ def _pixel_block_attributes(block: _PixelBlock, index_xyz: list[int] | None) -> 
     the module computes it. ``None`` is the whole volume's record, as ``file_to_data`` returns it."""
     attributes = Attribute(block.metadata)
     if index_xyz is None:
-        attributes["Origin"] = block.origin
+        attributes["Origin"] = block.geometry_text["Origin"]
     else:
         attributes["Origin"] = np.asarray(block.probe.TransformIndexToPhysicalPoint(index_xyz))
-    attributes["Spacing"] = block.spacing
-    attributes["Direction"] = block.direction
+    attributes["Spacing"] = block.geometry_text["Spacing"]
+    attributes["Direction"] = block.geometry_text["Direction"]
     if index_xyz is not None:
         direction = block.direction.reshape(len(block.spacing), len(block.spacing))
         attributes["Origin"] = block.origin + direction @ (np.asarray(index_xyz, dtype=np.float64) * block.spacing)

--- a/tests/unit/test_data_manager.py
+++ b/tests/unit/test_data_manager.py
@@ -1045,12 +1045,54 @@ def test_inline_augmentations_disable_persistent_workers() -> None:
     assert without_augmentations.dataLoader_args["persistent_workers"] is True
 
 
-def test_data_prediction_disables_persistent_workers_by_default() -> None:
-    dataset = DataPrediction(augmentations=None)
+def test_data_prediction_disables_persistent_workers() -> None:
+    dataset = DataPrediction(augmentations=None, num_workers=2)
 
-    assert cast(int, dataset.dataLoader_args["num_workers"]) >= 1
+    assert dataset.dataLoader_args["num_workers"] == 2
     assert dataset.dataLoader_args["prefetch_factor"] == 2
     assert dataset.dataLoader_args["persistent_workers"] is False
+
+
+def _prepared_prediction(root: Path, file_format: str, **kwargs) -> DataPrediction:
+    """A prediction over two 8x8 cases stored in ``file_format``, its managers built."""
+    store = Dataset(root, file_format)
+    for name in ("CASE_000", "CASE_001"):
+        store.write("CT", name, np.zeros((1, 8, 8), np.float32), _image_attributes([0.0, 0.0], [1.0, 1.0]))
+    dataset = DataPrediction(
+        augmentations=None,
+        dataset_filenames=[f"{root}:{file_format}"],
+        groups_src={"CT": Group(groups_dest={"CT": GroupTransform(transforms=None, patch_transforms=None)})},
+        patch=DatasetPatch(patch_size=[4, 4], overlap=None),
+        subset=PredictionSubset(),
+        **kwargs,
+    )
+    dataset.prepare()
+    return dataset
+
+
+@pytest.mark.parametrize(
+    ("file_format", "spins_workers"),
+    [("mha", False), ("nii.gz", True)],
+    ids=["a region read decodes the region", "a region read decodes the volume"],
+)
+def test_prediction_spins_workers_only_where_a_patch_read_decodes_the_volume(
+    tmp_path: Path, file_format: str, spins_workers: bool
+) -> None:
+    """One pass in grid order: a batch costs more through shared memory than read in place, unless
+    the store has to decode the whole volume per patch, where the decodes then run in parallel."""
+    pytest.importorskip("SimpleITK")
+
+    dataset = _prepared_prediction(tmp_path / file_format, file_format)
+
+    assert (dataset.resolved_num_workers > 0) is spins_workers
+
+
+def test_an_explicit_worker_count_wins_over_the_read_route(tmp_path: Path) -> None:
+    pytest.importorskip("SimpleITK")
+
+    dataset = _prepared_prediction(tmp_path / "mha", "mha", num_workers=3)
+
+    assert dataset.resolved_num_workers == 3
 
 
 def test_data_prediction_forwards_its_declared_augmentations() -> None:

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -914,6 +914,26 @@ def test_a_region_off_the_raw_block_is_the_one_itk_decodes(
         assert dict(attributes) == dict(want_attributes)
 
 
+def test_every_patch_of_a_grid_records_what_itk_records(tmp_path: Path, monkeypatch) -> None:
+    """The geometry a record carries is printed once for the file; each patch keeps its own origin.
+
+    Character for character against ITK's own reader, on every patch of a grid: a record built from
+    the file's printed geometry says the same thing as one printed per patch."""
+    from konfai.utils import dataset as dataset_module
+
+    path, _ = _write_block_fixture(tmp_path, "rotated.mha")
+    backend = _block_backend(path)
+    windows = [
+        (slice(None), slice(z, z + 4), slice(y, y + 4), slice(x, x + 4)) for z in (0, 5) for y in (0, 6) for x in (0, 7)
+    ]
+    got = [backend.file_to_data_slice("", "rotated", window)[1] for window in windows]
+    monkeypatch.setattr(dataset_module, "_pixel_block", lambda path: None)
+    want = [backend.file_to_data_slice("", "rotated", window)[1] for window in windows]
+
+    assert [dict(record) for record in got] == [dict(record) for record in want]
+    assert len({record["Origin"] for record in got}) == len(windows)
+
+
 @pytest.mark.parametrize("kind", _BLOCK_LEFT_TO_ITK)
 def test_a_file_the_block_route_declines_is_still_read_by_itk(tmp_path: Path, kind: str) -> None:
     """Compressed, detached, rescaled, or another format: the block route steps aside, ITK answers."""

--- a/tests/unit/test_patching.py
+++ b/tests/unit/test_patching.py
@@ -36,6 +36,7 @@ from konfai.data.patching import (
     Mean,
     StreamingAccumulator,
     Trim,
+    blend_axes,
     blend_overlap,
 )
 from konfai.utils.dataset import Dataset
@@ -169,7 +170,7 @@ def test_free_axis_reassembles_like_its_concrete_extent(free_axis, combine_cls):
         combine = None
         if combine_cls is not None:
             combine = combine_cls()
-            kept = [i if i > 1 else 1 for i in patch_size]  # the ModelPatch.init blend-window contract
+            kept = blend_axes(patch_size)
             combine.set_patch_config(kept, blend_overlap(overlap, kept))
         acc = Accumulator(slices, patch_size, patch_combine=combine, batch=True)
         for i, sl in enumerate(slices):
@@ -500,6 +501,37 @@ def test_blend_recovers_the_source_in_low_precision(combine_cls):
     for index, patch_slice in enumerate(slices):
         accumulator.add_layer(index, full[(slice(None), *patch_slice)].to(torch.float16))
     torch.testing.assert_close(accumulator.assemble().float(), full, rtol=0, atol=5e-3)
+
+
+@pytest.mark.parametrize("combine_cls", [Mean, Cosinus, Gaussian])
+@pytest.mark.parametrize(
+    ("patch", "weighted_axes"),
+    [([6, 12, 14], [0]), ([1, 12, 14], []), ([10, 12, 14], [])],
+)
+def test_an_axis_the_grid_does_not_tile_carries_no_share(combine_cls, patch, weighted_axes):
+    """One grid position on an axis makes the patch the whole of the blend weight there, so its share
+    is exactly one and the blend skips it: same values, one pass over the patch fewer. A grid that
+    tiles a single voxel at a time, or nothing at all, leaves nothing to weight and no staging buffer.
+    """
+    shape, overlap = [10, 12, 14], 2
+    full = torch.rand(2, *shape)
+    slices = get_patch_slices_from_shape(patch, shape, overlap)
+    combine = combine_cls()
+    axes = blend_axes(patch)
+    combine.set_patch_config(axes, blend_overlap(overlap, axes))
+    accumulator = Accumulator(slices, patch, patch_combine=combine, batch=False)
+    for index, patch_slice in enumerate(slices):
+        block = full[(slice(None), *patch_slice)]
+        # The loader hands the patch over with its singleton axes dropped; the accumulator puts them back.
+        tiled = [extent for extent in block.shape[1:] if extent > 1]
+        accumulator.add_layer(index, block.reshape(block.shape[0], *tiled))
+
+    # The share is keyed by the patch's own extent, and the blend asks for it at full rank.
+    probe = torch.zeros(2, *[min(size, extent) for size, extent in zip(patch, shape, strict=True)])
+    weighted = [dim for dim in range(3) if accumulator._share(dim, 0, probe) is not None]
+    assert weighted == weighted_axes
+    assert (accumulator._weighted is not None) == bool(weighted_axes)
+    torch.testing.assert_close(accumulator.assemble(), full, rtol=0, atol=1e-6)
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/unit/test_predictor.py
+++ b/tests/unit/test_predictor.py
@@ -23,11 +23,15 @@ re-raised), but only when the destination serves disjoint files per entry
 ever written from two threads. Pure ``threading``/``queue``, no fork and no signals, so the behaviour
 is the same on Linux, macOS and Windows."""
 
+import math
 import time
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
 from konfai.data.augmentation import Flip
+from konfai.data.patching import blend_axes
 from konfai.predictor import PREDICTION_CLOCK, _AsyncWriter
 from konfai.utils.dataset import Dataset
 from konfai.utils.errors import PredictorError
@@ -120,3 +124,69 @@ def test_a_built_in_reduction_binds_from_its_own_block_like_a_custom_one(write_c
     assert isinstance(output.reduction, Mean)
     block = ruamel.yaml.YAML().load(path.read_text())["Predictor"]["outputs_dataset"]["L"]["OutputDataset"]
     assert "Mean" in block
+
+
+def _output_dataset(write_config, monkeypatch, name: str = "L"):
+    """An output dataset with its declared blend window built, as ``prepare`` leaves it."""
+    from konfai.predictor import OutSameAsGroupDataset
+
+    write_config(f"Predictor:\n  outputs_dataset:\n    {name}:\n      OutputDataset: {{}}\n")
+    monkeypatch.setenv("KONFAI_ROOT", "Predictor")
+    output = OutSameAsGroupDataset(
+        same_as_group="a:b",
+        dataset_filename="./Out:mha",
+        before_reduction_transforms={},
+        after_reduction_transforms={},
+        final_transforms={},
+    )
+    output.prepare(name)
+    return output
+
+
+def _configure_blend(output, patch_size, overlap) -> None:
+    """Hand ``output`` the run's patch config the way the prediction loop does."""
+    from konfai.predictor import _Predictor
+
+    _Predictor(
+        world_size=1,
+        global_rank=0,
+        local_rank=0,
+        autocast=False,
+        predict_path=Path("."),
+        data_log=None,
+        outputs_dataset={"L": output},
+        model_composite=SimpleNamespace(module=SimpleNamespace(get_networks=dict)),
+        dataloader_prediction=SimpleNamespace(
+            dataset=SimpleNamespace(get_patch_config=lambda: (patch_size, overlap), data_augmentations_list=[])
+        ),
+    )
+
+
+@pytest.mark.parametrize("patch_size", [[1, 4, 3], [4, 1, 3], [4, 4, 1]])
+def test_a_singleton_patch_axis_still_carries_its_blend_window(write_config, monkeypatch, patch_size) -> None:
+    """A 2.5-D grid tiles one axis a voxel at a time. The accumulator reads one window per spatial axis,
+    so the untiled axes have to be handed over too, as a single broadcast entry: dropping them leaves the
+    trailing axis with no window at all."""
+    output = _output_dataset(write_config, monkeypatch)
+    _configure_blend(output, patch_size, 1)
+    assert [window.numel() for window in output.patch_combine.windows_1d] == blend_axes(patch_size)
+
+
+@pytest.mark.parametrize("patch_size", [[1, 3, 3], [3, 1, 3], [3, 3, 1]])
+def test_a_grid_with_a_singleton_patch_axis_reassembles_its_case(write_config, monkeypatch, patch_size) -> None:
+    """The same grid, blended: the loader drops the singleton axis of each patch, the accumulator puts it
+    back, and the case comes out of the blend as it went in."""
+    from konfai.data.patching import Accumulator
+    from konfai.utils.utils import get_patch_slices_from_shape
+
+    output = _output_dataset(write_config, monkeypatch)
+    _configure_blend(output, patch_size, 0)
+
+    shape = [6, 6, 6]  # tiles exactly at overlap 0: no padded border patch to crop
+    volume = torch.arange(math.prod(shape), dtype=torch.float32).reshape(1, *shape)
+    slices = get_patch_slices_from_shape(patch_size, shape, 0)
+    accumulator = Accumulator(slices, patch_size, output.patch_combine, batch=False)
+    for index, patch in enumerate(slices):
+        selector = tuple(s.start if s.stop - s.start == 1 else s for s in patch)
+        accumulator.add_layer(index, volume[(slice(None), *selector)].clone())
+    assert torch.equal(accumulator.assemble(), volume)

--- a/tests/unit/test_predictor.py
+++ b/tests/unit/test_predictor.py
@@ -31,10 +31,11 @@ from types import SimpleNamespace
 import pytest
 import torch
 from konfai.data.augmentation import Flip
-from konfai.data.patching import blend_axes
-from konfai.predictor import PREDICTION_CLOCK, _AsyncWriter
+from konfai.data.patching import Accumulator, blend_axes
+from konfai.predictor import PREDICTION_CLOCK, OutSameAsGroupDataset, _AsyncWriter, _Predictor
 from konfai.utils.dataset import Dataset
 from konfai.utils.errors import PredictorError
+from konfai.utils.utils import get_patch_slices_from_shape
 
 
 def test_async_writer_charges_its_writes_to_the_writer_s_own_phase() -> None:
@@ -107,7 +108,6 @@ def test_a_built_in_reduction_binds_from_its_own_block_like_a_custom_one(write_c
     carries was read by nothing; every operator now binds from its block, and the write-back says so."""
     import ruamel.yaml
     from konfai.data.reduction import Mean
-    from konfai.predictor import OutSameAsGroupDataset
 
     path = write_config("Predictor:\n  outputs_dataset:\n    L:\n      OutputDataset:\n        reduction: Mean\n")
     monkeypatch.setenv("KONFAI_ROOT", "Predictor")
@@ -126,11 +126,9 @@ def test_a_built_in_reduction_binds_from_its_own_block_like_a_custom_one(write_c
     assert "Mean" in block
 
 
-def _output_dataset(write_config, monkeypatch, name: str = "L"):
+def _output_dataset(write_config, monkeypatch) -> OutSameAsGroupDataset:
     """An output dataset with its declared blend window built, as ``prepare`` leaves it."""
-    from konfai.predictor import OutSameAsGroupDataset
-
-    write_config(f"Predictor:\n  outputs_dataset:\n    {name}:\n      OutputDataset: {{}}\n")
+    write_config("Predictor:\n  outputs_dataset:\n    L:\n      OutputDataset: {}\n")
     monkeypatch.setenv("KONFAI_ROOT", "Predictor")
     output = OutSameAsGroupDataset(
         same_as_group="a:b",
@@ -139,14 +137,12 @@ def _output_dataset(write_config, monkeypatch, name: str = "L"):
         after_reduction_transforms={},
         final_transforms={},
     )
-    output.prepare(name)
+    output.prepare("L")
     return output
 
 
-def _configure_blend(output, patch_size, overlap) -> None:
+def _configure_blend(output: OutSameAsGroupDataset, patch_size: list[int], overlap: int) -> None:
     """Hand ``output`` the run's patch config the way the prediction loop does."""
-    from konfai.predictor import _Predictor
-
     _Predictor(
         world_size=1,
         global_rank=0,
@@ -176,9 +172,6 @@ def test_a_singleton_patch_axis_still_carries_its_blend_window(write_config, mon
 def test_a_grid_with_a_singleton_patch_axis_reassembles_its_case(write_config, monkeypatch, patch_size) -> None:
     """The same grid, blended: the loader drops the singleton axis of each patch, the accumulator puts it
     back, and the case comes out of the blend as it went in."""
-    from konfai.data.patching import Accumulator
-    from konfai.utils.utils import get_patch_slices_from_shape
-
     output = _output_dataset(write_config, monkeypatch)
     _configure_blend(output, patch_size, 0)
 


### PR DESCRIPTION
TITLE: Blending and reads: a blend that could not run, a header printed once

BODY:
Changes on the read and reassembly path. A 2.5-D grid (a `patch_size` holding a 1, e.g. `[1, 192, 192]`) plus any overlap ended PREDICTION's first patch in `IndexError: list index out of range`, because the prediction loop gave the blend window only the axes longer than one voxel while the accumulator reads one window per spatial axis: the two spellings of that rule, and a third in the tests, are now one `blend_axes` helper. The blend then skips the axes the grid holds a single position on, where the share is exactly 1, dropping both the pass over the patch and the staging buffer. A raw block now carries its geometry as an attribute holds it, printed when its header is read instead of reprinted per region. And a one-pass loader's default worker count resolves to zero, keeping the old count only where a store cannot serve a region and each patch decodes the whole volume; an explicit `num_workers` still wins, and training's default is untouched.

## Measured

Blend, CPU, `Accumulator.add_layer` over one case's grid, 48 channels (scratchpad `bench_blend.py`, `OMP_NUM_THREADS=8`, best of 3):

| grid | before | after |
|---|---|---|
| patch [96, 128, 160] on [128, 192, 192], overlap 32, 3 axes tiled | 372-379 ms | 373-384 ms (unchanged, no axis skipped) |
| patch [96, 192, 192] on [256, 192, 192], overlap 32, 1 axis tiled | 571-575 ms | 382-388 ms, -33 % (143 -> 96 ms/patch) |
| patch [1, 192, 192] on [160, 192, 192], 8 channels, 2.5-D | 19.2-19.5 ms | 16.5-18.0 ms, -13 % |

Geometry header (`CUDA_VISIBLE_DEVICES=`, 3 cases x 160 regions off an uncompressed .mha, 18 header keys):

- header of one patch 140.2 us -> 74.8 us; whole-volume record 99.9 us -> 4.9 us
- read+header, [1, 192, 192] 0.091 s -> 0.061 s; read+header, [64, 64, 64] 0.111 s -> 0.080 s
- printing a float array costs 24 us for three elements and 30 us for nine; handing text through `__setitem__` costs 0.04 us

Loader workers (`CUDA_VISIBLE_DEVICES=`, quiet 24-core host, 3 cases, whole runs, best of two), w0 / w1 / w2 / w4 seconds:

| case | w0 | w1 | w2 | w4 |
|---|---|---|---|---|
| patches stream off an uncompressed .mha, 3-D [96,96,96] (default now 0) | 0.15 | 0.32 | 0.31 | 0.34 |
| patches stream off an uncompressed .mha, 2.5-D [1,512,512] (default now 0) | 0.31 | 0.53 | 0.49 | 0.50 |
| every patch decodes the volume, compressed .mha, 2.5-D [1,512,512] (default stays 4) | 21.15 | 21.53 | 12.47 | 7.84 |
| every patch decodes the volume, compressed .mha, 3-D [32,32,32] (default stays 4) | 3.95 | 3.72 | 1.97 | 1.29 |
| case buffered whole by a whole-volume stage, 2.5-D [1,512,512] (default now 0) | 0.46 | 0.71 | 0.69 | 0.69 |
| EVALUATION, uncompressed .mha, 0.02 GB budget (default now 0) | 0.18 | 0.44 | 0.39 | 0.37 |

Asking every manager how its case is read costs 3 ms of a 302 ms prepare over 200 cases. End to end on the CPU, PREDICTION over a [160, 192, 192] case with patch [1, 192, 192] and overlap 0 raised at the first blend and now completes (prediction 1.4 s = fetch 0.5 + forward 0.0 + blend 0.0 + finalize(case) 0.8).

## Values

Nothing moves. The blend change is bit for bit: `x * 1.0` is `x` and the remaining axes keep their order, and a PREDICTION over a [288, 192, 192] case, patch [96, 192, 192], overlap 32, Cosinus, writing the blended float volume gives the same file both ways (md5 `cf0b065701d57b84612bccc6bdb14c84`). A region's record is compared character for character against ITK's own reader on every patch of a grid. The loader's worker count decides who reads a patch, never what it holds.

## Tests

`test_predictor.py::test_a_singleton_patch_axis_still_carries_its_blend_window` and `::test_a_grid_with_a_singleton_patch_axis_reassembles_its_case` (six cases, all six raising `IndexError` before this); `test_patching.py::test_an_axis_the_grid_does_not_tile_carries_no_share` (nine cases over Mean/Cosinus/Gaussian and three grids, six fail before this); `test_dataset.py::test_every_patch_of_a_grid_records_what_itk_records`; plus the `test_data_manager.py` cases for the resolved default.

## Stack

Stacked on `pr/1.8.2-13-training-step`; merge after it. Before deleting this branch, retarget the next PR of the stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved data-loading worker selection based on dataset format and read patterns.
  - Prediction and evaluation workflows now avoid unnecessary caching and background workers.
  - Explicit worker settings are preserved when provided.

- **Bug Fixes**
  - Improved patch blending for singleton and untiled dimensions.
  - Prevented unnecessary blending work when weighting is uniform.
  - Improved reconstruction accuracy for tiled volumes.

- **Reliability**
  - Preserved image geometry and patch origins consistently across rotated-image reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->