### PR TITLE
Four defects the review found

### DIFF
--- a/docs/source/concepts/streaming.md
+++ b/docs/source/concepts/streaming.md
@@ -81,13 +81,14 @@ per group), so it ignores the dtype you stored, size-changing transforms and
 augmented copies. It is a switch, not an allocator limit.
 
 It also bounds only the buffers the pipeline holds for your data, the OME-Zarr
-decoded-chunk cache among them: a third of the budget, never more than the
-budget, and never below a 256 MiB floor unless the budget itself is smaller,
-set on every rank of every workflow. The
-interpreter, torch and its CUDA context, the model and each worker's own
-working set sit outside it, so the peak RSS a run reports is the budget plus a
-floor that does not move when the budget does: lowering the budget lowers the
-peak by roughly what you took off, never to the budget itself.
+decoded-chunk cache among them: a third of the budget, on every rank of every
+workflow. Under a 768 MiB budget that third is below the 256 MiB the cache is
+worth, where a region touching more chunks than it holds decodes them again; the
+TRANSFORM plan says so in its header. The interpreter, torch and its CUDA
+context, the model and each worker's own working set sit outside it, so the peak
+RSS a run reports is the budget plus a floor that does not move when the budget
+does: lowering the budget lowers the peak by roughly what you took off, never to
+the budget itself.
 
 ## What decides whether a chain streams
 

--- a/docs/source/config_guide/evaluation.md
+++ b/docs/source/config_guide/evaluation.md
@@ -125,16 +125,18 @@ A split that ran for more than a second closes with a line accounting for it,
 phase by phase, in the rank's log:
 
 ```text
-[KonfAI] evaluation TRAIN 4.0 s = wait(load) 0.6 + h2d 0.0 + MAE 0.2 + PSNR 0.1 + SSIM 2.5 + map 0.3 + flush 0.0 + other 0.1
+[KonfAI] evaluation TRAIN 4.0 s = wait(load) 0.6 + h2d 0.2 + MAE 0.2 + PSNR 0.1 + SSIM 2.5 + map 0.3 + other 0.1
 ```
 
 `wait(load)` is the wait for the loader's next case or patch, `h2d` the move to
 the metric device, then one figure per metric name, `map` the error-map writes of
 the SaveMap metrics and `flush` the combination of a streamed case's partial
-states; what the named phases do not account for is `other`. The sum closes
-exactly. On a GPU a metric's figure is the time to enqueue its kernels, not to
-run them: a slow kernel shows up in whatever next waits on the device, typically
-the next `h2d` or a metric that reads a value back.
+states; what the named phases do not account for is `other`, so the sum closes
+exactly. A phase that spent nothing is left out: the run above read its cases
+whole, so it carries no `flush`. On a GPU a metric's figure is the time to
+enqueue its kernels, not to run them: a slow kernel shows up in whatever next
+waits on the device, typically the next `h2d` or a metric that reads a value
+back.
 
 ## Examples
 

--- a/docs/source/reference/components/storage-backends.md
+++ b/docs/source/reference/components/storage-backends.md
@@ -66,13 +66,13 @@ because publishing an entry is a rename and an object store has none: point the
 `Write:` at a local path.
 
 Give a remote run a `memory_budget` that holds its working set. The store's
-decoded-chunk cache is a third of that budget in every workflow (never more than
-the budget, and never less than 256 MiB while the budget allows it: a transform
-plan says when it does not), and a cache miss on a remote root is a download
-where a local one is a decode. The same pair of brains, the same chain, the same
-link at 1.6 MB/s: 1.898 GB downloaded in 19:12 with the cache at a share of free
-RAM, 2.573 GB in 38:34 with it bounded to a third of a declared 4 GiB. The output
-was identical either way; only the number of times a chunk was fetched changed.
+decoded-chunk cache is a third of that budget in every workflow (a transform plan
+says when that third is below the 256 MiB the cache is worth), and a cache miss
+on a remote root is a download where a local one is a decode. The same pair of
+brains, the same chain, the same link at 1.6 MB/s: 1.898 GB downloaded in 19:12
+with the cache at a share of free RAM, 2.573 GB in 38:34 with it bounded to a
+third of a declared 4 GiB. The output was identical either way; only the number
+of times a chunk was fetched changed.
 
 A root that cannot be reached raises and names the reason. That is the whole
 point of routing these probes rather than leaving them on `os`: `os.path.exists`

--- a/konfai/data/case_reduction.py
+++ b/konfai/data/case_reduction.py
@@ -459,14 +459,22 @@ class CaseReduction:
         written against (see :class:`~konfai.data.reduction.Reduction`)), and the result comes back
         without it. The axis matters to any operator that places things side by side.
         """
-        self.operator.start()
+        with SWEEP_CLOCK.phase("chain"):
+            self.operator.start()
         for manager in self.managers:
             # No name holds the region past its accumulate: one that did would keep a second member
             # region resident, which the plan does not price (1162 MiB against 778 on a 5 x 384 MiB
-            # float32 cohort folded whole).
-            self.operator.accumulate(self._member_region(manager, region))
+            # float32 cohort folded whole). The read stays outside the phase, and the argument dies
+            # with the frame that times the fold of it.
+            self._accumulate(self._member_region(manager, region))
         with SWEEP_CLOCK.phase("chain"):
             return self.operator.finalize().squeeze(0)
+
+    def _accumulate(self, member: torch.Tensor) -> None:
+        """Fold one member region in, on the run's clock: an incremental operator does the
+        reduction's own arithmetic here, and the region dies with this frame."""
+        with SWEEP_CLOCK.phase("chain"):
+            self.operator.accumulate(member)
 
     def _member_region(self, manager: DatasetManager, region: tuple[slice, ...]) -> torch.Tensor:
         """One member's region, in the stack-axis layout every operator is written against."""

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -3072,21 +3072,53 @@ class DatasetManager:
         except DatasetManagerError:
             return False
 
-    def _sweep_rows(self, spatial: list[int], channels: int, depth: int | None = None) -> int:
+    def _sweep_rows(
+        self,
+        spatial: list[int],
+        channels: int,
+        plans: Sequence["_ReadStagePlan"] = (),
+        depth: int | None = None,
+    ) -> int:
         """The tallest region the sweep will cut whatever the budget: ``SWEEP_SLAB_ROWS`` on a CPU,
         taller on a GPU as its free memory allows. What the budget then affords is
         :meth:`_sweep_tile`'s.
+
+        The device's share is held to the SAME price as everything else (:meth:`sweep_block_bytes`),
+        which counts the source a region pulls and what the widest stage allocates on top of it: a
+        region counted as one landed plane raised the cap by the pull ratio of a GPU ``Resample``,
+        and nothing else bounded it where no host budget was declared.
         """
         cap = max(1, int(SWEEP_SLAB_ROWS))
-        _source, _landed, peak, _working = self._chain_channels(channels)
-        plane = int(np.prod(spatial[1:], dtype=np.int64)) * peak * _SWEEP_ELEMENT_BYTES
-        if plane > 0 and self._chain_device is not None and self._chain_device.type == "cuda":
+        if self._chain_device is not None and self._chain_device.type == "cuda":
             # On a GPU the transfers and launches per region are the cost: taller regions, as far as
             # a quarter of the free device memory allows (measured +10-20 % at 500^3 over 64 rows).
-            resident = sum(_sweep_resident_regions(_sweep_pipeline_depth() if depth is None else depth))
             free_bytes, _total = torch.cuda.mem_get_info(self._chain_device)
-            cap = max(cap, min(_SWEEP_SLAB_ROWS_DEVICE, int(free_bytes * 0.25 / (plane * resident))))
+            affordable = self._rows_within(spatial, channels, plans, depth, free_bytes * 0.25, _SWEEP_SLAB_ROWS_DEVICE)
+            cap = max(cap, affordable)
         return cap
+
+    def _rows_within(
+        self,
+        spatial: list[int],
+        channels: int,
+        plans: Sequence["_ReadStagePlan"],
+        depth: int | None,
+        budget: float,
+        cap: int,
+    ) -> int:
+        """The tallest region up to ``cap`` rows whose priced block holds inside ``budget``, ``1``
+        when none does: the one search both ceilings (the rank's budget, the device's free memory)
+        are answered by."""
+        depth = _sweep_pipeline_depth() if depth is None else depth
+        low, high = 1, max(1, int(cap))
+        while low < high:
+            middle = (low + high + 1) // 2
+            tile = self._sweep_shape(spatial, plans, middle)
+            if self.sweep_block_bytes(spatial, channels, plans, tile, depth) <= budget:
+                low = middle
+            else:
+                high = middle - 1
+        return low
 
     def _sweep_shape(self, spatial: list[int], plans: Sequence["_ReadStagePlan"], rows: int) -> list[int]:
         """The block ``rows`` rows of the landing become: the slab itself, or the cube of the same
@@ -3170,19 +3202,12 @@ class DatasetManager:
         search is over the height, because that is the one free parameter of the decomposition.
         """
         depth = _sweep_pipeline_depth() if depth is None else depth
-        cap = self._sweep_rows(spatial, channels, depth)
+        cap = self._sweep_rows(spatial, channels, plans, depth)
         budget = self._sweep_budget_bytes
         if not budget or budget <= 0:
             return self._sweep_shape(spatial, plans, cap)
