### PR TITLE
docs: state the constraint, not the history, in comments

### DIFF
--- a/konfai-mcp/konfai_mcp/server_support.py
+++ b/konfai-mcp/konfai_mcp/server_support.py
@@ -99,11 +99,7 @@ class DatasetGroupUnreadableError(ValueError):
 
 
 def aggregate_case_statistics(stats: dict[str, dict[str, Any]]) -> dict[str, dict[str, dict[str, Any]]]:
-    """Aggregate per-case statistics into the KonfAI ``case``/``aggregates`` payload shape.
-
-    Vendored in the MCP package so it depends only on KonfAI's public API: the
-    equivalent logic also lives inline in ``Dataset.get_statistics``.
-    """
+    """Aggregate per-case statistics into the KonfAI ``case``/``aggregates`` payload shape."""
     result: dict[str, dict[str, dict[str, Any]]] = {"case": {}, "aggregates": {}}
     if not stats:
         return result

--- a/konfai/data/case_reduction.py
+++ b/konfai/data/case_reduction.py
@@ -115,9 +115,8 @@ class ReductionPlan:
     #: What ONE member's region makes the store decode ABOVE the window it asked for
     #: (:meth:`~konfai.data.patching.DatasetManager.region_reads`). A chunked backend decodes whole
     #: blocks, so below one stored block this is the SAME figure at every height: it is charged flat
-    #: and never divided by the rows. Measured on the prep's cohort at 4.51 GiB for a 17-row region
-    #: whose own tensor was 70 MiB, and 4.57 GiB for a 4-row one -- the sizing had been cutting the
-    #: height to buy memory that cutting cannot buy.
+    #: and never divided by the rows: measured on the prep's cohort at 4.51 GiB for a 17-row region
+    #: whose own tensor was 70 MiB, and 4.57 GiB for a 4-row one.
     read_bytes: int = 0
     #: Members read from a store that cannot serve a bounded region read (a gzipped NIfTI, a
     #: compressed MetaImage, NRRD), by name, with the store's format: every region asked of such a

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -2065,16 +2065,15 @@ class Resample(TransformInverse):
         the sampling grid already costs; at a field solved four times coarser per axis it is a
         sixteenth of that, and the plan should not charge the same for the two.
 
-        The plan priced it at nothing: a fold over native-resolution fields announced 12.41 GiB and
-        held 38.2. Answered from headers alone; a case whose grids are not both known yet answers
-        the class's figure rather than guessing.
+        Answered from headers alone; a case whose grids are not both known yet answers the class's
+        figure rather than guessing.
         """
         base = float(self.working_multiple)
         # NOT the general walk. A map that does not factorise is walked coordinate by coordinate in
         # float64 and holds 21.4 to 21.6 volumes-worth where a separable one holds 0.19 to 2.85 --
         # but that walk slabs ITSELF against the declared budget (konfai.data.sampling), so it is
         # bounded whatever the region is. Charging the region for it as well would shrink every
-        # resampling chain sevenfold to make room for memory the walk no longer takes.
+        # resampling chain sevenfold for memory the walk does not take.
         if self.displacement is None:
             return base
         try:

--- a/konfai/utils/budget.py
+++ b/konfai/utils/budget.py
@@ -94,13 +94,8 @@ class MemoryBudget:
         return max(0.0, per_rank - (resident_bytes() or 0))
 
 
-#: How a declared per-rank budget divides between the consumers that can be holding AT ONCE. Every
-#: one of them used to choose its own fraction of the whole figure, in its own file, and nothing
-#: summed them: a fold's regions took a half, a member's chain was handed all of it, the folds a
-#: stat pass keeps took another half and the store's chunk cache a third, so a run could honour
-#: every share and still hold one and a half times what it declared.
-#:
-#: Shares of ONE declaration, so they add to one. Which consumers are simultaneous is a property of
+#: How a declared per-rank budget divides between the consumers that can be holding AT ONCE:
+#: shares of ONE declaration, so they add to one. Which consumers are simultaneous is a property of
 #: the call path, not of this table: a whole-volume fallback and a swept tile are alternatives and
 #: each may take the route's whole share, while a fold's regions and its members' chains are not,
 #: because a member's sweep fires from inside the fold loop.

--- a/konfai/utils/runtime.py
+++ b/konfai/utils/runtime.py
@@ -1123,8 +1123,7 @@ def apply_cpu_thread_budget(world_size: int | None = None) -> None:
 
         # A THIRD of the share: a pipelined sweep runs three of these at once, the decode of the
         # region being read, the assembly of the one before it, the encode of the one being written.
-        # Re-measured under the split-thread sweep, where the chain no longer runs on the reading
-        # thread. 24 cores, ExaSPIM 513x1331x1776 through a stored affine, two runs per point,
+        # Measured with the chain off the reading thread: 24 cores, ExaSPIM 513x1331x1776 through a stored affine, two runs per point,
         # nothing else moved (a wrapper sets this alone, not OMP_NUM_THREADS, which would move ITK
         # with it). Wall clock, host path then device path:
         #   4  -> 12.1 / 13.4 s     4  -> 5.1 / 5.2 s

--- a/tests/unit/test_memory_budget.py
+++ b/tests/unit/test_memory_budget.py
@@ -664,9 +664,11 @@ _HALO_EVALUATION = """Evaluator:
 """
 
 
-def test_a_halo_metric_no_longer_vetoes_the_patched_evaluation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_a_halo_metric_evaluates_patched_under_a_budget_the_case_exceeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """SSIM beside MAE under a budget the case exceeds: the run takes the patched path, reading
-    each slot with SSIM's halo, where SSIM once kept the whole run on the whole-volume path."""
+    each slot with SSIM's halo."""
     pytest.importorskip("SimpleITK")
     import numpy as np
     from konfai.evaluator import Evaluator

--- a/tests/unit/test_patching.py
+++ b/tests/unit/test_patching.py
@@ -204,8 +204,8 @@ def test_declared_free_axis_keeps_the_fraction_overlap_after_restart_concretizat
     derived_slices = get_patch_slices_from_shape(declared, shape, None)
     assert _axis_overlaps(declared_slices, [512, 128, 128]) == _axis_overlaps(derived_slices, [512, 128, 128])
 
-    # Regression: on the concretized grid the derived flag is False (no ``0`` left) and would take the
-    # remainder branch; carrying declared_free_axis=True restores the exact fraction default on the tiled axes.
+    # On the concretized grid the derived flag is False (no ``0`` left), which takes the remainder
+    # branch; carrying declared_free_axis=True keeps the fraction default on the tiled axes.
     remainder = get_patch_slices_from_shape(concrete, shape, None, None, False)
     fixed = get_patch_slices_from_shape(concrete, shape, None, None, True)
     assert _axis_overlaps(remainder, concrete) == [0, 0, 0]


### PR DESCRIPTION
Comments that narrated a previous design, a previous bug or a re-measurement
keep the measured figure and the rule it settles; a docstring and a test
name that referred to removed code or to what once happened are reworded.

Stacked on #149: merge that one first.