### PR TITLE
The memory budget holds what it declares

### DIFF
--- a/konfai/data/materialize.py
+++ b/konfai/data/materialize.py
@@ -32,7 +32,6 @@ import sys
 import warnings
 from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass
-from typing import NamedTuple
 
 if sys.version_info >= (3, 11):
     from enum import StrEnum
@@ -54,7 +53,9 @@ from konfai.data.patching import (
     FALLBACK_INFLIGHT_FACTOR,
     AugmentedStage,
     DatasetManager,
+    SweepSegment,
     _PendingSweep,
+    _pull_block_voxels,
     _ReadStagePlan,
     _stage_failures_explained,
     _stage_name,
@@ -63,23 +64,8 @@ from konfai.data.patching import (
 )
 from konfai.data.transform import LocalityKind, Reduce, Resample, Save, Transform
 from konfai.utils.budget import format_bytes
-from konfai.utils.dataset import Attribute, Dataset
+from konfai.utils.dataset import Attribute
 from konfai.utils.errors import PatchError
-
-
-class _SweepSegment(NamedTuple):
-    """One segment the streamed route sweeps: where it reads from, what it lands, how it pulls."""
-
-    dataset: Dataset
-    group: str
-    entry: str
-    source_shape: list[int]
-    landing: list[int]
-    plans: tuple[_ReadStagePlan, ...]
-
-    @property
-    def channels(self) -> int:
-        return int(self.source_shape[0])
 
 
 class Verdict(StrEnum):
@@ -418,7 +404,7 @@ class CaseMaterializer:
         manager = self.manager
         if not any(
             extent < segment.landing[axis]
-            for segment in self._sweep_segments() or []
+            for segment in self.manager.sweep_segments() or []
             for axis, extent in enumerate(manager._sweep_tile(segment.landing, segment.channels, segment.plans))
         ):
             return False
@@ -478,56 +464,17 @@ class CaseMaterializer:
             self._peak_case_bytes = peak * CASE_ELEMENT_BYTES
         return self._peak_case_bytes
 
-    def working_multiple(self) -> float:
-        """What the whole-volume path allocates beyond the case and its in-flight copy, in
-        volumes-worth: the largest a stage of the chain declares (``Transform.working_multiple``)."""
-        return max(
-            (float(stage.working_multiple) for stage in self.manager.transforms if isinstance(stage, Transform)),
-            default=0.0,
-        )
-
     def fallback_working_set_bytes(self) -> int:
         """The bytes a whole-volume fallback of this case holds at its peak: the case, its in-flight
         copy, and the widest stage's own buffers, all sized on the largest intermediate."""
-        return int(self.peak_case_bytes() * (FALLBACK_INFLIGHT_FACTOR + self.working_multiple()))
-
-    def _sweep_segments(self, a: int = 0, apply_augmentations: bool = False) -> list[_SweepSegment] | None:
-        """Every segment the streamed route sweeps: one per unsatisfied ``Save`` (each sweeps ITS
-        source) plus the head past the last boundary, which is read only if stages follow it.
-        ``None`` when the chain cannot stream at all."""
-        source = self.manager._resolve_patch_stream_source(a, apply_augmentations)
-        if source is None:
-            return None
-        segments = [
-            _SweepSegment(
-                sweep.source_dataset,
-                sweep.source_group,
-                sweep.source_entry,
-                [int(extent) for extent in sweep.source_shape],
-                list(sweep.out_spatial),
-                sweep.stage_plans,
-            )
-            for sweep in source.pending_sweeps
-        ]
-        if source.stage_plans:
-            segments.append(
-                _SweepSegment(
-                    source.dataset,
-                    source.group,
-                    source.entry,
-                    list(source.shape),
-                    list(source.stage_plans[-1].out_shape),
-                    source.stage_plans,
-                )
-            )
-        return segments
+        return int(self.peak_case_bytes() * (FALLBACK_INFLIGHT_FACTOR + self.manager.working_multiple()))
 
     def predicted_stream_read_factor(self, a: int = 0, apply_augmentations: bool = False) -> float | None:
         """About how many times the streamed route reads the source (a halo re-reads its overlap, a
         regrid pulls each slab's window, a store without bounded reads decodes the volume once per
         slab), from the plan's own pull maps: the number the route is chosen with. ``None`` when the
         chain cannot stream."""
-        segments = self._sweep_segments(a, apply_augmentations)
+        segments = self.manager.sweep_segments(a, apply_augmentations)
         if segments is None:
             return None
         # Priced by the dominant segment: a max, not a sum -- the segments read different stores,
@@ -535,7 +482,7 @@ class CaseMaterializer:
         factors = [self._segment_read_factor(segment) for segment in segments]
         return max(factors) if factors else 1.0
 
-    def _segment_read_factor(self, segment: _SweepSegment) -> float:
+    def _segment_read_factor(self, segment: SweepSegment) -> float:
         """One segment's reads over its source's voxels, block by block through the plan's own pulls."""
         tile = self.manager._sweep_tile(segment.landing, segment.channels, segment.plans)
         targets = list(_sweep_targets(segment.landing, tile))
@@ -545,10 +492,5 @@ class CaseMaterializer:
         dataset, group, entry = segment.dataset, segment.group, segment.entry
         if dataset.is_dataset_exist(group, entry) and not dataset.bounded_region_reads(group, entry):
             return float(max(1, len(targets)))  # every block decodes the whole store
-        read = 0
-        for target in targets:
-            span = list(target)
-            for plan in reversed(segment.plans):
-                span = list(plan.pull(tuple(span))) if plan.pull is not None else span
-            read += int(np.prod([max(0, part.stop - part.start) for part in span], dtype=np.int64))
+        read = sum(_pull_block_voxels(segment.landing, tile, segment.plans))
         return float(read) / float(max(1, int(np.prod(segment.source_shape[1:], dtype=np.int64))))

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -52,9 +52,10 @@ from konfai.data.transform import (
     split_expand,
     stat_seed_valid,
 )
+from konfai.utils.budget import format_bytes
 from konfai.utils.config import apply_config, config
 from konfai.utils.dataset import Attribute, Dataset, DataStream, as_channel_first
-from konfai.utils.errors import ConfigError, PatchError, TransformError
+from konfai.utils.errors import ConfigError, DatasetManagerError, PatchError, TransformError
 from konfai.utils.runtime import preserved_rng, rank_cpu_share, seed_all
 from konfai.utils.utils import (
     OverlapSpec,
@@ -91,10 +92,15 @@ _STREAM_STAT_KEYS = frozenset(_STREAM_STATS)
 # VOLUME it allows is what DatasetManager._sweep_tile then shapes into the block actually read.
 SWEEP_SLAB_ROWS = 64
 
-# What a sweep holds per row while in flight (the pulled source region and the landed block) and
-# the bytes each element travels as (float32 through the chain). See DatasetManager._sweep_rows.
-# A pipelined sweep holds more: _sweep_resident_slabs counts them.
-_SWEEP_RESIDENT_SLABS = 2
+# The bytes each element travels as through a sweep (float32). What a sweep holds in those elements
+# is _sweep_resident_regions, and DatasetManager.sweep_block_bytes prices it.
+#
+# What a streamed case holds beside its regions, whatever they are: the manager's state, the chain's
+# stage objects, the store handles, the allocator's slack. Measured as the resident set above the
+# interpreter floor that the priced regions do not account for, on the memory-limit cohort: 25 MiB
+# (a bare Write), 8 (Gradient), 11 (Resample), 27 (Resample then Gradient). A floor the sizing cannot
+# lower, so the TRANSFORM plan's header states it instead of leaving it to be found in a resident set.
+SWEEP_ENGINE_FLOOR_BYTES = 32 << 20
 #: The most blocks a sweep keeps in flight, whatever the budget leaves room for: past a second
 #: one the jitter it absorbs is already absorbed (DatasetManager._sweep_depth).
 _SWEEP_MAX_DEPTH = 3
@@ -503,16 +509,15 @@ def _cubic_tile(spatial: list[int], voxels: int, align: int) -> list[int]:
     ]
 
 
-def _pull_voxels(spatial: list[int], tile: Sequence[int], plans: Sequence["_ReadStagePlan"]) -> int:
-    """The source voxels a decomposition into ``tile`` blocks materialises, from the plans' own pull
-    maps: closed form, no voxel read."""
-    total = 0
+def _pull_block_voxels(spatial: list[int], tile: Sequence[int], plans: Sequence["_ReadStagePlan"]) -> Iterator[int]:
+    """The source voxels each block of a decomposition into ``tile`` materialises, from the plans'
+    own pull maps: closed form, no voxel read. Their sum is what the decomposition reads, their
+    largest what one block of it holds."""
     for target in _sweep_targets(spatial, tile):
         span = list(target)
         for plan in reversed(plans):
             span = list(plan.pull(tuple(span))) if plan.pull is not None else span
-        total += int(np.prod([max(0, part.stop - part.start) for part in span], dtype=np.int64))
-    return total
+        yield int(np.prod([max(0, part.stop - part.start) for part in span], dtype=np.int64))
 
 
 def _sweep_pipeline_depth() -> int:
@@ -521,11 +526,27 @@ def _sweep_pipeline_depth() -> int:
     return 1 if rank_cpu_share() > 1 else 0
 
 
-def _sweep_resident_slabs(depth: int) -> int:
-    """How many blocks' worth a sweep of pipeline ``depth`` holds at once: the pulled region and
-    the landed block of the one in the chain, and, pipelined, the ``depth`` blocks queued ahead,
-    the one the reader holds while the queue is full, and the one being written behind."""
-    return _SWEEP_RESIDENT_SLABS + (depth + 2 if depth else 0)
+def _sweep_resident_regions(depth: int) -> tuple[int, int]:
+    """How many pulled source regions and how many landed blocks a sweep of pipeline ``depth`` holds
+    at once: the region the chain is running on, and, pipelined, the ``depth`` queued ahead of it
+    plus the one the reader holds while the queue is full; against the block being landed and,
+    pipelined, the one being written behind it."""
+    return (1, 1) if depth < 1 else (depth + 2, 2)
+
+
+class SweepSegment(NamedTuple):
+    """One segment the streamed route sweeps: where it reads from, what it lands, how it pulls."""
+
+    dataset: Dataset
+    group: str
+    entry: str
+    source_shape: list[int]
+    landing: list[int]
+    plans: tuple["_ReadStagePlan", ...]
+
+    @property
+    def channels(self) -> int:
+        return int(self.source_shape[0])
 
 
 class SweepClock:
@@ -2654,17 +2675,61 @@ class DatasetManager:
         )
         return sweep, evolved, None
 
+    def sweep_segments(self, a: int = 0, apply_augmentations: bool = False) -> list[SweepSegment] | None:
+        """Every segment the streamed route sweeps: one per unsatisfied ``Save`` (each sweeps ITS
+        source) plus the head past the last boundary, which is read only if stages follow it.
+        ``None`` when the chain cannot stream at all.
+
+        Public because three consumers ask the same question of one plan: what the run will sweep,
+        what the plan prices it at, and whether the budget holds a region of it.
+        """
+        source = self._resolve_patch_stream_source(a, apply_augmentations)
+        if source is None:
+            return None
+        segments = [
+            SweepSegment(
+                sweep.source_dataset,
+                sweep.source_group,
+                sweep.source_entry,
+                [int(extent) for extent in sweep.source_shape],
+                list(sweep.out_spatial),
+                sweep.stage_plans,
+            )
+            for sweep in source.pending_sweeps
+        ]
+        if source.stage_plans:
+            segments.append(
+                SweepSegment(
+                    source.dataset,
+                    source.group,
+                    source.entry,
+                    list(source.shape),
+                    list(source.stage_plans[-1].out_shape),
+                    source.stage_plans,
+                )
+            )
+        return segments
+
     def can_stream_patch(self, a: int, apply_augmentations: bool = True) -> bool:
-        return self._resolve_patch_stream_source(a, apply_augmentations) is not None
+        return self.stream_refusal(a, apply_augmentations) is None
 
     def stream_refusal(self, a: int = 0, apply_augmentations: bool = True) -> str | None:
         """Why this copy cannot stream (the reified refusal) or ``None`` when it can.
 
         Resolves the plan (a probe, never a write) and hands back the first stage-level reason the
-        planner met: the whole-volume fallback stays available, but it stops being silent."""
-        if self._resolve_patch_stream_source(a, apply_augmentations) is not None:
-            return None
-        return self._stream_refusals.get((a, apply_augmentations), "the chain cannot stream.")
+        planner met, or, past that, the budget one: a chain whose smallest region does not fit is
+        not a chain that streams, and routing it away here is what makes the whole-volume pass
+        price and refuse it before a byte is written, instead of the sweep meeting it at its first
+        slab. The whole-volume fallback stays available, but neither refusal is silent."""
+        segments = self.sweep_segments(a, apply_augmentations)
+        if segments is None:
+            return self._stream_refusals.get((a, apply_augmentations), "the chain cannot stream.")
+        try:
+            for segment in segments:
+                self._sweep_tile(segment.landing, segment.channels, segment.plans)
+        except DatasetManagerError as refusal:
+            return str(refusal.args[0])
+        return None
 
     @property
     def spatial_shape(self) -> list[int]:
@@ -2743,9 +2808,6 @@ class DatasetManager:
         replay where the fold will run. CPU collapses to None: opt-in only, because this same
         machinery loads training cases inside DataLoader workers, where a CUDA default is wrong."""
         self._chain_device = device if device is not None and device.type != "cpu" else None
-
-    def _device_budget(self, budget_bytes: float | None) -> float | None:
-        return device_capped_budget(budget_bytes, self._chain_device)
 
     def _set_rewrite(self, rewrite: bool) -> None:
         """The rewrite knob the materialization engine sets for one call: under it every
@@ -2996,59 +3058,117 @@ class DatasetManager:
         second block in flight recovers 0.5 s of a 6.7 s run and a third recovers none.
         """
         depth = _sweep_pipeline_depth()
-        while depth and depth < _SWEEP_MAX_DEPTH and self._sweep_tile(spatial, channels, plans, depth + 1) == tile:
+        while depth and depth < _SWEEP_MAX_DEPTH and self._keeps_the_block(spatial, channels, plans, tile, depth + 1):
             depth += 1
         return depth
 
-    def _sweep_rows(self, spatial: list[int], channels: int, depth: int | None = None) -> int:
-        """How many rows one sweep region spans on the landing's first axis: the cap
-        (``SWEEP_SLAB_ROWS`` on a CPU, taller on a GPU as its memory allows), lowered by the budget
-        (half of it over everything a sweep of this ``depth`` holds at once:
-        :func:`_sweep_resident_slabs`), never below one row. Sized on the source's channels at four
-        bytes each: the landed block's are not known before the first region, and the fallback
-        budget check refuses on real shapes.
+    def _keeps_the_block(
+        self, spatial: list[int], channels: int, plans: Sequence["_ReadStagePlan"], tile: list[int], depth: int
+    ) -> bool:
+        """Whether a queue of ``depth`` still leaves the sweep exactly ``tile``: a deeper one the
+        budget cannot hold refuses, and a refusal here is the answer no, not the sweep's failure."""
+        try:
+            return self._sweep_tile(spatial, channels, plans, depth) == tile
+        except DatasetManagerError:
+            return False
 
-        This is the HEIGHT rule alone; :meth:`_sweep_tile` turns the volume it allows into the block
-        the sweep actually reads.
+    def _sweep_rows(self, spatial: list[int], channels: int, depth: int | None = None) -> int:
+        """The tallest region the sweep will cut whatever the budget: ``SWEEP_SLAB_ROWS`` on a CPU,
+        taller on a GPU as its free memory allows. What the budget then affords is
+        :meth:`_sweep_tile`'s.
         """
         cap = max(1, int(SWEEP_SLAB_ROWS))
