### PR TITLE
refactor: fold the config subtree with a loop and take the NaN mask once

### DIFF
--- a/konfai/evaluator.py
+++ b/konfai/evaluator.py
@@ -150,27 +150,20 @@ class Statistics:
 
     @staticmethod
     def get_statistic(values: list[float]) -> dict[str, float]:
-        """
-        Compute statistical aggregates for a list of metric values.
-
-        Args:
-            values (list of float): Values to summarize.
-
-        Returns:
-            dict[str, float]: A dictionary containing:
-                - max, min, std
-                - 25th, 50th, and 75th percentiles
-                - mean and count
-        """
+        """Max, min, std, quartiles, mean and count of the non-NaN ``values``: all NaN when there is none."""
+        array = np.asarray(values, dtype=float)
+        count = int(np.count_nonzero(~np.isnan(array)))
+        if count == 0:
+            return dict.fromkeys(("max", "min", "std", "25pc", "50pc", "75pc", "mean"), np.nan) | {"count": 0.0}
         return {
-            "max": float(np.nanmax(values)) if np.any(~np.isnan(values)) else np.nan,
-            "min": float(np.nanmin(values)) if np.any(~np.isnan(values)) else np.nan,
-            "std": float(np.nanstd(values)) if np.any(~np.isnan(values)) else np.nan,
-            "25pc": float(np.nanpercentile(values, 25)) if np.any(~np.isnan(values)) else np.nan,
-            "50pc": float(np.nanpercentile(values, 50)) if np.any(~np.isnan(values)) else np.nan,
-            "75pc": float(np.nanpercentile(values, 75)) if np.any(~np.isnan(values)) else np.nan,
-            "mean": float(np.nanmean(values)) if np.any(~np.isnan(values)) else np.nan,
-            "count": float(np.count_nonzero(~np.isnan(values))),
+            "max": float(np.nanmax(array)),
+            "min": float(np.nanmin(array)),
+            "std": float(np.nanstd(array)),
+            "25pc": float(np.nanpercentile(array, 25)),
+            "50pc": float(np.nanpercentile(array, 50)),
+            "75pc": float(np.nanpercentile(array, 75)),
+            "mean": float(np.nanmean(array)),
+            "count": float(count),
         }
 
     @staticmethod

--- a/konfai/utils/config.py
+++ b/konfai/utils/config.py
@@ -315,18 +315,12 @@ class Config:
             ledger.opened(tuple(self.keys), self.config if isinstance(self.config, collections.abc.Mapping) else ())
         return self
 
-    def create_dictionary(self, data, keys, i) -> dict:
-        if keys[i] not in data:
-            data = {keys[i]: data}
-        if i == 0:
-            return data
-        else:
-            i -= 1
-            return self.create_dictionary(data, keys, i)
-
     def __exit__(self, exc_type, value, traceback) -> None:
         # Only the visited subtree is folded back; the merge preserves the rest of the tree untouched.
-        subtree = self.create_dictionary(self.config, self.keys, len(self.keys) - 1)
+        subtree = self.config
+        for key in reversed(self.keys):
+            if key not in subtree:
+                subtree = {key: subtree}
         if self._shared is not None:
             _merge_into(self._shared.tree, subtree)
             return


### PR DESCRIPTION
Config.__exit__ wraps the visited subtree under its keys in a loop
instead of a recursive helper. Statistics.get_statistic counts the
non-NaN values once and returns the all-NaN row directly when there
are none.

Stacked on #146: merge that one first.