-        low, high = 1, cap  # low is never taken as affordable: the refusal below answers for it
-        while low < high:
-            middle = (low + high + 1) // 2
-            tile = self._sweep_shape(spatial, plans, middle)
-            if self.sweep_block_bytes(spatial, channels, plans, tile, depth) <= budget:
-                low = middle
-            else:
-                high = middle - 1
-        tile = self._sweep_shape(spatial, plans, low)
+        # The search never takes one row as affordable: the refusal below answers for it.
+        tile = self._sweep_shape(spatial, plans, self._rows_within(spatial, channels, plans, depth, budget, cap))
         held = self.sweep_block_bytes(spatial, channels, plans, tile, depth)
         if held > budget:
             raise DatasetManagerError(

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -34,10 +34,8 @@ import torch
 
 try:
     import SimpleITK as sitk
-    from SimpleITK.SimpleITK import _SetImageFromArray as _set_image_from_array
 except ImportError:
     sitk = None  # type: ignore[assignment]
-    _set_image_from_array = None
 import torch.nn.functional as F
 
 from konfai import cuda_visible_devices
@@ -70,6 +68,23 @@ from konfai.utils.errors import ReductionError, TransformError
 from konfai.utils.ITK import _require_simpleitk
 from konfai.utils.runtime import NeedDevice
 from konfai.utils.utils import get_module, split_path_spec
+
+
+def _optional_image_filler() -> Any:
+    """SimpleITK's own in-place array fill (``_SetImageFromArray``), or ``None``.
+
+    A private symbol, so it is optional on its own: guarded together with the package, a SimpleITK
+    that does not export it would have read as no SimpleITK at all. Its caller
+    (:class:`_SitkInput`) allocates a fresh image instead when it is missing.
+    """
+    try:
+        from SimpleITK.SimpleITK import _SetImageFromArray
+    except ImportError:
+        return None
+    return _SetImageFromArray
+
+
+_set_image_from_array = _optional_image_filler() if sitk is not None else None
 
 
 class LocalityKind(Enum):

--- a/konfai/network/network.py
+++ b/konfai/network/network.py
@@ -342,8 +342,9 @@ class Measure:
 
         def set_window(self, n: int) -> None:
             """Keep at least the last ``n`` values and weights. Grows only; until it is called the
-            history is unbounded. A window widened mid-run holds what it had until ``n`` more values
-            arrive: the reads in between average the values held, fewer than they ask for."""
+            history is unbounded. A window widened mid-run keeps the values it already held, so a
+            window of ``m`` values reaches ``n`` after ``n - m`` more arrive: the reads in between
+            average the values held, fewer than they ask for."""
             if self._values.maxlen is not None and self._values.maxlen >= n:
                 return
             self._values = deque(self._values, maxlen=n)

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -992,12 +992,14 @@ class Trainer(DistributedObject):
             if state != State.TRAIN:
                 state_dict = self._load()
             self.model.load(state_dict, init=True, ema=False, override_lr=self.override_lr)
-        if self.ema_decay > 0:
-            self.model_ema = AveragedModel(self.model, **self._ema_update())
-            if state_dict is not None:
-                self.model_ema.module.load(state_dict, init=False, ema=True)
-                if "Model_EMA_n_averaged" in state_dict:
-                    self.model_ema.n_averaged.fill_(cast(int, state_dict["Model_EMA_n_averaged"]))
+            # The EMA weights are restored from the same checkpoint: the startup line accounts for
+            # them where the reader looks for the weights, not in what setup does around them.
+            if self.ema_decay > 0:
+                self.model_ema = AveragedModel(self.model, **self._ema_update())
+                if state_dict is not None:
+                    self.model_ema.module.load(state_dict, init=False, ema=True)
+                    if "Model_EMA_n_averaged" in state_dict:
+                        self.model_ema.n_averaged.fill_(cast(int, state_dict["Model_EMA_n_averaged"]))
 
         (statistics_directory() / self.name).mkdir(exist_ok=True)
         shutil.copyfile(self.config_path_src, self.config_namefile)

--- a/konfai/transformer.py
+++ b/konfai/transformer.py
@@ -596,17 +596,17 @@ class Transformer(DistributedObject):
 
     @staticmethod
     def _remote_destination(manager: DatasetManager, *destinations: Dataset) -> str | None:
-        """Why no route writes the chain's Saves, or ``None``: the first of ``destinations`` (the
-        chain's own Saves when none is named) that is a remote root, as :func:`uri.refuse_write`
-        refuses it. Asked of the plan, not of the first slab: every route ends in that refusal, and
-        the whole-volume one reads and transforms a case before reaching it."""
-        if not destinations:
-            destinations = tuple(
-                save_destination(stage, manager.dataset, manager.group_dest)[0]
-                for stage in manager.transforms
-                if isinstance(stage, Save)
-            )
-        for destination in destinations:
+        """Why no route writes this chain, or ``None``: the first destination that is a remote root,
+        as :func:`uri.refuse_write` refuses it. The chain's own Saves are always among them, and
+        ``destinations`` names what the route adds (a reduction's own output). Asked of the plan, not
+        of the first slab: every route ends in that refusal, and the whole-volume one reads and
+        transforms a case before reaching it."""
+        chain = tuple(
+            save_destination(stage, manager.dataset, manager.group_dest)[0]
+            for stage in manager.transforms
+            if isinstance(stage, Save)
+        )
+        for destination in (*destinations, *chain):
             try:
                 uri.refuse_write(destination.filename)
             except DatasetManagerError as error:

--- a/konfai/utils/chain_diff.py
+++ b/konfai/utils/chain_diff.py
@@ -121,6 +121,25 @@ def _stage_name(classpath: str) -> str:
     return classpath.split(":")[-1].split(".")[-1].split("/")[0]
 
 
+def _stage_identity(classpath: str) -> str:
+    """The module-qualified class a chain key names: what decides whether two stages are the same.
+
+    A bare name is the built-in the loader resolves it to (:meth:`TransformLoader.get_transform`:
+    ``konfai.data.transform`` first, ``konfai.data.augmentation`` second, which is the order that
+    holds before the ``Expand`` marker this comparison stops at), so ``Normalize`` and
+    ``konfai.data.transform:Normalize`` are one stage; two ``Normalize`` from different modules are
+    two, and reading one chain's values says nothing about the other's.
+    """
+    from konfai.data import augmentation, transform
+
+    module, separator, _ = classpath.rpartition(":")
+    name = _stage_name(classpath)
+    if separator:
+        return f"{module}:{name}"
+    home = transform if hasattr(transform, name) else augmentation
+    return f"{home.__name__}:{name}"
+
+
 def _groups(dataset: Mapping[str, Any]) -> dict[tuple[str, str], Mapping[str, Any]]:
     """Every ``(group_src, group_dest)`` group a ``Dataset`` tree declares, in declaration order."""
     groups = {}
@@ -138,17 +157,26 @@ def _alters_values(classpath: str) -> bool:
     """
     from konfai.data import transform
 
-    module, separator, _ = classpath.rpartition(":")
-    if separator and module != transform.__name__:
+    module, _, name = _stage_identity(classpath).rpartition(":")
+    if module != transform.__name__:
         return True
-    stage = getattr(transform, _stage_name(classpath), None)
+    stage = getattr(transform, name, None)
     if not isinstance(stage, type) or not issubclass(stage, transform.Transform):
         return True
     return stage.alters_values
 
 
-def _stages(chain: Any) -> list[tuple[str, dict[str, Any]]]:
-    """The stages of one chain that shape what the model reads, as ``(class, arguments)``."""
+@dataclass(frozen=True)
+class _Stage:
+    """One chain stage as it is compared: the class it names and the arguments that shape values."""
+
+    name: str
+    identity: str
+    arguments: dict[str, Any]
+
+
+def _stages(chain: Any) -> list[_Stage]:
+    """The stages of one chain that shape what the model reads."""
     stages = []
     for classpath, arguments in _mapping(chain).items():
         name = _stage_name(str(classpath))
@@ -157,35 +185,39 @@ def _stages(chain: Any) -> list[tuple[str, dict[str, Any]]]:
         if not _alters_values(str(classpath)):
             continue
         given = _plain(_mapping(arguments))
-        stages.append((name, {key: value for key, value in given.items() if key != _OUTPUT_ONLY_ARGUMENT}))
+        arguments = {key: value for key, value in given.items() if key != _OUTPUT_ONLY_ARGUMENT}
+        stages.append(_Stage(name, _stage_identity(str(classpath)), arguments))
     return stages
 
 
 def _stage_differences(
     group: str,
     chain: str,
-    trained: list[tuple[str, dict[str, Any]]],
-    applied: list[tuple[str, dict[str, Any]]],
+    trained: list[_Stage],
+    applied: list[_Stage],
 ) -> Iterator[ChainDifference]:
     """Walk two chains of one group position by position, yielding where they disagree."""
     for index in range(max(len(trained), len(applied))):
         if index >= len(trained):
             yield ChainDifference(
-                group, chain, index, applied[index][0], "applied here, absent from the training chain"
+                group, chain, index, applied[index].name, "applied here, absent from the training chain"
             )
             continue
         if index >= len(applied):
-            yield ChainDifference(group, chain, index, trained[index][0], "in the training chain, not applied here")
+            yield ChainDifference(group, chain, index, trained[index].name, "in the training chain, not applied here")
             continue
-        (trained_stage, trained_arguments), (applied_stage, applied_arguments) = trained[index], applied[index]
-        if trained_stage != applied_stage:
-            detail = f"the training chain has '{trained_stage}' at this position"
-            yield ChainDifference(group, chain, index, applied_stage, detail)
+        trained_stage, applied_stage = trained[index], applied[index]
+        if trained_stage.identity != applied_stage.identity:
+            # Two classes of the same name, from two modules: the short name names neither of them.
+            named = trained_stage.name == applied_stage.name
+            here = applied_stage.identity if named else applied_stage.name
+            there = trained_stage.identity if named else trained_stage.name
+            yield ChainDifference(group, chain, index, here, f"the training chain has '{there}' at this position")
             continue
         details = []
-        for key in sorted(trained_arguments.keys() | applied_arguments.keys()):
-            before, after = trained_arguments.get(key, _UNSET), applied_arguments.get(key, _UNSET)
+        for key in sorted(trained_stage.arguments.keys() | applied_stage.arguments.keys()):
+            before, after = trained_stage.arguments.get(key, _UNSET), applied_stage.arguments.get(key, _UNSET)
             if before != after:
                 details.append(f"{key}: {before!r} in training, {after!r} here")
         if details:
-            yield ChainDifference(group, chain, index, applied_stage, "; ".join(details))
+            yield ChainDifference(group, chain, index, applied_stage.name, "; ".join(details))

--- a/konfai/utils/config.py
+++ b/konfai/utils/config.py
@@ -215,14 +215,19 @@ def strict_config(root: str, refuse: bool = True) -> Iterator[None]:
     the whole block back over the user's file.
 
     The file is read once here and written once when the block ends, whatever the number of
-    contexts opened inside it: they all resolve against the tree held in memory. A build of N
+    contexts opened inside it, and whatever the number of blocks opened over the same file: they
+    all resolve against the one tree held in memory, read and written by the outermost. A build of N
     nested objects otherwise parses the file 2N+1 times and writes it N times (Config_GAN.yml, 7 KB,
     76 objects: 153 parses and 76 dumps, 2.96 s of a 4.7 s build; 0.05 s held in memory).
     """
     filename = os.environ.get("KONFAI_config_file")
     tree: dict = {}
+    # A block opened inside another one on the same file binds to the tree already held: reloading
+    # it would hide what the outer contexts bound, and flushing it would be undone by the outer
+    # flush of a tree that predates this block.
+    outer = _shared_tree(Path(filename)) if filename else None
     if filename and Path(filename).exists():
-        tree = _load_tree(filename)
+        tree = outer.tree if outer is not None else _load_tree(filename)
         if root not in tree:
             _report(
                 refuse,
@@ -231,7 +236,7 @@ def strict_config(root: str, refuse: bool = True) -> Iterator[None]:
                 " block appended to the file in its place.",
             )
     ledger = _KeyLedger()
-    shared = _SharedTree(Path(filename), tree) if filename else None
+    shared = _SharedTree(Path(filename), tree) if filename and outer is None else None
     _ledgers.append(ledger)
     if shared is not None:
         _shared_trees.append(shared)

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -58,7 +58,13 @@ from konfai import current_date
 from konfai.utils import uri
 from konfai.utils.budget import format_bytes, per_rank_budget_bytes
 from konfai.utils.errors import DatasetManagerError
-from konfai.utils.utils import SUPPORTED_EXTENSIONS, directory_volume_form, is_store_name, split_format_level
+from konfai.utils.utils import (
+    STORE_FORMS,
+    SUPPORTED_EXTENSIONS,
+    directory_volume_form,
+    is_store_name,
+    split_format_level,
+)
 
 _h5_file_locks: dict[str, threading.RLock] = {}
 _h5_file_locks_guard = threading.Lock()
@@ -2418,7 +2424,9 @@ class Dataset:
             if writing:
                 uri.refuse_write(self.filename)
                 return f"{base}.ome.zarr"
-            candidates = [f"{base}.ome.zarr", f"{base}.zarr", base]
+            # Every spelling is_store_name accepts, or a root whose first case names one of the
+            # others is detected as omezarr at setup and then fails to resolve.
+            candidates = [f"{base}{form}" for form in STORE_FORMS] + [base]
             for candidate in candidates:
                 if uri.is_dir(candidate):
                     return candidate
@@ -2572,10 +2580,9 @@ class Dataset:
         def get_group(self) -> list[str]:
             groups = []
             for name in uri.list_names(self.filename):
-                if name.endswith(".ome.zarr"):
-                    groups.append(name.removesuffix(".ome.zarr"))
-                elif name.endswith(".zarr"):
-                    groups.append(name.removesuffix(".zarr"))
+                form = next((form for form in STORE_FORMS if name.lower().endswith(form)), None)
+                if form is not None:
+                    groups.append(name[: -len(form)])
             return sorted(groups)
 
         def is_exist(self, group: str, name: str | None = None) -> bool:

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -2430,12 +2430,32 @@ class Dataset:
             for candidate in candidates:
                 if uri.is_dir(candidate):
                     return candidate
+            listed = self._listed_as(name)
+            if listed is not None:
+                return listed
             if not uri.is_uri(self.filename):
                 for candidate in candidates:  # a writer killed mid-replacement left the previous store aside
                     _recover_orphaned_backup(Path(candidate))
                     if os.path.isdir(candidate):  # recovered here, or published by whoever won the race
                         return candidate
             raise NameError(f"OME-Zarr group '{name}' not found in '{self.filename}'.")
+
+        def _listed_as(self, name: str) -> str | None:
+            """Where ``name``'s store sits when the directory spells its suffix in another case,
+            ``None`` when nothing there is that store.
+
+            ``is_store_name`` and :meth:`get_group` match the suffix case-insensitively, so a
+            ``CT.OME.ZARR`` is accepted at setup and listed as ``CT``; on a case-sensitive
+            filesystem the probes above, which are the accepted spellings in lower case, all miss
+            it. Only the miss pays the listing, and it lists one case's directory.
+            """
+            prefix, _, stem = name.rpartition("/")
+            directory = uri.join(self.filename, prefix) if prefix else self.filename
+            wanted = {f"{stem}{form}".lower() for form in STORE_FORMS}
+            for entry in uri.list_names(directory):
+                if entry.lower() in wanted:
+                    return uri.join(directory, entry)
+            return None
 
         @staticmethod
         def _attributes(metadata: dict[str, Any]) -> Attribute:

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -390,7 +390,9 @@ _STATISTICS_CHUNK_ELEMENTS = 8_000_000
 #: not released yet, a generator reading the next while its caller still names the last. Measured at
 #: 95.6 MiB of resident set for a 30.5 MiB block over a 78 MiB case.
 _STATISTICS_BLOCKS_IN_FLIGHT = 3
-#: The bytes a scanned element is priced at, as everything else the budget sizes prices them.
+#: The bytes a scanned element is priced at when the source's own size is not known: what everything
+#: else the budget sizes prices an element at. A block is the store's OWN dtype, never a cast copy,
+#: so where the store can be asked (:meth:`Dataset._scanned_element_bytes`) it answers instead.
 _STATISTICS_ELEMENT_BYTES = 4
 #: Elements one running-statistics update takes at once: its float64 temporaries then stay in cache,
 #: where a whole block's stream through memory. Below the block on purpose: the block is the READ
@@ -398,18 +400,17 @@ _STATISTICS_ELEMENT_BYTES = 4
 _STATISTICS_UPDATE_ELEMENTS = 1 << 18
 
 
-def _statistics_block_elements() -> int:
+def _statistics_block_elements(element_bytes: int = _STATISTICS_ELEMENT_BYTES) -> int:
     """Elements one block of a whole-volume scan may hold: its share of the budget this rank
-    published, since :data:`_STATISTICS_BLOCKS_IN_FLIGHT` of them are in flight at the peak. A fixed
-    read grain made a scan cost the same 95.6 MiB whatever the budget said. Without a declared
-    budget, the grain that keeps a chunked store's decode whole.
+    published, since :data:`_STATISTICS_BLOCKS_IN_FLIGHT` of them are in flight at the peak, each of
+    them ``element_bytes`` an element. A fixed read grain made a scan cost the same 95.6 MiB
+    whatever the budget said. Without a declared budget, the grain that keeps a chunked store's
+    decode whole.
     """
     budget = per_rank_budget_bytes()
     if budget is None:
         return _STATISTICS_CHUNK_ELEMENTS
-    return max(
-        1, min(_STATISTICS_CHUNK_ELEMENTS, int(budget / (_STATISTICS_BLOCKS_IN_FLIGHT * _STATISTICS_ELEMENT_BYTES)))
-    )
+    return max(1, min(_STATISTICS_CHUNK_ELEMENTS, int(budget / (_STATISTICS_BLOCKS_IN_FLIGHT * element_bytes))))
 
 
 def _statistics_plane_elements(shape: list[int] | tuple[int, ...], axis: int) -> int:
@@ -3323,11 +3324,17 @@ class Dataset:
         # A whole number of update pieces, so the fold sees the same sequence of pieces in the same
         # order whatever the read grain: the running mean and std are then the budget's business
         # only in how much is held, never in what they answer.
-        piece = _statistics_chunk_length(shape, 1, _STATISTICS_UPDATE_ELEMENTS)
-        rows = max(piece, _statistics_chunk_length(shape, 1, _statistics_block_elements()) // piece * piece)
         budget = per_rank_budget_bytes()
+        # Only a declared budget sizes anything from it, so only a declared budget pays the probe.
+        element_bytes = (
+            _STATISTICS_ELEMENT_BYTES if budget is None else self._scanned_element_bytes(groups, name, shape)
+        )
+        piece = _statistics_chunk_length(shape, 1, _STATISTICS_UPDATE_ELEMENTS)
+        rows = max(
+            piece, _statistics_chunk_length(shape, 1, _statistics_block_elements(element_bytes)) // piece * piece
+        )
         plane = _statistics_plane_elements(shape, 1)
-        held = rows * plane * _STATISTICS_BLOCKS_IN_FLIGHT * _STATISTICS_ELEMENT_BYTES
+        held = rows * plane * _STATISTICS_BLOCKS_IN_FLIGHT * element_bytes
         if budget is not None and held > budget:
             raise DatasetManagerError(
                 f"'{name}': the shortest block a whole-volume scan of '{groups}' can read holds"
@@ -3345,6 +3352,17 @@ class Dataset:
                 yield self.read_data_slice(groups, name, slices)[0]
 
         return slabs
+
+    def _scanned_element_bytes(self, groups: str, name: str, shape: list[int]) -> int:
+        """What one element of a scanned block costs: the store's own element size, read off a
+        one-voxel region.
+
+        A block of a scan is the bytes the store hands over, never a cast copy of them, so a
+        float64 source held twice what the budget was told at every block in flight. The probe is a
+        bounded read, which is the route this entry is on, and one voxel of it.
+        """
+        probe = (slice(0, 1),) * len(shape)
+        return max(1, int(self.read_data_slice(groups, name, probe)[0].dtype.itemsize))
 
     def read_data_quantile(self, groups: str, name: str, q: float) -> Any:
         """``numpy.quantile(volume, q)`` (the default ``linear`` method, to the value) without

--- a/konfai/utils/dataset.py
+++ b/konfai/utils/dataset.py
@@ -61,6 +61,7 @@ from konfai.utils.errors import DatasetManagerError
 from konfai.utils.utils import (
     STORE_FORMS,
     SUPPORTED_EXTENSIONS,
+    SUPPORTED_FORMATS,
     directory_volume_form,
     is_store_name,
     split_format_level,
@@ -3025,8 +3026,18 @@ class Dataset:
         downsample_method: str | None = None,
     ) -> None:
         base_format, self.level = split_format_level(file_format)
-        normalized_format = base_format.lower().removeprefix(".").replace("_", "-")
-        file_format = {"ome-zarr": "omezarr", "zarr": "omezarr"}.get(normalized_format, normalized_format)
+        normalized_format = base_format.lower().removeprefix(".")
+        # One vocabulary for a store: every spelling the walk accepts on disk is a token here, the
+        # dotted one included, since that is the suffix a store actually carries.
+        file_format = "omezarr" if f".{normalized_format}" in STORE_FORMS else normalized_format
+        if file_format not in SUPPORTED_FORMATS:
+            # Unchecked, the token reaches the SimpleITK writer, which either raises on an extension
+            # it cannot name or writes a file no backend of ours probes: 'hd5' for 'h5' wrote and read
+            # back correctly while ``is_dataset_exist`` said no, so a resumed run redid the work.
+            raise DatasetManagerError(
+                f"'{base_format}' is not a format KonfAI writes.",
+                "Use one of: " + ", ".join(sorted(SUPPORTED_FORMATS)) + ".",
+            )
         self.filename, self.is_directory = Dataset._normalize_path(filename, file_format)
         self.file_format = file_format
         # The store backend is auto-detected from what is actually on disk (like SitkFile already probes

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -1122,14 +1122,15 @@ def rank_pool() -> ThreadPoolExecutor | None:
     """
     global _rank_pool, _rank_pool_share
     workers = rank_cpu_share()
-    if workers <= 1:
-        return None
     with _rank_pool_lock:
         # The share changes within one process when a multi-rank build is followed by an inline
         # single-rank workflow: the pool is rebuilt at the new size, the old one's idle threads let go.
+        # A share of one keeps no pool at all, so the threads go with it.
         if _rank_pool is not None and _rank_pool_share != workers:
             _rank_pool.shutdown(wait=False)
-            _rank_pool = None
+            _rank_pool, _rank_pool_share = None, 0
+        if workers <= 1:
+            return None
         if _rank_pool is None:
             _rank_pool = ThreadPoolExecutor(max_workers=workers, thread_name_prefix="konfai-rank")
             _rank_pool_share = workers

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -1213,21 +1213,33 @@ def apply_cpu_thread_budget(world_size: int | None = None) -> None:
     _cpu_budget_applied = True
 
 
-def pin_gloo_to_loopback() -> None:
-    """Bind gloo to the loopback interface, for a world whose ranks all sit on this host.
+@contextmanager
+def pin_gloo_to_loopback(local: bool) -> Iterator[None]:
+    """Bind gloo to the loopback interface for a rendezvous whose ranks all sit on this host.
 
     gloo picks its interface by resolving the host's name. On a macOS runner that name is an mDNS
     ``.local`` name no resolver answers, and the rendezvous fails there rather than on the loopback
     that carries the whole single-node world (the streamed-prediction integration tests flaked on
-    the macos-latest runner for exactly that). An explicit ``GLOO_SOCKET_IFNAME`` keeps authority,
-    and a host with no loopback in ``if_nameindex`` is left to gloo's own resolution.
+    the macos-latest runner for exactly that). ``local`` says whether the world is that one: off
+    this host the loopback reaches no other rank, and gloo's own resolution stands.
+
+    gloo reads the variable as it builds the device, so it is taken back out of the environment
+    once the group is up: a later multi-node rendezvous in the same process, or a child that
+    inherits this environment, would otherwise be pinned to an interface reaching no other node.
+    An explicit ``GLOO_SOCKET_IFNAME`` keeps authority and is left untouched, and a host with no
+    loopback in ``if_nameindex`` is left to gloo's own resolution.
     """
-    if os.environ.get("GLOO_SOCKET_IFNAME"):
-        return
-    interfaces = {name for _, name in socket.if_nameindex()}
-    loopback = next((name for name in ("lo", "lo0") if name in interfaces), None)
+    loopback = None
+    if local and not os.environ.get("GLOO_SOCKET_IFNAME"):
+        interfaces = {name for _, name in socket.if_nameindex()}
+        loopback = next((name for name in ("lo", "lo0") if name in interfaces), None)
     if loopback is not None:
         os.environ["GLOO_SOCKET_IFNAME"] = loopback
+    try:
+        yield
+    finally:
+        if loopback is not None:
+            os.environ.pop("GLOO_SOCKET_IFNAME", None)
 
 
 def setup_gpu(world_size: int, rank: int | None = None, process_group: bool = True) -> tuple[int | None, int | None]:
@@ -1278,14 +1290,13 @@ def setup_gpu(world_size: int, rank: int | None = None, process_group: bool = Tr
         )
     else:
         if not dist.is_initialized():
-            if host_name == "localhost":
-                pin_gloo_to_loopback()
-            dist.init_process_group(
-                backend="gloo",
-                init_method=f"tcp://{host_name}:{port}",
-                rank=global_rank,
-                world_size=world_size,
-            )
+            with pin_gloo_to_loopback(local=host_name == "localhost"):
+                dist.init_process_group(
+                    backend="gloo",
+                    init_method=f"tcp://{host_name}:{port}",
+                    rank=global_rank,
+                    world_size=world_size,
+                )
     return global_rank, local_rank
 
 

--- a/konfai/utils/uri.py
+++ b/konfai/utils/uri.py
@@ -101,9 +101,16 @@ def filesystem(path: str | Path) -> Any:
             else f"Install the fsspec implementation for {protocol}.",
         ) from exc
     except (TypeError, ValueError) as exc:
+        # fsspec says "Protocol not known" for a scheme nothing registers, and that is not a
+        # configuration to check: the variables it would point at do not exist for it.
+        unknown = "not known" in str(exc).lower()
         raise DatasetManagerError(
-            f"'{protocol}://' refused its fsspec configuration: {exc}.",
-            "Check the FSSPEC_" + protocol.upper() + "_* variables and ~/.config/fsspec/.",
+            f"No filesystem is registered for '{protocol}://' ({exc})."
+            if unknown
+            else f"'{protocol}://' refused its fsspec configuration: {exc}.",
+            f"Install the fsspec implementation for {protocol}, or check the scheme for a typo."
+            if unknown
+            else "Check the FSSPEC_" + protocol.upper() + "_* variables and ~/.config/fsspec/.",
         ) from exc
 
 

--- a/konfai/utils/uri.py
+++ b/konfai/utils/uri.py
@@ -74,6 +74,14 @@ def join(root: str, *parts: str) -> str:
     return "/".join([root.rstrip("/"), *(str(part).strip("/") for part in parts if part)])
 
 
+def _is_registered(protocol: str) -> bool:
+    """Whether fsspec knows an implementation for ``protocol``, installed or not: the registry it
+    builds a filesystem from (already built, or known and waiting for its package)."""
+    from fsspec.registry import known_implementations, registry
+
+    return protocol in registry or protocol in known_implementations
+
+
 def filesystem(path: str | Path) -> Any:
     """The fsspec filesystem serving ``path``.
 
@@ -101,9 +109,10 @@ def filesystem(path: str | Path) -> Any:
             else f"Install the fsspec implementation for {protocol}.",
         ) from exc
     except (TypeError, ValueError) as exc:
-        # fsspec says "Protocol not known" for a scheme nothing registers, and that is not a
-        # configuration to check: the variables it would point at do not exist for it.
-        unknown = "not known" in str(exc).lower()
+        # A scheme nothing registers is not a configuration to check: the variables it would point
+        # at do not exist for it. Asked of fsspec's own registry, because the same exception types
+        # carry a configuration's own refusal, and its wording is not an interface.
+        unknown = not _is_registered(protocol)
         raise DatasetManagerError(
             f"No filesystem is registered for '{protocol}://' ({exc})."
             if unknown

--- a/konfai/utils/uri.py
+++ b/konfai/utils/uri.py
@@ -74,14 +74,6 @@ def join(root: str, *parts: str) -> str:
     return "/".join([root.rstrip("/"), *(str(part).strip("/") for part in parts if part)])
 
 
-def _is_registered(protocol: str) -> bool:
-    """Whether fsspec knows an implementation for ``protocol``, installed or not: the registry it
-    builds a filesystem from (already built, or known and waiting for its package)."""
-    from fsspec.registry import known_implementations, registry
-
-    return protocol in registry or protocol in known_implementations
-
-
 def filesystem(path: str | Path) -> Any:
     """The fsspec filesystem serving ``path``.
 
@@ -98,28 +90,28 @@ def filesystem(path: str | Path) -> Any:
             f"Reading a dataset from '{protocol}://' needs fsspec.",
             "Install it with: pip install konfai[omezarr]",
         ) from exc
