### PR TITLE
refactor: drop attributes nothing reads

### DIFF
--- a/konfai/data/patching.py
+++ b/konfai/data/patching.py
@@ -319,7 +319,7 @@ class _ReadStagePlan:
 
     def region_context(self, source: Sequence[slice], target: Sequence[slice]) -> RegionContext:
         """Where one region of this stage sits: the part of its input read, the part of its output due."""
-        return RegionContext(tuple(source), tuple(target), tuple(self.in_shape), tuple(self.out_shape))
+        return RegionContext(tuple(source), tuple(target), tuple(self.in_shape))
 
 
 def device_capped_budget(budget_bytes: float | None, device: "torch.device | None") -> float | None:
@@ -3509,7 +3509,7 @@ class DatasetManager:
             # volume (a mask) reads the part that lines up with it.
             spatial = tuple(int(extent) for extent in stream_source.shape[1:])
             region = tuple(plan.data_slices[len(plan.data_slices) - len(spatial) :])
-            context = RegionContext(region, region, spatial, spatial)
+            context = RegionContext(region, region, spatial)
             for stage in stream_source.stages:
                 tensor = stage.stream_region(self.name, tensor, context, cache_attribute)
             # The read plan is applied AFTER the chain, as the whole-volume path transforms before

--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -155,14 +155,13 @@ class RegionContext:
 
     ``source`` is the part of the stage's INPUT the tensor covers, ``target`` the part of its OUTPUT
     it must produce; they differ whenever the stage moves or resizes data (a halo read, a resample,
-    a warp onto another grid). ``source_shape`` and ``target_shape`` are the two whole extents those
-    regions are cut from: a region alone cannot say how far it is from an edge.
+    a warp onto another grid). ``source_shape`` is the whole extent the source region is cut from: a
+    region alone cannot say how far it is from an edge.
     """
 
     source: tuple[slice, ...]
     target: tuple[slice, ...]
     source_shape: tuple[int, ...]
-    target_shape: tuple[int, ...]
 
 
 @dataclass(frozen=True)
@@ -212,7 +211,6 @@ def stat_seed_valid(upstream: Iterable[PatchLocality]) -> bool:
 class Transform(NeedDevice, ABC):
     """Base class for transforms operating on tensors and cached attributes."""
 
-    supports_dataloader_workers = True
     #: What ``__call__`` allocates ON TOP of its input and its output, in volumes-worth of the case.
     #: Every sizing route reads it: the sweep prices a region with it, a reduction charges the member
     #: chain by it, the whole-volume fallback is sized against it.
@@ -3848,8 +3846,6 @@ class KonfAIInference(Transform):
     has cases; its GPU/RAM usage lives outside the ``memory_budget`` a TRANSFORM plan bounds. Inference
     over a cohort is PREDICTION's job; this stage is for an inference that feeds a later stage.
     """
