### PR TITLE
refactor(predictor): one OutputDataset instead of an ABC with one subclass

### DIFF
--- a/docs/source/concepts/model-graph.md
+++ b/docs/source/concepts/model-graph.md
@@ -144,7 +144,7 @@ Example:
 outputs_dataset:
   Head:Tanh:
     OutputDataset:
-      name_class: OutSameAsGroupDataset
+      name_class: OutputDataset
       group: sCT
       reduction: Mean
 ```

--- a/docs/source/config_guide/prediction.md
+++ b/docs/source/config_guide/prediction.md
@@ -163,7 +163,7 @@ Set `check_training_transforms: false` to silence it.
 outputs_dataset:
   Head:Tanh:
     OutputDataset:
-      name_class: OutSameAsGroupDataset
+      name_class: OutputDataset
       group: sCT
       same_as_group: MR:MR
       reduction: Mean
@@ -174,7 +174,7 @@ Important nested fields:
 | Field | Effect |
 | --- | --- |
 | output key | Selects the model output to export. |
-| `name_class` | Selects the output dataset implementation. |
+| `name_class` | Classpath of the output sink; a bare name resolves in `konfai.predictor` (default `OutputDataset`). |
 | `group` | Output group name written to disk. |
 | `dataset_filename` | Destination dataset path and format. |
 | `same_as_group` | Geometry reference group for exported volumes. |

--- a/examples/Registration/Prediction.yml
+++ b/examples/Registration/Prediction.yml
@@ -61,7 +61,7 @@ Predictor:
   outputs_dataset:
     MovingImageResample:  # Model output = MOVING warped into FIXED space
       OutputDataset:
-        name_class: OutSameAsGroupDataset
+        name_class: OutputDataset
         before_reduction_transforms: None
         after_reduction_transforms: None
         final_transforms:

--- a/examples/Segmentation/Prediction.yml
+++ b/examples/Segmentation/Prediction.yml
@@ -48,7 +48,7 @@ Predictor:
   outputs_dataset:
     UNetBlock_0:Head:Argmax:
       OutputDataset:
-        name_class: OutSameAsGroupDataset
+        name_class: OutputDataset
         before_reduction_transforms: None
         after_reduction_transforms: None
         final_transforms:

--- a/examples/Synthesis/Prediction.yml
+++ b/examples/Synthesis/Prediction.yml
@@ -78,7 +78,7 @@ Predictor:
   outputs_dataset:
     Head:Tanh:  # Model output used to generate the predicted dataset
       OutputDataset: # Output dataset built using the same spatial structure as the input group
-        name_class: OutSameAsGroupDataset
+        name_class: OutputDataset
         before_reduction_transforms: None
         after_reduction_transforms: None
         final_transforms:  # Final transforms applied before saving the prediction

--- a/konfai-apps/tests/assets/AppClientRemote/TinySynthesisApp/Prediction.yml
+++ b/konfai-apps/tests/assets/AppClientRemote/TinySynthesisApp/Prediction.yml
@@ -27,7 +27,7 @@ Predictor:
   outputs_dataset:
     Head:Tanh:
       OutputDataset:
-        name_class: OutSameAsGroupDataset
+        name_class: OutputDataset
         before_reduction_transforms: None
         after_reduction_transforms: None
         final_transforms:

--- a/konfai-apps/tests/integration/test_konfai_apps.py
+++ b/konfai-apps/tests/integration/test_konfai_apps.py
@@ -133,7 +133,7 @@ def _write_local_synthesis_app(app_dir: Path) -> None:
               outputs_dataset:
                 Head:Tanh:
                   OutputDataset:
-                    name_class: OutSameAsGroupDataset
+                    name_class: OutputDataset
                     before_reduction_transforms: None
                     after_reduction_transforms:
                       InferenceStack:

--- a/konfai-mcp/tests/test_mcp_server.py
+++ b/konfai-mcp/tests/test_mcp_server.py
@@ -58,7 +58,7 @@ Predictor:
   outputs_dataset:
     Model:
       OutputDataset:
-        name_class: OutSameAsGroupDataset
+        name_class: OutputDataset
         same_as_group: Labels:Labels
         dataset_filename: Dataset:mha
         group: Prediction

--- a/konfai-mcp/tests/test_mcp_server_pipeline.py
+++ b/konfai-mcp/tests/test_mcp_server_pipeline.py
@@ -130,7 +130,7 @@ def _prediction_config(dataset_dir: Path, train_name: str) -> str:
                 "outputs_dataset": {
                     "Head:Tanh": {
                         "OutputDataset": {
-                            "name_class": "OutSameAsGroupDataset",
+                            "name_class": "OutputDataset",
                             "before_reduction_transforms": None,
                             "after_reduction_transforms": None,
                             "final_transforms": None,

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -17,13 +17,11 @@
 """Prediction workflow classes and the streamed-write dispatcher."""
 
 import copy
-import importlib
 import os
 import queue
 import shutil
 import threading
 import warnings
-from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Mapping
 from contextlib import suppress
@@ -152,27 +150,116 @@ class _AsyncWriter:
             raise error
 
 
-class OutputDataset(Dataset, NeedDevice, ABC):
-    """
-    Abstract prediction sink that accumulates model outputs and writes them to disk.
+# Streaming pays per-slab work (the pipe traversal, region writes, the TTA aligner); when the
+# assembled accumulators of all copies are below this fraction of allocatable memory (a 2.5D case),
+# holding them whole costs nothing and the case takes the whole-volume path.
+# KONFAI_STREAM_WORTH_THRESHOLD overrides the fraction (tests set 0 to exercise the streamed
+# machinery on toy volumes). See OutputDataset._worth_streaming.
+_STREAM_WORTH_MIN_FRACTION = 0.05
 
-    Concrete subclasses define how layers are accumulated across patches,
-    augmentations, and multiple models before the final prediction volume is
-    materialized.
+
+def _slab_context(region: slice, spatial: list[int]) -> RegionContext:
+    """Where one z-slab of the accumulator grid sits: the same region as source and target."""
+    slices = (region, *(slice(0, int(extent)) for extent in spatial[1:]))
+    shape = tuple(int(extent) for extent in spatial)
+    return RegionContext(slices, slices, shape, shape)
+
+
+@dataclass(frozen=True)
+class _FinalizeStage:
+    """One step of the finalize chain, bound to how the chain applies it (forward or inverted)."""
+
+    transform: Transform
+    inverted: bool
+
+    def locality(self, attribute: Attribute) -> PatchLocality:
+        if self.inverted:
+            return cast(TransformInverse, self.transform).inverse_patch_locality(attribute)
+        return self.transform.patch_locality(attribute)
+
+    def __call__(self, name: str, tensor: torch.Tensor, attribute: Attribute) -> torch.Tensor:
+        if self.inverted:
+            return cast(TransformInverse, self.transform).inverse(name, tensor, attribute)
+        return self.transform(name, tensor, attribute)
+
+    def stream_region(
+        self, name: str, tensor: torch.Tensor, context: RegionContext, attribute: Attribute
+    ) -> torch.Tensor:
+        """The call, told where the region sits (both default to the whole-volume call)."""
+        if self.inverted:
+            return cast(TransformInverse, self.transform).stream_region_inverse(name, tensor, context, attribute)
+        return self.transform.stream_region(name, tensor, context, attribute)
+
+
+@dataclass(frozen=True)
+class _StreamPlan:
+    """How one case streams: the post-reduction stages, split into a per-slab pointwise prefix, a
+    streamed pipe of region and pointwise stages, and (past what streaming can honour) a
+    whole-volume tail.
+
+    ``to_sink`` streams straight into a region-write ``DataStream``; ``pipe_start`` is the first
+    region stage (``None`` when the chain is pointwise throughout), and the pipe runs from there to
+    the end: region stages compose, so their number is not limited. Without ``to_sink`` the prefix
+    streams into a post-reduction buffer and ``stages[tail_start:]`` runs once on it (the chain
+    split). The invariants: ``to_sink`` implies no tail, and a pipe implies ``to_sink``: a tail
+    swallows the region stages, so the buffer always sits on the accumulator grid.
     """
+
+    stages: list[_FinalizeStage]
+    pipe_start: int | None
+    tail_start: int
+    to_sink: bool
+    # Prefix stages whose declaration is SLAB: per-voxel value maps with a per-region side effect,
+    # run through ``Transform.stream_slab`` so they learn where each slab sits.
+    slab_stages: frozenset[int] = frozenset()
+
+    @property
+    def boundary(self) -> int:
+        """Where the per-slab pointwise prefix ends."""
+        return self.pipe_start if self.pipe_start is not None else self.tail_start
+
+    @property
+    def mode(self) -> str:
+        if not self.to_sink:
+            return "buffered"
+        return "region" if self.pipe_start is not None else "direct"
+
+
+@dataclass
+class _RegionState:
+    """One case's live streamed pipe: its slab scheduler and the geometry its closures share.
+
+    ``shapes[i]`` is the spatial shape between pipe stage ``i - 1`` and ``i`` (``shapes[0]`` the
+    accumulator's, ``shapes[-1]`` the written image's); a pointwise stage leaves it unchanged, so the
+    per-stage region bookkeeping folds through the same list the pull map composes over. The pipe's
+    stages themselves live in the ``produce``/``pull`` closures the stream was built on.
+    """
+
+    shapes: list[list[int]]
+    stream: SlabRegionStream | None = None
+    # The attribute the latest emission ran the pipe on: what the sink opens with.
+    attribute: Attribute | None = None
+
+
+@config("OutputDataset")
+class OutputDataset(Dataset, NeedDevice):
+    """The sink of one model output: accumulates a case's patches across its copies and models,
+    mirrors the geometry and transform chain of the input group ``same_as_group``, and writes the
+    result, streamed by slabs whenever that is byte-identical to the assembled path."""
 
     def __init__(
         self,
-        filename: str,
-        group: str,
-        before_reduction_transforms: dict[str, TransformLoader],
-        after_reduction_transforms: dict[str, TransformLoader],
-        final_transforms: dict[str, TransformLoader],
-        patch_combine: str | None,
-        reduction: str,
+        same_as_group: str = "default",
+        dataset_filename: str = "default|./Dataset:mha",
+        group: str = "default",
+        before_reduction_transforms: dict[str, TransformLoader] = {"default|Normalize": TransformLoader()},
+        after_reduction_transforms: dict[str, TransformLoader] = {"default|Normalize": TransformLoader()},
+        final_transforms: dict[str, TransformLoader] = {"default|Normalize": TransformLoader()},
+        patch_combine: str | None = None,
+        reduction: str = "Mean",
         attributes: list[str] | None = None,
     ) -> None:
-        filename, _, file_format = split_path_spec(filename)
+        filename, _, file_format = split_path_spec(dataset_filename)
         super().__init__(filename, file_format)
         # ``Dataset.__init__`` does not forward ``super().__init__()``, so the ``NeedDevice`` mixin is
         # never initialised through the MRO; call it explicitly so ``self.device`` always has its CPU
@@ -233,6 +320,23 @@ class OutputDataset(Dataset, NeedDevice, ABC):
         else:
             self._async_writes = None  # decided at the first write, once the device is placed
         self._writer: _AsyncWriter | None = None
+        self.group_src, self.group_dest = same_as_group.split(":")
+        # Slab streaming has no config knob: it is applied automatically, per case, whenever it is
+        # byte-identical to the assembled path (see ``_plan_stream``), finalizing each z-slab as its
+        # patches complete so RAM is bounded at one patch window; otherwise the whole-volume path is
+        # used transparently. ``KONFAI_STREAMED_WRITES=0`` is a global ops/debug kill-switch (also how
+        # a test gets the assembled reference), not a per-output option.
+        self._streaming_enabled = env_flag("KONFAI_STREAMED_WRITES", True)
+        self._stream_plans: dict[int, _StreamPlan | None] = {}
+        self._stream_sinks: dict[int, DataStream] = {}
+        self._region_states: dict[int, _RegionState] = {}
+        self._stream_buffers: dict[int, torch.Tensor] = {}
+        self._post_prefix_attributes: dict[int, Attribute] = {}
+        self._reported_paths: set[str] = set()
+        # One aligner per streamed case: the copies' accumulators emit slabs at their own pace, and
+        # the finalize needs every copy's rows together (the cross-copy reduction). A single copy is
+        # simply a one-stream aligner: same path, no special case.
+        self._aligners: dict[int, SlabAligner] = {}
 
     def set_memory_budget(self, budget_bytes: float | None) -> None:
         """The per-rank budget the streamed-vs-assembled route is priced against."""
@@ -340,10 +444,6 @@ class OutputDataset(Dataset, NeedDevice, ABC):
         for transform in self.final_transforms:
             transform.set_datasets([*datasets, self])
 
-    @abstractmethod
-    def setup(self, datasets: list[Dataset], groups: dict[str, list[str]]):
-        self.set_datasets(datasets)
-
     def set_patch_config(
         self,
         patch_size: list[int] | None,
@@ -373,19 +473,6 @@ class OutputDataset(Dataset, NeedDevice, ABC):
                 for transform in transform_type:
                     transform.to(device)
 
-    @abstractmethod
-    def add_layer(
-        self,
-        index_dataset: int,
-        index_augmentation: int,
-        index_patch: int,
-        layer: torch.Tensor,
-        dataset: DatasetIter,
-        attribute: Attribute | None = None,
-        number_of_channels_per_model: list[int] | None = None,
-    ):
-        raise NotImplementedError()
-
     def is_done(self, index: int) -> bool:
         # ``.get``: a streamed case cleans itself up inside ``add_layer`` (its slabs are already on
         # disk), so by the time the run loop asks, the index is gone and the answer is "nothing to do".
@@ -393,10 +480,6 @@ class OutputDataset(Dataset, NeedDevice, ABC):
         if accumulators is None or len(accumulators) != self.nb_data_augmentation:
             return False
         return all(acc.is_full() for acc in accumulators.values())
-
-    @abstractmethod
-    def get_output(self, index: int, number_of_channels_per_model: list[int], dataset: DatasetIter) -> torch.Tensor:
-        raise NotImplementedError()
 
     def _submit_final_write(self, name: str, tensor: torch.Tensor, attribute: Attribute) -> None:
         """Queue one whole-volume entry write (D2H copy included) on the write path."""
@@ -412,15 +495,6 @@ class OutputDataset(Dataset, NeedDevice, ABC):
         self.attributes.pop(index)
         self._submit_final_write(name, layer, attribute)
 
-    def reset(self) -> None:
-        """Drop every in-flight accumulation (the OOM-restart path re-runs the rank's cases from scratch)."""
-        self.output_layer_accumulator.clear()
-        self.attributes.clear()
-        self.names.clear()
-        self._accum_device.clear()
-        self._reduce_device.clear()
-        self._pin_buffer = None
-
     def __str__(self) -> str:
         params = {
             "filename": self.filename,
@@ -435,146 +509,6 @@ class OutputDataset(Dataset, NeedDevice, ABC):
 
     def __repr__(self) -> str:
         return str(self)
-
-
-# Streaming pays per-slab work (the pipe traversal, region writes, the TTA aligner); when the
-# assembled accumulators of all copies are below this fraction of allocatable memory (a 2.5D case),
-# holding them whole costs nothing and the case takes the whole-volume path.
-# KONFAI_STREAM_WORTH_THRESHOLD overrides the fraction (tests set 0 to exercise the streamed
-# machinery on toy volumes). See OutSameAsGroupDataset._worth_streaming.
-_STREAM_WORTH_MIN_FRACTION = 0.05
-
-
-def _slab_context(region: slice, spatial: list[int]) -> RegionContext:
-    """Where one z-slab of the accumulator grid sits: the same region as source and target."""
-    slices = (region, *(slice(0, int(extent)) for extent in spatial[1:]))
-    shape = tuple(int(extent) for extent in spatial)
-    return RegionContext(slices, slices, shape, shape)
-
-
-@dataclass(frozen=True)
-class _FinalizeStage:
-    """One step of the finalize chain, bound to how the chain applies it (forward or inverted)."""
-
-    transform: Transform
-    inverted: bool
-
-    def locality(self, attribute: Attribute) -> PatchLocality:
-        if self.inverted:
-            return cast(TransformInverse, self.transform).inverse_patch_locality(attribute)
-        return self.transform.patch_locality(attribute)
-
-    def __call__(self, name: str, tensor: torch.Tensor, attribute: Attribute) -> torch.Tensor:
-        if self.inverted:
-            return cast(TransformInverse, self.transform).inverse(name, tensor, attribute)
-        return self.transform(name, tensor, attribute)
-
-    def stream_region(
-        self, name: str, tensor: torch.Tensor, context: RegionContext, attribute: Attribute
-    ) -> torch.Tensor:
-        """The call, told where the region sits (both default to the whole-volume call)."""
-        if self.inverted:
-            return cast(TransformInverse, self.transform).stream_region_inverse(name, tensor, context, attribute)
-        return self.transform.stream_region(name, tensor, context, attribute)
-
-
-@dataclass(frozen=True)
-class _StreamPlan:
-    """How one case streams: the post-reduction stages, split into a per-slab pointwise prefix, a
-    streamed pipe of region and pointwise stages, and (past what streaming can honour) a
-    whole-volume tail.
-
-    ``to_sink`` streams straight into a region-write ``DataStream``; ``pipe_start`` is the first
-    region stage (``None`` when the chain is pointwise throughout), and the pipe runs from there to
-    the end: region stages compose, so their number is not limited. Without ``to_sink`` the prefix
-    streams into a post-reduction buffer and ``stages[tail_start:]`` runs once on it (the chain
-    split). The invariants: ``to_sink`` implies no tail, and a pipe implies ``to_sink``: a tail
-    swallows the region stages, so the buffer always sits on the accumulator grid.
-    """
-
-    stages: list[_FinalizeStage]
-    pipe_start: int | None
-    tail_start: int
-    to_sink: bool
-    # Prefix stages whose declaration is SLAB: per-voxel value maps with a per-region side effect,
-    # run through ``Transform.stream_slab`` so they learn where each slab sits.
-    slab_stages: frozenset[int] = frozenset()
-
-    @property
-    def boundary(self) -> int:
-        """Where the per-slab pointwise prefix ends."""
-        return self.pipe_start if self.pipe_start is not None else self.tail_start
-
-    @property
-    def mode(self) -> str:
-        if not self.to_sink:
-            return "buffered"
-        return "region" if self.pipe_start is not None else "direct"
-
-
-@dataclass
-class _RegionState:
-    """One case's live streamed pipe: its slab scheduler and the geometry its closures share.
-
-    ``shapes[i]`` is the spatial shape between pipe stage ``i - 1`` and ``i`` (``shapes[0]`` the
-    accumulator's, ``shapes[-1]`` the written image's); a pointwise stage leaves it unchanged, so the
-    per-stage region bookkeeping folds through the same list the pull map composes over. The pipe's
-    stages themselves live in the ``produce``/``pull`` closures the stream was built on.
-    """
-
-    shapes: list[list[int]]
-    stream: SlabRegionStream | None = None
-    # The attribute the latest emission ran the pipe on: what the sink opens with.
-    attribute: Attribute | None = None
-
-
-@config("OutputDataset")
-class OutSameAsGroupDataset(OutputDataset):
-    """
-    Output dataset that mirrors the geometry and transform chain of an input group.
-
-    This is the default output writer used by KonfAI prediction workflows.
-    """
-
-    def __init__(
-        self,
-        same_as_group: str = "default",
-        dataset_filename: str = "default|./Dataset:mha",
-        group: str = "default",
-        before_reduction_transforms: dict[str, TransformLoader] = {"default|Normalize": TransformLoader()},
-        after_reduction_transforms: dict[str, TransformLoader] = {"default|Normalize": TransformLoader()},
-        final_transforms: dict[str, TransformLoader] = {"default|Normalize": TransformLoader()},
-        patch_combine: str | None = None,
-        reduction: str = "Mean",
-        attributes: list[str] | None = None,
-    ) -> None:
-        super().__init__(
-            dataset_filename,
-            group,
-            before_reduction_transforms,
-            after_reduction_transforms,
-            final_transforms,
-            patch_combine,
-            reduction,
-            attributes,
-        )
-        self.group_src, self.group_dest = same_as_group.split(":")
-        # Slab streaming has no config knob: it is applied automatically, per case, whenever it is
-        # byte-identical to the assembled path (see ``_plan_stream``), finalizing each z-slab as its
-        # patches complete so RAM is bounded at one patch window; otherwise the whole-volume path is
-        # used transparently. ``KONFAI_STREAMED_WRITES=0`` is a global ops/debug kill-switch (also how
-        # a test gets the assembled reference), not a per-output option.
-        self._streaming_enabled = env_flag("KONFAI_STREAMED_WRITES", True)
-        self._stream_plans: dict[int, _StreamPlan | None] = {}
-        self._stream_sinks: dict[int, DataStream] = {}
-        self._region_states: dict[int, _RegionState] = {}
-        self._stream_buffers: dict[int, torch.Tensor] = {}
-        self._post_prefix_attributes: dict[int, Attribute] = {}
-        self._reported_paths: set[str] = set()
-        # One aligner per streamed case: the copies' accumulators emit slabs at their own pace, and
-        # the finalize needs every copy's rows together (the cross-copy reduction). A single copy is
-        # simply a one-stream aligner: same path, no special case.
-        self._aligners: dict[int, SlabAligner] = {}
 
     def add_layer(
         self,
@@ -1261,6 +1195,7 @@ class OutSameAsGroupDataset(OutputDataset):
         return result, attribute
 
     def reset(self) -> None:
+        """Drop every in-flight accumulation (the OOM-restart path re-runs the rank's cases from scratch)."""
         # Aborting an attempt mid-stream: abort each open sink so the backend removes the partial
         # entry (a reader must never see a half-written volume); the restart rewrites it.
         error = PredictorError("prediction restart: the partial streamed output is discarded")
@@ -1275,7 +1210,12 @@ class OutSameAsGroupDataset(OutputDataset):
         self._stream_buffers.clear()
         self._post_prefix_attributes.clear()
         self._aligners.clear()
-        super().reset()
+        self.output_layer_accumulator.clear()
+        self.attributes.clear()
+        self.names.clear()
+        self._accum_device.clear()
+        self._reduce_device.clear()
+        self._pin_buffer = None
 
     def _close_stream(self, index: int) -> None:
         """Finalize the case's sink and drop its bookkeeping (``is_done`` then reports nothing left)."""
@@ -1297,8 +1237,7 @@ class OutSameAsGroupDataset(OutputDataset):
         self._reduce_device.pop(index, None)
 
     def setup(self, datasets: list[Dataset], groups: dict[str, list[str]]):
-        super().setup(datasets, groups)
-
+        self.set_datasets(datasets)
         if self.group_src not in groups.keys():
             raise PredictorError(f"Source group '{self.group_src}' not found. Available groups: {list(groups.keys())}.")
 
@@ -1497,17 +1436,21 @@ class OutSameAsGroupDataset(OutputDataset):
         return result.cpu() if result.device.type != "cpu" else result
 
 
+# ``name_class: OutSameAsGroupDataset`` is what published Prediction.yml carry.
+OutSameAsGroupDataset = OutputDataset
+
+
 @config("OutputDataset")
 class OutputDatasetLoader:
-    """Factory that instantiates output dataset classes from predictor config."""
+    """Builds one output's sink from ``Predictor.outputs_dataset.<layer>``: ``name_class`` is the
+    sink's classpath, a bare name resolving in ``konfai.predictor``."""
 
-    def __init__(self, name_class: str = "OutSameAsGroupDataset") -> None:
+    def __init__(self, name_class: str = "OutputDataset") -> None:
         self.name_class = name_class
 
     def get_output_dataset(self, layer_name: str) -> OutputDataset:
-        return apply_config(f"Predictor.outputs_dataset.{layer_name}")(
-            getattr(importlib.import_module("konfai.predictor"), self.name_class)
-        )()
+        module, name = get_module(self.name_class, "konfai.predictor")
+        return apply_config(f"Predictor.outputs_dataset.{layer_name}")(getattr(module, name))()
 
 
 def _prediction_report(clock: SweepClock, min_seconds: float = 1.0) -> str | None:

--- a/tests/assets/Workflows/Prediction.yml
+++ b/tests/assets/Workflows/Prediction.yml
@@ -26,7 +26,7 @@ Predictor:
   outputs_dataset:
     Head:Tanh:
       OutputDataset:
-        name_class: OutSameAsGroupDataset
+        name_class: OutputDataset
         before_reduction_transforms: None
         after_reduction_transforms: None
         final_transforms:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -24,7 +24,7 @@ import pytest
 import torch
 from konfai.data.augmentation import DataAugmentationsList
 from konfai.data.data_manager import DatasetIter
-from konfai.predictor import Mean, OutSameAsGroupDataset, Reduction
+from konfai.predictor import Mean, OutputDataset, Reduction
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.utils import get_patch_slices_from_shape
 
@@ -214,7 +214,7 @@ def _drive_tta(
         def get_dataset_from_index(group_dest: str, index: int):
             return DummyManager()
 
-    output_dataset = OutSameAsGroupDataset(
+    output_dataset = OutputDataset(
         same_as_group="src:dest",
         dataset_filename=f"{tmp_path}/output.h5:h5" if file_format == "h5" else f"{tmp_path}/output:{file_format}",
         group="out",

--- a/tests/unit/test_golden_run.py
+++ b/tests/unit/test_golden_run.py
@@ -158,7 +158,7 @@ def _predict_config(dataset: Path) -> dict:
             "outputs_dataset": {
                 "Head:Softmax": {
                     "OutputDataset": {
-                        "name_class": "OutSameAsGroupDataset",
+                        "name_class": "OutputDataset",
                         "before_reduction_transforms": "None",
                         "after_reduction_transforms": "None",
                         "final_transforms": {

--- a/tests/unit/test_memory_limit.py
+++ b/tests/unit/test_memory_limit.py
@@ -177,7 +177,7 @@ def route():
                 "num_workers": 0,
             },
             "outputs_dataset": {"Head:Scale": {"OutputDataset": {
-                "name_class": "OutSameAsGroupDataset",
+                "name_class": "OutputDataset",
                 "before_reduction_transforms": "None",
                 "after_reduction_transforms": "None",
                 "final_transforms": "None",

--- a/tests/unit/test_predictor.py
+++ b/tests/unit/test_predictor.py
@@ -32,7 +32,7 @@ import pytest
 import torch
 from konfai.data.augmentation import Flip
 from konfai.data.patching import Accumulator, blend_axes
-from konfai.predictor import PREDICTION_CLOCK, OutSameAsGroupDataset, _AsyncWriter, _Predictor
+from konfai.predictor import PREDICTION_CLOCK, OutputDataset, _AsyncWriter, _Predictor
 from konfai.utils.dataset import Dataset
 from konfai.utils.errors import PredictorError
 from konfai.utils.utils import get_patch_slices_from_shape
@@ -111,7 +111,7 @@ def test_a_built_in_reduction_binds_from_its_own_block_like_a_custom_one(write_c
 
     path = write_config("Predictor:\n  outputs_dataset:\n    L:\n      OutputDataset:\n        reduction: Mean\n")
     monkeypatch.setenv("KONFAI_ROOT", "Predictor")
-    output = OutSameAsGroupDataset(
+    output = OutputDataset(
         same_as_group="a:b",
         dataset_filename="./Out:mha",
         before_reduction_transforms={},
@@ -126,11 +126,11 @@ def test_a_built_in_reduction_binds_from_its_own_block_like_a_custom_one(write_c
     assert "Mean" in block
 
 
-def _output_dataset(write_config, monkeypatch) -> OutSameAsGroupDataset:
+def _output_dataset(write_config, monkeypatch) -> OutputDataset:
     """An output dataset with its declared blend window built, as ``prepare`` leaves it."""
     write_config("Predictor:\n  outputs_dataset:\n    L:\n      OutputDataset: {}\n")
     monkeypatch.setenv("KONFAI_ROOT", "Predictor")
-    output = OutSameAsGroupDataset(
+    output = OutputDataset(
         same_as_group="a:b",
         dataset_filename="./Out:mha",
         before_reduction_transforms={},
@@ -141,7 +141,7 @@ def _output_dataset(write_config, monkeypatch) -> OutSameAsGroupDataset:
     return output
 
 
-def _configure_blend(output: OutSameAsGroupDataset, patch_size: list[int], overlap: int) -> None:
+def _configure_blend(output: OutputDataset, patch_size: list[int], overlap: int) -> None:
     """Hand ``output`` the run's patch config the way the prediction loop does."""
     _Predictor(
         world_size=1,

--- a/tests/unit/test_predictor_memory.py
+++ b/tests/unit/test_predictor_memory.py
@@ -27,7 +27,7 @@ from konfai.predictor import (
     PREDICTION_CLOCK,
     Mean,
     ModelComposite,
-    OutSameAsGroupDataset,
+    OutputDataset,
     _colocate_loaded_modules,
     _prediction_report,
     _Predictor,
@@ -201,7 +201,7 @@ def test_output_dataset_uses_batch_attributes_when_manager_cache_is_cold() -> No
             assert index == 0
             return DummyManager()
 
-    output_dataset = OutSameAsGroupDataset(
+    output_dataset = OutputDataset(
         same_as_group="src:dest",
         dataset_filename="./Output:mha",
         group="out",
@@ -279,7 +279,7 @@ def test_output_dataset_offloads_patch_predictions_to_cpu_before_accumulating() 
             self.cpu_calls += 1
             return torch.ones(1, 2, 2)
 
-    output_dataset = OutSameAsGroupDataset(
+    output_dataset = OutputDataset(
         same_as_group="src:dest",
         dataset_filename="./Output:mha",
         group="out",
@@ -401,8 +401,8 @@ def test_patch_headers_are_copied_only_for_a_patch_inverse_to_undo_on() -> None:
             self.undone_on.append(cache_attribute)
             return tensor
 
-    def output_dataset() -> OutSameAsGroupDataset:
-        return OutSameAsGroupDataset(
+    def output_dataset() -> OutputDataset:
+        return OutputDataset(
             same_as_group="src:dest",
             dataset_filename="./Output:mha",
             group="out",
@@ -433,7 +433,7 @@ def test_get_output_hands_the_assembled_volume_on_as_a_view() -> None:
     the member itself, a fold of several copies first, Median/Vote/Concat build a new tensor), so
     the accumulator's own buffer, which assemble() has already let go of, can be the answer.
     """
-    output_dataset = OutSameAsGroupDataset(
+    output_dataset = OutputDataset(
         same_as_group="src:dest",
         dataset_filename="./Output:mha",
         group="out",
@@ -690,7 +690,7 @@ def test_gate_approved_blend_falls_back_to_cpu_when_the_allocation_fails() -> No
         def cpu(self) -> torch.Tensor:
             return torch.ones(1, 2, 2)
 
-    output_dataset = OutSameAsGroupDataset(
+    output_dataset = OutputDataset(
         same_as_group="src:dest",
         dataset_filename="./Output:mha",
         group="out",
@@ -745,7 +745,7 @@ def test_mid_blend_oom_stays_fatal() -> None:
         def element_size() -> int:
             return 4
 
-    output_dataset = OutSameAsGroupDataset(
+    output_dataset = OutputDataset(
         same_as_group="src:dest",
         dataset_filename="./Output:mha",
         group="out",
@@ -814,10 +814,10 @@ def test_ensemble_load_colocates_late_added_head_on_gpu() -> None:
 # ---------------------------------------------------------------------------
 # CPU offload of patch predictions (pinned staging buffer)
 # ---------------------------------------------------------------------------
-def _dataset(monkeypatch: pytest.MonkeyPatch) -> OutSameAsGroupDataset:
+def _dataset(monkeypatch: pytest.MonkeyPatch) -> OutputDataset:
     monkeypatch.setenv("KONFAI_config_file", "unused.yml")
     monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
-    return OutSameAsGroupDataset(same_as_group="default:default", dataset_filename="default|./Dataset:mha")
+    return OutputDataset(same_as_group="default:default", dataset_filename="default|./Dataset:mha")
 
 
 def test_offload_cpu_tensor_is_passed_through(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -888,7 +888,7 @@ def test_a_grid_swept_off_axis_zero_takes_the_whole_volume_path(monkeypatch: pyt
         def get_dataset_from_index(group_dest: str, index: int):
             return DummyManager()
 
-    output_dataset = OutSameAsGroupDataset(
+    output_dataset = OutputDataset(
         same_as_group="src:dest",
         dataset_filename="./Output:mha",
         group="out",
@@ -897,7 +897,7 @@ def test_a_grid_swept_off_axis_zero_takes_the_whole_volume_path(monkeypatch: pyt
     )
     output_dataset._streaming_enabled = True
     # A plan would exist if streaming were allowed to consider this case at all.
-    monkeypatch.setattr(OutSameAsGroupDataset, "_plan_stream", lambda self, *a, **k: object(), raising=True)
+    monkeypatch.setattr(OutputDataset, "_plan_stream", lambda self, *a, **k: object(), raising=True)
 
     output_dataset.add_layer(
         index_dataset=0,

--- a/tests/unit/test_predictor_reduction_device.py
+++ b/tests/unit/test_predictor_reduction_device.py
@@ -18,12 +18,12 @@ from typing import cast
 
 import pytest
 import torch
-from konfai.predictor import OutSameAsGroupDataset
+from konfai.predictor import OutputDataset
 from konfai.utils.utils import get_patch_slices_from_shape
 
 
-def _dataset(device: torch.device | int, nb_data_augmentation: int = 1) -> OutSameAsGroupDataset:
-    ds = OutSameAsGroupDataset.__new__(OutSameAsGroupDataset)
+def _dataset(device: torch.device | int, nb_data_augmentation: int = 1) -> OutputDataset:
+    ds = OutputDataset.__new__(OutputDataset)
     ds.device = device  # NeedDevice stores a torch.device on CPU and a CUDA ordinal (int) on GPU
     ds.nb_data_augmentation = nb_data_augmentation
     return ds
@@ -35,7 +35,7 @@ def test_output_dataset_device_defaults_to_cpu_without_to(monkeypatch: pytest.Mo
     # set, otherwise a CPU-only PREDICTION run (device propagation is CUDA-gated) raises AttributeError.
     monkeypatch.setenv("KONFAI_config_file", "unused.yml")
     monkeypatch.setenv("KONFAI_CONFIG_MODE", "Done")
-    ds = OutSameAsGroupDataset(same_as_group="default:default", dataset_filename="default|./Dataset:mha")
+    ds = OutputDataset(same_as_group="default:default", dataset_filename="default|./Dataset:mha")
     assert ds.device == torch.device("cpu")
     assert ds._reduction_device(torch.zeros(4, 8, dtype=torch.float16)).type == "cpu"
 

--- a/tests/unit/test_streamed_tta.py
+++ b/tests/unit/test_streamed_tta.py
@@ -33,7 +33,7 @@ from konfai.data.data_manager import DatasetIter, _interleaved_case_entries
 from konfai.data.patching import DatasetPatch, Gaussian, SlabAligner
 from konfai.data.transform import Flip as FlipTransform
 from konfai.data.transform import InferenceStack, LocalityKind, Sum
-from konfai.predictor import Concat, Mean, Median, OutSameAsGroupDataset
+from konfai.predictor import Concat, Mean, Median, OutputDataset
 from konfai.utils.dataset import Attribute, Dataset
 
 SHAPE = [6, 4, 3]
@@ -164,7 +164,7 @@ def _gate(augmentation, nb: int = 1) -> bool:
         def get_dataset_from_index(group_dest: str, index: int):
             return DummyManager()
 
-    output_dataset = OutSameAsGroupDataset.__new__(OutSameAsGroupDataset)
+    output_dataset = OutputDataset.__new__(OutputDataset)
     output_dataset.nb_data_augmentation = nb + 1
     output_dataset.group_dest = "dest"
     return output_dataset._tta_streamable(cast(DatasetIter, DummyDatasetIter()), 0, _geometry_attribute())

--- a/tests/unit/test_streamed_write_dispatcher.py
+++ b/tests/unit/test_streamed_write_dispatcher.py
@@ -49,7 +49,7 @@ from konfai.data.transform import (
     Transform,
     TransformInverse,
 )
-from konfai.predictor import Mean, OutSameAsGroupDataset, Reduction, _FinalizeStage
+from konfai.predictor import Mean, OutputDataset, Reduction, _FinalizeStage
 from konfai.utils.dataset import Attribute
 from konfai.utils.errors import PatchError
 
@@ -404,8 +404,8 @@ def _output_dataset(
     final: list[Transform] | None = None,
     file_format: str = "h5",
     nb_data_augmentation: int = 1,
-) -> OutSameAsGroupDataset:
-    ds = OutSameAsGroupDataset.__new__(OutSameAsGroupDataset)
+) -> OutputDataset:
+    ds = OutputDataset.__new__(OutputDataset)
     ds.nb_data_augmentation = nb_data_augmentation
     ds.reduction = reduction if reduction is not None else Mean()
     ds.before_reduction_transforms = before or []
@@ -554,7 +554,7 @@ def _drive_prediction(tmp_path, transforms, volume, monkeypatch, streamed=True, 
         def get_dataset_from_index(group_dest: str, index: int):
             return DummyManager()
 
-    output_dataset = OutSameAsGroupDataset(
+    output_dataset = OutputDataset(
         same_as_group="src:dest",
         dataset_filename=f"{tmp_path}/output.h5:h5",
         group="out",
@@ -642,9 +642,9 @@ def test_the_stream_worth_gate_prices_the_config_budget_not_the_machine(monkeypa
 
     monkeypatch.delenv("KONFAI_STREAM_WORTH_THRESHOLD", raising=False)
 
-    from konfai.predictor import OutSameAsGroupDataset
+    from konfai.predictor import OutputDataset
 
-    writer = OutSameAsGroupDataset.__new__(OutSameAsGroupDataset)
+    writer = OutputDataset.__new__(OutputDataset)
     writer.group_dest = "CT"
     writer.nb_data_augmentation = 1
     layer = torch.zeros(2, 1, dtype=torch.float32)


### PR DESCRIPTION
OutSameAsGroupDataset was the only sink; its body and the abstract base
are one config-bound class now, with the streaming helpers moved above
it. name_class is a classpath resolved like every other one (a bare name
in konfai.predictor); OutSameAsGroupDataset stays as an alias because
published Prediction.yml name it.

Stacked on #147: merge that one first.