-        resident = _sweep_resident_slabs(_sweep_pipeline_depth() if depth is None else depth)
         plane = int(np.prod(spatial[1:], dtype=np.int64)) * max(1, int(channels)) * _SWEEP_ELEMENT_BYTES
         if plane > 0 and self._chain_device is not None and self._chain_device.type == "cuda":
             # On a GPU the transfers and launches per region are the cost: taller regions, as far as
             # a quarter of the free device memory allows (measured +10-20 % at 500^3 over 64 rows).
+            resident = sum(_sweep_resident_regions(_sweep_pipeline_depth() if depth is None else depth))
             free_bytes, _total = torch.cuda.mem_get_info(self._chain_device)
             cap = max(cap, min(_SWEEP_SLAB_ROWS_DEVICE, int(free_bytes * 0.25 / (plane * resident))))
-        budget = self._sweep_budget_bytes
-        if not budget or budget <= 0:
-            return cap
-        if plane <= 0:
-            return cap
-        return max(1, min(cap, int(budget * 0.5 / (plane * resident))))
+        return cap
 
-    def _sweep_tile(
-        self, spatial: list[int], channels: int, plans: Sequence["_ReadStagePlan"] = (), depth: int | None = None
-    ) -> list[int]:
-        """The block one sweep region covers: the volume :meth:`_sweep_rows` allows, in the shape
-        that pulls the least.
+    def _sweep_shape(self, spatial: list[int], plans: Sequence["_ReadStagePlan"], rows: int) -> list[int]:
+        """The block ``rows`` rows of the landing become: the slab itself, or the cube of the same
+        volume where that pulls less.
 
         A region pulls the BOUNDING BOX of its own image under the chain's maps, so a slab spanning
         the trailing plane pays that plane's extent for every degree of shear where a cube pays its
         side: 1.79x the image against 1.09x on a 513x1331x1776 rigid+affine. Both are priced against
-        the plans' own pull maps (:func:`_pull_voxels`), and the cube wins only by
+        the plans' own pull maps (:func:`_pull_block_voxels`), and the cube wins only by
         ``_SWEEP_TILE_MARGIN``: the decomposition is also the shape a store gets chunked in. Without
         plans, the slab.
         """
         from konfai.utils.ome_zarr import CHUNK_SPATIAL_TILE
 
-        rows = self._sweep_rows(spatial, channels, depth)
         slab = [min(int(rows), int(spatial[0])), *(int(extent) for extent in spatial[1:])]
         voxels = int(rows) * int(np.prod(spatial[1:], dtype=np.int64))
         cube = _cubic_tile(spatial, voxels, CHUNK_SPATIAL_TILE)
         if cube == slab or not plans:
             return slab
-        cheaper = _pull_voxels(spatial, cube, plans) <= _pull_voxels(spatial, slab, plans) * _SWEEP_TILE_MARGIN
+        pulled = sum(_pull_block_voxels(spatial, cube, plans))
+        cheaper = pulled <= sum(_pull_block_voxels(spatial, slab, plans)) * _SWEEP_TILE_MARGIN
         return cube if cheaper else slab
+
+    def sweep_block_bytes(
+        self, spatial: list[int], channels: int, plans: Sequence["_ReadStagePlan"], tile: list[int], depth: int
+    ) -> int:
+        """What a sweep decomposed into ``tile`` holds at its peak: the source regions it has pulled
+        and the blocks it has landed, both counted by :func:`_sweep_resident_regions`, plus what the
+        widest stage of the chain allocates on top of the largest of them
+        (``Transform.working_multiple``). The landed block's channels are not known before the first
+        region, so the source's stand in, at ``_SWEEP_ELEMENT_BYTES`` each. Beside this, and outside
+        it, a streamed case holds ``SWEEP_ENGINE_FLOOR_BYTES`` the decomposition cannot lower.
+
+        Public because the sizing holds this figure to the budget and a caller sizing a budget for a
+        decomposition asks for it: one price, not two that drift apart.
+        """
+        pulled, landed = _sweep_resident_regions(depth)
+        block = int(np.prod(tile, dtype=np.int64))
+        pull = max(_pull_block_voxels(spatial, tile, plans), default=block) if plans else block
+        held = pulled * pull + landed * block + self.working_multiple() * max(pull, block)
+        return int(held * max(1, int(channels)) * _SWEEP_ELEMENT_BYTES)
+
+    def working_multiple(self) -> float:
+        """What this chain allocates beyond what it is handed, in volumes-worth: the largest a stage
+        declares (``Transform.working_multiple``)."""
+        return max(
+            (float(stage.working_multiple) for stage in self.transforms if isinstance(stage, Transform)), default=0.0
+        )
+
+    def _sweep_tile(
+        self, spatial: list[int], channels: int, plans: Sequence["_ReadStagePlan"] = (), depth: int | None = None
+    ) -> list[int]:
+        """The block one sweep region covers: the tallest the cap allows that still holds inside the
+        budget, in the shape that pulls the least (:meth:`_sweep_shape`).
+
+        The budget is what a sweep may HOLD, so it is the priced block (:meth:`sweep_block_bytes`)
+        that is held to it, never the landed rows alone: a REGRID pulling eight source voxels per
+        landed one, or a stage declaring eight volumes-worth of buffers, costs what it costs. The
+        search is over the height, because that is the one free parameter of the decomposition.
+        """
+        depth = _sweep_pipeline_depth() if depth is None else depth
+        cap = self._sweep_rows(spatial, channels, depth)
+        budget = self._sweep_budget_bytes
+        if not budget or budget <= 0:
+            return self._sweep_shape(spatial, plans, cap)
+        low, high = 1, cap  # low is never taken as affordable: the refusal below answers for it
+        while low < high:
+            middle = (low + high + 1) // 2
+            tile = self._sweep_shape(spatial, plans, middle)
+            if self.sweep_block_bytes(spatial, channels, plans, tile, depth) <= budget:
+                low = middle
+            else:
+                high = middle - 1
+        tile = self._sweep_shape(spatial, plans, low)
+        held = self.sweep_block_bytes(spatial, channels, plans, tile, depth)
+        if held > budget:
+            raise DatasetManagerError(
+                f"'{self.name}': no region of '{self.group_src}' fits the per-rank memory budget"
+                f" ({format_bytes(budget)}): the smallest one this chain can sweep holds"
+                f" {format_bytes(held)}.",
+                "Raise 'memory_budget'.",
+            )
+        return tile
 
     def _get_streamed_data(
         self,

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -3078,7 +3078,8 @@ class DatasetManager:
         :meth:`_sweep_tile`'s.
         """
         cap = max(1, int(SWEEP_SLAB_ROWS))
-        plane = int(np.prod(spatial[1:], dtype=np.int64)) * max(1, int(channels)) * _SWEEP_ELEMENT_BYTES
+        _source, _landed, peak, _working = self._chain_channels(channels)
+        plane = int(np.prod(spatial[1:], dtype=np.int64)) * peak * _SWEEP_ELEMENT_BYTES
         if plane > 0 and self._chain_device is not None and self._chain_device.type == "cuda":
             # On a GPU the transfers and launches per region are the cost: taller regions, as far as
             # a quarter of the free device memory allows (measured +10-20 % at 500^3 over 64 rows).
@@ -3115,9 +3116,10 @@ class DatasetManager:
         """What a sweep decomposed into ``tile`` holds at its peak: the source regions it has pulled
         and the blocks it has landed, both counted by :func:`_sweep_resident_regions`, plus what the
         widest stage of the chain allocates on top of the largest of them
-        (``Transform.working_multiple``). The landed block's channels are not known before the first
-        region, so the source's stand in, at ``_SWEEP_ELEMENT_BYTES`` each. Beside this, and outside
-        it, a streamed case holds ``SWEEP_ENGINE_FLOOR_BYTES`` the decomposition cannot lower.
+        (``Transform.working_multiple``). Each term is counted on the channels it actually holds
+        (:meth:`_chain_channels`), at ``_SWEEP_ELEMENT_BYTES`` each: the source pulls the source's,
+        the block lands the chain's. Beside this, and outside it, a streamed case holds
+        ``SWEEP_ENGINE_FLOOR_BYTES`` the decomposition cannot lower.
 
         Public because the sizing holds this figure to the budget and a caller sizing a budget for a
         decomposition asks for it: one price, not two that drift apart.
@@ -3125,8 +3127,29 @@ class DatasetManager:
         pulled, landed = _sweep_resident_regions(depth)
         block = int(np.prod(tile, dtype=np.int64))
         pull = max(_pull_block_voxels(spatial, tile, plans), default=block) if plans else block
-        held = pulled * pull + landed * block + self.working_multiple() * max(pull, block)
-        return int(held * max(1, int(channels)) * _SWEEP_ELEMENT_BYTES)
+        source, landed_channels, _peak, working = self._chain_channels(channels)
+        held = pulled * pull * source + landed * block * landed_channels + working * max(pull, block)
+        return int(held * _SWEEP_ELEMENT_BYTES)
+
+    def _chain_channels(self, channels: int) -> tuple[int, int, int, float]:
+        """What the channel axis costs along the chain, for the plan's arithmetic: the channels the
+        source pulls, the channels a block lands with, the widest the chain ever holds, and the
+        volumes-worth its widest stage allocates, that one counted on the channels that stage is
+        handed (``Transform.working_multiple``).
+
+        Identity for a chain that keeps the axis, where all three counts are the source's and the
+        last is :meth:`working_multiple` times it. ``OneHot`` is the stage that widens it, and a
+        block priced at the source's would be short by its class count.
+        """
+        source = held = landed = peak = max(1, int(channels))
+        working = 0.0
+        for stage in self.transforms:
+            if not isinstance(stage, Transform):
+                continue
+            working = max(working, float(stage.working_multiple) * held)
+            held = landed = max(1, int(stage.output_channels(held)))
+            peak = max(peak, held)
+        return source, landed, peak, working
 
     def working_multiple(self) -> float:
         """What this chain allocates beyond what it is handed, in volumes-worth: the largest a stage

--- a/konfai/evaluator.py
+++ b/konfai/evaluator.py
@@ -31,11 +31,11 @@ from konfai import config_file, cuda_visible_devices, evaluations_directory, kon
 from konfai.data.data_manager import BatchDataItem, BatchSample, DataMetric, DatasetIter
 from konfai.data.patching import SweepClock
 from konfai.network.network import build_configured_criterions
-from konfai.utils.budget import node_local_ranks
+from konfai.utils.budget import node_local_ranks, set_per_rank_budget
 from konfai.utils.config import apply_config, config, strict_config
 from konfai.utils.dataset import Attribute, Dataset, DataStream
 from konfai.utils.errors import ConfigError, EvaluatorError
