### PR TITLE
A fold's seconds, and what a memory budget buys

### DIFF
--- a/docs/source/usage/large-images.md
+++ b/docs/source/usage/large-images.md
@@ -80,7 +80,15 @@ The generator only calls `get_infos()` and `read_data_slice()`, never
 ## Tune in this order
 
 1. `memory_budget` first: `auto` decides from the dataset's size, an explicit
-   value below it forces streaming.
+   value below it forces streaming. Give it as much as the machine can spare:
+   the budget buys read locality, and a region that shrinks re-reads and
+   re-decodes chunks a taller one would have read once. On a 513x1331x1776
+   uint16 OME-Zarr resampled on one GPU, the whole run costs 5.0 s at 4 GiB,
+   10.9 s at 1 GiB, 22.8 s at 512 MiB and 49.1 s at 256 MiB, and the whole
+   difference is the wait on reads (0.2 s to 42.6 s); the chain itself stays
+   between 3.1 and 4.6 s. A budget pays where reading costs, so it pays most on
+   a compressed, remote or cache-cold store, and least on a small dataset the
+   operating system already holds in its page cache.
 2. `patch_size`: leave an axis at `0` and KonfAI sizes it, taking the whole
    volume when it fits and shrinking on OOM. Otherwise pin the largest size your
    model and context need.

--- a/konfai/data/case_reduction.py
+++ b/konfai/data/case_reduction.py
@@ -29,12 +29,14 @@ operator can accumulate.
 
 from __future__ import annotations
 
+import contextlib
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 
 import numpy as np
 import torch
 
