### PR TITLE
refactor(vram): share the OOM-restart measurements and the data_log parsing

### DIFF
--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -74,6 +74,7 @@ from konfai.data.transform import (
     TransformLoader,
 )
 from konfai.network.network import Model, ModelLoader, NetState, Network
+from konfai.utils import vram
 from konfai.utils.budget import node_local_ranks, resolve_memory_budget, set_per_rank_budget
 from konfai.utils.chain_diff import dataset_tree, input_chain_differences, training_dataset_tree
 from konfai.utils.clock import SweepClock, startup_clock
@@ -93,7 +94,6 @@ from konfai.utils.runtime import (
     safe_torch_load,
 )
 from konfai.utils.utils import concretize_patch_size, env_flag, get_module, size_free_axes, split_path_spec
-from konfai.utils.vram import next_patch_candidate, usable_vram
 
 #: This rank's prediction loop, phase by phase, summed over the cases it ran: the unit the line
 #: at the end of a run accounts for (see ``_prediction_report``).
@@ -1598,13 +1598,7 @@ class _Predictor:
                     ]
                 ),
             )
-        self.data_log: dict[str, tuple[DataLog, int]] = {}
-        if data_log is not None:
-            for data in data_log:
-                self.data_log[data.split("/")[0].replace(":", ".")] = (
-                    DataLog[data.split("/")[1]],
-                    int(data.split("/")[2]),
-                )
+        self.data_log = DataLog.parse(data_log)
         self._has_runtime_measures = any(
             network.measure is not None for network in self.model_composite.module.get_networks().values()
         )
@@ -2061,20 +2055,16 @@ class Predictor(DistributedObject):
             # h5 output as a directory and write the hidden dotfile Predictions/<run>/Dataset/.h5.
             output_dataset.rebase(self.predict_path)
         self.data_log = data_log
-        modules = []
-        for i, _ in self.model.named_modules():
-            modules.append(i)
-        if self.data_log is not None:
-            for k in self.data_log:
-                tmp = k.split("/")[0].replace(":", ".")
-                if tmp not in self.dataset.get_groups_dest() and tmp not in modules:
-                    raise PredictorError(
-                        f"Invalid key '{tmp}' in `data_log`.",
-                        f"This key is neither a destination group from the dataset ({self.dataset.get_groups_dest()})",
-                        f"nor a valid module name in the model ({modules}).",
-                        "Please check your `data_log` configuration,"
-                        " it should reference either a model output or a dataset group.",
-                    )
+        modules = [name for name, _ in self.model.named_modules()]
+        for target in DataLog.parse(self.data_log):
+            if target not in self.dataset.get_groups_dest() and target not in modules:
+                raise PredictorError(
+                    f"Invalid key '{target}' in `data_log`.",
+                    f"This key is neither a destination group from the dataset ({self.dataset.get_groups_dest()})",
+                    f"nor a valid module name in the model ({modules}).",
+                    "Please check your `data_log` configuration,"
+                    " it should reference either a model output or a dataset group.",
+                )
 
         self.gpu_checkpoints = gpu_checkpoints
         # Cut the grids with the model's downsampling multiple already known, so each case's free axis
@@ -2313,15 +2303,15 @@ class Predictor(DistributedObject):
                 # in-flight state: open streamed sinks abort and remove their partial entries, so a
                 # reader never sees a half-written volume even when the OOM is fatal, then read the
                 # honest free VRAM.
-                measured = self._transient_at_oom(device)
+                measured = vram.transient_at_oom(device)
                 for output_dataset in self.outputs_dataset.values():
                     output_dataset.reset()
                 if self._vram_patch_template is None:
                     raise  # no free axis declared: not auto-patched
-                candidate = self._shrunken_patch(measured, device)
+                candidate = self._shrunken_patch(measured, vram.usable_after_oom(device))
                 if candidate is None:
                     raise