-
-    supports_dataloader_workers = False
 
     def __init__(
         self,

--- a/konfai/models/python/generation/diffusionGan.py
+++ b/konfai/models/python/generation/diffusionGan.py
@@ -189,7 +189,6 @@ class DiscriminatorADA(network.Network):
             self.n = 4
             self.ada_target = 0.25
             self.ada_interval = 0.001
-            self.ada_kimg = 500
 
             self.measure = None
             self.names = []

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -162,7 +162,7 @@ def _slab_context(region: slice, spatial: list[int]) -> RegionContext:
     """Where one z-slab of the accumulator grid sits: the same region as source and target."""
     slices = (region, *(slice(0, int(extent)) for extent in spatial[1:]))
     shape = tuple(int(extent) for extent in spatial)
-    return RegionContext(slices, slices, shape, shape)
+    return RegionContext(slices, slices, shape)
 
 
 @dataclass(frozen=True)
@@ -407,22 +407,17 @@ class OutputDataset(Dataset, NeedDevice):
         return out
 
     def prepare(self, name_layer: str) -> None:
-        self.before_reduction_transforms = []
-        self.after_reduction_transforms = []
-        self.final_transforms = []
-        transforms_type = [
-            "before_reduction_transforms",
-            "after_reduction_transforms",
-            "final_transforms",
-        ]
         konfai_args = f"{konfai_root()}.outputs_dataset.{name_layer}.OutputDataset"
-        for name, _transform_type, transform_type in [
-            (k, getattr(self, f"_{k}"), getattr(self, k)) for k in transforms_type
-        ]:
-            if _transform_type is not None:
-                for classpath, transform in _transform_type.items():
-                    transform = transform.get_transform(classpath, konfai_args=f"{konfai_args}.{name}")
-                    transform_type.append(transform)
+
+        def build(name: str, loaders: dict[str, TransformLoader] | None) -> list[Transform]:
+            return [
+                loader.get_transform(classpath, konfai_args=f"{konfai_args}.{name}")
+                for classpath, loader in (loaders or {}).items()
+            ]
+
+        self.before_reduction_transforms = build("before_reduction_transforms", self._before_reduction_transforms)
+        self.after_reduction_transforms = build("after_reduction_transforms", self._after_reduction_transforms)
+        self.final_transforms = build("final_transforms", self._final_transforms)
 
         # A patch grid overlaps whether or not a combine is declared, so the overlap needs a
         # deterministic owner. Trim keeps each patch's central band: the bands tile the volume
@@ -463,15 +458,8 @@ class OutputDataset(Dataset, NeedDevice):
 
     def to(self, device: torch.device):
         super().to(device)
-        transforms_type = [
-            "before_reduction_transforms",
-            "after_reduction_transforms",
-            "final_transforms",
-        ]
-        for transform_type in [(getattr(self, k)) for k in transforms_type]:
-            if transform_type is not None:
-                for transform in transform_type:
-                    transform.to(device)
+        for transform in [*self.before_reduction_transforms, *self.after_reduction_transforms, *self.final_transforms]:
+            transform.to(device)
 
     def is_done(self, index: int) -> bool:
         # ``.get``: a streamed case cleans itself up inside ``add_layer`` (its slabs are already on
@@ -1047,7 +1035,7 @@ class OutputDataset(Dataset, NeedDevice):
         if kind is LocalityKind.REGRID:
             # Region-aware on both sides, and the geometry written from the FULL shape: what the
             # stage records on the way is one region's, and the case's answer is the whole grid's.
-            context = RegionContext(tuple(source), tuple(target), tuple(in_shape), tuple(out_shape))
+            context = RegionContext(tuple(source), tuple(target), tuple(in_shape))
             if stage.inverted:
                 remapper = cast(TransformInverse, stage.transform)
                 result = remapper.stream_region_inverse(name, block, context, Attribute(attribute))

--- a/konfai/utils/dicom.py
+++ b/konfai/utils/dicom.py
@@ -67,14 +67,12 @@ if TYPE_CHECKING:
 try:
     import pydicom
     from pydicom.dataset import Dataset as DicomDataset
-    from pydicom.sequence import Sequence as DicomSequence
 
     _PYDICOM_AVAILABLE = True
 except ImportError:
     _PYDICOM_AVAILABLE = False
     pydicom = None  # type: ignore[assignment]
     DicomDataset = None  # type: ignore[assignment,misc]
-    DicomSequence = None  # type: ignore[assignment]
 
 
 def _require_pydicom() -> None:

--- a/konfai/utils/model_builder.py
+++ b/konfai/utils/model_builder.py
@@ -142,7 +142,6 @@ class YamlNetwork(Network):
             dim=dim,
         )
         self.name = name
-        self.yaml_parameters = copy.deepcopy(parameters)
         _populate_graph(self, module_specs, parameters)
 
     def forward_tensor(self, *inputs: torch.Tensor) -> torch.Tensor:

--- a/tests/unit/test_dataset_streaming.py
+++ b/tests/unit/test_dataset_streaming.py
@@ -956,7 +956,7 @@ def _write_mask(path, z, y, x, seed=0):
 
 def _slab_context(z0: int, z1: int, shape: tuple[int, int, int]) -> RegionContext:
     region = (slice(z0, z1), slice(0, shape[1]), slice(0, shape[2]))
-    return RegionContext(region, region, shape, shape)
+    return RegionContext(region, region, shape)
 
 
 @pytest.mark.parametrize("slab", [1, 4, 5])