+    # Routing first, arguments second: `get_filesystem_class` answers whether the protocol reaches an
+    # implementation at all (ValueError if nothing registers it, ImportError naming the package if
+    # something does), so what `filesystem` then refuses is the configuration and nothing else.
     try:
-        return fsspec.filesystem(protocol)
+        fsspec.get_filesystem_class(protocol)
+    except ValueError as exc:
+        raise DatasetManagerError(
+            f"No filesystem is registered for '{protocol}://' ({exc}).",
+            f"Install the fsspec implementation for {protocol}, or check the scheme for a typo.",
+        ) from exc
     except ImportError as exc:
         extra = _SCHEME_EXTRAS.get(protocol)
         raise DatasetManagerError(
             f"No filesystem is installed for '{protocol}://' ({exc}).",
-            f"Install it with: pip install konfai[{extra}]"
-            if extra
-            else f"Install the fsspec implementation for {protocol}.",
+            f"Install it with: pip install konfai[{extra}]" if extra else str(exc),
         ) from exc
+    try:
+        return fsspec.filesystem(protocol)
     except (TypeError, ValueError) as exc:
-        # A scheme nothing registers is not a configuration to check: the variables it would point
-        # at do not exist for it. Asked of fsspec's own registry, because the same exception types
-        # carry a configuration's own refusal, and its wording is not an interface.
-        unknown = not _is_registered(protocol)
         raise DatasetManagerError(
-            f"No filesystem is registered for '{protocol}://' ({exc})."
-            if unknown
-            else f"'{protocol}://' refused its fsspec configuration: {exc}.",
-            f"Install the fsspec implementation for {protocol}, or check the scheme for a typo."
-            if unknown
-            else "Check the FSSPEC_" + protocol.upper() + "_* variables and ~/.config/fsspec/.",
+            f"'{protocol}://' refused its fsspec configuration: {exc}.",
+            "Check the FSSPEC_" + protocol.upper() + "_* variables and ~/.config/fsspec/.",
         ) from exc
 
 