-from konfai.utils.ome_zarr import set_chunk_cache_budget
+from konfai.utils.ome_zarr import bound_chunk_cache
 from konfai.utils.runtime import (
     DistributedObject,
     State,
@@ -309,7 +309,8 @@ class Evaluator(DistributedObject):
         self.dataset.auto_patch_allowed = all(getattr(metric, "reducible", False) for metric in criterions)
         self.dataset.patch_halo = max((int(getattr(metric, "halo", 0)) for metric in criterions), default=0)
         self.dataset.prepare()
-        set_chunk_cache_budget(self.dataset.resolved_budget().per_rank_bytes(node_local_ranks()))
+        set_per_rank_budget(self.dataset.resolved_budget().per_rank_bytes(node_local_ranks()))
+        bound_chunk_cache()
         # Set iff the budget actually patched: batches then carry one disjoint patch of a case, and
         # update() accumulates partial states until the case's last patch before recording it.
         self._streamed = self.dataset.patch is not None

--- a/konfai/network/network.py
+++ b/konfai/network/network.py
@@ -413,6 +413,12 @@ class Measure:
         self._targets: dict[tuple[str, torch.device], tuple[torch.Tensor, torch.Tensor]] = {}
 
     def _target(self, group: str, tensor: torch.Tensor, device: torch.device) -> torch.Tensor:
+        # Not on the step's critical path. Issued instead when the batch arrives, the epoch is 20.4 s
+        # against 20.2 on the shipped 2D example and 28.3 against 27.3 on a 3D UNet, and only the
+        # phase carrying the wait moves (``criteria`` to ``forward``). Made free outright (pinned
+        # memory, an asynchronous copy) the line's host wall falls from 24.0 s an epoch to 0.007 and
+        # the epoch still does not move: the host meets the device once a step anyway, where Dice
+        # reads its lowest label back.
         moved = self._targets.get((group, device))
         if moved is None or moved[0] is not tensor:
             moved = (tensor, tensor.to(device).detach())

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -75,12 +75,12 @@ from konfai.data.transform import (
     TransformLoader,
 )
 from konfai.network.network import Model, ModelLoader, NetState, Network
-from konfai.utils.budget import node_local_ranks, resolve_memory_budget
+from konfai.utils.budget import node_local_ranks, resolve_memory_budget, set_per_rank_budget
 from konfai.utils.chain_diff import dataset_tree, input_chain_differences, training_dataset_tree
 from konfai.utils.config import _escape_key_component, apply_config, config, strict_config
 from konfai.utils.dataset import Attribute, Dataset, DataStream
 from konfai.utils.errors import ConfigError, KonfAIError, PredictorError
-from konfai.utils.ome_zarr import set_chunk_cache_budget
+from konfai.utils.ome_zarr import bound_chunk_cache
 from konfai.utils.runtime import (
     DataLog,
     DistributedObject,
@@ -2053,7 +2053,8 @@ class Predictor(DistributedObject):
         self.datasets_filename = []
         self.predict_path = predictions_directory() / self.name
         per_rank_budget = self.dataset.resolved_budget().per_rank_bytes(node_local_ranks())
-        set_chunk_cache_budget(per_rank_budget)
+        set_per_rank_budget(per_rank_budget)
+        bound_chunk_cache()
         for output_dataset in self.outputs_dataset.values():
             output_dataset.set_memory_budget(per_rank_budget)
             self.datasets_filename.append(output_dataset.filename)

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -492,7 +492,9 @@ class _Trainer:
         below ``min_seconds``. ``forward`` is the graph walk alone, the criteria being timed inside it;
         what no phase names is ``other``, so the sum closes on the wall clock. On a device a phase
         is the time its kernels took to enqueue: the device's own time lands where the host next
-        waits for it (the loss read, a checkpoint's host copy, the validation)."""
+        waits for it, so ``criteria`` carries the forward's kernels: its first target upload waits on
+        them, 13.8 s of a 20.2 s epoch on the shipped 2D example. The rest lands at the loss read, a
+        checkpoint's host copy and the validation."""
         wall = clock.spent("epoch")
         if wall < min_seconds:
             return None

--- a/konfai/transformer.py
+++ b/konfai/transformer.py
@@ -176,10 +176,10 @@ class TransformPlan:
                 else ""
             )
             beside.append(f"decoded-chunk cache up to {format_bytes(self.chunk_cache_bytes)}{under}")
-        cache = " | held beside the regions: " + ", ".join(beside)
+        held_beside = " | held beside the regions: " + ", ".join(beside)
         return (
             f"[KonfAI] plan over {self.world_size} rank(s) | per-rank budget"
-            f" {format_bytes(self.budget_bytes)} ({self.budget_desc}){cache}"
+            f" {format_bytes(self.budget_bytes)} ({self.budget_desc}){held_beside}"
             f" | fallback working set = case x {CASE_ELEMENT_BYTES} B x ({FALLBACK_INFLIGHT_FACTOR}"
             f" + the widest stage's own buffers), headers-only estimate | output dtype/channels assumed"
             f" {self.dtype_hypothesis} until the first slab"

--- a/konfai/transformer.py
+++ b/konfai/transformer.py
@@ -47,6 +47,7 @@ from konfai.data.patching import (
     CASE_ELEMENT_BYTES,
     FALLBACK_INFLIGHT_FACTOR,
     SWEEP_CLOCK,
+    SWEEP_ENGINE_FLOOR_BYTES,
     DatasetManager,
     save_destination,
 )
@@ -164,12 +165,18 @@ class TransformPlan:
         return "\n".join(lines)
 
     def _header(self) -> str:
-        cache = f" | decoded-chunk cache {format_bytes(self.chunk_cache_bytes)} of it" if self.chunk_cache_bytes else ""
-        if 0 < self.chunk_cache_bytes < CHUNK_CACHE_FLOOR:
-            cache += (
+        # What a rank holds that the region sizing does not take out of the budget: said here rather
+        # than left to be discovered in a resident set.
+        beside = [f"engine ~{format_bytes(SWEEP_ENGINE_FLOOR_BYTES)}"]
+        if self.chunk_cache_bytes:
+            under = (
                 f" (under the {format_bytes(CHUNK_CACHE_FLOOR)} floor: a region touching more OME-Zarr"
                 " chunks than it holds decodes them again)"
+                if self.chunk_cache_bytes < CHUNK_CACHE_FLOOR
+                else ""
             )
+            beside.append(f"decoded-chunk cache up to {format_bytes(self.chunk_cache_bytes)}{under}")
+        cache = " | held beside the regions: " + ", ".join(beside)
         return (
             f"[KonfAI] plan over {self.world_size} rank(s) | per-rank budget"
             f" {format_bytes(self.budget_bytes)} ({self.budget_desc}){cache}"

--- a/konfai/transformer.py
+++ b/konfai/transformer.py
@@ -53,11 +53,11 @@ from konfai.data.patching import (
 )
 from konfai.data.transform import Save, split_expand
 from konfai.utils import uri
-from konfai.utils.budget import format_bytes, node_local_ranks
+from konfai.utils.budget import format_bytes, node_local_ranks, set_per_rank_budget
 from konfai.utils.config import apply_config, config, strict_config
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import ConfigError, DatasetManagerError, TransformerError
-from konfai.utils.ome_zarr import CHUNK_CACHE_FLOOR, set_chunk_cache_budget
+from konfai.utils.ome_zarr import CHUNK_CACHE_FLOOR, bound_chunk_cache
 from konfai.utils.runtime import (
     DistributedObject,
     State,
@@ -735,7 +735,8 @@ class Transformer(DistributedObject):
         # the plan must measure the same run setup() will enforce. The store's decoded-chunk cache
         # is bounded here too: it is part of what the process holds.
         self._budget_bytes = per_rank_budget
-        chunk_cache_bytes = set_chunk_cache_budget(per_rank_budget)
+        set_per_rank_budget(per_rank_budget)
+        chunk_cache_bytes = bound_chunk_cache()
         entries: list[TransformPlanEntry] = []
         probed: set[tuple[str, str]] = set()
         planned_dtypes: set[str] = set()

--- a/konfai/utils/budget.py
+++ b/konfai/utils/budget.py
@@ -75,6 +75,25 @@ class MemoryBudget:
         return self.total_bytes / max(1, world_size) if self.shared_across_ranks else self.total_bytes
 
 
+#: This rank's share of the budget, as the workflow that resolved it published it. Some consumers of
+#: a budget sit inside a ``Dataset``, which a workflow reaches through doors that carry no budget (a
+#: transform reading a companion volume, a statistics scan, a store's decoded-chunk cache): they read
+#: it from here instead of every door growing a parameter for them.
+_per_rank_bytes: float | None = None
+
+
+def set_per_rank_budget(budget_bytes: float | None) -> None:
+    """Publish this rank's budget. ``None`` (or a non-positive figure) means none was declared, which
+    is what every consumer falls back to its own default on."""
+    global _per_rank_bytes
+    _per_rank_bytes = float(budget_bytes) if budget_bytes and budget_bytes > 0 else None
+
+
+def per_rank_budget_bytes() -> float | None:
+    """This rank's declared budget, or ``None`` when none was."""
+    return _per_rank_bytes
+
+
 def _positive_int_env(name: str) -> int | None:
     """The environment variable NAME as a positive int; ``None`` when unset, zero or not a number."""
     try:

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -26,6 +26,7 @@ import functools
 import glob
 import itertools
 import math
+import mmap
 import os
 import re
 import shutil
@@ -1217,6 +1218,60 @@ class _ItkTransformDataStream(DataStream):
             Path(self._temporary_path).unlink(missing_ok=True)
 
 
+#: Handing a written page back to the kernel takes ``madvise``, which not every platform has; where
+#: it is missing, the pages of a raw-block stream stay resident until the map closes.
+_MADV_DONTNEED: int | None = getattr(mmap, "MADV_DONTNEED", None)
+
+
+class _RawBlockStream(DataStream):
+    """A local file whose pixels are one raw block: a header written once, then region writes into
+    the block through a map whose pages this process does not keep.
+
+    A shared file mapping holds every page written through it resident until it is unmapped, so a
+    stream over a volume ends up holding the whole volume, budget or no budget: +87 MiB of resident
+    set over a 78 MiB .mha swept in ten regions. Each written region is handed back to the kernel
+    instead (``MADV_DONTNEED``), which leaves the bytes in the page cache to be written out and
+    takes them out of this process's resident set: +8 MiB, one region's worth, over the same sweep.
+    """
+
+    def __init__(self, path: str, header: bytes, dtype: np.dtype, shape: Sequence[int]) -> None:
+        self.path = path
+        self.published_path = Path(path)
+        self._temporary_path = f"{path}.{self.temporary_suffix()}"
+        self._dtype = np.dtype(dtype)
+        self._offset = len(header)
+        elements = int(np.prod(shape, dtype=np.int64))
+        with open(self._temporary_path, "wb") as file:
+            file.write(header)
+            # Reserve the pixel block up front (sparse where the filesystem allows it).
+            file.truncate(self._offset + elements * self._dtype.itemsize)
+        self._handle = open(self._temporary_path, "r+b")
+        self._map = mmap.mmap(self._handle.fileno(), 0)
+        self._block = np.frombuffer(self._map, self._dtype, elements, self._offset).reshape(tuple(shape))
+
+    def _write_block(self, index: tuple[slice, ...], values: np.ndarray) -> None:
+        """Land ``values`` at ``index`` of the raw block and release the pages they landed on."""
+        region = self._block[index]
+        region[...] = values
+        if _MADV_DONTNEED is None:
+            return
+        first = self._offset + region.__array_interface__["data"][0] - self._block.ctypes.data
+        span = sum((extent - 1) * stride for extent, stride in zip(region.shape, region.strides, strict=True))
+        page = first - first % mmap.PAGESIZE
+        with contextlib.suppress(OSError):  # a filesystem whose pages cannot be dropped keeps them
+            self._map.madvise(_MADV_DONTNEED, page, first + span + region.itemsize - page)
+
+    def _close(self, success: bool) -> None:
+        self._map.flush()
+        del self._block  # an exported buffer keeps the map open, and the map must close before the file
+        self._map.close()
+        self._handle.close()
+        if success:
+            os.replace(self._temporary_path, self.path)
+        else:
+            os.remove(self._temporary_path)
+
+
 # NIfTI-1 datatype code for each NumPy dtype a streamed .nii can hold.
 _NIFTI_DATATYPES = {
     "uint8": 2,
@@ -1232,20 +1287,17 @@ _NIFTI_DATATYPES = {
 }
 
 
-class _NiftiDataStream(DataStream):
-    """Uncompressed NIfTI-1 written region by region: a hand-written 348-byte header, then a memmap
-    over the raw block. NIfTI's data order is x fastest with the vector dimension SLOWEST, which is
-    exactly the channel-first ``[C, Z, Y, X]`` layout in C order: the map is the block itself.
+class _NiftiDataStream(_RawBlockStream):
+    """Uncompressed NIfTI-1 written region by region: a hand-written 348-byte header, then the raw
+    block. NIfTI's data order is x fastest with the vector dimension SLOWEST, which is exactly the
+    channel-first ``[C, Z, Y, X]`` layout in C order: the block is the region index itself.
     The sform carries the geometry, and NIfTI speaks RAS where the pipeline speaks LPS: the
     affine's first two rows are negated on the way out, the one convention this class owns."""
 
     def __init__(self, path: str, shape: list[int], dtype: np.dtype, attributes: Attribute) -> None:
-        self.path = path
-        self.published_path = Path(path)
-        self._temporary_path = f"{path}.{self.temporary_suffix()}"
         channels, spatial = int(shape[0]), [int(extent) for extent in shape[1:]]
         # The header is written little-endian, so the block must be too.
-        self._dtype = np.dtype(dtype).newbyteorder("<")
+        block_dtype = np.dtype(dtype).newbyteorder("<")
         rank = len(spatial)  # 2 or 3: a 2-D image is a NIfTI of two dims, its third axis a 1
         size_xyz = [*spatial[::-1], *[1] * (3 - rank)]
         spacing = np.ones(3)
@@ -1261,8 +1313,8 @@ class _NiftiDataStream(DataStream):
         struct.pack_into("<8h", header, 40, rank if channels == 1 else 5, *size_xyz, 1, channels, 1, 1)
         if channels > 1:
             struct.pack_into("<h", header, 68, 1007)  # NIFTI_INTENT_VECTOR
-        struct.pack_into("<h", header, 70, _NIFTI_DATATYPES[self._dtype.name])
-        struct.pack_into("<h", header, 72, 8 * self._dtype.itemsize)
+        struct.pack_into("<h", header, 70, _NIFTI_DATATYPES[block_dtype.name])
+        struct.pack_into("<h", header, 72, 8 * block_dtype.itemsize)
         struct.pack_into("<8f", header, 76, 1.0, *(float(part) for part in spacing), 1.0, 1.0, 1.0, 1.0)
         struct.pack_into("<f", header, 108, 352.0)  # vox_offset: the header plus the empty-extension flag
         struct.pack_into("<2f", header, 112, 1.0, 0.0)  # scl_slope / scl_inter: identity
@@ -1272,26 +1324,10 @@ class _NiftiDataStream(DataStream):
         struct.pack_into("<4f", header, 296, *(float(part) for part in affine[1]))
         struct.pack_into("<4f", header, 312, *(float(part) for part in affine[2]))
         header[344:348] = b"n+1\x00"
-        total = int(np.prod([channels, *spatial], dtype=np.int64)) * self._dtype.itemsize
-        with open(self._temporary_path, "wb") as file:
-            file.write(bytes(header))
-            file.write(b"\x00\x00\x00\x00")  # no extensions
-            # Reserve the pixel block up front (sparse where the filesystem allows it).
-            file.truncate(352 + total)
-        self._memmap = np.memmap(
-            self._temporary_path, dtype=self._dtype, mode="r+", offset=352, shape=(channels, *spatial)
-        )
+        super().__init__(path, bytes(header) + b"\x00\x00\x00\x00", block_dtype, (channels, *spatial))
 
     def write_slice(self, slices: tuple[slice, ...], data: np.ndarray) -> None:
-        self._memmap[slices] = data
-
-    def _close(self, success: bool) -> None:
-        self._memmap.flush()
-        del self._memmap
-        if success:
-            os.replace(self._temporary_path, self.path)
-        else:
-            os.remove(self._temporary_path)
+        self._write_block(slices, data)
 
 
 # MetaImage ElementType for each NumPy dtype a streamed .mha can hold.
@@ -1309,18 +1345,15 @@ _MHA_ELEMENT_TYPES = {
 }
 
 
-class _MhaDataStream(DataStream):
-    """Uncompressed local-data MetaImage written region by region: a hand-written ASCII header, then a
-    memmap over the flat raw block. MetaIO stores vector pixels interleaved (channel fastest), so the
-    map is spatial-first ``[.., Y, X, C]`` and ``write_slice`` moves the channel axis last."""
+class _MhaDataStream(_RawBlockStream):
+    """Uncompressed local-data MetaImage written region by region: a hand-written ASCII header, then
+    the flat raw block. MetaIO stores vector pixels interleaved (channel fastest), so the block is
+    spatial-first ``[.., Y, X, C]`` and ``write_slice`` moves the channel axis last."""
 
     def __init__(self, path: str, shape: list[int], dtype: np.dtype, attributes: Attribute) -> None:
-        self.path = path
-        self.published_path = Path(path)
-        self._temporary_path = f"{path}.{self.temporary_suffix()}"
         spatial = list(shape[1:])
-        # The header declares BinaryDataByteOrderMSB=False, so the map must be explicitly little-endian.
-        self._dtype = np.dtype(dtype).newbyteorder("<")
+        # The header declares BinaryDataByteOrderMSB=False, so the block must be explicitly little-endian.
+        block_dtype = np.dtype(dtype).newbyteorder("<")
         fields: list[tuple[str, str]] = [
             ("ObjectType", "Image"),
             ("NDims", str(len(spatial))),
@@ -1342,26 +1375,12 @@ class _MhaDataStream(DataStream):
             fields.append(("ElementNumberOfChannels", str(shape[0])))
         # Attribute entries ride along as MetaIO user fields, like WriteImage embeds image metadata.
         fields += [(k, str(v)) for k, v in attributes.items() if str(v) and "\n" not in str(v) and " " not in k]
-        fields += [("ElementType", _MHA_ELEMENT_TYPES[self._dtype.name]), ("ElementDataFile", "LOCAL")]
+        fields += [("ElementType", _MHA_ELEMENT_TYPES[block_dtype.name]), ("ElementDataFile", "LOCAL")]
         header = "".join(f"{key} = {value}\n" for key, value in fields).encode("utf-8")
-        with open(self._temporary_path, "wb") as file:
-            file.write(header)
-            # Reserve the pixel block up front (sparse where the filesystem allows it).
-            file.truncate(len(header) + int(np.prod([*spatial, shape[0]], dtype=np.int64)) * self._dtype.itemsize)
-        self._memmap = np.memmap(
-            self._temporary_path, dtype=self._dtype, mode="r+", offset=len(header), shape=(*spatial, shape[0])
-        )
+        super().__init__(path, header, block_dtype, (*spatial, shape[0]))
 
     def write_slice(self, slices: tuple[slice, ...], data: np.ndarray) -> None:
-        self._memmap[(*slices[1:], slices[0])] = np.moveaxis(data, 0, -1)
-
-    def _close(self, success: bool) -> None:
-        self._memmap.flush()
-        del self._memmap
-        if success:
-            os.replace(self._temporary_path, self.path)
-        else:
-            os.remove(self._temporary_path)
+        self._write_block((*slices[1:], slices[0]), np.moveaxis(data, 0, -1))
 
 
 class _OmeZarrDataStream(DataStream):

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -56,6 +56,7 @@ except ImportError:
 
 from konfai import current_date
 from konfai.utils import uri
+from konfai.utils.budget import format_bytes, per_rank_budget_bytes
 from konfai.utils.errors import DatasetManagerError
 from konfai.utils.utils import SUPPORTED_EXTENSIONS, directory_volume_form, is_store_name, split_format_level
 
@@ -376,23 +377,44 @@ class Attribute(dict[str, Any]):
         return key in self and self[key] == value
 
 
-#: Elements a block of ``Dataset.iter_data_blocks`` holds: the read grain of a scan (the statistics
-#: fold, the quantile scan), whatever the backend.
+#: Elements a block of ``Dataset.iter_data_blocks`` holds when no budget was declared: the read grain
+#: of a scan (the statistics fold, the quantile scan), whatever the backend.
 _STATISTICS_CHUNK_ELEMENTS = 8_000_000
+#: Blocks a scan holds at its peak: the map of the one being read, its copy, and the copy the fold has
+#: not released yet, a generator reading the next while its caller still names the last. Measured at
+#: 95.6 MiB of resident set for a 30.5 MiB block over a 78 MiB case.
+_STATISTICS_BLOCKS_IN_FLIGHT = 3
+#: The bytes a scanned element is priced at, as everything else the budget sizes prices them.
+_STATISTICS_ELEMENT_BYTES = 4
 #: Elements one running-statistics update takes at once: its float64 temporaries then stay in cache,
 #: where a whole block's stream through memory. Below the block on purpose: the block is the READ
 #: grain, and a chunked store decodes a chunk once per read that touches it.
 _STATISTICS_UPDATE_ELEMENTS = 1 << 18
 
 
-def _statistics_chunk_length(shape: list[int] | tuple[int, ...], axis: int, budget: int) -> int:
-    """How far along ``axis`` a chunk may reach to hold about ``budget`` elements.
-
-    A chunk spans every other axis whole (channels included), so the per-step cost is the volume
-    divided by ``axis``; the length is that budget over the per-step cost, floored to one step.
+def _statistics_block_elements() -> int:
+    """Elements one block of a whole-volume scan may hold: its share of the budget this rank
+    published, since :data:`_STATISTICS_BLOCKS_IN_FLIGHT` of them are in flight at the peak. A fixed
+    read grain made a scan cost the same 95.6 MiB whatever the budget said. Without a declared
+    budget, the grain that keeps a chunked store's decode whole.
     """
-    per_step = int(np.prod([extent for other, extent in enumerate(shape) if other != axis], dtype=np.int64))
-    return max(1, budget // max(1, per_step))
+    budget = per_rank_budget_bytes()
+    if budget is None:
+        return _STATISTICS_CHUNK_ELEMENTS
+    return max(
+        1, min(_STATISTICS_CHUNK_ELEMENTS, int(budget / (_STATISTICS_BLOCKS_IN_FLIGHT * _STATISTICS_ELEMENT_BYTES)))
+    )
+
+
+def _statistics_plane_elements(shape: list[int] | tuple[int, ...], axis: int) -> int:
+    """What one step along ``axis`` costs: a chunk spans every other axis whole (channels included)."""
+    return int(np.prod([extent for other, extent in enumerate(shape) if other != axis], dtype=np.int64))
+
+
+def _statistics_chunk_length(shape: list[int] | tuple[int, ...], axis: int, budget: int) -> int:
+    """How far along ``axis`` a chunk may reach to hold about ``budget`` elements: that budget over
+    the per-step cost, floored to one step."""
+    return max(1, budget // max(1, _statistics_plane_elements(shape, axis)))
 
 
 def _update_pieces(block: np.ndarray) -> Iterator[np.ndarray]:
@@ -1228,10 +1250,10 @@ class _RawBlockStream(DataStream):
     the block through a map whose pages this process does not keep.
 
     A shared file mapping holds every page written through it resident until it is unmapped, so a
-    stream over a volume ends up holding the whole volume, budget or no budget: +87 MiB of resident
-    set over a 78 MiB .mha swept in ten regions. Each written region is handed back to the kernel
-    instead (``MADV_DONTNEED``), which leaves the bytes in the page cache to be written out and
-    takes them out of this process's resident set: +8 MiB, one region's worth, over the same sweep.
+    stream over a volume ends up holding the whole volume, budget or no budget: 64 MiB of resident
+    growth over a 64 MiB volume written in sixteen slabs. Each written region is handed back to the
+    kernel instead (``MADV_DONTNEED``), which leaves the bytes in the page cache to be written out
+    and takes them out of this process's resident set: 0 MiB over the same sixteen slabs.
     """
 
     def __init__(self, path: str, header: bytes, dtype: np.dtype, shape: Sequence[int]) -> None:
@@ -1255,7 +1277,7 @@ class _RawBlockStream(DataStream):
         region[...] = values
         if _MADV_DONTNEED is None:
             return
-        first = self._offset + region.__array_interface__["data"][0] - self._block.ctypes.data
+        first = self._offset + region.ctypes.data - self._block.ctypes.data
         span = sum((extent - 1) * stride for extent, stride in zip(region.shape, region.strides, strict=True))
         page = first - first % mmap.PAGESIZE
         with contextlib.suppress(OSError):  # a filesystem whose pages cannot be dropped keeps them
@@ -3271,7 +3293,20 @@ class Dataset:
                 yield resident[0]
 
             return whole
-        rows = _statistics_chunk_length(shape, 1, _STATISTICS_CHUNK_ELEMENTS)
+        # A whole number of update pieces, so the fold sees the same sequence of pieces in the same
+        # order whatever the read grain: the running mean and std are then the budget's business
+        # only in how much is held, never in what they answer.
+        piece = _statistics_chunk_length(shape, 1, _STATISTICS_UPDATE_ELEMENTS)
+        rows = max(piece, _statistics_chunk_length(shape, 1, _statistics_block_elements()) // piece * piece)
+        budget = per_rank_budget_bytes()
+        plane = _statistics_plane_elements(shape, 1)
+        held = rows * plane * _STATISTICS_BLOCKS_IN_FLIGHT * _STATISTICS_ELEMENT_BYTES
+        if budget is not None and held > budget:
+            raise DatasetManagerError(
+                f"'{name}': the shortest block a whole-volume scan of '{groups}' can read holds"
+                f" {format_bytes(held)}, over the per-rank memory budget ({format_bytes(budget)}).",
+                "Raise 'memory_budget'.",
+            )
 
         def slabs() -> Iterator[np.ndarray]:
             for start in range(0, int(shape[1]), rows):

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -1614,6 +1614,22 @@ def _pixel_block(path: str) -> _PixelBlock | None:
     return _pixel_block_at(path, (info.st_mtime_ns, info.st_size))
 
 
+def _mapped_band(path: str, dtype: np.dtype, offset: int, shape: Sequence[int], axis: int, index: slice) -> np.ndarray:
+    """The raw block mapped over ``index`` of ``axis`` alone, the axes above it holding one element
+    each, indexed as the block is.
+
+    Mapping the block whole makes the address space a run needs follow the file's size rather than
+    the budget its regions were sized against: 400 MiB of peak address space for a 128 MiB budget on
+    a 156 MiB source against 256 MiB on the same run at 78 MiB. Only the outermost axis holding more
+    than one element narrows the map: a region spanning it whole reaches from the block's first
+    plane to its last whatever the axes below select.
+    """
+    plane = int(np.prod(shape[axis + 1 :], dtype=np.int64)) * dtype.itemsize
+    start = int(index.start or 0)
+    rows = (int(shape[axis]) if index.stop is None else int(index.stop)) - start
+    return np.memmap(path, dtype, "r", offset + start * plane, (*shape[:axis], rows, *shape[axis + 1 :]))
+
+
 def _pixel_block_region(block: _PixelBlock, path: str, normalized: tuple[slice, ...]) -> np.ndarray:
     """One region off the raw block, channel-first and in the native byte order: the bytes ITK
     would decode, read through a memmap that touches the region's pages and no other.
@@ -1621,11 +1637,16 @@ def _pixel_block_region(block: _PixelBlock, path: str, normalized: tuple[slice, 
     A copy, always: a slab of whole planes is contiguous on the map, and an array that only
     guaranteed contiguity would be the map's own pages, read-only and unmapped with the map."""
     if block.interleaved:
-        mapped = np.memmap(path, block.dtype, "r", block.offset, (*block.shape[1:], block.shape[0]))
-        region = np.moveaxis(mapped[(*normalized[1:], normalized[0])], -1, 0)
+        # MetaIO's channel axis is the fastest, so the block is spatial-first.
+        shape, index = [*block.shape[1:], block.shape[0]], [*normalized[1:], normalized[0]]
     else:
-        mapped = np.memmap(path, block.dtype, "r", block.offset, block.shape)
-        region = mapped[normalized]
+        shape, index = list(block.shape), list(normalized)
+    axis = next((k for k, extent in enumerate(shape) if extent > 1), 0)
+    mapped = _mapped_band(path, block.dtype, block.offset, shape, axis, index[axis])
+    # The band starts where its own slice does, so of that slice only the step still reads on it.
+    region = mapped[(*index[:axis], slice(None, None, index[axis].step), *index[axis + 1 :])]
+    if block.interleaved:
+        region = np.moveaxis(region, -1, 0)
     return np.array(region, dtype=block.dtype.newbyteorder("="), order="C")
 
 

--- a/konfai/utils/ome_zarr.py
+++ b/konfai/utils/ome_zarr.py
@@ -441,8 +441,10 @@ class _DecodedChunkCache:
 
 
 #: The least the cache is worth: below a chunk or two of a large store, a region touching more
-#: chunks than it holds decodes them again. Kept while the budget allows it; a budget under it is
-#: not exceeded for the cache's sake, and the plan says the cache is under the floor.
+#: chunks than it holds decodes them again. It is what an undeclared budget's share is raised to; a
+#: declared budget never gives the cache more than its share, and the plan says when that is under
+#: the floor. A cache allowed the floor out of a 128 MiB budget took the budget whole, while the
+#: sweep went on sizing its regions against the same 128 MiB: the run was priced at 2x its budget.
 CHUNK_CACHE_FLOOR = 256 << 20
 #: The share of a DECLARED per-rank budget the cache may take. A third, because a budget is spent on
 #: what the chain holds as well, and the cache is the cheapest of the three to give up.
@@ -466,14 +468,13 @@ def set_chunk_cache_budget(budget_bytes: float | None) -> int:
 
 
 def _chunk_cache_capacity() -> int:
-    """What the cache may hold: a third of the declared budget, the floor where a third is under it,
-    the budget itself where even the floor is over it; a share of what this process may allocate
-    when nothing was declared."""
+    """What the cache may hold: its share of the declared budget, never more, so a budget under the
+    floor bounds the cache instead of the floor taking the budget whole; a share of what this process
+    may allocate when nothing was declared, where the floor is what makes the cache worth having."""
     from konfai.utils.budget import available_memory_bytes
 
     if _chunk_cache_budget is not None:
-        share = int(_chunk_cache_budget * _CHUNK_CACHE_BUDGET_SHARE)
-        return min(_chunk_cache_budget, max(CHUNK_CACHE_FLOOR, share))
+        return int(_chunk_cache_budget * _CHUNK_CACHE_BUDGET_SHARE)
     return max(CHUNK_CACHE_FLOOR, int(available_memory_bytes()[0] * 0.05))
 
 

--- a/konfai/utils/ome_zarr.py
+++ b/konfai/utils/ome_zarr.py
@@ -450,31 +450,25 @@ CHUNK_CACHE_FLOOR = 256 << 20
 #: what the chain holds as well, and the cache is the cheapest of the three to give up.
 _CHUNK_CACHE_BUDGET_SHARE = 1 / 3
 
-_chunk_cache_budget: int | None = None
 
-
-def set_chunk_cache_budget(budget_bytes: float | None) -> int:
-    """Bound the decoded-chunk cache by the run's per-rank memory budget, and answer the capacity
-    it has from now on: the cache is part of what the process holds, so it never exceeds the
-    budget. ``None``, or no call at all, leaves it the share of free RAM an undeclared budget means
-    everywhere else.
-    """
-    global _chunk_cache_budget
-    _chunk_cache_budget = int(budget_bytes) if budget_bytes and budget_bytes > 0 else None
-    capacity = _chunk_cache_capacity()
+def bound_chunk_cache() -> int:
+    """Resize the decoded-chunk cache to the budget this rank published
+    (:func:`~konfai.utils.budget.set_per_rank_budget`) and answer its capacity from now on."""
+    capacity = chunk_cache_capacity()
     if _CHUNK_CACHE is not None:
         _CHUNK_CACHE.set_capacity(capacity)
     return capacity
 
 
-def _chunk_cache_capacity() -> int:
+def chunk_cache_capacity() -> int:
     """What the cache may hold: its share of the declared budget, never more, so a budget under the
     floor bounds the cache instead of the floor taking the budget whole; a share of what this process
     may allocate when nothing was declared, where the floor is what makes the cache worth having."""
-    from konfai.utils.budget import available_memory_bytes
+    from konfai.utils.budget import available_memory_bytes, per_rank_budget_bytes
 
-    if _chunk_cache_budget is not None:
-        return int(_chunk_cache_budget * _CHUNK_CACHE_BUDGET_SHARE)
+    declared = per_rank_budget_bytes()
+    if declared is not None:
+        return int(declared * _CHUNK_CACHE_BUDGET_SHARE)
     return max(CHUNK_CACHE_FLOOR, int(available_memory_bytes()[0] * 0.05))
 
 
@@ -484,7 +478,7 @@ _CHUNK_CACHE: _DecodedChunkCache | None = None
 def _chunk_cache() -> _DecodedChunkCache:
     global _CHUNK_CACHE
     if _CHUNK_CACHE is None:
-        _CHUNK_CACHE = _DecodedChunkCache(_chunk_cache_capacity())
+        _CHUNK_CACHE = _DecodedChunkCache(chunk_cache_capacity())
     return _CHUNK_CACHE
 
 

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -66,7 +66,7 @@ from konfai import (
     transforms_directory,
 )
 from konfai.utils import State  # also the re-export ``konfai.utils.runtime.State`` callers import
-from konfai.utils.budget import available_cpus, node_local_ranks
+from konfai.utils.budget import available_cpus, node_local_ranks, set_per_rank_budget
 from konfai.utils.errors import ConfigError, KonfAIError
 from konfai.utils.utils import env_flag
 
@@ -843,11 +843,12 @@ class DistributedObject(ABC):
         Set here, on the rank: a spawned rank is a new process, and a bound set by the launcher is
         a module global the child never sees.
         """
-        from konfai.utils.ome_zarr import set_chunk_cache_budget
+        from konfai.utils.ome_zarr import bound_chunk_cache
 
         dataset = getattr(self, "dataset", None)
         if dataset is not None and hasattr(dataset, "resolved_budget"):
-            set_chunk_cache_budget(dataset.resolved_budget().per_rank_bytes(node_local_ranks(world_size)))
+            set_per_rank_budget(dataset.resolved_budget().per_rank_bytes(node_local_ranks(world_size)))
+            bound_chunk_cache()
 
     def __call__(self, rank: int | None = None) -> None:
         world_size = self.world_size

--- a/tests/unit/test_data_stream.py
+++ b/tests/unit/test_data_stream.py
@@ -19,6 +19,7 @@ indistinguishable from a whole-volume ``write``, remove partial entries on failu
 that cannot serve region writes."""
 
 import os
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -632,3 +633,32 @@ def test_a_live_writers_backup_is_left_alone(tmp_path: Path, file_format: str) -
 
     fresh = Dataset(tmp_path / "store", file_format)
     assert not fresh.is_dataset_exist("CT", "CASE_001")
+
+
+def _resident_bytes() -> int:
+    for line in Path("/proc/self/status").read_text().splitlines():
+        if line.startswith("VmRSS"):
+            return int(line.split()[1]) * 1024
+    return 0
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="/proc/self/status is Linux's")
+@pytest.mark.parametrize("file_format", ["mha", "nii"])
+def test_a_raw_block_stream_does_not_hold_what_it_has_written(tmp_path: Path, file_format: str) -> None:
+    """A written region goes to the page cache, not to this process's resident set: a shared map
+    keeps every page written through it until it is unmapped, which makes a stream of a volume hold
+    the volume whatever budget sized its regions."""
+    slab = np.full((1, 4, 512, 512), 3.5, dtype=np.float32)  # 4 MiB, sixteen of them
+    volume = [1, 16 * slab.shape[1], *slab.shape[2:]]
+    dataset = Dataset(tmp_path / "streamed", file_format)
+    stream = dataset.open_data_stream("CT", "CASE_001", volume, slab.dtype, _image_attributes())
+    assert stream is not None
+    with stream:
+        before = _resident_bytes()
+        for start in range(0, volume[1], slab.shape[1]):
+            spatial = (slice(start, start + slab.shape[1]), slice(0, volume[2]), slice(0, volume[3]))
+            stream.write_slice((slice(0, 1), *spatial), slab)
+        held = _resident_bytes() - before
+
+    assert held < 4 * slab.nbytes, f"held {held / (1 << 20):.0f} MiB of a {16 * slab.nbytes / (1 << 20):.0f} MiB volume"
+    np.testing.assert_array_equal(dataset.read_data("CT", "CASE_001")[0], np.broadcast_to(3.5, volume))

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1137,6 +1137,32 @@ def test_a_full_plane_region_off_the_raw_block_owns_its_bytes(tmp_path: Path, ki
     np.testing.assert_array_equal(tensor.numpy(), data[region] + 1)
 
 
+#: A three-plane slab of the twelve-plane fixture, as a share of the block the read must map. A
+#: NIfTI vector volume stores each channel whole, one after the other, so a slab of it reaches from
+#: the first channel's first plane to the last channel's last: the span IS the block.
+_SLAB_SHARE_OF_THE_BLOCK = {"scalar.mha": 0.25, "scalar.nii": 0.25, "vector.mha": 0.25, "vector.nii": 1.0}
+
+
+@pytest.mark.parametrize("kind", sorted(_SLAB_SHARE_OF_THE_BLOCK))
+def test_a_region_read_maps_the_smallest_span_that_holds_it(tmp_path: Path, kind: str, monkeypatch) -> None:
+    """The address space a run needs follows the regions its budget sized, not the source's size."""
+    path, data = _write_block_fixture(tmp_path, kind)
+    mapped: list[int] = []
+    original = np.memmap
+
+    def spy(*args, **kwargs):
+        block = original(*args, **kwargs)
+        mapped.append(block.nbytes)
+        return block
+
+    monkeypatch.setattr(np, "memmap", spy)
+    region = (slice(None), slice(2, 5), slice(None), slice(None))
+    got, _ = _block_backend(path).file_to_data_slice("", path.name.split(".", 1)[0], region)
+
+    np.testing.assert_array_equal(got, data[region])
+    assert mapped == [int(data.nbytes * _SLAB_SHARE_OF_THE_BLOCK[kind])]
+
+
 def test_image_to_data_owns_the_vector_image_bytes_whatever_its_size() -> None:
     """A vector image of one voxel is contiguous however its axes are moved: the array must still be
     a copy, not a view into a buffer the image takes with it."""

--- a/tests/unit/test_dataset_statistics.py
+++ b/tests/unit/test_dataset_statistics.py
@@ -28,6 +28,7 @@ from typing import Any
 import numpy as np
 import pytest
 from konfai.utils import dataset as dataset_module
+from konfai.utils.budget import set_per_rank_budget
 from konfai.utils.dataset import (
     Dataset,
     _finalize_running_statistics,
@@ -35,6 +36,7 @@ from konfai.utils.dataset import (
     _update_pieces,
     _update_running_statistics,
 )
+from konfai.utils.errors import DatasetManagerError
 
 sitk = pytest.importorskip("SimpleITK")
 
@@ -325,3 +327,76 @@ def test_a_block_is_folded_in_pieces_along_its_first_spatial_axis(monkeypatch: p
     assert all(np.shares_memory(piece, block) for piece in pieces)
     vector = _volume((50,))
     assert [piece.shape for piece in _update_pieces(vector)] == [(50,)]
+
+
+# ---------------------------------------------------------------- the budget is the read grain
+
+
+@pytest.fixture
+def budgeted_scan(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pieces of about a hundred elements, so a block of the small volumes below snaps to whole rows
+    rather than to the one piece the whole volume is; and the published budget put back after."""
+    monkeypatch.setattr(dataset_module, "_STATISTICS_UPDATE_ELEMENTS", 100)
+    yield
+    set_per_rank_budget(None)
+
+
+def _scan_blocks(dataset: Dataset, monkeypatch: pytest.MonkeyPatch) -> list[tuple[int, ...]]:
+    """The shapes a scan of ``CT/P0`` reads, and the statistics it answers with."""
+    blocks: list[tuple[int, ...]] = []
+    real = Dataset.read_data_slice
+
+    def counted(self: Dataset, groups: str, name: str, slices: tuple[slice, ...]) -> Any:
+        data, attributes = real(self, groups, name, slices)
+        blocks.append(data.shape)
+        return data, attributes
+
+    monkeypatch.setattr(Dataset, "read_data_slice", counted)
+    return blocks
+
+
+def test_a_declared_budget_is_what_the_scan_reads_a_block_of(
+    tmp_path: Path, image_attributes, monkeypatch: pytest.MonkeyPatch, budgeted_scan: None
+) -> None:
+    """A fixed read grain made a whole-volume scan cost the same whatever the budget said: 95.6 MiB
+    of resident set over a 78 MiB case at 512, 128 and 32 MiB alike."""
+    dataset = Dataset(tmp_path / "store", "mha")
+    dataset.write("CT", "P0", _volume((1, 64, 40, 40)), image_attributes([0.0, 0.0, 0.0], [1.0, 1.0, 1.0]))
+    read = {}
+    for budget in (None, 3 * 4 * 32 * 40 * 40, 3 * 4 * 8 * 40 * 40):
+        set_per_rank_budget(budget)
+        blocks = _scan_blocks(dataset, monkeypatch)
+        dataset.read_data_statistics("CT", "P0")
+        read[budget] = max(shape[1] for shape in blocks)
+
+    assert read[3 * 4 * 8 * 40 * 40] < read[3 * 4 * 32 * 40 * 40] <= read[None]
+
+
+def test_the_scan_answers_the_same_whatever_the_budget_read_it_in(
+    tmp_path: Path, image_attributes, budgeted_scan: None
+) -> None:
+    """The budget is how much is held, never what is computed: the fold sees the same pieces in the
+    same order whatever the read grain, because a block is a whole number of them."""
+    dataset = Dataset(tmp_path / "store", "mha")
+    dataset.write("CT", "P0", _volume((1, 64, 40, 40)), image_attributes([0.0, 0.0, 0.0], [1.0, 1.0, 1.0]))
+    set_per_rank_budget(None)
+    reference = dataset.read_data_statistics("CT", "P0")
+
+    for budget in (3 * 4 * 32 * 40 * 40, 3 * 4 * 8 * 40 * 40, 3 * 4 * 4 * 40 * 40):
+        set_per_rank_budget(budget)
+        got = dataset.read_data_statistics("CT", "P0")
+        for key in _KEYS:
+            np.testing.assert_array_equal(got[key], reference[key], err_msg=f"{key} at {budget} B")
+
+
+def test_a_budget_the_shortest_block_of_a_scan_exceeds_is_refused(
+    tmp_path: Path, image_attributes, budgeted_scan: None
+) -> None:
+    """The floor of the read grain is the fold's own piece, so a budget under it refuses naming both
+    figures rather than reading a block it cannot hold."""
+    dataset = Dataset(tmp_path / "store", "mha")
+    dataset.write("CT", "P0", _volume((1, 64, 40, 40)), image_attributes([0.0, 0.0, 0.0], [1.0, 1.0, 1.0]))
+    set_per_rank_budget(4096)
+
+    with pytest.raises(DatasetManagerError, match=r"over the per-rank memory budget \(4.00 KiB\)"):
+        dataset.read_data_statistics("CT", "P0")

--- a/tests/unit/test_memory_budget.py
+++ b/tests/unit/test_memory_budget.py
@@ -31,7 +31,7 @@ from konfai.data.data_manager import (
     DataTrain,
 )
 from konfai.utils import budget, runtime
-from konfai.utils.budget import AUTO_MEMORY_SAFETY_FRACTION, parse_memory_budget_bytes
+from konfai.utils.budget import AUTO_MEMORY_SAFETY_FRACTION, parse_memory_budget_bytes, set_per_rank_budget
 from konfai.utils.errors import ConfigError
 
 # --------------------------------------------------------------------------------------
@@ -497,7 +497,8 @@ def _chunk_cache_restored():
     from konfai.utils import ome_zarr
 
     yield
-    ome_zarr.set_chunk_cache_budget(None)
+    set_per_rank_budget(None)
+    ome_zarr.bound_chunk_cache()
 
 
 @pytest.mark.parametrize(
@@ -516,7 +517,8 @@ def test_the_chunk_cache_takes_a_third_of_a_declared_budget_and_no_floor_raises_
     budget, the sweep going on sizing its regions against the same 128 MiB."""
     from konfai.utils import ome_zarr
 
-    assert ome_zarr.set_chunk_cache_budget(declared) == capacity
+    set_per_rank_budget(declared)
+    assert ome_zarr.bound_chunk_cache() == capacity
     assert ome_zarr._chunk_cache().capacity == capacity
 
 
@@ -526,7 +528,8 @@ def test_an_undeclared_budget_leaves_the_chunk_cache_its_share_of_free_ram(
     from konfai.utils import ome_zarr
 
     monkeypatch.setattr(budget, "available_memory_bytes", lambda: (100 * 2**30, "host"))
-    assert ome_zarr.set_chunk_cache_budget(None) == 5 * 2**30
+    set_per_rank_budget(None)
+    assert ome_zarr.bound_chunk_cache() == 5 * 2**30
 
 
 _WORKFLOW_ENV = (
@@ -709,11 +712,13 @@ def test_a_declared_budget_bounds_the_chunk_cache_in_prediction_and_evaluation(
         monkeypatch.delenv(key)
     _tiny_cohort(tmp_path)
 
-    ome_zarr.set_chunk_cache_budget(None)
+    set_per_rank_budget(None)
+    ome_zarr.bound_chunk_cache()
     assert ome_zarr._chunk_cache().capacity >= ome_zarr.CHUNK_CACHE_FLOOR
     _build_evaluator(tmp_path, monkeypatch)
     assert ome_zarr._chunk_cache().capacity == (64 << 20) // 3
 
-    ome_zarr.set_chunk_cache_budget(None)
+    set_per_rank_budget(None)
+    ome_zarr.bound_chunk_cache()
     _build_predictor(tmp_path, monkeypatch)
     assert ome_zarr._chunk_cache().capacity == (64 << 20) // 3

--- a/tests/unit/test_memory_budget.py
+++ b/tests/unit/test_memory_budget.py
@@ -503,16 +503,17 @@ def _chunk_cache_restored():
 @pytest.mark.parametrize(
     ("declared", "capacity"),
     [
-        (64 << 20, 64 << 20),  # under the floor: the budget itself, never more than it
-        (512 << 20, 256 << 20),  # a third would be under the floor: the floor
+        (64 << 20, (64 << 20) // 3),  # a third, well under the floor: the rest is the regions'
+        (512 << 20, (512 << 20) // 3),  # a third, still under the floor
         (3 << 30, 1 << 30),  # a third
     ],
 )
-def test_the_chunk_cache_takes_a_third_of_the_budget_and_never_more_than_it(
+def test_the_chunk_cache_takes_a_third_of_a_declared_budget_and_no_floor_raises_it(
     declared: int, capacity: int, _chunk_cache_restored: None
 ) -> None:
-    """The cache is part of what the process holds, so a budget it exceeded would be exceeded
-    before a region was read."""
+    """The cache is part of what the process holds, so a budget it exceeded would be exceeded before
+    a region was read; and a floor raising it to the whole budget priced a 128 MiB run at 2x its
+    budget, the sweep going on sizing its regions against the same 128 MiB."""
     from konfai.utils import ome_zarr
 
     assert ome_zarr.set_chunk_cache_budget(declared) == capacity
@@ -711,8 +712,8 @@ def test_a_declared_budget_bounds_the_chunk_cache_in_prediction_and_evaluation(
     ome_zarr.set_chunk_cache_budget(None)
     assert ome_zarr._chunk_cache().capacity >= ome_zarr.CHUNK_CACHE_FLOOR
     _build_evaluator(tmp_path, monkeypatch)
-    assert ome_zarr._chunk_cache().capacity == 64 << 20
+    assert ome_zarr._chunk_cache().capacity == (64 << 20) // 3
 
     ome_zarr.set_chunk_cache_budget(None)
     _build_predictor(tmp_path, monkeypatch)
-    assert ome_zarr._chunk_cache().capacity == 64 << 20
+    assert ome_zarr._chunk_cache().capacity == (64 << 20) // 3

--- a/tests/unit/test_memory_limit.py
+++ b/tests/unit/test_memory_limit.py
@@ -46,8 +46,8 @@ pytestmark = pytest.mark.skipif(
 #: Measured minima on the cohort below: 1.25x (PREDICTION), 1.9x (EVALUATION), 2.0x (TRANSFORM).
 _ADDRESS_SPACE_MULTIPLE = 3
 #: Resident bytes a route may hold above the interpreter floor, as a multiple of its declared budget
-#: and over the floor below. Measured over a 666 MiB interpreter floor: 0.67x (PREDICTION), 0.20x
-#: (TRANSFORM at 512 MiB), 0.79x (at 128), 0.67x (at 64), 1.31x (EVALUATION at 128), 0.55x (at 512).
+#: and over the floor below. Measured over a 667 MiB interpreter floor: 0.41x (PREDICTION at 128
+#: MiB), 0.33x / 1.05x / 1.17x (TRANSFORM at 512, 128, 64), 0.55x / 1.42x (EVALUATION at 512, 128).
 #: A whole-volume read of the cohort's case is 2 x 78 MiB before its working copies: over both.
 _RESIDENT_MULTIPLE = 2
 #: What a route holds that no budget shrinks: the workflow's objects, the chain's stages, the store

--- a/tests/unit/test_memory_limit.py
+++ b/tests/unit/test_memory_limit.py
@@ -21,10 +21,10 @@ past the cap fails where the process runs, not in a reader's judgement. The cap 
 floor measured here (torch + SimpleITK + the workflow modules, in an identically pinned
 environment) plus what the route is allowed above it, and the child reports the peak RSS it reached.
 
-Two ceilings, because they bound two different things. The address space carries the whole-file
-mapping every uncompressed-MetaImage region read creates (``_pixel_block_region``) on top of the
-working set, so it is the looser of the two; the resident set is the working set itself, and it is
-what a budget is about. A route that read a case whole instead of streaming it breaks both.
+Two ceilings, because they bound two different things. The address space carries the maps a region
+read and a region write hold on top of the working set, so it is the looser of the two; the resident
+set is the working set itself, and it is what a budget is about. A route that read a case whole
+instead of streaming it breaks both.
 """
 
 import json
@@ -45,10 +45,15 @@ pytestmark = pytest.mark.skipif(
 #: Address space a route may map above the interpreter floor, as a multiple of its declared budget.
 #: Measured minima on the cohort below: 1.25x (PREDICTION), 1.9x (EVALUATION), 2.0x (TRANSFORM).
 _ADDRESS_SPACE_MULTIPLE = 3
-#: Resident bytes a route may hold above the interpreter floor, same unit. Measured over a 666 MiB
-#: floor: 0.88x (PREDICTION), 1.35x (TRANSFORM), 1.31x (EVALUATION at 128 MiB), 0.55x (at 512 MiB).
+#: Resident bytes a route may hold above the interpreter floor, as a multiple of its declared budget
+#: and over the floor below. Measured over a 666 MiB interpreter floor: 0.67x (PREDICTION), 0.20x
+#: (TRANSFORM at 512 MiB), 0.79x (at 128), 0.67x (at 64), 1.31x (EVALUATION at 128), 0.55x (at 512).
 #: A whole-volume read of the cohort's case is 2 x 78 MiB before its working copies: over both.
 _RESIDENT_MULTIPLE = 2
+#: What a route holds that no budget shrinks: the workflow's objects, the chain's stages, the store
+#: handles, the allocator's slack. Measured at 25 to 27 MiB on this cohort, which is what
+#: ``konfai.data.patching.SWEEP_ENGINE_FLOOR_BYTES`` declares and the TRANSFORM plan's header prints.
+_ENGINE_FLOOR = 32 * (1 << 20)
 
 _MIB = 1 << 20
 #: 2 groups x 20.5 M voxels of float32: over the 17.9 M the 512 MiB sizing allows, so both budgets
@@ -133,7 +138,8 @@ def route():
     chain = [Resample(spacing=[2.0, 2.0, 2.0]), Gradient()]
     if whole:
         chain.append(Standardize())  # GLOBAL_STAT: no region serves it, the case goes whole-volume
-    out = ROOT / ("OutWhole" if whole else "Out")
+    # One output per run: an existing one is a resume, and a run that resumed would measure nothing.
+    out = ROOT / f"Out_{BUDGET.replace('!', '_')}"
     konfai.transform(
         "MEMORY_LIMIT",
         f"{ROOT / 'Dataset'}:mha",
@@ -286,10 +292,12 @@ def floor(cohort: Path) -> dict:
 
 def _within_its_budget(source: str, budget_bytes: int, floor: dict, cohort: Path) -> dict:
     """Run one route under the cap its budget earns it, and hold it to the resident ceiling."""
-    measured = _run(source, _cap(floor, _ADDRESS_SPACE_MULTIPLE * budget_bytes), f"{budget_bytes}b", cohort)
+    measured = _run(
+        source, _cap(floor, _ENGINE_FLOOR + _ADDRESS_SPACE_MULTIPLE * budget_bytes), f"{budget_bytes}b", cohort
+    )
     assert measured["outcome"] == "ok", measured["detail"]
     held = (measured["resident_kib"] - floor["resident_kib"]) * 1024
-    assert held <= _RESIDENT_MULTIPLE * budget_bytes, (
+    assert held <= _ENGINE_FLOOR + _RESIDENT_MULTIPLE * budget_bytes, (
         f"held {held / _MIB:.0f} MiB above the interpreter floor for a budget of {budget_bytes / _MIB:.0f} MiB"
     )
     return measured
@@ -304,13 +312,34 @@ def test_a_streamed_evaluation_holds_the_budget_it_declared(budget_mib: int, flo
     assert "disjoint patches" in measured["log"] and "halo of 3" in measured["log"]
 
 
-def test_a_streamed_transform_holds_the_budget_it_declared(floor: dict, cohort: Path) -> None:
-    """Resample (REGRID) then Gradient (HALO): a chain that streams, so the sweep sizes its slabs
-    from the budget and the case is never resident."""
-    _within_its_budget(_TRANSFORM, 128 * _MIB, floor, cohort)
+def test_a_streamed_transform_tracks_the_budget_it_declared(floor: dict, cohort: Path) -> None:
+    """Resample (REGRID) then Gradient (HALO): a chain that streams, so the sweep sizes its regions
+    from the budget and the case is never resident.
 
+    Not only inside the budget but FOLLOWING it. A sizing that priced the landed rows alone held the
+    same 173 MiB at 512, 128 and 32 MiB alike, because what this chain holds is what its regions pull
+    (four source voxels per landed one) and what Gradient allocates over them (eight volumes-worth),
+    neither of which the landed rows say anything about.
+    """
+    held = {}
+    for budget_mib in (512, 128, 64):
+        measured = _within_its_budget(_TRANSFORM, budget_mib * _MIB, floor, cohort)
+        held[budget_mib] = (measured["resident_kib"] - floor["resident_kib"]) * 1024
+
+    assert held[64] < held[128] < held[512], f"flat against the budget: {held}"
     plan = (cohort / "Transforms" / "MEMORY_LIMIT" / "log_0.txt").read_text(encoding="utf-8")
     assert "1 STREAM" in plan and "0 WHOLE-VOLUME" in plan
+
+
+def test_a_transform_refuses_a_budget_no_region_of_its_chain_fits(floor: dict, cohort: Path) -> None:
+    """The floor of the sizing is a refusal, not a one-row sweep: one row of this landing pulls four
+    rows of the source and Gradient allocates eight of them over it, so a 1 MiB budget buys nothing
+    and the message says what the smallest region holds."""
+    measured = _run(_TRANSFORM, _cap(floor, 256 * _MIB), "1MiB", cohort)
+
+    assert measured["outcome"] == "TransformerError", measured
+    assert "1.00 MiB" in measured["detail"] and "no region of 'CT' fits" in measured["detail"]
+    assert not (cohort / "Out_1MiB").exists(), "refused before a byte"
 
 
 def test_a_patched_prediction_holds_the_budget_it_declared(floor: dict, cohort: Path) -> None:
@@ -335,4 +364,4 @@ def test_a_transform_refuses_a_case_its_budget_cannot_hold_whole(floor: dict, co
 
     assert measured["outcome"] == "TransformerError", measured
     assert "1.00 MiB" in measured["detail"]
-    assert not (cohort / "OutWhole").exists(), "refused before a byte"
+    assert not (cohort / "Out_1MiB_whole").exists(), "refused before a byte"

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -29,9 +29,19 @@ import pytest
 import torch
 from konfai.metric.schedulers import Constant, PolyLRScheduler
 from konfai.network.blocks import Add
-from konfai.network.network import Measure, ModuleArgsDict, Network, _channels_last
+from konfai.network.network import CriterionsAttr, Measure, ModuleArgsDict, Network, _channels_last
 from konfai.utils.dataset import Attribute
 from konfai.utils.errors import ConfigError, MeasureError
+
+
+class _BatchItem:
+    """One group of a collated batch, as ``Network.forward`` reads it."""
+
+    def __init__(self, tensor: torch.Tensor, is_input: bool) -> None:
+        self.tensor = tensor
+        self.is_input = is_input
+        self.attribute = [Attribute()]
+
 
 # --------------------------------------------------------------------------------------
 # ModuleArgsDict branch routing (named_forward / forward)
@@ -351,14 +361,11 @@ def test_get_loss_pairs_every_accumulated_loss_with_its_own_weight_under_a_narro
 # --------------------------------------------------------------------------------------
 
 
-class _CriterionAttr:
-    def __init__(self) -> None:
-        self.start = 0
-        self.stop = None
-        self.schedulers = {Constant(1.0): 1}
-        self.group = 0
-        self.is_loss = True
-        self.accumulation = True
+def _criterion_attr(start: int = 0, accumulation: bool = False) -> CriterionsAttr:
+    """A criterion's wiring metadata with its schedulers resolved, as ``CriterionsLoader`` leaves it."""
+    attributes = CriterionsAttr(start=start, accumulation=accumulation)
+    attributes.schedulers = {Constant(): None}
+    return attributes
 
 
 def _make_accumulating_measure(scaler) -> tuple[Measure, torch.Tensor]:
@@ -366,7 +373,7 @@ def _make_accumulating_measure(scaler) -> tuple[Measure, torch.Tensor]:
     measure = Measure.__new__(Measure)
     criterion = torch.nn.MSELoss()
     key = f"out:tgt:{criterion.__class__.__name__}"
-    measure.outputs_criterions = {"out": {"tgt": {criterion: _CriterionAttr()}}}
+    measure.outputs_criterions = {"out": {"tgt": {criterion: _criterion_attr(accumulation=True)}}}
     measure._loss = {0: {key: Measure.Loss(criterion.__class__.__name__, "out", "tgt", 0, True, True)}}
     measure._targets = {}
     measure.scaler = scaler
@@ -401,12 +408,6 @@ def test_accumulation_backward_without_scaler_is_plain_backward() -> None:
     assert torch.count_nonzero(output.grad) > 0
 
 
-class _PlainLossAttr(_CriterionAttr):
-    def __init__(self) -> None:
-        super().__init__()
-        self.accumulation = False  # a normal, non-accumulation loss in the SAME numeric group
-
-
 def test_accumulation_backward_not_refired_by_plain_loss_in_same_group() -> None:
     """A plain (non-accumulation) loss sharing the numeric group must NOT re-fire the accumulation
     backward: the accumulated backward runs exactly once, for the accumulation loss itself."""
@@ -416,7 +417,10 @@ def test_accumulation_backward_not_refired_by_plain_loss_in_same_group() -> None
     measure = Measure.__new__(Measure)
     acc_crit = torch.nn.MSELoss()
     plain_crit = torch.nn.L1Loss()
-    measure.outputs_criterions = {"out": {"tgt": {acc_crit: _CriterionAttr(), plain_crit: _PlainLossAttr()}}}
+    # The plain loss is a normal, non-accumulation loss in the SAME numeric group.
+    measure.outputs_criterions = {
+        "out": {"tgt": {acc_crit: _criterion_attr(accumulation=True), plain_crit: _criterion_attr()}}
+    }
     measure._loss = {
         0: {
             f"out:tgt:{acc_crit.__class__.__name__}": Measure.Loss("MSELoss", "out", "tgt", 0, True, True),
@@ -776,8 +780,7 @@ def test_composite_criteria_are_scheduled_on_the_owning_networks_counter() -> No
     """A composite root never steps its own _it (only networks owning measure+optimizer do), so
     criteria scheduled on the root's counter freeze at 0: start/stop windows and loss-weight
     schedulers of a GAN never fire. Measure.update must receive the OWNING network's _it."""
-    from konfai.metric.schedulers import Constant
-    from konfai.network.network import CriterionsAttr, Measure
+    from konfai.network.network import Measure
 
     class Generator(Network):
         def __init__(self) -> None:
@@ -792,8 +795,7 @@ def test_composite_criteria_are_scheduled_on_the_owning_networks_counter() -> No
     root = Gan()
     sub = next(net for name, net in root.get_networks().items() if name.endswith(".Generator"))
     measure = Measure("Generator", {})
-    attr = CriterionsAttr()
-    attr.schedulers = {Constant(): None}
+    attr = _criterion_attr()
     measure.outputs_criterions = {"Generator.Head": {"CT": {torch.nn.L1Loss(): attr}}}
     measure.init(root, ["CT"])
     sub.measure = measure
@@ -811,13 +813,7 @@ def test_composite_criteria_are_scheduled_on_the_owning_networks_counter() -> No
 
     sub.measure.update = recording_update  # type: ignore[method-assign]
 
-    class _BatchItem:
-        def __init__(self, tensor):
-            self.tensor = tensor
-            self.is_input = True
-            self.attribute = [Attribute()]
-
-    batch = {"CT": _BatchItem(torch.ones(1, 1, 4, 4))}
+    batch = {"CT": _BatchItem(torch.ones(1, 1, 4, 4), True)}
     for _step in range(3):
         root.forward(batch)
         root.backward(root)
@@ -832,8 +828,7 @@ def test_a_target_group_is_moved_once_per_forward_and_not_for_a_criterion_outsid
     """Measure.update ran once per completed output group and moved the group's target each time: the
     shipped Segmentation config uploaded SEG twice per step, a deep-supervision config once per head,
     and a criterion outside its start/stop window still paid for the upload it never read."""
-    from konfai.metric.schedulers import Constant
-    from konfai.network.network import CriterionsAttr, Measure
+    from konfai.network.network import Measure
 
     class Net(Network):
         def __init__(self) -> None:
@@ -841,16 +836,13 @@ def test_a_target_group_is_moved_once_per_forward_and_not_for_a_criterion_outsid
             self.add_module("Logits", torch.nn.Conv2d(1, 3, 1))
             self.add_module("Softmax", torch.nn.Softmax(dim=1))
 
-    def attr(start: int = 0) -> CriterionsAttr:
-        attributes = CriterionsAttr(start=start)
-        attributes.schedulers = {Constant(): None}
-        return attributes
-
     model = Net()
     measure = Measure("Net", {})
     measure.outputs_criterions = {
-        "Logits": {"SEG": {torch.nn.CrossEntropyLoss(): attr(), torch.nn.MSELoss(): attr(start=5)}},
-        "Softmax": {"SEG": {torch.nn.L1Loss(): attr()}},
+        "Logits": {
+            "SEG": {torch.nn.CrossEntropyLoss(): _criterion_attr(), torch.nn.MSELoss(): _criterion_attr(start=5)}
+        },
+        "Softmax": {"SEG": {torch.nn.L1Loss(): _criterion_attr()}},
     }
     measure.init(model, ["SEG"])
     model.measure = measure
@@ -867,12 +859,6 @@ def test_a_target_group_is_moved_once_per_forward_and_not_for_a_criterion_outsid
 
     monkeypatch.setattr(torch.Tensor, "to", counting_to)
 
-    class _BatchItem:
-        def __init__(self, tensor: torch.Tensor, is_input: bool) -> None:
-            self.tensor = tensor
-            self.is_input = is_input
-            self.attribute = [Attribute()]
-
     batch = {"CT": _BatchItem(torch.randn(2, 1, 4, 4), True), "SEG": _BatchItem(seg, False)}
     model.forward(batch)
     assert len(moved) == 1, "one upload for the two output groups reading SEG"
@@ -882,16 +868,15 @@ def test_a_target_group_is_moved_once_per_forward_and_not_for_a_criterion_outsid
     model.forward(batch)
     assert len(moved) == 2, "the next forward uploads again (a new batch in the run)"
 
-    measure.outputs_criterions["Logits"]["SEG"] = {torch.nn.MSELoss(): attr(start=50)}
-    measure.outputs_criterions["Softmax"]["SEG"] = {torch.nn.L1Loss(): attr(start=50)}
+    measure.outputs_criterions["Logits"]["SEG"] = {torch.nn.MSELoss(): _criterion_attr(start=50)}
+    measure.outputs_criterions["Softmax"]["SEG"] = {torch.nn.L1Loss(): _criterion_attr(start=50)}
     model.forward(batch)
     assert len(moved) == 2, "every criterion outside its window: nothing uploaded"
 
 
 def test_forward_charges_the_criteria_to_the_clock_apart_from_the_walk() -> None:
     from konfai.data.patching import SweepClock
-    from konfai.metric.schedulers import Constant
-    from konfai.network.network import CriterionsAttr, Measure
+    from konfai.network.network import Measure
 
     class Net(Network):
         def __init__(self) -> None:
@@ -900,18 +885,11 @@ def test_forward_charges_the_criteria_to_the_clock_apart_from_the_walk() -> None
 
     model = Net()
     measure = Measure("Net", {})
-    attr = CriterionsAttr()
-    attr.schedulers = {Constant(): None}
+    attr = _criterion_attr()
     measure.outputs_criterions = {"Head": {"CT": {torch.nn.L1Loss(): attr}}}
     measure.init(model, ["CT"])
     model.measure = measure
     model.init_outputs_group()
-
-    class _BatchItem:
-        def __init__(self, tensor: torch.Tensor, is_input: bool) -> None:
-            self.tensor = tensor
-            self.is_input = is_input
-            self.attribute = [Attribute()]
 
     batch = {"CT": _BatchItem(torch.ones(1, 1, 4, 4), True)}
     clock = SweepClock()
@@ -929,8 +907,7 @@ def test_measure_update_moves_the_criterion_onto_the_outputs_device_once() -> No
     A criterion with its own tensors (``CrossEntropyLoss(weight=...)``) stayed on CPU while the batch
     trained on cuda:0 and every step raised 'Expected all tensors to be on the same device'. Measure
     must move the criterion onto the output's device, and only when the device changes."""
-    from konfai.metric.schedulers import Constant
-    from konfai.network.network import CriterionsAttr, Measure
+    from konfai.network.network import Measure
 
     class Net(Network):
         def __init__(self) -> None:
@@ -939,8 +916,7 @@ def test_measure_update_moves_the_criterion_onto_the_outputs_device_once() -> No
 
     model = Net()
     criterion = torch.nn.CrossEntropyLoss(weight=torch.tensor([1.0, 5.0, 10.0]))
-    attr = CriterionsAttr()
-    attr.schedulers = {Constant(): None}
+    attr = _criterion_attr()
     measure = Measure("Net", {})
     measure.outputs_criterions = {"Head": {"SEG": {criterion: attr}}}
     measure.init(model, ["SEG"])

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -941,6 +941,7 @@ def test_a_forked_child_builds_its_own_rank_pool(monkeypatch) -> None:
 def test_a_rank_bounds_the_chunk_cache_by_its_own_share_of_the_budget(monkeypatch) -> None:
     """A spawned rank is a new process: a bound the launcher set is a module global it never sees,
     so the rank sets it at its own entry, from the budget every workflow's dataset resolves."""
+    from konfai.utils import budget as budget_module
     from konfai.utils import ome_zarr
 
     class FakeBudget:
@@ -968,7 +969,8 @@ def test_a_rank_bounds_the_chunk_cache_by_its_own_share_of_the_budget(monkeypatc
     monkeypatch.setattr(rt, "TensorBoard", lambda *a, **k: contextlib.nullcontext())
     monkeypatch.setattr(rt.torch.cuda, "is_available", lambda: False)
     monkeypatch.setenv("KONFAI_INLINE_SINGLE_RANK", "1")
-    monkeypatch.setattr(ome_zarr, "_chunk_cache_budget", None)
+    monkeypatch.setattr(budget_module, "_per_rank_bytes", None)
     rt.execute_distributed_object(FakeObject(), gpu=None, cpu=1)
 
-    assert ome_zarr._chunk_cache_budget == 96 << 20
+    assert budget_module.per_rank_budget_bytes() == 96 << 20
+    assert ome_zarr._chunk_cache().capacity == ome_zarr.chunk_cache_capacity()

--- a/tests/unit/test_streamed_oracle.py
+++ b/tests/unit/test_streamed_oracle.py
@@ -113,7 +113,7 @@ class Route:
 ROUTES = (Route("one-region", None), Route("few-regions", 0.25), Route("row-regions", 0.0))
 
 
-def _budget_for(manager: DatasetManager, shape: Sequence[int], route: Route) -> float | None:
+def _budget_for(manager: DatasetManager, route: Route) -> float | None:
     """The smallest per-rank budget under which the sweep cuts regions of ``route``'s height.
 
     Found by bisecting the production sizing rule rather than by restating it: the test says how
@@ -198,7 +198,7 @@ def _sweep(
     """Write ``stage`` over the case region by region, cut as ``route`` says, and read back what landed."""
     stage.set_datasets([dataset])
     manager = _manager(dataset, group, [stage, Save(f"{destination}:h5")])
-    budget = _budget_for(manager, dataset.get_infos(group, CASE_NAME)[0], route)
+    budget = _budget_for(manager, route)
     with monkeypatch.context() as context:
         regions = _count_regions(context)
         verdict = CaseMaterializer(manager).materialize(fallback_budget_bytes=budget)
@@ -513,7 +513,7 @@ def test_a_streamed_copy_equals_the_whole_volume_copy(name: str, copies: int, ro
     augmentation.load(1.0)
 
     streamed = _expanded(dataset, augmentation, copies, tmp_path / "streamed")
-    budget = _budget_for(streamed, dataset.get_infos("Intensity", CASE_NAME)[0], route)
+    budget = _budget_for(streamed, route)
     outcomes = CaseMaterializer(streamed).materialize_copies(list(range(1, copies + 1)), fallback_budget_bytes=budget)
     whole = _expanded(dataset, augmentation, copies, tmp_path / "whole")
     for a in range(1, copies + 1):
@@ -552,7 +552,7 @@ def test_a_transform_after_the_marker_reads_its_companion_where_the_block_sits(r
 
     mask.set_datasets([dataset])
     streamed = _manager(dataset, "Intensity", chain(tmp_path / "streamed"))
-    budget = _budget_for(streamed, dataset.get_infos("Intensity", CASE_NAME)[0], route)
+    budget = _budget_for(streamed, route)
     outcomes = CaseMaterializer(streamed).materialize_copies([1, 2], fallback_budget_bytes=budget)
     assert set(outcomes.values()) == {(Verdict.STREAM, Regime.SHARED)}
 

--- a/tests/unit/test_streamed_oracle.py
+++ b/tests/unit/test_streamed_oracle.py
@@ -55,7 +55,7 @@ from konfai.data.augmentation import CutOUT, DataAugmentation, Elastix, Noise, R
 from konfai.data.augmentation import Flip as FlipDraw
 from konfai.data.case_reduction import CaseReduction
 from konfai.data.materialize import CaseMaterializer, Regime, Verdict
-from konfai.data.patching import DatasetManager
+from konfai.data.patching import DatasetManager, SweepSegment
 from konfai.data.transform import (
     Clip,
     Crop,
@@ -70,7 +70,7 @@ from konfai.data.transform import (
     Write,
 )
 from konfai.utils.dataset import Attribute, Dataset
-from konfai.utils.errors import PatchError, TransformError
+from konfai.utils.errors import DatasetManagerError, PatchError, TransformError
 from oracle_support import (
     AUGMENTATION_ATOL,
     CASE_NAME,
@@ -117,23 +117,40 @@ def _budget_for(manager: DatasetManager, shape: Sequence[int], route: Route) -> 
     """The smallest per-rank budget under which the sweep cuts regions of ``route``'s height.
 
     Found by bisecting the production sizing rule rather than by restating it: the test says how
-    tall a region should be, and ``_sweep_rows`` says what budget buys it. A stage that lands on
-    another grid than it reads gets a height close to the one asked, which is all the matrix needs.
+    tall a region should be, and ``_sweep_tile`` says what budget buys it. Asked with the landing
+    and the pull maps the sweep itself will use, because that is what the budget is spent on.
     """
     if route.height is None:
         return None
-    channels, spatial = int(shape[0]), [int(extent) for extent in shape[1:]]
-    rows = max(1, int(route.height * spatial[0]))
+    # Every copy the run will sweep, each with the landing and the pull maps of its own chain: a
+    # draw that samples through an affine pulls more than the shared prefix, and the budget the
+    # matrix asks for is the one that buys the height on all of them.
+    augmented = manager._expand is not None
+    copies = [0] if not augmented else list(range(1, int(manager._expand.nb) + 1))
+    segments = {a: manager.sweep_segments(a, augmented) or [] for a in copies}
+    rows = max(1, int(route.height * int(manager.shapes[copies[0]][0])))
     low, high = 1.0, float(2**48)
     for _ in range(64):
         middle = (low + high) / 2
         manager.set_memory_budget(middle)
-        if manager._sweep_rows(spatial, channels) < rows:
+        if min(_sweep_height(manager, sweeps) for sweeps in segments.values()) < rows:
             low = middle
         else:
             high = middle
     manager.set_memory_budget(None)
     return high
+
+
+def _sweep_height(manager: DatasetManager, segments: Sequence[SweepSegment]) -> int:
+    """The shortest region the sizing buys these segments under the budget the manager currently
+    carries; zero where one of them does not fit, which is below every height the routes ask for."""
+    heights = []
+    for segment in segments:
+        try:
+            heights.append(manager._sweep_tile(segment.landing, segment.channels, segment.plans)[0])
+        except DatasetManagerError:
+            return 0
+    return min(heights, default=0)
 
 
 # ---------------------------------------------------------------- driving one case both ways

--- a/tests/unit/test_streamed_read_dispatcher.py
+++ b/tests/unit/test_streamed_read_dispatcher.py
@@ -380,6 +380,15 @@ def test_a_saved_clip_bound_is_the_cases_statistic_not_the_regions(streaming_dat
     assert float(attribute["Max"]) == float(volume.max())
 
 
+def _one_row_budget(manager: DatasetManager) -> float:
+    """The smallest budget this chain sweeps under: what one row of its landing holds, priced by the
+    production rule rather than restated here."""
+    segment = (manager.sweep_segments(0) or [])[-1]
+    tile = manager._sweep_shape(segment.landing, segment.plans, 1)
+    depth = patching._sweep_pipeline_depth()
+    return float(manager.sweep_block_bytes(segment.landing, segment.channels, segment.plans, tile, depth))
+
+
 def test_the_predicted_read_factor_prices_the_route_not_the_answer(streaming_dataset_stub) -> None:
     """A pointwise chain reads the source once; a store without bounded reads decodes it per slab.
 
@@ -407,9 +416,10 @@ def test_the_predicted_read_factor_prices_the_route_not_the_answer(streaming_dat
         def bounded_region_reads(self, group_src: str, name: str) -> bool:
             return False
 
-    # A tiny budget cuts the sweep into 8 one-row slabs, each decoding the whole store.
+    # A budget that holds one row and no more cuts the sweep into 8 one-row slabs, each decoding
+    # the whole store.
     unbounded = manager(_Unbounded(volume))
-    unbounded.set_memory_budget(1024.0)
+    unbounded.set_memory_budget(_one_row_budget(unbounded))
     assert CaseMaterializer(unbounded).predicted_stream_read_factor(0) == pytest.approx(8.0)
 
 
@@ -637,8 +647,9 @@ def test_the_read_factor_grows_as_the_budget_cuts_finer_slabs(streaming_dataset_
         transforms=[Dilate(2)],
         data_augmentations_list=[],
     )
+    one_row = _one_row_budget(manager)
     factors = []
-    for budget in (None, 64_000.0, 16_000.0, 8_000.0):
+    for budget in (None, 8 * one_row, 3 * one_row, one_row):
         manager.set_memory_budget(budget)
         factors.append(CaseMaterializer(manager).predicted_stream_read_factor(0))
     # The ~1.0 first factor holds only while the no-budget sweep covers the volume in ONE slab;

--- a/tests/unit/test_sweep_pipeline.py
+++ b/tests/unit/test_sweep_pipeline.py
@@ -37,7 +37,7 @@ from konfai.data.patching import (
     _ReadAhead,
     _stage_failure,
     _sweep_pipeline_depth,
-    _sweep_resident_slabs,
+    _sweep_resident_regions,
     _WriteBehind,
 )
 from konfai.data.transform import Clip, LocalityKind, PatchLocality, RegionContext, Resample, Save, Transform
@@ -425,7 +425,7 @@ def test_a_pipelined_sweep_holds_no_more_blocks_than_the_height_rule_prices(
     ahead, the one the reader holds while the queue is full, and the one being written behind.
     Counted here as blocks between their read and their write, with a writer slower than the
     reader so the queue fills and the reader blocks on it."""
-    from konfai.data.patching import RegionWriter, _sweep_resident_slabs
+    from konfai.data.patching import RegionWriter, _sweep_resident_regions
 
     depth = 1
     monkeypatch.setattr(patching_module, "SWEEP_SLAB_ROWS", 3)
@@ -459,13 +459,14 @@ def test_a_pipelined_sweep_holds_no_more_blocks_than_the_height_rule_prices(
 
     assert counts["peak"] >= depth + 2, "the pipeline did not overlap: nothing was measured"
     # The block in the chain is two slabs (pulled and landed); every other block in flight is one.
-    assert counts["peak"] + 1 <= _sweep_resident_slabs(depth), f"{counts['peak']} blocks in flight"
+    assert counts["peak"] + 1 <= sum(_sweep_resident_regions(depth)), f"{counts['peak']} blocks in flight"
 
 
-def test_the_height_rule_prices_the_blocks_each_depth_holds() -> None:
-    """The block in the chain (pulled and landed), ``depth`` queued ahead, one in the reader's hand
-    while the queue is full, one written behind: none past depth 0, and no more than that."""
-    assert [_sweep_resident_slabs(depth) for depth in range(4)] == [2, 5, 6, 7]
+def test_the_sizing_prices_the_regions_and_blocks_each_depth_holds() -> None:
+    """Pulled regions: the one in the chain, ``depth`` queued ahead, one in the reader's hand while
+    the queue is full. Landed blocks: the one being landed and the one written behind. None past
+    depth 0, and no more than that."""
+    assert [_sweep_resident_regions(depth) for depth in range(4)] == [(1, 1), (3, 2), (4, 2), (5, 2)]
 
 
 # ---------------------------------------------------------------- the publish is a write, and is waited for

--- a/tests/unit/test_sweep_tiling.py
+++ b/tests/unit/test_sweep_tiling.py
@@ -30,14 +30,16 @@ import torch
 from konfai.data import patching as patching_module
 from konfai.data.materialize import CaseMaterializer, Verdict
 from konfai.data.patching import (
+    _SWEEP_ELEMENT_BYTES,
     DatasetManager,
     DatasetPatch,
     _cubic_tile,
     _pull_block_voxels,
     _sweep_pipeline_depth,
+    _sweep_resident_regions,
     _sweep_targets,
 )
-from konfai.data.transform import Resample, Save
+from konfai.data.transform import OneHot, Resample, Save
 from konfai.utils.dataset import Attribute, Dataset, _store_chunks
 from konfai.utils.errors import DatasetManagerError
 
@@ -197,6 +199,25 @@ def _priced(manager: DatasetManager, plans, rows: int) -> int:
 def _block_voxels(manager: DatasetManager, plans) -> int:
     """The landed voxels of the block the sizing picks under the budget the manager carries."""
     return int(np.prod(manager._sweep_tile(list(LANDING), 1, plans), dtype=np.int64))
+
+
+def test_a_chain_that_widens_the_channel_axis_is_priced_on_what_it_lands(tmp_path: Path) -> None:
+    """``OneHot`` lands one block per class. The source is still pulled at one channel, so the price
+    grows by the classes on the landed term alone, not by a flat multiple of the whole."""
+    source, _volume = _sheared_fixture(tmp_path)
+    classes = 4
+    plain = _manager(source, [Save(f"{tmp_path / 'out'}:h5")])
+    widened = _manager(source, [OneHot(classes), Save(f"{tmp_path / 'out'}:h5")])
+    tile = plain._sweep_shape(list(LANDING), (), 5)
+    depth = _sweep_pipeline_depth()
+
+    _pulled, landed = _sweep_resident_regions(depth)
+    block = int(np.prod(tile, dtype=np.int64))
+    before = plain.sweep_block_bytes(list(LANDING), 1, (), tile, depth)
+    after = widened.sweep_block_bytes(list(LANDING), 1, (), tile, depth)
+
+    assert (after - before) == landed * block * (classes - 1) * _SWEEP_ELEMENT_BYTES
+    assert after < before * classes  # the pulled regions did not widen with it
 
 
 def test_the_sizing_takes_the_tallest_region_the_budget_holds(tmp_path: Path) -> None:

--- a/tests/unit/test_sweep_tiling.py
+++ b/tests/unit/test_sweep_tiling.py
@@ -29,9 +29,17 @@ import pytest
 import torch
 from konfai.data import patching as patching_module
 from konfai.data.materialize import CaseMaterializer, Verdict
-from konfai.data.patching import DatasetManager, DatasetPatch, _cubic_tile, _pull_voxels, _sweep_targets
+from konfai.data.patching import (
+    DatasetManager,
+    DatasetPatch,
+    _cubic_tile,
+    _pull_block_voxels,
+    _sweep_pipeline_depth,
+    _sweep_targets,
+)
 from konfai.data.transform import Resample, Save
 from konfai.utils.dataset import Attribute, Dataset, _store_chunks
+from konfai.utils.errors import DatasetManagerError
 
 pytest.importorskip("SimpleITK")
 
@@ -47,7 +55,7 @@ def _attributes(direction: np.ndarray | None = None) -> Attribute:
 
 
 #: The landing, and the height rule these tests pin, chosen so the two decompositions are far apart:
-#: the slab reads 2.40x the source where the cube reads 0.91x (printed by _pull_voxels below).
+#: the slab reads 2.40x the source where the cube reads 0.91x (printed by _pull_block_voxels below).
 LANDING = (48, 128, 128)
 ROWS = 12
 
@@ -157,7 +165,7 @@ def test_a_sheared_resample_takes_the_cube_and_reads_less_for_it(
     tile = manager._sweep_tile(spatial, 1, plans)
 
     assert tile != slab, "a 20-degree x-z shear makes the full-plane slab the expensive decomposition"
-    assert _pull_voxels(spatial, tile, plans) < _pull_voxels(spatial, slab, plans)
+    assert sum(_pull_block_voxels(spatial, tile, plans)) < sum(_pull_block_voxels(spatial, slab, plans))
 
 
 def test_an_axis_aligned_chain_prices_the_two_the_same_and_keeps_the_slab(
@@ -175,6 +183,60 @@ def test_an_axis_aligned_chain_prices_the_two_the_same_and_keeps_the_slab(
     manager = _manager(source, [resample, Save(f"{tmp_path / 'out'}:h5")])
 
     assert manager._sweep_tile(list(LANDING), 1, _sweep_plans(manager)) == [ROWS, *LANDING[1:]]
+
+
+# ---------------------------------------------------------------- what the budget buys
+
+
+def _priced(manager: DatasetManager, plans, rows: int) -> int:
+    """What a decomposition of ``rows`` rows holds, priced as the sizing prices it."""
+    tile = manager._sweep_shape(list(LANDING), plans, rows)
+    return manager.sweep_block_bytes(list(LANDING), 1, plans, tile, _sweep_pipeline_depth())
+
+
+def _block_voxels(manager: DatasetManager, plans) -> int:
+    """The landed voxels of the block the sizing picks under the budget the manager carries."""
+    return int(np.prod(manager._sweep_tile(list(LANDING), 1, plans), dtype=np.int64))
+
+
+def test_the_sizing_takes_the_tallest_region_the_budget_holds(tmp_path: Path) -> None:
+    """The budget is spent, not halved and spent: what the chosen block holds fits, and one row more
+    does not."""
+    source, _volume = _sheared_fixture(tmp_path)
+    manager = _manager(source, [Save(f"{tmp_path / 'out'}:h5")])
+    budget = _priced(manager, (), 5)
+    manager.set_memory_budget(float(budget))
+
+    rows = manager._sweep_tile(list(LANDING), 1)[0]
+    assert _priced(manager, (), rows) <= budget < _priced(manager, (), rows + 1)
+
+
+def test_a_regrid_pays_for_what_it_pulls_and_not_for_what_it_lands(tmp_path: Path) -> None:
+    """The bytes a region costs are the source's box under the chain's maps, so the same budget buys
+    a resample onto a sheared grid a smaller block than it buys a chain that reads where it lands."""
+    source, _volume = _sheared_fixture(tmp_path)
+    resample = Resample(reference="TARGET", reference_group="GRID", reference_dataset=f"{tmp_path / 'ref'}:h5")
+    regrid = _manager(source, [resample, Save(f"{tmp_path / 'out'}:h5")])
+    pointwise = _manager(source, [Save(f"{tmp_path / 'flat'}:h5")])
+    plans = _sweep_plans(regrid)
+    budget = float(_priced(pointwise, (), 8))
+    regrid.set_memory_budget(budget)
+    pointwise.set_memory_budget(budget)
+
+    assert _priced(regrid, plans, 8) > _priced(pointwise, (), 8), "the shear pulls more than it lands"
+    assert _block_voxels(regrid, plans) < _block_voxels(pointwise, ())
+
+
+def test_a_budget_no_region_fits_refuses_with_both_figures(tmp_path: Path) -> None:
+    """A budget one row of the landing does not fit is not a one-row sweep: it is a refusal naming
+    the budget and what the smallest region holds, so the reader knows what to raise it to."""
+    source, _volume = _sheared_fixture(tmp_path)
+    manager = _manager(source, [Save(f"{tmp_path / 'out'}:h5")])
+    manager.set_memory_budget(_priced(manager, (), 1) / 2.0)
+
+    with pytest.raises(DatasetManagerError, match=r"no region of 'CT' fits the per-rank memory budget"):
+        manager._sweep_tile(list(LANDING), 1)
+    assert manager.stream_refusal(0) is not None, "and the plan routes the case away from streaming"
 
 
 # ---------------------------------------------------------------- the values are still the values

--- a/tests/unit/test_transformer_workflow.py
+++ b/tests/unit/test_transformer_workflow.py
@@ -1043,7 +1043,9 @@ def test_a_run_time_fallback_refusal_names_the_budget_it_broke(tmp_path: Path, m
 
     _write_source(tmp_path)
     config_path = _write_config(tmp_path, _STREAMABLE.format(out=tmp_path / "out"))
-    config_path.write_text(config_path.read_text().replace("memory_budget: auto", "memory_budget: 1KiB"))
+    # Between the smallest region this chain can sweep (1.56 KiB) and the whole volume it falls
+    # back to (7.50 KiB): the plan streams, and only the fallback the failure forces is over budget.
+    config_path.write_text(config_path.read_text().replace("memory_budget: auto", "memory_budget: 4KiB"))
     workflow = _build(tmp_path)
     workflow.setup(1)
     monkeypatch.setattr(
@@ -1053,7 +1055,7 @@ def test_a_run_time_fallback_refusal_names_the_budget_it_broke(tmp_path: Path, m
     )
 
     with (
-        pytest.raises(TransformerError, match=r"exceeds the per-rank budget \(1.00 KiB\)"),
+        pytest.raises(TransformerError, match=r"exceeds the per-rank budget \(4.00 KiB\)"),
         pytest.warns(UserWarning),
     ):
         workflow.run_process(1, 0, 0, [])
@@ -1696,10 +1698,10 @@ _SNAPSHOT_SUMMARY = (
 )
 
 _SNAPSHOT_REPORT = """\
-[KonfAI] plan over 2 rank(s) | per-rank budget 96.00 KiB ('98304b', per rank: x2 = 192.00 KiB on the node) | decoded-chunk cache 96.00 KiB of it (under the 256.00 MiB floor: a region touching more OME-Zarr chunks than it holds decodes them again) | fallback working set = case x 4 B x (2 + the widest stage's own buffers), headers-only estimate | output dtype/channels assumed float32 / source channels until the first slab
+[KonfAI] plan over 2 rank(s) | per-rank budget 96.00 KiB ('98304b', per rank: x2 = 192.00 KiB on the node) | held beside the regions: engine ~32.00 MiB, decoded-chunk cache up to 32.00 KiB (under the 256.00 MiB floor: a region touching more OME-Zarr chunks than it holds decodes them again) | fallback working set = case x 4 B x (2 + the widest stage's own buffers), headers-only estimate | output dtype/channels assumed float32 / source channels until the first slab
 [KonfAI] 1 case(s) of 'CT' are DROPPED: the run keeps the cases every groups_src shares, minus what 'subset' excludes.
   CT -> A (Clip -> Write <tmp>/out_a:h5): 3 case(s) -- 1 STREAM, 1 LOAD, 0 WHOLE-VOLUME, 1 SKIP (output already written)
-    (1 case(s)) LOAD: fits the per-rank budget (~64.00 KiB vs 96.00 KiB); streaming would read ~4.0x the source
+    (1 case(s)) LOAD: fits the per-rank budget (~64.00 KiB vs 96.00 KiB); streaming would read ~2.0x the source
   CT -> B (Clip -> Standardize -> Write <tmp>/out_b:h5): 3 case(s) -- 0 STREAM, 0 LOAD, 3 WHOLE-VOLUME, 0 SKIP (output already written)
     (3 case(s)) WHOLE-VOLUME: stage 1 'Standardize' needs whole-volume statistics, but an earlier stage changes the values: the stored volume's statistic is not this stage's input.
     worst fallback case ~= 96.00 KiB vs per-rank budget 96.00 KiB
@@ -1733,10 +1735,10 @@ def test_the_plan_text_is_the_snapshot(tmp_path: Path, monkeypatch: pytest.Monke
 
 
 def test_the_plan_bounds_the_chunk_cache_by_the_budget_and_says_when_it_is_under_the_floor(tmp_path: Path) -> None:
-    """The store's decoded-chunk cache is part of what the process holds: a third of the budget,
-    never more than the budget, and the header names it. Under the floor the cache cannot keep a
-    region's chunks, and the header says that rather than the run paying every decode twice in
-    silence."""
+    """The store's decoded-chunk cache is part of what the process holds: a third of the budget and
+    never more, whatever the floor, because the sizing spends the rest on regions. Under the floor
+    the cache cannot keep a region's chunks, and the header says that rather than the run paying
+    every decode twice in silence."""
     from konfai.utils import ome_zarr
 
     _write_source(tmp_path)
@@ -1745,13 +1747,13 @@ def test_the_plan_bounds_the_chunk_cache_by_the_budget_and_says_when_it_is_under
     try:
         config_path.write_text(text.replace("memory_budget: auto", "memory_budget: 98304b"))
         report = _build(tmp_path).compute_plan().report()
-        assert ome_zarr._chunk_cache().capacity == 98304
-        assert "decoded-chunk cache 96.00 KiB of it (under the 256.00 MiB floor:" in report
+        assert ome_zarr._chunk_cache().capacity == 98304 // 3
+        assert "decoded-chunk cache up to 32.00 KiB (under the 256.00 MiB floor:" in report
 
         config_path.write_text(text.replace("memory_budget: auto", "memory_budget: 3GiB"))
         report = _build(tmp_path).compute_plan().report()
         assert ome_zarr._chunk_cache().capacity == 1 << 30
-        assert "decoded-chunk cache 1.00 GiB of it | " in report
+        assert "decoded-chunk cache up to 1.00 GiB" in report
     finally:
         ome_zarr.set_chunk_cache_budget(None)
 

--- a/tests/unit/test_transformer_workflow.py
+++ b/tests/unit/test_transformer_workflow.py
@@ -25,6 +25,7 @@ import pytest
 from konfai.data.materialize import Regime, Verdict
 from konfai.data.reduction import Mean
 from konfai.data.transform import Reduce
+from konfai.utils.budget import set_per_rank_budget
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import ConfigError, TransformerError
 
@@ -1755,7 +1756,8 @@ def test_the_plan_bounds_the_chunk_cache_by_the_budget_and_says_when_it_is_under
         assert ome_zarr._chunk_cache().capacity == 1 << 30
         assert "decoded-chunk cache up to 1.00 GiB" in report
     finally:
-        ome_zarr.set_chunk_cache_budget(None)
+        set_per_rank_budget(None)
+        ome_zarr.bound_chunk_cache()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`memory_budget` is what TRANSFORM promises: name the RAM a rank may use and the run stays inside it. It did not.
The harness this stack added (`tests/unit/test_memory_limit.py`, which runs each streamed route in a child capped
by `RLIMIT_AS` and reports the peak RSS it reached) measured a resident set that did not move with the budget at
all, and profiling found why, in six places. Five of them are the ones the harness pointed at; the sixth and
largest was found first and had nothing to do with sizing: a raw-block stream wrote through one shared map of the
file, and every dirtied page stayed resident until close, so a run held its whole output whatever the budget.

Each written region is now handed back to the kernel; a region read maps only the outermost band that holds it,
not the file; the sweep prices a region against what it PULLS and HOLDS rather than what it lands, binary-searches
the tallest region that fits, and refuses with both figures where not one row fits; the decoded-chunk cache takes
a third of a declared budget instead of all of it; the whole-volume statistics scan reads blocks the budget sizes
and refuses one it cannot hold; and one seam (`konfai/utils/budget.py`) publishes the rank's figure where a
`Dataset` can read it, so the cache stops keeping its own copy of the same number.

## Measured

All on a CPU-only host, `CUDA_VISIBLE_DEVICES=`, children pinned `OMP_NUM_THREADS=1 MALLOC_ARENA_MAX=1`, cohort
two groups of 200x320x320 float32 (78 MiB per group), peak RSS above a 667 MiB interpreter floor.

| what | before | after |
|---|---|---|
| TRANSFORM resident, 512 MiB budget | 173 MiB | 166 MiB |
| TRANSFORM resident, 128 MiB budget | 173 MiB | 133 MiB |
| TRANSFORM resident, 64 MiB budget | 173 MiB | 75 MiB |
| A raw-block stream, 64 MiB written in sixteen 4 MiB slabs | 64 MiB of resident growth | 0 MiB |
| TRANSFORM peak above the floor, 128 / 32 MiB budget | 193 / 161 MiB | 145 / 92 MiB |
| PREDICTION peak above the floor (writes an mha slab by slab) | 113 MiB | 51 MiB |
| Address space a TRANSFORM needs, 128 MiB budget, 101.6 MiB/group cohort | 267 MiB | 146 MiB (1.14x the budget) |
| One `read_data_statistics` over the 78 MiB case, peak RSS | 95.6 MiB at any budget | 95.5 / 95.7 / 67.3 / 34.5 / 13.9 at 512 / 128 / 64 / 32 / 8 MiB |
| An OME-Zarr source at a 128 MiB budget | priced at 2x (cache 128 + regions 128) | at most 1.33x |
| The plan's read factor on the snapshot cohort | 4.0x | 2.0x |

The sweep was flat because it priced the rows it LANDS: a `Resample` to 2 mm pulls four source voxels per landed
one, and `Gradient` allocates eight volumes-worth, neither of which a landed row says anything about.

## Values

Nothing moves. The streamed output stays byte-equal to the whole-volume pass over the whole differential oracle
matrix, whose budgets are bisected through the same sizing rule (`tests/unit/test_streamed_oracle.py`, green).
One value change was found and removed rather than accepted: a budget-sized statistics block moved the fold's
piece boundaries and the mean of the same case came back one ulp apart at two grains, so a block is now a whole
number of the fold's own update pieces and the fold sees the same pieces in the same order at any grain.

## Stated, not enforced

What a streamed case holds beside its regions measures 25 to 27 MiB on this cohort. Adding it to the priced block
makes every budget under about 32 MiB refuse, and those budgets are how ten tests force a fine decomposition, so
the TRANSFORM header prints `held beside the regions: engine ~32.00 MiB` instead of hiding it. Two limits stay
open and are named here rather than in silence: EVALUATION still tracks poorly below 128 MiB (2.5x at 64), being
sized by `DataMetric._maybe_auto_patch` and not by the sweep; and the DataLoader's collate copy on the patch route
is still unpriced.

## Tests

`test_a_raw_block_stream_does_not_hold_what_it_has_written` (held 64 MiB of a 64 MiB volume before),
`test_a_region_read_maps_the_smallest_span_that_holds_it` (failed on three of four layouts before), three sizing
tests in `test_sweep_tiling.py`, `test_a_streamed_transform_tracks_the_budget_it_declared` and
`test_a_transform_refuses_a_budget_no_region_of_its_chain_fits` in the harness (flat, and "ok" instead of a
refusal at 1 MiB, before), three in `test_dataset_statistics.py` including bit-equality of the fold across six
budgets. Retired with the code they described: `_device_budget` (never called),
`CaseMaterializer.working_multiple` and `_sweep_segments` (moved onto the manager, so the plan, the read factor
and the budget check ask one object), and `_segment_read_factor`'s hand-rolled copy of the pull loop.

The last commit is unrelated housekeeping the work surfaced: the criteria tests built hand-rolled stubs of
`CriterionsAttr` that had drifted from the class, and the target's copy cost is now recorded at the line it is
about.

## Stack

Stacked on `pr/1.8.2-14-read-and-blend`; merge after it. Before deleting this branch, retarget the next PR of the
stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent per-process memory budgeting across prediction, evaluation, transformation, and dataset statistics workflows.
  * Improved streaming for large image datasets by limiting mapped file regions and controlling memory usage.
  * Enhanced processing plans with clearer memory and cache allocation details.

* **Bug Fixes**
  * Operations now refuse gracefully when the configured budget cannot accommodate even the smallest processing region.
  * Improved chunk-cache sizing for constrained memory environments.

* **Documentation**
  * Clarified timing reports and memory usage information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->