### PR TITLE
refactor: bind a model in one call, one conv builder per residual block

### DIFF
--- a/konfai/data/transform.py
+++ b/konfai/data/transform.py
@@ -22,7 +22,7 @@ import os
 import tempfile
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
 from multiprocessing import current_process, get_context
@@ -4077,23 +4077,28 @@ class Norm(Transform):
         return shape[:-1]
 
 
-class Variance(Transform):
+class _MemberSpread(Transform):
+    """A per-voxel spread across the leading member axis (no spatial neighbour); one member spreads 0."""
+
     # Measured at 2.00 on the CUDA allocator, in volumes-worth of what it is handed.
     working_multiple = 2.0
+    _spread: Callable[[torch.Tensor, int], torch.Tensor]
 
     def __init__(self) -> None:
         super().__init__()
 
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
-        # Variance across the leading member axis at each voxel: no spatial neighbour.
         return PatchLocality(LocalityKind.POINTWISE)
 
     def __call__(self, name: str, tensors: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
-        # Keep the leading member axis in BOTH branches: the N>1 var(0) drops it and re-adds it via
-        # unsqueeze(0), so the single-member zeros must unsqueeze too or the output rank is off by one.
-        return (
-            tensors.float().var(0).unsqueeze(0) if tensors.shape[0] > 1 else torch.zeros_like(tensors[0]).unsqueeze(0)
-        )
+        # The member axis stays in both branches: var/std drop it and unsqueeze re-adds it.
+        if tensors.shape[0] > 1:
+            return self._spread(tensors.float(), 0).unsqueeze(0)
+        return torch.zeros_like(tensors[0]).unsqueeze(0)
+
+
+class Variance(_MemberSpread):
+    _spread = staticmethod(torch.var)
 
 
 class SegmentationDisagreement(Transform):
@@ -4155,21 +4160,8 @@ class Percentage(Transform):
         return tensors / self.baseline * 100.0
 
 
-class StandardDeviation(Transform):
-    # Measured at 2.00 on the CUDA allocator, in volumes-worth of what it is handed.
-    working_multiple = 2.0
-
-    def __init__(self) -> None:
-        super().__init__()
-
-    def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
-        # Standard deviation across the leading member axis at each voxel: no spatial neighbour.
-        return PatchLocality(LocalityKind.POINTWISE)
-
-    def __call__(self, name: str, tensors: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
-        return (
-            tensors.float().std(0).unsqueeze(0) if tensors.shape[0] > 1 else torch.zeros_like(tensors[0]).unsqueeze(0)
-        )
+class StandardDeviation(_MemberSpread):
+    _spread = staticmethod(torch.std)
 
 
 class Statistics(Transform):

--- a/konfai/models/python/classification/resnet.py
+++ b/konfai/models/python/classification/resnet.py
@@ -38,78 +38,54 @@ from konfai.utils.errors import ConfigError
 # wide_resnet101_2: https://download.pytorch.org/models/wide_resnet101_2-32ee1156.pth
 
 
+def _conv(
+    in_channels: int,
+    out_channels: int,
+    kernel_size: int,
+    stride: int,
+    activation: str,
+    dim: int,
+    alias: list[list[str]],
+) -> blocks.ConvBlock:
+    """One conv + BatchNorm (+ activation) of a torchvision residual block; ``padding`` keeps the extent."""
+    config = blocks.BlockConfig(
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=kernel_size // 2,
+        bias=False,
+        activation=activation,
+        norm_mode=blocks.NormMode.BATCH.name,
+    )
+    return blocks.ConvBlock(in_channels, out_channels, [config], dim=dim, alias=alias)
+
+
 class AbstractResBlock(network.ModuleArgsDict, ABC):
     def __init__(self, in_channels: int, out_channels: int, downsample: bool, dim: int):
         super().__init__()
 
-
-class ResBlock(AbstractResBlock):
-    def __init__(self, in_channels: int, out_channels: int, downsample: bool, dim: int):
-        super().__init__(in_channels, out_channels, downsample, dim)
-        # As in torchvision BasicBlock: project the shortcut whenever the block is strided OR
-        # changes channel count, otherwise the residual Add receives mismatched tensors.
+    def _add_shortcut(self, in_channels: int, out_channels: int, downsample: bool, dim: int) -> None:
+        # As in torchvision: project the shortcut whenever the block is strided OR changes channel
+        # count, otherwise the residual Add receives mismatched tensors. Called where torchvision
+        # places ``downsample``: pretrained weights pair by execution order.
         if downsample or in_channels != out_channels:
             self.add_module(
                 "Shortcut",
-                blocks.ConvBlock(
-                    in_channels,
-                    out_channels,
-                    [
-                        blocks.BlockConfig(
-                            kernel_size=1,
-                            stride=2 if downsample else 1,
-                            padding=0,
-                            bias=False,
-                            activation="None",
-                            norm_mode=blocks.NormMode.BATCH.name,
-                        )
-                    ],
-                    dim=dim,
-                    alias=[["0"], ["1"], []],
-                ),
+                _conv(in_channels, out_channels, 1, 2 if downsample else 1, "None", dim, [["0"], ["1"], []]),
                 in_branch=[1],
                 out_branch=[1],
                 alias=["downsample"],
             )
 
+
+class ResBlock(AbstractResBlock):
+    def __init__(self, in_channels: int, out_channels: int, downsample: bool, dim: int):
+        super().__init__(in_channels, out_channels, downsample, dim)
+        self._add_shortcut(in_channels, out_channels, downsample, dim)
+        stride = 2 if downsample else 1
         self.add_module(
-            "ConvBlock_0",
-            blocks.ConvBlock(
-                in_channels,
-                out_channels,
-                [
-                    blocks.BlockConfig(
-                        kernel_size=3,
-                        stride=2 if downsample else 1,
-                        padding=1,
-                        bias=False,
-                        activation="ReLU",
-                        norm_mode=blocks.NormMode.BATCH.name,
-                    )
-                ],
-                dim=dim,
-                alias=[["conv1"], ["bn1"], []],
-            ),
+            "ConvBlock_0", _conv(in_channels, out_channels, 3, stride, "ReLU", dim, [["conv1"], ["bn1"], []])
         )
-        self.add_module(
-            "ConvBlock_1",
-            blocks.ConvBlock(
-                out_channels,
-                out_channels,
-                [
-                    blocks.BlockConfig(
-                        kernel_size=3,
-                        stride=1,
-                        padding=1,
-                        bias=False,
-                        activation="None",
-                        norm_mode=blocks.NormMode.BATCH.name,
-                    )
-                ],
-                dim=dim,
-                alias=[["conv2"], ["bn2"], []],
-            ),
-        )
+        self.add_module("ConvBlock_1", _conv(out_channels, out_channels, 3, 1, "None", dim, [["conv2"], ["bn2"], []]))
         self.add_module("Residual", blocks.Add(), in_branch=[0, 1])
         self.add_module("ReLU", torch.nn.ReLU())
 
@@ -117,90 +93,13 @@ class ResBlock(AbstractResBlock):
 class ResBottleneckBlock(AbstractResBlock):
     def __init__(self, in_channels: int, out_channels: int, downsample: bool, dim: int):
         super().__init__(in_channels, out_channels, downsample, dim)
-        self.add_module(
-            "ConvBlock_0",
-            blocks.ConvBlock(
-                in_channels,
-                out_channels // 4,
-                [
-                    blocks.BlockConfig(
-                        kernel_size=1,
-                        stride=1,
-                        padding=0,
-                        bias=False,
-                        activation="ReLU",
-                        norm_mode=blocks.NormMode.BATCH.name,
-                    )
-                ],
-                dim=dim,
-                alias=[["conv1"], ["bn1"], []],
-            ),
-        )
-        self.add_module(
-            "ConvBlock_1",
-            blocks.ConvBlock(
-                out_channels // 4,
-                out_channels // 4,
-                [
-                    blocks.BlockConfig(
-                        kernel_size=3,
-                        stride=2 if downsample else 1,
-                        padding=1,
-                        bias=False,
-                        activation="ReLU",
-                        norm_mode=blocks.NormMode.BATCH.name,
-                    )
-                ],
-                dim=dim,
-                alias=[["conv2"], ["bn2"], []],
-            ),
-        )
-        self.add_module(
-            "ConvBlock_2",
-            blocks.ConvBlock(
-                out_channels // 4,
-                out_channels,
-                [
-                    blocks.BlockConfig(
-                        kernel_size=1,
-                        stride=1,
-                        padding=0,
-                        bias=False,
-                        # No activation on conv3/bn3 before the residual add (torchvision
-                        # Bottleneck); a ReLU here diverges from the pretrained architecture.
-                        activation="None",
-                        norm_mode=blocks.NormMode.BATCH.name,
-                    )
-                ],
-                dim=dim,
-                alias=[["conv3"], ["bn3"], []],
-            ),
-        )
-
-        if downsample or in_channels != out_channels:
-            self.add_module(
-                "Shortcut",
-                blocks.ConvBlock(
-                    in_channels,
-                    out_channels,
-                    [
-                        blocks.BlockConfig(
-                            kernel_size=1,
-                            stride=2 if downsample else 1,
-                            padding=0,
-                            bias=False,
-                            activation="None",
-                            norm_mode=blocks.NormMode.BATCH.name,
-                        )
-                    ],
-                    dim=dim,
-                    alias=[["0"], ["1"], []],
-                ),
-                in_branch=[1],
-                out_branch=[1],
-                alias=["downsample"],
-            )
-
+        width = out_channels // 4
+        stride = 2 if downsample else 1
+        self.add_module("ConvBlock_0", _conv(in_channels, width, 1, 1, "ReLU", dim, [["conv1"], ["bn1"], []]))
+        self.add_module("ConvBlock_1", _conv(width, width, 3, stride, "ReLU", dim, [["conv2"], ["bn2"], []]))
+        # No activation on conv3/bn3 before the residual add (torchvision Bottleneck).
+        self.add_module("ConvBlock_2", _conv(width, out_channels, 1, 1, "None", dim, [["conv3"], ["bn3"], []]))
+        self._add_shortcut(in_channels, out_channels, downsample, dim)
         self.add_module("Residual", blocks.Add(), in_branch=[0, 1])
         self.add_module("ReLU", torch.nn.ReLU())
 

--- a/konfai/network/network.py
+++ b/konfai/network/network.py
@@ -1547,6 +1547,21 @@ class Network(ModuleArgsDict, ABC):
             if not len(layers_name):
                 break
 
+    def bind(
+        self,
+        autocast: bool,
+        state: State,
+        group_dest: list[str],
+        gradient_checkpoints: list[str] | None = None,
+        gpu_checkpoints: list[str] | None = None,
+    ) -> None:
+        """Wire the root model to the dataset's destination groups for ``state``: every network's
+        criteria and patch, the output groups the measures address, and the channel trace the
+        checkpoints are placed on."""
+        self.init(autocast, state, group_dest)
+        self.init_outputs_group()
+        self._compute_channels_trace(self, self.in_channels, gradient_checkpoints, gpu_checkpoints)
+
     def init_outputs_group(self):
         for network in self.get_networks().values():
             if not network.measure:

--- a/konfai/predictor.py
+++ b/konfai/predictor.py
@@ -2002,9 +2002,9 @@ class Predictor(DistributedObject):
         # rounds up to a valid input size (the graph (hence the factor) is final before init()).
         self.dataset.set_free_axis_multiple(self.model.downsampling_factor())
         self.dataset.prepare()
-        self.model.init(self.autocast, State.PREDICTION, self.dataset.get_groups_dest())
-        self.model.init_outputs_group()
-        self.model._compute_channels_trace(self.model, self.model.in_channels, None, self.gpu_checkpoints)
+        self.model.bind(
+            self.autocast, State.PREDICTION, self.dataset.get_groups_dest(), gpu_checkpoints=self.gpu_checkpoints
+        )
         # The per-axis multiple a free patch axis rounds up to, read off the model's downsampling graph.
         self._downsampling_factor = self.model.downsampling_factor()
         self.output_modules = [name for name, _, _ in self.model.named_module_args_dict()]

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -942,13 +942,8 @@ class Trainer(DistributedObject):
             # actual training happens later in the distributed runtime.
             seed_all(self.manual_seed)
         self.dataset.prepare()
-        self.model.init(self.autocast, state, self.dataset.get_groups_dest())
-        self.model.init_outputs_group()
-        self.model._compute_channels_trace(
-            self.model,
-            self.model.in_channels,
-            self.gradient_checkpoints,
-            self.gpu_checkpoints,
+        self.model.bind(
+            self.autocast, state, self.dataset.get_groups_dest(), self.gradient_checkpoints, self.gpu_checkpoints
         )
         # The per-axis multiple a free patch axis rounds up to, read off the model's downsampling graph.
         self._downsampling_factor = self.model.downsampling_factor()


### PR DESCRIPTION
Network.bind wires criteria, output groups and the channel trace; the
trainer and the predictor no longer call a private method in the same
three-step sequence. The resnet blocks build their convolutions through
one helper and their shortcut through one method, at the insertion
position each block had. Variance and StandardDeviation share a base.

Stacked on #152: merge that one first.