--- a/konfai/utils/utils.py
+++ b/konfai/utils/utils.py
@@ -418,6 +418,10 @@ def storage_form(path: Path) -> str:
     return "" if path.is_dir() else path.suffix
 
 
+#: Longest first, so `.ome.zarr` wins over its `.zarr` tail wherever a name is matched or stripped.
+STORE_FORMS = sorted(_STORE_FORMS, key=len, reverse=True)
+
+
 def is_store_name(name: str) -> bool:
     """Whether ``name`` is spelled as an OME-Zarr store, by its extension alone: no disk is probed."""
     lowered = name.lower()

--- a/pixi.lock
+++ b/pixi.lock
@@ -1980,7 +1980,7 @@ packages:
 - pypi: ./
   name: konfai
   requires_dist:
-  - torch
+  - torch>=2.3
   - tqdm
   - numpy
   - ruamel-yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,9 @@ classifiers = [
 ]
 
 dependencies = [
-  "torch",
+  # 2.3 is the first torch with the unsigned dtypes: a uint16 store (what microscopy writes) reaches
+  # torch.from_numpy on the read route, and torch.uint16 is named where a label map's sign is read.
+  "torch>=2.3",
   "tqdm",
   "numpy",
   "ruamel.yaml",

--- a/tests/unit/test_augmentation.py
+++ b/tests/unit/test_augmentation.py
@@ -585,6 +585,9 @@ def test_an_augmentation_group_is_handed_the_case_not_a_clone_of_it(tmp_path: Pa
     dataset.write("CT", "CASE", np.random.default_rng(0).random((1, 6, 7, 8)).astype(np.float32), attributes)
     flip = Flip(f_prob=[1.0, 1.0, 1.0])
     flip.load(0.5)
+    # The selection is drawn from the global RNG, so the seed is the fixture: at 0.5 over eight
+    # copies one run in 128 selects all of them or none, and the case below covers neither.
+    torch.manual_seed(0)
     group = DataAugmentationsList(nb=8)
     group.data_augmentations = [flip]
     manager = DatasetManager(0, "CT", "CT", "CASE", dataset, None, [], [group])

--- a/tests/unit/test_case_reduction.py
+++ b/tests/unit/test_case_reduction.py
@@ -21,6 +21,7 @@ never assembled, that a cases which does not agree on its grid is refused before
 and that a chain continues after the reduction."""
 
 import itertools
+import time
 import weakref
 from pathlib import Path
 
@@ -664,12 +665,37 @@ def test_a_reduction_accounts_for_every_second_of_its_own_wall_clock(tmp_path: P
     assert engine.materialize() is True
 
     wall = SWEEP_CLOCK.spent("sweep")
-    named = sum(SWEEP_CLOCK.spent(phase) for phase in ("chain", "fetch", "wait(read)", "wait(write)"))
+    phases = {phase: SWEEP_CLOCK.spent(phase) for phase in ("chain", "fetch", "wait(read)", "wait(write)")}
     assert wall > 0.0
-    assert 0.0 <= wall - named <= wall, "a phase is counted outside the fold it belongs to"
+    # Every phase of the line is recorded, or the report accounts for the run by leaving it out.
+    assert all(spent > 0.0 for spent in phases.values()), phases
+    assert 0.0 <= wall - sum(phases.values()) <= wall, "a phase is counted outside the fold it belongs to"
     # No pipeline: the store's own seconds are the seconds the fold stands still.
     assert SWEEP_CLOCK.spent("wait(read)") >= SWEEP_CLOCK.spent("read") > 0.0
     assert SWEEP_CLOCK.spent("wait(write)") >= SWEEP_CLOCK.spent("write") > 0.0
+
+
+def test_the_fold_charges_the_operator_s_own_work_to_the_chain(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An incremental operator does the reduction in ``accumulate``, not in ``finalize``.
+
+    Timed around ``finalize`` alone, the line credited a ``Mean`` or a ``Std`` with the last
+    division and left every addition it made in ``other``: the phase that is supposed to say what
+    the reduction costs under-reported it by the whole of the fold.
+    """
+    delay = 0.02
+    accumulate = Mean.accumulate
+
+    def slow(self: Mean, member: torch.Tensor) -> None:
+        time.sleep(delay)
+        accumulate(self, member)
+
+    monkeypatch.setattr(Mean, "accumulate", slow)
+    SWEEP_CLOCK.reset()
+    engine, _destination, _volumes = _run(tmp_path, [], Reduce(operator="Mean", output="timed"), [])
+    assert engine.materialize() is True
+
+    assert SWEEP_CLOCK.spent("chain") >= CASES * delay
+    assert SWEEP_CLOCK.spent("read") < CASES * delay, "the member reads are not the operator's work"
 
 
 def test_an_incremental_fold_holds_one_member_region_at_a_time(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -21,6 +21,7 @@ Covers ``Config`` file handling and error messages, ``apply_config`` type bindin
 keys), and the config env-var bookkeeping.
 """
 
+import functools
 import os
 import sys
 import threading
@@ -283,6 +284,30 @@ def test_apply_config_rejects_unknown_boolean_string(write_config) -> None:
 
     with pytest.raises(ConfigError, match="expected bool"):
         apply_config("Root")(Root)()
+
+
+def test_predictor_binds_check_training_transforms_from_the_file(write_config, monkeypatch) -> None:
+    """``check_training_transforms: false`` under ``Predictor:`` reaches the constructor.
+
+    The key silences the warning a prediction raises when a model input is not preprocessed the way
+    its checkpoint trained on it; bound off ``Predictor``'s own signature here, so a rename of the
+    parameter shows up as a key that no longer binds. The body is captured rather than run: what is
+    at stake is the binding, not the workflow.
+    """
+    from konfai.predictor import Predictor
+
+    write_config("Predictor:\n  check_training_transforms: false\n")
+    bound: dict[str, object] = {}
+
+    @functools.wraps(Predictor.__init__)
+    def capture(_self, **kwargs) -> None:
+        bound.update(kwargs)
+
+    monkeypatch.setattr(Predictor, "__init__", capture)
+
+    apply_config()(Predictor)()
+
+    assert bound["check_training_transforms"] is False
 
 
 def test_apply_config_instantiates_dict_of_nested_objects(write_config) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -972,6 +972,22 @@ def test_a_strict_block_writes_the_file_a_context_materialized(tmp_path: Path, m
     assert written["Root"] == {"depth": 1, "kept": 0, "Nested": {"width": 2}}
 
 
+def test_a_block_opened_inside_another_one_on_the_same_file_keeps_both_blocks_writes(write_config) -> None:
+    """One file, two blocks: what the inner one bound is on disk beside what the outer one bound.
+
+    Each block loading its own tree would have the outer's flush, of a tree read before the inner
+    block existed, land last and take the inner's roots back to what the file held."""
+    config_path = write_config("Root:\n  kept: 1\nOther:\n  kept: 2\n")
+    with strict_config("Root"):
+        outer = apply_config("Root")(_StrictRoot)()
+        with strict_config("Other"):
+            inner = apply_config("Other")(_StrictRoot)()
+    assert (outer.kept, inner.kept) == (1, 2)
+    written = ruamel.yaml.YAML().load(config_path.read_text(encoding="utf-8"))
+    assert written["Root"] == {"kept": 1, "depth": 1, "Nested": {"width": 2}}
+    assert written["Other"] == {"kept": 2, "depth": 1, "Nested": {"width": 2}}
+
+
 _EXAMPLES = Path(__file__).resolve().parents[2] / "examples"
 _WORKFLOWS = {
     "Trainer": ("konfai.trainer", "Trainer", "TRAIN", {"KONFAI_CHECKPOINTS_DIRECTORY", "KONFAI_STATISTICS_DIRECTORY"}),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -25,6 +25,7 @@ import functools
 import os
 import sys
 import threading
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Literal
 
@@ -998,11 +999,17 @@ _WORKFLOWS = {
 
 
 def _shipped_workflow_configs() -> list[str]:
-    return sorted(
-        str(path.relative_to(_EXAMPLES))
-        for path in _EXAMPLES.glob("*/*.yml")
-        if next(iter(ruamel.yaml.YAML().load(path.read_text(encoding="utf-8")))) in _WORKFLOWS
-    )
+    """Every shipped config whose first key names a workflow.
+
+    This feeds a parametrize, so it runs at collection: an example that is empty (no mapping at
+    all) or opens on a sequence is not one of these files, and must not take the module's
+    collection down with it."""
+    relatives = []
+    for path in _EXAMPLES.glob("*/*.yml"):
+        tree = ruamel.yaml.YAML().load(path.read_text(encoding="utf-8"))
+        if isinstance(tree, Mapping) and next(iter(tree), None) in _WORKFLOWS:
+            relatives.append(str(path.relative_to(_EXAMPLES)))
+    return sorted(relatives)
 
 
 def _bind_shipped_config(relative: str, workdir: Path, strict: bool, monkeypatch: pytest.MonkeyPatch) -> bytes:

--- a/tests/unit/test_dataset_statistics.py
+++ b/tests/unit/test_dataset_statistics.py
@@ -301,6 +301,9 @@ def test_the_fold_reads_a_bounded_store_by_blocks_and_never_whole(
 
     monkeypatch.setattr(Dataset, "read_data_slice", counted)
     dataset.read_data_statistics("CT", "P0")
+    # Under a declared budget the blocks are priced off a one-voxel read of the store; the blocks
+    # themselves are the rest, and they cover the volume whether or not that probe happened.
+    blocks = [shape for shape in blocks if int(np.prod(shape)) > 1]
     assert len(blocks) > 1 and all(shape[0] == 1 and shape[2:] == (12, 10) for shape in blocks)
     assert sum(shape[1] for shape in blocks) == 37
 
@@ -400,3 +403,26 @@ def test_a_budget_the_shortest_block_of_a_scan_exceeds_is_refused(
 
     with pytest.raises(DatasetManagerError, match=r"over the per-rank memory budget \(4.00 KiB\)"):
         dataset.read_data_statistics("CT", "P0")
+
+
+def test_a_scan_of_a_float64_source_reads_blocks_the_budget_holds(
+    tmp_path: Path, image_attributes, monkeypatch: pytest.MonkeyPatch, budgeted_scan: None
+) -> None:
+    """A block is the bytes the store hands over, not a float32 copy of them.
+
+    Priced at four bytes an element whatever the source, the three blocks a scan holds in flight
+    over a float64 store came to twice the budget the run was given, and nothing said so.
+    """
+    dataset = Dataset(tmp_path / "store", "mha")
+    volume = _volume((1, 64, 40, 40), dtype=np.float64)
+    dataset.write("CT", "P0", volume, image_attributes([0.0, 0.0, 0.0], [1.0, 1.0, 1.0]))
+    assert dataset.read_data_slice("CT", "P0", (slice(0, 1),) * 4)[0].dtype == np.float64
+
+    budget = dataset_module._STATISTICS_BLOCKS_IN_FLIGHT * 8 * 8 * 40 * 40  # three eight-row float64 blocks
+    set_per_rank_budget(budget)
+    blocks = _scan_blocks(dataset, monkeypatch)
+    got = dataset.read_data_statistics("CT", "P0")
+
+    held = max(int(np.prod(shape)) for shape in blocks) * 8 * dataset_module._STATISTICS_BLOCKS_IN_FLIGHT
+    assert held <= budget, f"{held} B held against a {budget} B budget"
+    _assert_close_to_numpy(got, volume)

--- a/tests/unit/test_ome_zarr_data_surface.py
+++ b/tests/unit/test_ome_zarr_data_surface.py
@@ -699,3 +699,24 @@ def test_a_store_named_in_any_accepted_spelling_resolves_and_lists(tmp_path: Pat
         dataset = Dataset(str(root), "omezarr")
         assert dataset.get_group() == ["CT"], form
         assert dataset.is_dataset_exist("CT", "CASE"), form
+
+
+def test_a_store_whose_suffix_is_not_lower_case_resolves_and_reads(tmp_path: Path) -> None:
+    """The walk matches the suffix case-insensitively; the resolution has to as well.
+
+    `CT.OME.ZARR` is accepted as a store name and listed as the group `CT`, but on a case-sensitive
+    filesystem the probed spellings are all lower case: the read of a group the same object just
+    reported raised `NameError: OME-Zarr group not found`.
+    """
+    from konfai.utils.utils import is_store_name
+
+    (tmp_path / "CASE").mkdir()
+    create_ome_zarr_store(tmp_path / "CASE" / "CT.OME.ZARR", (1, 2, 3, 4), "<u1", spacing=[1.0, 1.0, 1.0])
+    assert is_store_name("CT.OME.ZARR")
+
+    dataset = Dataset(str(tmp_path), "omezarr")
+
+    assert dataset.get_group() == ["CT"]
+    assert dataset.is_dataset_exist("CT", "CASE")
+    assert dataset.get_infos("CT", "CASE")[0] == [1, 2, 3, 4]
+    assert dataset.read_data("CT", "CASE")[0].shape == (1, 2, 3, 4)

--- a/tests/unit/test_ome_zarr_data_surface.py
+++ b/tests/unit/test_ome_zarr_data_surface.py
@@ -701,6 +701,22 @@ def test_a_store_named_in_any_accepted_spelling_resolves_and_lists(tmp_path: Pat
         assert dataset.is_dataset_exist("CT", "CASE"), form
 
 
+def test_a_format_token_the_writer_does_not_know_is_refused_by_name(tmp_path: Path) -> None:
+    """Every spelling the walk accepts on disk is a token the writer accepts, the dotted one first.
+    A token nothing knows is refused here rather than handed to SimpleITK, which wrote 'hd5' for
+    'h5' and read it back correctly while ``is_dataset_exist`` said no: a resumed run redid the work.
+    """
+    from konfai.utils.errors import DatasetManagerError
+    from konfai.utils.utils import STORE_FORMS
+
+    for form in STORE_FORMS:
+        assert Dataset(str(tmp_path / form.strip(".")), form.removeprefix(".")).file_format == "omezarr", form
+
+    for token in ("hd5", "niigz", "ome zarr", ""):
+        with pytest.raises(DatasetManagerError, match="not a format KonfAI writes"):
+            Dataset(str(tmp_path / "refused"), token)
+
+
 def test_a_store_whose_suffix_is_not_lower_case_resolves_and_reads(tmp_path: Path) -> None:
     """The walk matches the suffix case-insensitively; the resolution has to as well.
 

--- a/tests/unit/test_ome_zarr_data_surface.py
+++ b/tests/unit/test_ome_zarr_data_surface.py
@@ -683,3 +683,19 @@ def test_a_declared_patch_epoch_decodes_fewer_chunks_than_recency_alone(
     lru, planned = epoch(False), epoch(True)
 
     assert sum(planned.values()) < sum(lru.values()), f"{planned} against LRU's {lru}"
+
+
+def test_a_store_named_in_any_accepted_spelling_resolves_and_lists(tmp_path: Path) -> None:
+    """`is_store_name` accepts five spellings, so all five have to resolve: a root whose entry is
+    named with one the reader does not try is accepted at setup and then raises `NameError` on its
+    first read, while `get_group` reports no groups at all."""
+    from konfai.utils.utils import STORE_FORMS, is_store_name
+
+    for form in STORE_FORMS:
+        root = tmp_path / form.strip(".")
+        (root / "CASE").mkdir(parents=True)
+        create_ome_zarr_store(root / "CASE" / f"CT{form}", (1, 2, 3, 4), "<u1", spacing=[1.0, 1.0, 1.0])
+        assert is_store_name(f"CT{form}"), form
+        dataset = Dataset(str(root), "omezarr")
+        assert dataset.get_group() == ["CT"], form
+        assert dataset.is_dataset_exist("CT", "CASE"), form

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -180,6 +180,19 @@ def _packages_find_config() -> dict:
 
 
 @pytest.mark.skipif(tomllib is None, reason="requires tomllib (Python 3.11+) or the tomli backport")
+def test_the_declared_torch_floor_covers_the_dtypes_the_pipeline_reads() -> None:
+    """A uint16 store reaches ``torch.from_numpy``, and ``torch.uint16`` is named where a label
+    map's sign is read: both are torch 2.3. Without a floor, pip is free to resolve an older torch
+    and the run fails on a dtype instead of at install time."""
+    assert tomllib is not None
+    pyproject = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    torch_requirement = next(dep for dep in pyproject["project"]["dependencies"] if dep.startswith("torch"))
+    floor = torch_requirement.removeprefix("torch>=")
+    assert floor != torch_requirement, f"no lower bound on torch: {torch_requirement!r}"
+    assert tuple(int(part) for part in floor.split(".")) >= (2, 3)
+
+
+@pytest.mark.skipif(tomllib is None, reason="requires tomllib (Python 3.11+) or the tomli backport")
 def test_wheel_excludes_sibling_packages_but_keeps_namespace_subpackages() -> None:
     config = _packages_find_config()
     packages = find_namespace_packages(where=str(_REPO_ROOT), include=config["include"], exclude=config["exclude"])

--- a/tests/unit/test_predictor_chain_check.py
+++ b/tests/unit/test_predictor_chain_check.py
@@ -124,6 +124,12 @@ def test_a_shipped_example_preprocesses_its_inputs_the_way_it_trained(
             "'CT:CT' transforms[0] Normalize: the training chain has 'Clip' at this position",
             id="another-stage-at-the-same-position",
         ),
+        pytest.param(
+            {"custom_a:Normalize": {"min_value": 0}},
+            {"custom_b:Normalize": {"min_value": 0}},
+            "'CT:CT' transforms[0] custom_b:Normalize: the training chain has 'custom_a:Normalize' at this position",
+            id="the-same-class-name-from-another-module",
+        ),
     ],
 )
 def test_a_differing_stage_is_named_with_its_group_index_and_arguments(
@@ -167,6 +173,11 @@ def test_a_differing_stage_is_named_with_its_group_index_and_arguments(
             {"Clip": {"min_value": 0}},
             {"konfai.data.transform:Clip": {"min_value": 0}},
             id="the-module-qualified-spelling-of-one-stage",
+        ),
+        pytest.param(
+            {"Noise": {"prob": 1}},
+            {"konfai.data.augmentation:Noise": {"prob": 1}},
+            id="the-module-qualified-spelling-of-a-draw-declared-before-the-marker",
         ),
     ],
 )

--- a/tests/unit/test_remote_dataset.py
+++ b/tests/unit/test_remote_dataset.py
@@ -162,6 +162,18 @@ def test_konfai_declares_no_credentials_of_its_own(monkeypatch: pytest.MonkeyPat
 # ---------------------------------------------------------------- what a remote root cannot do
 
 
+def test_an_unregistered_scheme_is_not_reported_as_a_configuration_to_check() -> None:
+    """fsspec answers "Protocol not known" for a scheme nothing registers, and the variables the
+    configuration hint names do not exist for it: pointing a user at them sends them looking for a
+    setting they cannot write."""
+    pytest.importorskip("fsspec")
+    with pytest.raises(DatasetManagerError) as raised:
+        uri.filesystem("nosuchproto://bucket/key")
+    message = " ".join(str(part) for part in raised.value.args)
+    assert "No filesystem is registered for 'nosuchproto://'" in message
+    assert "FSSPEC_" not in message
+
+
 def test_a_remote_root_in_a_format_that_reads_files_is_refused(memory_root: str) -> None:
     """Only the store backend reads a URI; the others open a path, and a path is what a URI is not."""
     with pytest.raises(DatasetManagerError, match="only ':omezarr' can read"):

--- a/tests/unit/test_remote_dataset.py
+++ b/tests/unit/test_remote_dataset.py
@@ -174,6 +174,30 @@ def test_an_unregistered_scheme_is_not_reported_as_a_configuration_to_check() ->
     assert "FSSPEC_" not in message
 
 
+def test_which_refusal_a_scheme_gets_is_read_off_the_registry_not_off_the_wording(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same exception types carry both refusals, and only the registry tells them apart.
+
+    Classified on the text of the exception, a registered filesystem refusing a bucket it does not
+    know was reported as a scheme nothing implements (install something), and any wording fsspec
+    changes turns an unregistered scheme into configuration variables the user cannot write.
+    """
+    fsspec = pytest.importorskip("fsspec")
+
+    def refuse(protocol: str, **kwargs: object) -> object:
+        raise ValueError(f"bucket for {protocol} not known to this endpoint")
+
+    monkeypatch.setattr(fsspec, "filesystem", refuse)
+    with pytest.raises(DatasetManagerError) as configured:
+        uri.filesystem("memory://bucket/key")
+    with pytest.raises(DatasetManagerError) as unregistered:
+        uri.filesystem("nosuchproto://bucket/key")
+
+    assert "refused its fsspec configuration" in " ".join(str(part) for part in configured.value.args)
+    assert "No filesystem is registered" in " ".join(str(part) for part in unregistered.value.args)
+
+
 def test_a_remote_root_in_a_format_that_reads_files_is_refused(memory_root: str) -> None:
     """Only the store backend reads a URI; the others open a path, and a path is what a URI is not."""
     with pytest.raises(DatasetManagerError, match="only ':omezarr' can read"):

--- a/tests/unit/test_resample_transform.py
+++ b/tests/unit/test_resample_transform.py
@@ -23,10 +23,17 @@ an axis-aligned grid passes a map that is wrong in exactly the ways this stage c
 import sys
 from pathlib import Path
 
+import konfai.data.transform as transform_module
 import numpy as np
 import pytest
 import torch
-from konfai.data.transform import LocalityKind, RegionContext, Resample, _SitkInput
+from konfai.data.transform import (
+    LocalityKind,
+    RegionContext,
+    Resample,
+    _optional_image_filler,
+    _SitkInput,
+)
 from konfai.utils.dataset import Attribute
 from konfai.utils.errors import TransformError
 
@@ -643,6 +650,26 @@ class TestTheHostRouteReusesItsInputImage:
             assert np.array_equal(sitk.GetArrayViewFromImage(image), other)
         holder.drop()
         assert holder.filled(array) is not first
+
+    def test_a_simpleitk_without_the_in_place_fill_is_still_a_simpleitk(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The fill is a private symbol of the wrapper: optional on its own.
+
+        Guarded in the same clause as the package, a SimpleITK not exporting it made the whole
+        module read as no SimpleITK at all, and every stage needing one refused with an install
+        hint for a package that is installed.
+        """
+        import SimpleITK.SimpleITK as core
+
+        monkeypatch.delattr(core, "_SetImageFromArray")
+        assert _optional_image_filler() is None
+        assert transform_module.sitk is not None
+
+        monkeypatch.setattr(transform_module, "_set_image_from_array", None)
+        holder = _SitkInput()
+        array = np.arange(24, dtype=np.float32).reshape(2, 3, 4)
+        first = holder.filled(array)
+        assert holder.filled(array + 1.0) is not first
+        assert np.array_equal(sitk.GetArrayViewFromImage(holder.filled(array + 1.0)), array + 1.0)
 
     def test_a_sweep_keeps_the_image_and_a_whole_volume_call_does_not(self):
         image = _image()

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -905,9 +905,13 @@ def test_the_rank_pool_is_rebuilt_when_the_share_changes(monkeypatch) -> None:
     eight = rt.rank_pool()
     assert eight is not four and eight is not None and eight._max_workers == 8
     assert rt.rank_pool() is eight
+    # A share of one keeps no pool: the one built for the wider share is let go with its threads,
+    # instead of idling for the rest of the process.
     monkeypatch.setenv("OMP_NUM_THREADS", "1")
     assert rt.rank_pool() is None
-    eight.shutdown(wait=False)
+    assert rt._rank_pool is None
+    with pytest.raises(RuntimeError):
+        eight.submit(int)
 
 
 def _map_in_child() -> None:

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -288,11 +288,16 @@ def test_a_workflow_without_collectives_gets_its_rank_and_no_process_group(monke
 
 
 def _gloo_rendezvous(monkeypatch) -> dict[str, object]:
-    """Drive ``setup_gpu`` down its gloo branch and report what it passed to torch."""
+    """Drive ``setup_gpu`` down its gloo branch and report what it passed to torch, plus the
+    interface gloo would have read as it built its device (``interface``)."""
     initialized: dict[str, object] = {}
+
+    def init_process_group(**kwargs) -> None:
+        initialized.update(kwargs, interface=os.environ.get("GLOO_SOCKET_IFNAME"))
+
     monkeypatch.setattr(rt.torch.cuda, "is_available", lambda: False)
     monkeypatch.setattr(rt.dist, "is_initialized", lambda: False)
-    monkeypatch.setattr(rt.dist, "init_process_group", lambda **kwargs: initialized.update(kwargs))
+    monkeypatch.setattr(rt.dist, "init_process_group", init_process_group)
     monkeypatch.setenv("KONFAI_MASTER_PORT", "29500")
     return initialized
 
@@ -309,17 +314,21 @@ def test_a_single_node_gloo_world_is_pinned_to_the_loopback_interface(monkeypatc
 
     assert initialized["backend"] == "gloo"
     assert initialized["init_method"] == "tcp://localhost:29500"
-    assert os.environ["GLOO_SOCKET_IFNAME"] in {name for _, name in rt.socket.if_nameindex()}
+    assert initialized["interface"] in {name for _, name in rt.socket.if_nameindex()}
+    # The pin lasts the rendezvous: left behind, it would follow a later multi-node group, or a
+    # child of this process, onto an interface that reaches no other node.
+    assert "GLOO_SOCKET_IFNAME" not in os.environ
 
 
 @pytest.mark.skipif(os.name == "nt", reason="setup_gpu builds no process group on Windows")
 def test_an_explicit_gloo_interface_keeps_authority(monkeypatch):
     monkeypatch.setenv("GLOO_SOCKET_IFNAME", "eth0")
     monkeypatch.delenv("SLURM_JOB_NODELIST", raising=False)
-    _gloo_rendezvous(monkeypatch)
+    initialized = _gloo_rendezvous(monkeypatch)
 
     rt.setup_gpu(2, 0)
 
+    assert initialized["interface"] == "eth0"
     assert os.environ["GLOO_SOCKET_IFNAME"] == "eth0"
 
 
@@ -335,6 +344,7 @@ def test_a_multi_node_gloo_world_is_left_to_its_own_interface(monkeypatch):
     rt.setup_gpu(2, 0)
 
     assert initialized["init_method"] == "tcp://node001:29500"
+    assert initialized["interface"] is None
     assert "GLOO_SOCKET_IFNAME" not in os.environ
 
 

--- a/tests/unit/test_sweep_tiling.py
+++ b/tests/unit/test_sweep_tiling.py
@@ -306,3 +306,29 @@ def test_an_axis_whose_only_small_divisor_is_a_sliver_is_left_alone() -> None:
     """A chunk one voxel wide costs a reader the store; an oversized one costs it some bytes."""
     chunks = _store_chunks([1, 513, 1331, 1776], [1, 513, 641, 641], np.uint16)
     assert chunks == (1, 128, 641, 641)
+
+
+def test_the_device_ceiling_prices_what_a_region_pulls_and_holds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A GPU raises the region height as its free memory allows, and free memory is the whole price.
+
+    Counted as one landed plane per resident region, the ceiling ignored the source box a REGRID
+    pulls and the buffers the widest stage declares: a chain resampling through a sheared grid was
+    given a region the device could not hold, and where no host budget was declared nothing else
+    bounded it.
+    """
+    monkeypatch.setattr(patching_module, "SWEEP_SLAB_ROWS", ROWS)
+    source, _volume = _sheared_fixture(tmp_path)
+    resample = Resample(reference="TARGET", reference_group="GRID", reference_dataset=f"{tmp_path / 'ref'}:h5")
+    manager = _manager(source, [resample, Save(f"{tmp_path / 'out'}:h5")])
+    plans = _sweep_plans(manager)
+    free = 4 * _priced(manager, plans, 2 * ROWS)  # a quarter of it is what a region of 2 x ROWS holds
+    monkeypatch.setattr(manager, "_chain_device", torch.device("cuda"), raising=False)
+    monkeypatch.setattr(torch.cuda, "mem_get_info", lambda device=None: (free, free))
+
+    tile = manager._sweep_tile(list(LANDING), 1, plans)  # no host budget: the device is the only ceiling
+    held = manager.sweep_block_bytes(list(LANDING), 1, plans, tile, _sweep_pipeline_depth())
+
+    assert held <= free * 0.25, "the region the device was given does not fit the device"
+    assert held > _priced(manager, plans, ROWS), "and the device still buys a taller region than the host default"

--- a/tests/unit/test_trainer.py
+++ b/tests/unit/test_trainer.py
@@ -549,7 +549,9 @@ def test_restoring_the_ema_weights_is_charged_to_the_checkpoint_phase(tmp_path: 
         trainer.setup(1)
 
     assert trainer.model_ema is not None
-    assert clock.spent("checkpoint") >= 0.05
+    # A sleep can return a hair short of what it asked for (0.04977 on a Windows runner), so the
+    # bound is the sleep less the platform's timer granularity. Charged to setup it would be 0.
+    assert clock.spent("checkpoint") >= 0.04
 
 
 # ---- RESUME LR override ----

--- a/tests/unit/test_trainer.py
+++ b/tests/unit/test_trainer.py
@@ -508,6 +508,50 @@ def test_ema_runs_torchs_fused_rule_and_matches_the_per_tensor_one(monkeypatch) 
     assert Trainer._ema_update(cast(Any, stub)) == {"avg_fn": stub._avg_fn}
 
 
+def test_restoring_the_ema_weights_is_charged_to_the_checkpoint_phase(tmp_path: Path, monkeypatch) -> None:
+    """The EMA copy is restored from the same checkpoint as the model, and the startup line
+    accounts for it there: reported under ``setup`` it would read as the loaders' cost."""
+    import time
+
+    from konfai.utils.runtime import restart_startup_clock
+
+    class _SlowLoad:
+        def load(self, state_dict: dict, **kwargs) -> None:
+            del state_dict, kwargs
+            time.sleep(0.05)
+
+    monkeypatch.setattr(trainer_module, "checkpoints_directory", lambda: tmp_path / "Checkpoints")
+    monkeypatch.setattr(trainer_module, "statistics_directory", lambda: tmp_path / "Statistics")
+    monkeypatch.setattr(trainer_module, "konfai_state", lambda: "TRAIN")
+    monkeypatch.setattr(
+        trainer_module,
+        "AveragedModel",
+        lambda model, **kwargs: SimpleNamespace(module=_SlowLoad(), n_averaged=torch.zeros(1, dtype=torch.long)),
+    )
+    (tmp_path / "Statistics").mkdir()
+    config_path = tmp_path / "Config.yml"
+    config_path.write_text("Trainer:\n", encoding="utf-8")
+
+    trainer = cast(Any, Trainer.__new__(Trainer))
+    trainer.name = "RUN"
+    trainer.size = 1
+    trainer.it = 0
+    trainer.ema_decay = 0.999
+    trainer.model_ema = None
+    trainer.override_lr = None
+    trainer.model = cast(Any, SimpleNamespace(load=lambda *args, **kwargs: None))
+    trainer.dataset = cast(Any, SimpleNamespace(get_data=lambda world_size: ([], [], [])))
+    trainer.config_path_src = config_path
+    trainer.config_namefile = tmp_path / "Statistics" / "RUN" / "Config_0.yml"
+
+    clock = restart_startup_clock()
+    with clock.phase("setup"):
+        trainer.setup(1)
+
+    assert trainer.model_ema is not None
+    assert clock.spent("checkpoint") >= 0.05
+
+
 # ---- RESUME LR override ----
 
 # Resume/fine-tune learning-rate override semantics for ``Network.load``.

--- a/tests/unit/test_transformer_workflow.py
+++ b/tests/unit/test_transformer_workflow.py
@@ -722,6 +722,25 @@ def test_a_reduction_that_cannot_stream_refuses_whatever_on_fallback_says(tmp_pa
         _build(tmp_path).setup(1)
 
 
+def test_a_reduction_chain_is_refused_for_a_remote_save_before_its_terminal_write(tmp_path: Path) -> None:
+    """A reduction names its own output, and the chain it folds may Save somewhere else on the way.
+    Both are destinations no route can write when they are remote, and the plan says so before a
+    member is read: the terminal Write being local does not excuse the Save."""
+    pytest.importorskip("fsspec")
+    _write_source(tmp_path, cases=2)
+    _write_config(
+        tmp_path,
+        "              Clip:\n                min_value: 0.0\n                max_value: 50.0\n"
+        "              Save:\n                dataset: memory://bucket/cache:h5\n"
+        "              Reduce:\n                operator: Mean\n                output: atlas\n"
+        "              Write:\n"
+        f"                dataset: {tmp_path / 'out'}:h5\n",
+    )
+    plan = _build(tmp_path).compute_plan()
+    assert [entry.verdict for entry in plan.entries] == ["REFUSED"]
+    assert "remote root" in (plan.entries[0].reason or "")
+
+
 def test_a_finished_reduction_is_skipped_on_the_second_run(tmp_path: Path) -> None:
     _write_source(tmp_path, cases=3)
     _write_config(


### PR DESCRIPTION
Four defects the review of #123 found, each verified against the code and pinned by a test that fails without
the change. They are grouped here rather than folded into the branch that introduced them because the whole
stack merges as one release and a reviewer is better served by finding a finding and its answer in one place.

**A store's decoded chunks were never forgotten on Windows.** A reader keys them by the string it is handed,
which `OmeZarrFile._path` builds with `uri.join`, on forward slashes whatever the platform; a writer names the
same store with a `Path`, and `str(Path)` is backslashed there, so `clear_ome_zarr_cache` matched nothing. A
store replaced on disk then kept serving the chunks of the store it replaced, and a replacement can differ down
to the key its level-0 array lives under. `store_identity` is one spelling, taken by the read, the schedule and
the invalidation alike. POSIX is unaffected, which is why no test caught it: there the two spellings are already
equal.

**A reduction chain's intermediate `Save` escaped the remote refusal.** `_remote_destination` scanned the
chain's own Saves only when the caller named no destination, and the reduction path names one (its output). A
chain such as `Clip -> Save: memory://bucket/cache -> Reduce -> Write: ./out` was planned REDUCE, so the run
read and transformed every member before `uri.refuse_write` raised inside the sweep. The chain's Saves are now
always among the destinations checked. The new test reports REDUCE without the change.

**An unregistered scheme was reported as a configuration to check.** fsspec answers `ValueError: Protocol not
known` for a scheme nothing registers, and the message pointed the reader at `FSSPEC_<PROTO>_*` variables and
`~/.config/fsspec/` that do not exist for a protocol fsspec has never heard of. The two cases now say which one
happened.

**Two accepted store spellings could not be read.** `is_store_name` accepts `.ome.zarr`, `.ome-zarr`,
`.ome_zarr`, `.omezarr` and `.zarr`; the reader tried three of them, so a cohort carrying one of the other two
was detected as `omezarr` at setup and then raised `NameError: OME-Zarr group not found` on its first read,
with `get_group()` reporting no groups at all. The accepted set is published once (`STORE_FORMS`, longest first
so a compound extension wins over its tail) and both the resolution and the listing take it.

## Values

Nothing moves on the platform and the spellings that already worked. Where a route was broken it now works: a
read after a store is replaced on Windows sees the store that is there; a chain with a remote `Save` is refused
before a member is read instead of after; a store named `CT.omezarr` or `CT.ome-zarr` reads.

## Tests

`test_a_store_named_with_a_path_forgets_the_chunks_read_under_its_uri_spelling` (a `PureWindowsPath` names what
a forward-slash read keyed), `test_a_reduction_chain_is_refused_for_a_remote_save_before_its_terminal_write`,
`test_an_unregistered_scheme_is_not_reported_as_a_configuration_to_check`, and
`test_a_store_named_in_any_accepted_spelling_resolves_and_lists`. Each fails on the branch below.

## Not taken from the review

One finding is already answered further up the stack: the streaming page's sentence about the decoded-chunk
cache taking "a third of the budget" is corrected in #137, which states the floor and the cap beside the share.

## Stack

Stacked on `pr/1.8.2-16-reduce-clock`; merge after it. It is the last PR of the stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of remote destinations across chained workflows.
  * OME-Zarr stores now resolve consistently across supported naming formats, URI paths, and Windows paths.
  * Cache handling now treats equivalent path spellings as the same store.
  * Clarified errors for unknown URI schemes and configuration-related filesystem issues.

* **Tests**
  * Added coverage for cross-platform paths, store discovery, remote workflow validation, and filesystem error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->