--- a/tests/unit/test_resample_transform.py
+++ b/tests/unit/test_resample_transform.py
@@ -224,7 +224,7 @@ def test_the_streamed_slabs_agree_with_the_whole_volume(device: torch.device, ro
             target = (slice(start, stop), slice(0, SIZE[1]), slice(0, SIZE[2]))
             source = tuple(stage.stream_region_source(CASE, target, list(SIZE), Attribute(attribute)))
             block = volume[(slice(None), *source)]
-            context = RegionContext(source, target, tuple(SIZE), tuple(SIZE))
+            context = RegionContext(source, target, tuple(SIZE))
             streamed[(slice(None), *target)] = stage.stream_region(CASE, block, context, Attribute(attribute))
         span = float((reference.max() - reference.min()).item())
         torch.testing.assert_close(streamed, reference, rtol=0.0, atol=1e-5 * span, msg=label)
@@ -680,7 +680,7 @@ class TestTheHostRouteReusesItsInputImage:
         stage = _stage(image, _euler(image))  # never separable: the host route runs ITK
         target = (slice(0, 4), slice(0, SIZE[1]), slice(0, SIZE[2]))
         source = tuple(stage.stream_region_source(CASE, target, list(SIZE), Attribute(attribute)))
-        context = RegionContext(source, target, tuple(SIZE), tuple(SIZE))
+        context = RegionContext(source, target, tuple(SIZE))
         stage.stream_region(CASE, volume[(slice(None), *source)], context, Attribute(attribute))
         held = stage._sitk_input._image
         assert held is not None

--- a/tests/unit/test_streamed_read_dispatcher.py
+++ b/tests/unit/test_streamed_read_dispatcher.py
@@ -489,7 +489,7 @@ def test_streamed_nearest_resample_matches_whole_volume_at_any_ratio(n_in: int, 
 
     target = tuple(slice(0, n_out) for _ in range(3))
     window = resample.stream_region_source("case", target, [n_in] * 3, Attribute(attribute))
-    context = RegionContext(tuple(window), target, (n_in,) * 3, (n_out,) * 3)
+    context = RegionContext(tuple(window), target, (n_in,) * 3)
     got = resample.stream_region("case", volume[(slice(None), *window)], context, Attribute(attribute))
     torch.testing.assert_close(got, expected, rtol=0, atol=0)
 
@@ -505,7 +505,7 @@ def test_streamed_resample_handles_2d(dtype: torch.dtype) -> None:
 
     target = (slice(0, 5), slice(0, 6))
     window = resample.stream_region_source("case", target, [9, 11], Attribute(attribute))
-    context = RegionContext(tuple(window), target, (9, 11), (5, 6))
+    context = RegionContext(tuple(window), target, (9, 11))
     got = resample.stream_region("case", volume[(slice(None), *window)], context, Attribute(attribute))
     torch.testing.assert_close(got, expected, rtol=0, atol=0)
 

--- a/tests/unit/test_streamed_write_dispatcher.py
+++ b/tests/unit/test_streamed_write_dispatcher.py
@@ -234,7 +234,7 @@ def test_stream_rescale_nearest_is_byte_identical_to_the_whole_volume_inverse(se
         lambda window, target, source: resample.stream_region_inverse(
             "case",
             window,
-            RegionContext(tuple(source), tuple(target), tuple(in_shape), tuple(out_shape)),
+            RegionContext(tuple(source), tuple(target), tuple(in_shape)),
             Attribute(attribute),
         ),
         in_shape,
@@ -264,7 +264,7 @@ def test_stream_rescale_linear_matches_the_whole_volume_inverse_to_float_roundin
         lambda window, target, source: resample.stream_region_inverse(
             "case",
             window,
-            RegionContext(tuple(source), tuple(target), tuple(in_shape), tuple(out_shape)),
+            RegionContext(tuple(source), tuple(target), tuple(in_shape)),
             Attribute(attribute),
         ),
         in_shape,
@@ -318,7 +318,7 @@ def test_stream_window_is_bounded_by_the_pull_span() -> None:
         lambda window, target, source: resample.stream_region_inverse(
             "case",
             window,
-            RegionContext(tuple(source), tuple(target), tuple(in_shape), tuple(out_shape)),
+            RegionContext(tuple(source), tuple(target), tuple(in_shape)),
             Attribute(attribute),
         ),
         in_shape,

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -971,7 +971,6 @@ def test_a_streamed_mask_refuses_a_mask_off_the_stage_input_grid(tmp_path: Path)
         source=(slice(0, 2), slice(0, 8), slice(0, 8)),
         target=(slice(0, 2), slice(0, 8), slice(0, 8)),
         source_shape=(8, 8, 8),
-        target_shape=(8, 8, 8),
     )
     mask = Mask(path="MASK")
     mask.set_datasets([store])
@@ -1003,7 +1002,6 @@ def test_a_streamed_mask_declares_the_windows_of_the_mask_it_will_read(tmp_path:
             source=(slice(z, z + 2), slice(0, 8), slice(0, 8)),
             target=(slice(z, z + 2), slice(0, 8), slice(0, 8)),
             source_shape=(8, 8, 8),
-            target_shape=(8, 8, 8),
         )
         for z in (0, 2)
     ]
@@ -1034,7 +1032,6 @@ def test_a_streamed_mha_mask_is_read_by_region_and_never_held_whole(tmp_path: Pa
         source=(slice(1, 4), slice(0, 8), slice(0, 8)),
         target=(slice(1, 4), slice(0, 8), slice(0, 8)),
         source_shape=(8, 8, 8),
-        target_shape=(8, 8, 8),
     )
     out = stage.stream_region("CASE", torch.ones(1, 3, 8, 8), context, Attribute())
     np.testing.assert_array_equal(out[0, :, 0, 0].numpy(), [-1, 1, 1])  # rows 1..3 of the mask: 0, 1, 1


### PR DESCRIPTION
RegionContext.target_shape, Transform.supports_dataloader_workers, the
YAML model's yaml_parameters copy, DiscriminatorADA.ada_kimg and the
unused pydicom Sequence import go. OutputDataset builds its transform
lists and moves them by name instead of through getattr on strings.

Stacked on #150: merge that one first.