-from konfai.data.patching import DatasetManager, RegionWriter, device_capped_budget, save_destination
+from konfai.data.patching import SWEEP_CLOCK, DatasetManager, RegionWriter, device_capped_budget, save_destination
 from konfai.data.reduction import Reduction
 from konfai.data.transform import LocalityKind, PatchLocality, Reduce, Save, Transform, stat_seed_valid
 from konfai.utils.dataset import (
@@ -57,6 +59,18 @@ _POST_KINDS = frozenset({LocalityKind.POINTWISE, LocalityKind.GLOBAL_STAT})
 
 #: Bytes per sample assumed when sizing regions from headers alone, before a dtype is known.
 _ASSUMED_ITEMSIZE = 4
+
+
+@contextlib.contextmanager
+def _awaited(phase: str) -> Iterator[None]:
+    """A phase the fold both performs and stands still for.
+
+    The fold has no pipeline: every member's region is read, and every slab written, on its own
+    thread. So the store's own seconds ARE the seconds the loop waits, which is what
+    :meth:`~konfai.data.patching.SweepClock.report` prints on either side of its bar.
+    """
+    with SWEEP_CLOCK.phase(f"wait({phase})"), SWEEP_CLOCK.phase(phase):
+        yield
 
 
 @dataclass(frozen=True)
@@ -447,8 +461,17 @@ class CaseReduction:
         """
         self.operator.start()
         for manager in self.managers:
-            self.operator.accumulate(manager.read_region(region).unsqueeze(0))
-        return self.operator.finalize().squeeze(0)
+            # No name holds the region past its accumulate: one that did would keep a second member
+            # region resident, which the plan does not price (1162 MiB against 778 on a 5 x 384 MiB
+            # float32 cohort folded whole).
+            self.operator.accumulate(self._member_region(manager, region))
+        with SWEEP_CLOCK.phase("chain"):
+            return self.operator.finalize().squeeze(0)
+
+    def _member_region(self, manager: DatasetManager, region: tuple[slice, ...]) -> torch.Tensor:
+        """One member's region, in the stack-axis layout every operator is written against."""
+        with _awaited("read"):
+            return manager.read_region(region).unsqueeze(0)
 
     def _folds(self, spatial: list[int]):
         """Every region's fold, in order: the loop both passes share."""
@@ -457,9 +480,11 @@ class CaseReduction:
 
     def _apply_post(self, block: torch.Tensor, attribute: Attribute, rank: int) -> np.ndarray:
         scope = Attribute(attribute)
-        for stage in self.post:
-            block = stage(self.reduce.output, block, scope)
-        array = block.cpu().numpy()
+        with SWEEP_CLOCK.phase("chain"):
+            for stage in self.post:
+                block = stage(self.reduce.output, block, scope)
+        with SWEEP_CLOCK.phase("fetch"):
+            array = block.cpu().numpy()
         if array.ndim != rank:
             raise ReductionError(
                 f"A stage after the Reduce returned a rank-{array.ndim} region where the"
@@ -567,6 +592,12 @@ class CaseReduction:
             )
             raise ReductionError(f"The reduction into '{self.reduce.output}' cannot stream: {plan.refusal}.", remedy)
 
+        with SWEEP_CLOCK.phase("sweep"):
+            self._write_folds(plan)
+        return True
+
+    def _write_folds(self, plan: ReductionPlan) -> None:
+        """Every region of the reduced volume, folded and written in order, under one clock."""
         spatial = plan.spatial
         attribute = self._output_attributes(plan)
         rank = len(spatial) + 1
@@ -583,9 +614,10 @@ class CaseReduction:
         try:
             for region, folded in folds:
                 array = self._apply_post(folded, attribute, rank)
-                writer.write(None, (slice(0, int(array.shape[0])), *region), array, attribute)
-            writer.close()
+                with _awaited("write"):
+                    writer.write(None, (slice(0, int(array.shape[0])), *region), array, attribute)
+            with _awaited("write"):
+                writer.close()
         except BaseException as exception:
             writer.abort(exception)
             raise
-        return True

--- a/tests/unit/test_case_reduction.py
+++ b/tests/unit/test_case_reduction.py
@@ -27,7 +27,7 @@ import numpy as np
 import pytest
 import torch
 from konfai.data.case_reduction import CaseReduction, ReductionPlan, split_chain
-from konfai.data.patching import DatasetManager
+from konfai.data.patching import SWEEP_CLOCK, DatasetManager
 from konfai.data.reduction import Concat, Mean, Median, Reduction, Vote
 from konfai.data.transform import (
     Clip,
@@ -649,3 +649,23 @@ def test_a_budget_with_room_folds_the_whole_volume(tmp_path: Path) -> None:
     # A caller that names a ceiling still gets it.
     engine.fit_budget(64 * 1024**3, cap=2)
     assert engine.slab_rows == 2
+
+
+def test_a_reduction_accounts_for_every_second_of_its_own_wall_clock(tmp_path: Path) -> None:
+    """A work item that reads N volumes must appear in the run's one accounting line.
+
+    Measured on a 5 x 384 MiB cohort (.audit-local/bench/bench_reduce_expand.py): the member reads
+    are 13-40 % of the work item, the operator 13-37 %, the write 4-9 %. None of it was attributed:
+    the fold reads through ``read_region``, which no phase of the sweep clock covers.
+    """
+    SWEEP_CLOCK.reset()
+    engine, _destination, _volumes = _run(tmp_path, [], Reduce(operator="Mean", output="clocked"), [])
+    assert engine.materialize() is True
+
+    wall = SWEEP_CLOCK.spent("sweep")
+    named = sum(SWEEP_CLOCK.spent(phase) for phase in ("chain", "fetch", "wait(read)", "wait(write)"))
+    assert wall > 0.0
+    assert 0.0 <= wall - named <= wall, "a phase is counted outside the fold it belongs to"
+    # No pipeline: the store's own seconds are the seconds the fold stands still.
+    assert SWEEP_CLOCK.spent("wait(read)") >= SWEEP_CLOCK.spent("read") > 0.0
+    assert SWEEP_CLOCK.spent("wait(write)") >= SWEEP_CLOCK.spent("write") > 0.0

--- a/tests/unit/test_case_reduction.py
+++ b/tests/unit/test_case_reduction.py
@@ -21,6 +21,7 @@ never assembled, that a cases which does not agree on its grid is refused before
 and that a chain continues after the reduction."""
 
 import itertools
+import weakref
 from pathlib import Path
 
 import numpy as np
@@ -669,3 +670,27 @@ def test_a_reduction_accounts_for_every_second_of_its_own_wall_clock(tmp_path: P
     # No pipeline: the store's own seconds are the seconds the fold stands still.
     assert SWEEP_CLOCK.spent("wait(read)") >= SWEEP_CLOCK.spent("read") > 0.0
     assert SWEEP_CLOCK.spent("wait(write)") >= SWEEP_CLOCK.spent("write") > 0.0
+
+
+def test_an_incremental_fold_holds_one_member_region_at_a_time(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``resident_regions == 2`` is a promise about what is alive, not only about what is planned.
+
+    A name in the fold loop still holding the region the accumulator has already folded keeps a
+    second one resident: one member region over the priced peak, which on a 5 x 384 MiB float32
+    cohort folded whole measured 1162 MiB against 778.
+    """
+    alive: list[weakref.ref] = []
+    read_region = DatasetManager.read_region
+
+    def counted(self, target, a=0, apply_augmentations=False):
+        tensor = read_region(self, target, a, apply_augmentations)
+        alive.append(weakref.ref(tensor))
+        resident = sum(1 for reference in alive if reference() is not None)
+        assert resident == 1, f"{resident} member regions alive while reading the next one"
+        return tensor
+
+    monkeypatch.setattr(DatasetManager, "read_region", counted)
+    engine, _destination, _volumes = _run(tmp_path, [], Reduce(operator="Mean", output="one_at_a_time"), [])
+    assert engine.plan().resident_regions == 2
+    assert engine.materialize() is True
+    assert len(alive) > CASES, "the fold read fewer regions than it has cases"


### PR DESCRIPTION
A `Reduce` work item printed no `[KonfAI] sweep` line: the fold reads its members through `read_region`, which
no clock phase covered, so the one chain shape that reads N volumes was the one whose seconds were unattributed.
It is charged now, through the vocabulary the sweep already uses. On a five-case `Median` fold with a `Resample`
before it, at a 64 MiB budget, the line reads `sweep 9.5 s = chain 1.3 + wait(read) 8.1 + wait(write) 0.1`, which
says at once what the plan cannot: 85 percent of that item is the pull.

The fold has no pipeline, so a phase is both what it performs and what it stands still for, and the two are
charged together rather than invented apart.

## Measured

The bench that drove this is kept at `.audit-local/bench/bench_reduce_expand.py`. It runs one row per process on
synthetic h5 cohorts (one case 384x512x512 float32, uint8 for `Vote`), CPU only, `OMP_NUM_THREADS=8`, fastest of
three, and reports the plan's verdict, the clock, the wall clock, the peak RSS and the file traffic. What it says
about the two shapes, over 39 rows:

- Read passes are exact: every reduce row reads N times the volume and no more, and the shared `Expand` pass
  reads 384 MiB for two, three and five copies, so it does read once. Zero whole-volume reads in 39 rows.
- No route announced `STREAM` and then fell back: the plan's verdict equals the run's outcome in every row.
- Every `working_multiple_for` holds: held is under priced at every count and dtype, the tightest being `Median`
  at six members, 92.1 bytes per voxel against 96.0 priced.

Building the bench caught one defect in this branch's own first draft: binding the member region to a name in
`_fold` kept a second one resident, 1162 MiB against 778 on a five-case `Mean` (768 priced). The fix is in the
first commit and the second pins the lifetime with weak references rather than a peak threshold: the same fold is
back to 777 MiB, 1.01 times its priced peak.

## Values

Nothing moves. Both commits are about what is charged and what is kept alive, not about what is computed.

## Documentation

The large-images page said how to set `memory_budget` and not what raising it does. It buys read locality, and
the page now says so with the measurement: the same ExaSPIM run costs 5.0 s at 4 GiB, 10.9 s at 1 GiB, 22.8 s at
512 MiB and 49.1 s at 256 MiB, and the whole of that difference is the wait on reads (0.2 s to 42.6 s) while the
chain stays between 3.1 and 4.6 s. It also says where that is not true: a small dataset the page cache already
holds re-reads at memory speed, and there a taller region buys nothing.

## Tests

`test_case_reduction.py` gains the region-lifetime test, which fails on the base branch.

## Stack

Stacked on `pr/1.8.2-15-budget`; merge after it. It is the last PR of the stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded large-image memory-budget guidance with benchmark results across multiple budget sizes.
  * Added recommendations explaining where memory settings have the greatest impact.

* **Improvements**
  * Improved timing visibility for reduction workflows, including reading, processing, and writing stages.
  * Improved incremental processing behavior to release completed regions promptly while maintaining planned data residency.

* **Tests**
  * Added coverage verifying accurate end-to-end timing and controlled memory usage during incremental reductions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->