-                self._reset_cuda_peak(device)
+                vram.reset_peak(device)
                 print(
                     f"[KonfAI] VRAM: rank {global_rank} ran out of memory -> "
                     f"re-planning the free patch axes to {candidate} and restarting this rank's cases."
@@ -2330,7 +2320,7 @@ class Predictor(DistributedObject):
                 self.dataset.replan_patch(candidate)
                 dataloader = self.dataset.get_data(world_size)[0][global_rank][0]
 
-    def _shrunken_patch(self, measured: int | None, device: int | None) -> list[int] | None:
+    def _shrunken_patch(self, measured: int | None, usable: float) -> list[int] | None:
         """One shrink step for the free patch axes after a CUDA OOM (``None`` = not auto, or floor).
 
         The first OOM starts from the worst prepared case at full extent (the size the failed grid
@@ -2348,14 +2338,15 @@ class Predictor(DistributedObject):
         candidate = self._vram_patch_candidate or concretize_patch_size(
             self._vram_patch_template, worst, self._downsampling_factor
         )
-        usable = self._usable_vram_after_oom(device)
         reserve = self._accumulation_reserve(candidate, worst)
         snap = self._downsampling_factor
         if reserve is not None:
-            shrunk = next_patch_candidate(candidate, self._vram_patch_template, worst, measured, usable - reserve, snap)
+            shrunk = vram.next_patch_candidate(
+                candidate, self._vram_patch_template, worst, measured, usable - reserve, snap
+            )
             if shrunk is not None:
                 return shrunk
-        return next_patch_candidate(candidate, self._vram_patch_template, worst, measured, usable, snap)
+        return vram.next_patch_candidate(candidate, self._vram_patch_template, worst, measured, usable, snap)
 
     def _accumulation_reserve(self, candidate: list[int], worst: list[int]) -> float | None:
         """Bytes each case keeps resident while its patches accumulate, per output writer: the
@@ -2377,42 +2368,6 @@ class Predictor(DistributedObject):
             voxels = candidate[0] * np.prod(worst[1:], dtype=np.int64) if streams else np.prod(worst, dtype=np.int64)
             reserve += float((out_channels + 1) * voxels * elem * nb_augmentation)
         return reserve
-
-    @staticmethod
-    def _reset_cuda_peak(device: int | None) -> None:
-        """Drop the failed attempt's high-water mark so the rerun measures its own steps.
-
-        ``max_memory_allocated`` only rises: left in place, the full-extent attempt's peak would
-        overstate every later transient: a second shrink would overshoot, and the accumulation
-        gate would keep the rerun's blend on the CPU.
-        """
-        if device is None:
-            return
-        try:
-            torch.cuda.reset_peak_memory_stats(device)
-        except Exception:  # nosec B110 - stale stats only cost precision, never correctness
-            pass
-
-    def _transient_at_oom(self, device: int | None) -> int | None:
-        """The failed step's measured transient (CUDA peak over resident), ``None`` when unreadable."""
-        if device is None:
-            return None
-        try:
-            transient = int(torch.cuda.max_memory_allocated(device) - torch.cuda.memory_allocated(device))
-        except Exception:  # nosec B110 - an unreadable measurement just falls back to the fixed step
-            return None
-        return transient if transient > 0 else None
-
-    def _usable_vram_after_oom(self, device: int | None) -> float:
-        """The VRAM budget the next attempt's step may claim, read once the failed state is freed."""
-        if device is None:
-            return 0.0
-        try:
-            torch.cuda.empty_cache()
-            free, _ = torch.cuda.mem_get_info(device)
-        except Exception:  # nosec B110 - an unreadable budget refuses the restart (the OOM re-raises)
-            return 0.0
-        return usable_vram(free)
 
     def __str__(self) -> str:
         params = {

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -49,6 +49,7 @@ from konfai import (
 )
 from konfai.data.data_manager import BatchSample, DataTrain
 from konfai.network.network import Model, ModelLoader, NetState, Network
+from konfai.utils import vram
 from konfai.utils.clock import SweepClock, startup_clock
 from konfai.utils.config import apply_config, config, strict_config
 from konfai.utils.errors import ConfigError, TrainerError
@@ -67,7 +68,6 @@ from konfai.utils.runtime import (
     synchronize_data,
 )
 from konfai.utils.utils import concretize_patch_size, size_free_axes
-from konfai.utils.vram import next_patch_candidate, usable_vram
 
 
 class EarlyStoppingBase:
@@ -296,13 +296,7 @@ class _Trainer:
         self._loss_keys: set[str] = set()
         if self.global_rank == 0 and self.save_checkpoint_mode == "BEST":
             self._initialize_best_checkpoint_state()
-        self.data_log: dict[str, tuple[DataLog, int]] = {}
-        if data_log is not None:
-            for data in data_log:
-                self.data_log[data.split("/")[0].replace(":", ".")] = (
-                    DataLog[data.split("/")[1]],
-                    int(data.split("/")[2]),
-                )
+        self.data_log = DataLog.parse(data_log)
 
     def __enter__(self):
         return self
@@ -1127,9 +1121,9 @@ class Trainer(DistributedObject):
                 # optimizer.step(), so no weights are updated. The rare case where it fires mid-step
                 # instead leaves that first batch's partial update in place (the restart continues from
                 # it); this is a bounded one-batch perturbation, not worth a whole-run state snapshot.
-                measured = self._transient_at_oom(device)
+                measured = vram.transient_at_oom(device)
                 self.model.zero_grad(set_to_none=True)
-                candidate = self._shrunken_patch(measured, self._usable_vram_after_oom(device))
+                candidate = self._shrunken_patch(measured, vram.usable_after_oom(device))
                 # Every rank must train the same grid, so the shrink is agreed at a rendezvous: each
                 # failing rank proposes its own candidate and all adopt the per-axis MIN. A rank that
                 # did NOT run out never reaches this all-gather; the job then dies at the collective
@@ -1152,7 +1146,7 @@ class Trainer(DistributedObject):
                 )
                 self._vram_patch_candidate = agreed
                 self.dataset.replan_patch(agreed)
-                self._reset_cuda_peak(device)
+                vram.reset_peak(device)
                 dataloaders = self.dataset.get_data(world_size)[0][global_rank]
 
     def _shrunken_patch(self, measured: int | None, usable: float) -> list[int] | None:
@@ -1169,40 +1163,9 @@ class Trainer(DistributedObject):
         candidate = self._vram_patch_candidate or concretize_patch_size(
             self._vram_patch_template, worst, self._downsampling_factor
         )
-        return next_patch_candidate(
+        return vram.next_patch_candidate(
             candidate, self._vram_patch_template, worst, measured, usable, self._downsampling_factor
         )
-
-    @staticmethod
-    def _reset_cuda_peak(device: int | None) -> None:
-        """Drop the failed attempt's high-water mark so the rerun measures its own steps."""
-        if device is None:
-            return
-        try:
-            torch.cuda.reset_peak_memory_stats(device)
-        except Exception:  # nosec B110 - stale stats only cost precision, never correctness
-            pass
-
-    def _transient_at_oom(self, device: int | None) -> int | None:
-        """The failed step's measured transient (CUDA peak over resident), ``None`` when unreadable."""
-        if device is None:
-            return None
-        try:
-            transient = int(torch.cuda.max_memory_allocated(device) - torch.cuda.memory_allocated(device))
-        except Exception:  # nosec B110 - an unreadable measurement just falls back to the fixed step
-            return None
-        return transient if transient > 0 else None
-
-    def _usable_vram_after_oom(self, device: int | None) -> float:
-        """The VRAM budget the next attempt's step may claim, read once the failed state is freed."""
-        if device is None:
-            return 0.0
-        try:
-            torch.cuda.empty_cache()
-            free, _ = torch.cuda.mem_get_info(device)
-        except Exception:  # nosec B110 - an unreadable budget refuses the restart (the OOM re-raises)
-            return 0.0
-        return usable_vram(free)
 
 
 def build_train(

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -405,6 +405,16 @@ class DataLog(Enum):
     VIDEO = "VIDEO"
     AUDIO = "AUDIO"
 
+    @classmethod
+    def parse(cls, entries: list[str] | None) -> dict[str, tuple["DataLog", int]]:
+        """``{target: (strategy, count)}`` from ``"group_or_module/STRATEGY/N"`` entries; a ``:``-spelled
+        module path is keyed by its dotted name."""
+        parsed: dict[str, tuple[DataLog, int]] = {}
+        for entry in entries or []:
+            target, strategy, count = entry.split("/")
+            parsed[target.replace(":", ".")] = (cls[strategy], int(count))
+        return parsed
+
     def __call__(self, tb: SummaryWriter, name: str, layer: torch.Tensor, it: int):
         if self == DataLog.SIGNAL:
             return [

--- a/konfai/utils/vram.py
+++ b/konfai/utils/vram.py
@@ -27,6 +27,8 @@ transient when there is one, a fixed factor when the OOM left no number) re-plan
 restarts. When everything fits (the common case) nothing here runs at all.
 """
 
+import torch
+
 #: Fraction of the free VRAM a step may claim; the reserve absorbs allocator fragmentation and
 #: transients the measured run did not exercise (mirrors the accumulation gate's margin).
 VRAM_BUDGET_SAFETY_FRACTION = 0.8
@@ -41,6 +43,41 @@ def usable_vram(free_bytes: float, resident_bytes: float = 0.0, margin: float = 
     nothing extra for training, whose resident set is already allocated when ``free_bytes`` is read).
     """
     return free_bytes * margin - resident_bytes
+
+
+def transient_at_oom(device: int | None) -> int | None:
+    """The failed step's transient (CUDA peak over resident), ``None`` off CUDA or when unreadable."""
+    if device is None:
+        return None
+    try:
+        transient = int(torch.cuda.max_memory_allocated(device) - torch.cuda.memory_allocated(device))
+    except Exception:  # nosec B110 - an unreadable measurement falls back to the fixed shrink step
+        return None
+    return transient if transient > 0 else None
+
+
+def reset_peak(device: int | None) -> None:
+    """Drop the failed attempt's high-water mark, so the rerun measures its own steps: the mark
+    only rises, and the full-extent attempt's would overstate every later transient."""
+    if device is None:
+        return
+    try:
+        torch.cuda.reset_peak_memory_stats(device)
+    except Exception:  # nosec B110 - stale stats only cost precision, never correctness
+        pass
+
+
+def usable_after_oom(device: int | None) -> float:
+    """The VRAM the next attempt's step may claim, read once the failed state is freed; ``0.0``
+    (which refuses the restart) off CUDA or when unreadable."""
+    if device is None:
+        return 0.0
+    try:
+        torch.cuda.empty_cache()
+        free, _ = torch.cuda.mem_get_info(device)
+    except Exception:  # nosec B110
+        return 0.0
+    return usable_vram(free)
 
 
 def next_patch_candidate(

--- a/tests/integration/test_konfai_auto_patch_prediction.py
+++ b/tests/integration/test_konfai_auto_patch_prediction.py
@@ -40,6 +40,7 @@ from pathlib import Path
 import torch
 
 import konfai.predictor as predictor_module
+import konfai.utils.vram as vram_module
 from konfai.predictor import build_predict, predict
 from konfai.trainer import train
 
@@ -57,8 +58,8 @@ def install_auto_patch_probes() -> None:
         return original_run(self)
 
     predictor_module._Predictor.run = run_with_forced_oom
-    predictor_module.Predictor._transient_at_oom = lambda self, device: None
-    predictor_module.Predictor._usable_vram_after_oom = lambda self, device: 1.0
+    vram_module.transient_at_oom = lambda device: None
+    vram_module.usable_after_oom = lambda device: 1.0
 
 
 def main() -> None:

--- a/tests/integration/test_konfai_auto_patch_training.py
+++ b/tests/integration/test_konfai_auto_patch_training.py
@@ -38,6 +38,7 @@ from pathlib import Path
 import torch
 
 import konfai.trainer as trainer_module
+import konfai.utils.vram as vram_module
 from konfai.trainer import build_train
 
 ATTEMPTS = []
@@ -54,8 +55,8 @@ def install_auto_patch_probes() -> None:
         return original_run(self)
 
     trainer_module._Trainer.run = run_with_forced_oom
-    trainer_module.Trainer._transient_at_oom = lambda self, device: None
-    trainer_module.Trainer._usable_vram_after_oom = lambda self, device: 1.0
+    vram_module.transient_at_oom = lambda device: None
+    vram_module.usable_after_oom = lambda device: 1.0
 
 
 def main() -> None:

--- a/tests/unit/test_vram_sizing.py
+++ b/tests/unit/test_vram_sizing.py
@@ -162,7 +162,7 @@ class _Data:
         return self._worst
 
 
-def _predictor(out_channels, nb_augmentation, reduction, margined, candidate=None):
+def _predictor(out_channels, nb_augmentation, reduction, candidate=None):
     predictor = Predictor.__new__(Predictor)
     predictor._vram_patch_template = [0, 0, 0]
     predictor._vram_patch_candidate = candidate
@@ -172,7 +172,6 @@ def _predictor(out_channels, nb_augmentation, reduction, margined, candidate=Non
     predictor.combine = Mean()
     predictor.path_to_models = ["model.pt"]
     predictor.outputs_dataset = {"Head.Tanh": _Writer(nb_augmentation, reduction)}
-    predictor._usable_vram_after_oom = lambda device: margined
     return predictor
 
 
@@ -184,23 +183,23 @@ class TestPredictorShrinkBudget:
         # reserve = (3+1)ch x 100^3 x 2B x 2aug = 1.6e7 -> usable 1e6 of the 1.7e7 margined budget;
         # measured 8e6 -> exact isotropic step (1/8)^(1/3) halves each axis. Without the reserve the
         # measurement would claim a fit and only the fixed 0.8 step would apply.
-        predictor = _predictor(3, nb_augmentation=2, reduction=Mean(), margined=1.7e7)
-        assert predictor._shrunken_patch(8_000_000, device=None) == [50, 50, 50]
+        predictor = _predictor(3, nb_augmentation=2, reduction=Mean())
+        assert predictor._shrunken_patch(8_000_000, usable=1.7e7) == [50, 50, 50]
 
     def test_a_streaming_writer_reserves_only_its_window(self):
         # Single augmentation + voxel-local reduction -> window = candidate_z x cross-section:
         # reserve 8e5 -> usable 3.2e6, measured 6.4e6 -> per-axis (1/2)^(1/3). A volume reserve
         # (8e6) would not fit the 4e6 budget and would have fallen back to [8, 85, 85].
-        predictor = _predictor(3, nb_augmentation=1, reduction=Mean(), margined=4e6, candidate=[10, 100, 100])
-        assert predictor._shrunken_patch(6_400_000, device=None) == [7, 79, 79]
+        predictor = _predictor(3, nb_augmentation=1, reduction=Mean(), candidate=[10, 100, 100])
+        assert predictor._shrunken_patch(6_400_000, usable=4e6) == [7, 79, 79]
 
     def test_an_unfittable_reserve_falls_back_to_the_forward_alone(self):
         # The non-streamable volume reserve (1.6e7) exceeds the whole budget (1e6): the writer will
         # blend on the CPU, and the patch is still sized for the forward instead of refusing.
-        predictor = _predictor(3, nb_augmentation=2, reduction=_SpatialReduction(), margined=1e6)
-        assert predictor._shrunken_patch(8_000_000, device=None) == [50, 50, 50]
+        predictor = _predictor(3, nb_augmentation=2, reduction=_SpatialReduction())
+        assert predictor._shrunken_patch(8_000_000, usable=1e6) == [50, 50, 50]
 
     def test_unpriceable_channels_skip_the_reserve(self):
-        predictor = _predictor(None, nb_augmentation=2, reduction=Mean(), margined=1e6)
+        predictor = _predictor(None, nb_augmentation=2, reduction=Mean())
         assert predictor._accumulation_reserve([100, 100, 100], [100, 100, 100]) is None
-        assert predictor._shrunken_patch(8_000_000, device=None) == [50, 50, 50]
+        assert predictor._shrunken_patch(8_000_000, usable=1e6) == [50, 50, 50]


### PR DESCRIPTION
The trainer and the predictor each carried the same three CUDA readings
around their OOM-restart loop (transient at OOM, peak reset, usable VRAM
after the failed step). They are module functions of konfai.utils.vram
now, and the shrink step takes the usable budget as a number.

DataLog.parse replaces the two copies of the "target/STRATEGY/N" parsing;
the predictor's key validation runs on the parsed targets.

Stacked on #142: merge that one first.