### PR TITLE
refactor(clock): move the wall-clock reporters to konfai.utils.clock

### DIFF
--- a/konfai/api.py
+++ b/konfai/api.py
@@ -116,7 +116,8 @@ def _launch(
     lock's exit restores to the caller's. ``ranks`` sizes the lock and stays the caller's own
     expression: the entry points do not all derive it from ``gpu``/``cpu`` the same way.
     """
-    from konfai.utils.runtime import execute_distributed_object, restart_startup_clock
+    from konfai.utils.clock import restart_startup_clock
+    from konfai.utils.runtime import execute_distributed_object
 
     with _one_workflow_at_a_time(ranks):
         with restart_startup_clock().phase("build"):  # this call's own clock, not the previous workflow's

--- a/konfai/data/case_reduction.py
+++ b/konfai/data/case_reduction.py
@@ -82,7 +82,7 @@ def _awaited(phase: str) -> Iterator[None]:
 
     The fold has no pipeline: every member's region is read, and every slab written, on its own
     thread. So the store's own seconds ARE the seconds the loop waits, which is what
-    :meth:`~konfai.data.patching.SweepClock.report` prints on either side of its bar.
+    :meth:`~konfai.utils.clock.SweepClock.report` prints on either side of its bar.
     """
     with SWEEP_CLOCK.phase(f"wait({phase})"), SWEEP_CLOCK.phase(phase):
         yield

--- a/konfai/data/data_manager.py
+++ b/konfai/data/data_manager.py
@@ -56,17 +56,11 @@ from konfai.utils.budget import (
     node_local_ranks,
     resolve_memory_budget,
 )
+from konfai.utils.clock import startup_clock
 from konfai.utils.config import config
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import ConfigError, DatasetManagerError, TransformerError
-from konfai.utils.runtime import (
-    State,
-    get_cpu_info,
-    get_memory,
-    get_memory_info,
-    memory_forecast,
-    startup_clock,
-)
+from konfai.utils.runtime import State, get_cpu_info, get_memory, get_memory_info, memory_forecast
 from konfai.utils.utils import SUPPORTED_FORMATS, OverlapSpec, resolve_patch, split_path_spec
 
 # A cached case is a float32 tensor (torch's default dtype, and the default TensorCast's target), so

--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -28,7 +28,6 @@ import hashlib
 import itertools
 import queue
 import threading
-import time
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Iterator, Sequence
@@ -53,6 +52,7 @@ from konfai.data.transform import (
     stat_seed_valid,
 )
 from konfai.utils.budget import format_bytes, peak_resident_bytes, reset_resident_peak, resident_bytes
+from konfai.utils.clock import SweepClock
 from konfai.utils.config import apply_config, config
 from konfai.utils.dataset import Attribute, Dataset, DataStream, as_channel_first
 from konfai.utils.dataset import chunk_hull_voxels as _chunk_hull_voxels
@@ -678,63 +678,6 @@ class SweepSegment(NamedTuple):
     @property
     def channels(self) -> int:
         return int(self.source_shape[0])
-
-
-class SweepClock:
-    """Where a sweep's wall clock went, phase by phase, so none of it is unattributed.
-
-    A phase is accumulated by exactly one thread (the read by the producer, the write by the
-    writer, the rest by the sweep's own), so the additions need no lock, and the report is read
-    once both helpers have been joined. Two ``perf_counter`` calls per phase per block: the cost
-    is the report's own, not a mode the run has to be put into.
-    """
-
-    _END = object()
-
-    def __init__(self) -> None:
-        self._spent: dict[str, float] = {}
-
-    def reset(self) -> None:
-        self._spent = {}
-
-    def spent(self, name: str) -> float:
-        return self._spent.get(name, 0.0)
-
-    @contextlib.contextmanager
-    def phase(self, name: str) -> Iterator[None]:
-        start = time.perf_counter()
-        try:
-            yield
-        finally:
-            self._spent[name] = self._spent.get(name, 0.0) + time.perf_counter() - start
-
-    def waiting(self, name: str, blocks: Iterable[Any]) -> Iterator[Any]:
-        """``blocks``, charging to ``name`` the time spent waiting for each one."""
-        blocks = iter(blocks)
-        while True:
-            with self.phase(name):
-                block = next(blocks, SweepClock._END)
-            if block is SweepClock._END:
-                return
-            yield block
-
-    def report(self, min_seconds: float = 1.0) -> str | None:
-        """One line accounting for the sweeps' wall clock, or ``None`` below ``min_seconds``.
-
-        The sum before the bar is the sweep's own thread and closes exactly: what its phases do
-        not name is ``other``, the part of the run nothing has explained yet. After the bar are
-        the read and the write themselves, which run beside that thread when the sweep pipelines
-        and inside its ``wait`` when it does not.
-        """
-        wall = self.spent("sweep")
-        if wall < min_seconds:
-            return None  # a sweep this short has nothing to account for, and says so by saying nothing
-        named = {phase: self.spent(phase) for phase in ("chain", "fetch", "wait(read)", "wait(write)")}
-        parts = " + ".join(f"{phase} {value:.1f}" for phase, value in named.items())
-        return (
-            f"[KonfAI] sweep {wall:.1f} s = {parts} + other {wall - sum(named.values()):.1f}"
-            f" | stages read {self.spent('read'):.1f} s, write {self.spent('write'):.1f} s"
-        )
 
 
 #: This rank's sweeps, summed over the cases it ran: the unit the report is about.

--- a/konfai/evaluator.py
+++ b/konfai/evaluator.py
@@ -29,9 +29,9 @@ from torch.utils.data import DataLoader
 
 from konfai import config_file, cuda_visible_devices, evaluations_directory, konfai_root
 from konfai.data.data_manager import BatchDataItem, BatchSample, DataMetric, DatasetIter
-from konfai.data.patching import SweepClock
 from konfai.network.network import build_configured_criterions
 from konfai.utils.budget import node_local_ranks, set_per_rank_budget
+from konfai.utils.clock import SweepClock
 from konfai.utils.config import apply_config, config, strict_config
 from konfai.utils.dataset import Attribute, Dataset, DataStream
 from konfai.utils.errors import ConfigError, EvaluatorError

--- a/konfai/network/network.py
+++ b/konfai/network/network.py
@@ -45,8 +45,9 @@ from torch.utils.checkpoint import checkpoint
 
 from konfai import cuda_visible_devices, konfai_root
 from konfai.data.data_manager import BatchSample
-from konfai.data.patching import Accumulator, ModelPatch, SweepClock
+from konfai.data.patching import Accumulator, ModelPatch
 from konfai.metric.schedulers import Scheduler
+from konfai.utils.clock import SweepClock
 from konfai.utils.config import apply_config, config
 from konfai.utils.errors import ConfigError, MeasureError, TrainerError
 from konfai.utils.runtime import State, get_device, get_gpu_memory

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -54,7 +54,6 @@ from konfai.data.patching import (
     SlabAligner,
     SlabRegionStream,
     StreamingAccumulator,
-    SweepClock,
     _halo_radii,
     _HaloPull,
     _RemapPull,
@@ -77,6 +76,7 @@ from konfai.data.transform import (
 from konfai.network.network import Model, ModelLoader, NetState, Network
 from konfai.utils.budget import node_local_ranks, resolve_memory_budget, set_per_rank_budget
 from konfai.utils.chain_diff import dataset_tree, input_chain_differences, training_dataset_tree
+from konfai.utils.clock import SweepClock, startup_clock
 from konfai.utils.config import _escape_key_component, apply_config, config, strict_config
 from konfai.utils.dataset import Attribute, Dataset, DataStream
 from konfai.utils.errors import ConfigError, KonfAIError, PredictorError
@@ -91,7 +91,6 @@ from konfai.utils.runtime import (
     description,
     run_distributed_app,
     safe_torch_load,
-    startup_clock,
 )
 from konfai.utils.utils import concretize_patch_size, env_flag, get_module, size_free_axes, split_path_spec
 from konfai.utils.vram import next_patch_candidate, usable_vram

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -48,8 +48,8 @@ from konfai import (
     statistics_directory,
 )
 from konfai.data.data_manager import BatchSample, DataTrain
-from konfai.data.patching import SweepClock
 from konfai.network.network import Model, ModelLoader, NetState, Network
+from konfai.utils.clock import SweepClock, startup_clock
 from konfai.utils.config import apply_config, config, strict_config
 from konfai.utils.errors import ConfigError, TrainerError
 from konfai.utils.live_control import LiveControl
@@ -64,7 +64,6 @@ from konfai.utils.runtime import (
     run_distributed_app,
     safe_torch_load,
     seed_all,
-    startup_clock,
     synchronize_data,
 )
 from konfai.utils.utils import concretize_patch_size, size_free_axes

--- a/konfai/utils/clock.py
+++ b/konfai/utils/clock.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Where a run's wall clock went, phase by phase: one accounting vocabulary for every workflow."""
+
+import contextlib
+import time
+from collections.abc import Iterable, Iterator
+from typing import Any
+
+
+class SweepClock:
+    """Wall clock spent per named phase, reported as one line that closes on the total.
+
+    A phase is accumulated by exactly one thread (a sweep's read by its producer, its write by the
+    writer, the rest by the loop's own), so the additions need no lock; the report is read once
+    every helper thread has been joined. Two ``perf_counter`` calls per phase per block.
+    """
+
+    _END = object()
+
+    def __init__(self) -> None:
+        self._spent: dict[str, float] = {}
+
+    def reset(self) -> None:
+        self._spent = {}
+
+    def spent(self, name: str) -> float:
+        return self._spent.get(name, 0.0)
+
+    @contextlib.contextmanager
+    def phase(self, name: str) -> Iterator[None]:
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            self._spent[name] = self._spent.get(name, 0.0) + time.perf_counter() - start
+
+    def waiting(self, name: str, blocks: Iterable[Any]) -> Iterator[Any]:
+        """``blocks``, charging to ``name`` the time spent waiting for each one."""
+        blocks = iter(blocks)
+        while True:
+            with self.phase(name):
+                block = next(blocks, SweepClock._END)
+            if block is SweepClock._END:
+                return
+            yield block
+
+    def report(self, min_seconds: float = 1.0) -> str | None:
+        """One line accounting for the sweeps' wall clock, or ``None`` below ``min_seconds``.
+
+        The sum before the bar is the sweep's own thread and closes exactly: what its phases do
+        not name is ``other``. After the bar are the read and the write themselves, which run
+        beside that thread when the sweep pipelines and inside its ``wait`` when it does not.
+        """
+        wall = self.spent("sweep")
+        if wall < min_seconds:
+            return None
+        named = {phase: self.spent(phase) for phase in ("chain", "fetch", "wait(read)", "wait(write)")}
+        parts = " + ".join(f"{phase} {value:.1f}" for phase, value in named.items())
+        return (
+            f"[KonfAI] sweep {wall:.1f} s = {parts} + other {wall - sum(named.values()):.1f}"
+            f" | stages read {self.spent('read'):.1f} s, write {self.spent('write'):.1f} s"
+        )
+
+
+class StartupClock:
+    """Where a run's time went before its ranks start, phase by phase.
+
+    Built at the launcher's entry, carried to the ranks on the workflow object, reported once by
+    rank 0 as it starts. The build's phases (``cases``: the cohort listed, ``grids``: the managers
+    built, ``model``: the network built) and the setup's (``checkpoint``: the weights loaded) are
+    taken out of ``build`` and ``setup``, which then read as their remainders; ``launch`` is spawn
+    to the rank's start. The two stamps are ``time.time``: a rank reads them on another node under
+    a cluster launch, where a process counter means nothing.
+    """
+
+    def __init__(self) -> None:
+        self._phases = SweepClock()
+        self.started = time.time()
+        self.launched: float | None = None
+
+    def phase(self, name: str) -> contextlib.AbstractContextManager[None]:
+        return self._phases.phase(name)
+
+    def spent(self, name: str) -> float:
+        return self._phases.spent(name)
+
+    def launch(self) -> None:
+        self.launched = time.time()
+
+    def report(self, min_seconds: float = 1.0) -> str | None:
+        """One line accounting for the wall clock since the launcher's entry, or ``None`` below
+        ``min_seconds``; ``other`` is what no phase names."""
+        now = time.time()
+        wall = now - self.started
+        if wall < min_seconds:
+            return None
+        nested = {name: self.spent(name) for name in ("cases", "grids", "model")}
+        named = {
+            "build": max(0.0, self.spent("build") - sum(nested.values())),
+            **nested,
+            "checkpoint": self.spent("checkpoint"),
+            "setup": max(0.0, self.spent("setup") - self.spent("checkpoint")),
+            "launch": 0.0 if self.launched is None else now - self.launched,
+        }
+        parts = " + ".join(f"{name} {value:.1f}" for name, value in named.items())
+        return f"[KonfAI] startup {wall:.1f} s = {parts} + other {wall - sum(named.values()):.1f}"
+
+
+_startup_clock: StartupClock | None = None
+
+
+def startup_clock() -> StartupClock:
+    """This process's startup clock, built on first use."""
+    global _startup_clock
+    if _startup_clock is None:
+        _startup_clock = StartupClock()
+    return _startup_clock
+
+
+def restart_startup_clock() -> StartupClock:
+    """A fresh startup clock: the Python API runs several workflows in one process, each its own."""
+    global _startup_clock
+    _startup_clock = StartupClock()
+    return _startup_clock

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -32,7 +32,7 @@ import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import AbstractContextManager, closing, contextmanager
+from contextlib import closing, contextmanager
 from enum import Enum
 from functools import wraps
 from pathlib import Path
@@ -67,6 +67,7 @@ from konfai import (
 )
 from konfai.utils import State  # also the re-export ``konfai.utils.runtime.State`` callers import
 from konfai.utils.budget import available_cpus, node_local_ranks, set_per_rank_budget
+from konfai.utils.clock import StartupClock, restart_startup_clock, startup_clock
 from konfai.utils.errors import ConfigError, KonfAIError
 from konfai.utils.utils import env_flag
 
@@ -672,72 +673,6 @@ def seed_all(seed: int) -> None:
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
-
-
-class StartupClock:
-    """Where a run's time went before its ranks start, phase by phase, in the sweep's format.
-
-    Built at the launcher's entry (:func:`run_distributed_app`), carried to the ranks on the
-    workflow object, reported once by rank 0 as it starts. The build's phases (``cases``: the
-    cohort listed, ``grids``: the managers built, ``model``: the network built) and the setup's
-    (``checkpoint``: the weights loaded) are taken out of ``build`` and ``setup``, which then read
-    as their remainders (the config bound, the workflow's own init; the loaders made); ``launch``
-    is spawn to the rank's start. The two stamps are ``time.time``: a rank reads them on another
-    node under a cluster launch, where a process counter means nothing; the phases are the
-    launcher's own and use the process counter.
-    """
-
-    def __init__(self) -> None:
-        from konfai.data.patching import SweepClock  # imports this module: bound at first use
-
-        self._phases = SweepClock()
-        self.started = time.time()
-        self.launched: float | None = None
-
-    def phase(self, name: str) -> AbstractContextManager[None]:
-        return self._phases.phase(name)
-
-    def spent(self, name: str) -> float:
-        return self._phases.spent(name)
-
-    def launch(self) -> None:
-        self.launched = time.time()
-
-    def report(self, min_seconds: float = 1.0) -> str | None:
-        """One line accounting for the wall clock since the launcher's entry, or ``None`` below
-        ``min_seconds``; ``other`` is what no phase names."""
-        now = time.time()
-        wall = now - self.started
-        if wall < min_seconds:
-            return None
-        nested = {name: self.spent(name) for name in ("cases", "grids", "model")}
-        named = {
-            "build": max(0.0, self.spent("build") - sum(nested.values())),
-            **nested,
-            "checkpoint": self.spent("checkpoint"),
-            "setup": max(0.0, self.spent("setup") - self.spent("checkpoint")),
-            "launch": 0.0 if self.launched is None else now - self.launched,
-        }
-        parts = " + ".join(f"{name} {value:.1f}" for name, value in named.items())
-        return f"[KonfAI] startup {wall:.1f} s = {parts} + other {wall - sum(named.values()):.1f}"
-
-
-_startup_clock: StartupClock | None = None
-
-
-def startup_clock() -> StartupClock:
-    """This process's startup clock, built on first use."""
-    global _startup_clock
-    if _startup_clock is None:
-        _startup_clock = StartupClock()
-    return _startup_clock
-
-
-def restart_startup_clock() -> StartupClock:
-    """A fresh startup clock: the Python API runs several workflows in one process, each its own."""
-    global _startup_clock
-    _startup_clock = StartupClock()
-    return _startup_clock
 
 
 class DistributedObject(ABC):

--- a/tests/unit/test_data_manager.py
+++ b/tests/unit/test_data_manager.py
@@ -46,8 +46,9 @@ from konfai.data.data_manager import (
 )
 from konfai.data.patching import DatasetManager, DatasetPatch
 from konfai.data.transform import Gradient, TensorCast, Transform, TransformLoader
+from konfai.utils.clock import restart_startup_clock
 from konfai.utils.dataset import Attribute, Dataset
-from konfai.utils.runtime import State, restart_startup_clock
+from konfai.utils.runtime import State
 from konfai.utils.utils import split_path_spec
 from torch.utils.data._utils.pin_memory import pin_memory as torch_pin_memory
 

--- a/tests/unit/test_evaluator_update.py
+++ b/tests/unit/test_evaluator_update.py
@@ -25,9 +25,10 @@ from types import SimpleNamespace
 import pytest
 import torch
 from konfai.data.data_manager import BatchDataItem
-from konfai.data.patching import DatasetPatch, SweepClock
+from konfai.data.patching import DatasetPatch
 from konfai.evaluator import Evaluator, Statistics
 from konfai.metric.measure import MAE, MSE, SSIM
+from konfai.utils.clock import SweepClock
 
 
 def _evaluator(metrics: dict[str, dict[str, dict[torch.nn.Module, None]]], streamed: bool = False) -> Evaluator:

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -874,8 +874,8 @@ def test_a_target_group_is_moved_once_per_forward_and_not_for_a_criterion_outsid
 
 
 def test_forward_charges_the_criteria_to_the_clock_apart_from_the_walk() -> None:
-    from konfai.data.patching import SweepClock
     from konfai.network.network import Measure
+    from konfai.utils.clock import SweepClock
 
     class Net(Network):
         def __init__(self) -> None:

--- a/tests/unit/test_predictor_memory.py
+++ b/tests/unit/test_predictor_memory.py
@@ -21,7 +21,6 @@ import pytest
 import torch
 import tqdm
 from konfai.data.data_manager import BatchDataItem, DatasetIter
-from konfai.data.patching import SweepClock
 from konfai.data.transform import TransformInverse
 from konfai.network.network import Network
 from konfai.predictor import (
@@ -33,6 +32,7 @@ from konfai.predictor import (
     _prediction_report,
     _Predictor,
 )
+from konfai.utils.clock import SweepClock
 from konfai.utils.dataset import Attribute
 
 

--- a/tests/unit/test_trainer.py
+++ b/tests/unit/test_trainer.py
@@ -373,7 +373,7 @@ def test_validation_request_and_live_tunables_ride_one_broadcast(tmp_path: Path,
 
 
 def test_epoch_report_closes_on_the_wall_clock_with_the_criteria_apart_from_the_forward() -> None:
-    from konfai.data.patching import SweepClock
+    from konfai.utils.clock import SweepClock
 
     clock = SweepClock()
     clock._spent = {
@@ -490,7 +490,7 @@ def test_restoring_the_ema_weights_is_charged_to_the_checkpoint_phase(tmp_path: 
     accounts for it there: reported under ``setup`` it would read as the loaders' cost."""
     import time
 
-    from konfai.utils.runtime import restart_startup_clock
+    from konfai.utils.clock import restart_startup_clock
 
     class _SlowLoad:
         def load(self, state_dict: dict, **kwargs) -> None:


### PR DESCRIPTION
SweepClock lived in the patching engine and StartupClock in the runtime, which imported it lazily to break the cycle. Both are wall-clock accounting used by every workflow; they now share one module with no import cycle.

Stacked on #141: merge that one first.