### PR TITLE
test: mark the tests above eight seconds slow

### DIFF
--- a/tests/unit/test_data_stream.py
+++ b/tests/unit/test_data_stream.py
@@ -600,7 +600,7 @@ def test_the_listing_names_a_case_whose_only_version_is_an_orphaned_backup(tmp_p
     assert sorted(fresh.get_names("CT")) == ["CASE_000", "CASE_001"]
 
 
-@pytest.mark.parametrize("file_format", ["mha", "omezarr"])
+@pytest.mark.parametrize("file_format", ["mha", pytest.param("omezarr", marks=pytest.mark.slow)])
 def test_recovery_never_lands_on_a_publish_that_won_the_race(tmp_path: Path, file_format: str, monkeypatch) -> None:
     """A writer can publish between the moment recovery finds the entry missing and the moment it
     puts the backup back. The move itself must refuse then, because a second existence check would

--- a/tests/unit/test_memory_limit.py
+++ b/tests/unit/test_memory_limit.py
@@ -303,6 +303,7 @@ def _within_its_budget(source: str, budget_bytes: int, floor: dict, cohort: Path
     return measured
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("budget_mib", [512, 128])
 def test_a_streamed_evaluation_holds_the_budget_it_declared(budget_mib: int, floor: dict, cohort: Path) -> None:
     """The case exceeds both budgets, so both runs cut it into disjoint patches read with SSIM's
@@ -312,6 +313,7 @@ def test_a_streamed_evaluation_holds_the_budget_it_declared(budget_mib: int, flo
     assert "disjoint patches" in measured["log"] and "halo of 3" in measured["log"]
 
 
+@pytest.mark.slow
 def test_a_streamed_transform_tracks_the_budget_it_declared(floor: dict, cohort: Path) -> None:
     """Resample (REGRID) then Gradient (HALO): a chain that streams, so the sweep sizes its regions
     from the budget and the case is never resident.

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -74,7 +74,7 @@ import konfai.utils.config
     subprocess.run([sys.executable, "-c", script], check=True, capture_output=True, text=True)
 
 
-def test_transform_and_blocks_import_without_simpleitk() -> None:
+def test_transform_imports_without_simpleitk() -> None:
     """Modules using SimpleITK guard it at point-of-use, so import must succeed without it."""
     script = """
 import builtins
@@ -88,10 +88,8 @@ def import_without_simpleitk(name, *args, **kwargs):
 
 builtins.__import__ = import_without_simpleitk
 import konfai.data.transform
-import konfai.network.blocks
 
 assert konfai.data.transform.sitk is None
-assert konfai.network.blocks.sitk is None
 try:
     konfai.data.transform._require_simpleitk()
 except Exception as exc:

--- a/tests/unit/test_pretrained_bridge.py
+++ b/tests/unit/test_pretrained_bridge.py
@@ -52,6 +52,7 @@ def _konfai_logits(net: Network, inputs: torch.Tensor) -> torch.Tensor:
     return logits
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("dim,input_shape", [(2, (1, 1, 32, 32)), (3, (1, 1, 16, 16, 16))])
 def test_monai_pretrained_weights_drive_the_konfai_graph(dim: int, input_shape: tuple[int, ...]) -> None:
     pytest.importorskip("monai")

--- a/tests/unit/test_resample_transform.py
+++ b/tests/unit/test_resample_transform.py
@@ -541,6 +541,7 @@ def test_the_plan_keeps_a_case_s_bound_and_the_run_holds_one_case_s_stages():
     torch.testing.assert_close(rank("CASE_003", volume, Attribute(attribute)), first, rtol=0.0, atol=0.0)
 
 
+@pytest.mark.slow
 def test_the_slabbed_walk_lands_each_slab_in_the_one_output(monkeypatch: pytest.MonkeyPatch) -> None:
     """Above the walk budget the general path gathers slab by slab, and each slab is written into
     the output as it lands: bit for bit the single pass, with no parts held for a cat."""
@@ -572,6 +573,7 @@ def _diagonal_maps(image) -> list[tuple[str, "sitk.Transform"]]:
     ]
 
 
+@pytest.mark.slow
 def test_a_diagonal_stored_map_resamples_separably_within_the_routes_it_replaces() -> None:
     """A stored translation, an axis-aligned scale or their composition factorises: the region is
     read one axis at a time, from the very coordinates the general walk computes, and no coordinate

--- a/tests/unit/test_sampling.py
+++ b/tests/unit/test_sampling.py
@@ -167,6 +167,7 @@ def test_the_host_resampler_and_the_walk_agree_on_an_integer_payload():
             assert int((apart > 0).sum()) <= apart.numel() // 500, f"{label}/{mode}: the seam is not a seam"
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("oblique", [False, True], ids=["axis-aligned", "oblique"])
 def test_the_whole_grid_matches_simpleitk(oblique: bool):
     device = torch.device("cpu")
@@ -181,7 +182,9 @@ def test_the_whole_grid_matches_simpleitk(oblique: bool):
 
 
 @pytest.mark.parametrize("device", DEVICES, ids=DEVICE_IDS)
-@pytest.mark.parametrize("rows", [3, 7, SIZE[0]], ids=["slab-3", "slab-7", "whole"])
+@pytest.mark.parametrize(
+    "rows", [pytest.param(3, marks=pytest.mark.slow), 7, SIZE[0]], ids=["slab-3", "slab-7", "whole"]
+)
 def test_the_streamed_slabs_agree_with_the_whole_volume(device: torch.device, rows: int):
     """A slab and the whole volume put every sample in the same place, to a stated bound.
 


### PR DESCRIPTION
The dev loop (test-fast) skips them; the full run keeps them. The
packaging test no longer imports blocks, which does not use SimpleITK.

Stacked on #148: merge that one first.