### PR TITLE
test: one geometry helper for the unit tests

### DIFF
--- a/tests/unit/oracle_support.py
+++ b/tests/unit/oracle_support.py
@@ -30,6 +30,7 @@ seed, which is how the oracle varies rank and geometry without varying anything 
 
 import inspect
 import types
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -328,6 +329,22 @@ def _field(geometry: Geometry) -> np.ndarray:
         shape[axis] = geometry.field_extents[axis]
         components.append(amplitude * wave.reshape(shape) * np.ones(geometry.field_extents))
     return np.stack(components).astype(np.float32)
+
+
+def geometry(
+    origin: Sequence[float] = (0.0, 0.0, 0.0),
+    spacing: Sequence[float] = (1.0, 1.0, 1.0),
+    direction: np.ndarray | Sequence[float] | None = None,
+) -> Attribute:
+    """The stored geometry of a volume: ``(x, y, z)`` origin and spacing, a flattened direction
+    (identity when not given)."""
+    attribute = Attribute()
+    attribute["Origin"] = np.asarray(origin, dtype=np.float64)
+    attribute["Spacing"] = np.asarray(spacing, dtype=np.float64)
+    attribute["Direction"] = (
+        (np.eye(len(origin)) if direction is None else np.asarray(direction)).astype(np.float64).reshape(-1)
+    )
+    return attribute
 
 
 def attributes(geometry: Geometry, group: str) -> Attribute:

--- a/tests/unit/test_case_expansion.py
+++ b/tests/unit/test_case_expansion.py
@@ -35,16 +35,13 @@ from konfai.data.patching import DatasetManager
 from konfai.data.transform import Clip, Expand, Mask, Resample, Save, TensorCast, Transform, Write, split_expand
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import PatchError, TransformError
+from oracle_support import geometry
 
 pytest.importorskip("SimpleITK")
 
 
 def _image_attributes() -> Attribute:
-    attributes = Attribute()
-    attributes["Origin"] = np.asarray([10.0, 20.0, 30.0])
-    attributes["Spacing"] = np.asarray([0.5, 1.5, 2.0])
-    attributes["Direction"] = np.eye(3, dtype=np.float64).reshape(-1)
-    return attributes
+    return geometry((10.0, 20.0, 30.0), (0.5, 1.5, 2.0))
 
 
 def _source(tmp_path: Path, name: str = "CASE_000") -> Dataset:

--- a/tests/unit/test_case_reduction.py
+++ b/tests/unit/test_case_reduction.py
@@ -59,16 +59,13 @@ from konfai.data.transform import (
 from konfai.utils.budget import BUDGET_SHARES
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import ReductionError, TransformError
+from oracle_support import geometry
 
 CASES = 4  # even on purpose: an even cases is where a lower-median would show
 
 
 def _attributes(spacing: tuple[float, float, float] = (1.0, 1.0, 2.0)) -> Attribute:
-    attribute = Attribute()
-    attribute["Origin"] = np.asarray([0.0, 0.0, 0.0])
-    attribute["Spacing"] = np.asarray(list(spacing))
-    attribute["Direction"] = np.eye(3, dtype=np.float64).reshape(-1)
-    return attribute
+    return geometry(spacing=spacing)
 
 
 def _cohort(

--- a/tests/unit/test_cohort_walk.py
+++ b/tests/unit/test_cohort_walk.py
@@ -32,6 +32,7 @@ import pytest
 from konfai.data.data_manager import DataPrediction, Group, GroupTransform, PredictionSubset, Subset
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import DatasetManagerError
+from oracle_support import geometry
 
 pytest.importorskip("SimpleITK")
 
@@ -39,11 +40,7 @@ CASES = [f"CASE_{index:03d}" for index in range(8)]
 
 
 def _attributes() -> Attribute:
-    attribute = Attribute()
-    attribute["Origin"] = np.asarray([0.0, 0.0, 0.0])
-    attribute["Spacing"] = np.asarray([1.0, 1.0, 1.0])
-    attribute["Direction"] = np.eye(3, dtype=np.float64).reshape(-1)
-    return attribute
+    return geometry()
 
 
 def _root(tmp_path: Path, file_format: str) -> Dataset:

--- a/tests/unit/test_data_manager.py
+++ b/tests/unit/test_data_manager.py
@@ -50,6 +50,7 @@ from konfai.utils.clock import restart_startup_clock
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.runtime import State
 from konfai.utils.utils import split_path_spec
+from oracle_support import geometry
 from torch.utils.data._utils.pin_memory import pin_memory as torch_pin_memory
 
 # --------------------------------------------------------------------------------------
@@ -366,11 +367,7 @@ def test_cache_worker_count_never_drops_below_one() -> None:
 
 
 def _image_attributes(origin: list[float], spacing: list[float]) -> Attribute:
-    attributes = Attribute()
-    attributes["Origin"] = np.asarray(origin, dtype=np.float64)
-    attributes["Spacing"] = np.asarray(spacing, dtype=np.float64)
-    attributes["Direction"] = np.eye(len(origin), dtype=np.float64).reshape(-1)
-    return attributes
+    return geometry(origin, spacing)
 
 
 def test_streaming_tensorcast_persists_source_dtype_for_inverse(streaming_dataset_stub) -> None:

--- a/tests/unit/test_data_stream.py
+++ b/tests/unit/test_data_stream.py
@@ -25,16 +25,13 @@ from pathlib import Path
 import numpy as np
 import pytest
 from konfai.utils.dataset import Attribute, Dataset, is_staging_entry
+from oracle_support import geometry
 
 pytest.importorskip("SimpleITK")
 
 
 def _image_attributes() -> Attribute:
-    attributes = Attribute()
-    attributes["Origin"] = np.asarray([10.0, 20.0, 30.0])
-    attributes["Spacing"] = np.asarray([0.5, 1.5, 2.0])
-    attributes["Direction"] = np.asarray([1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1.0, 0.0])
-    return attributes
+    return geometry((10.0, 20.0, 30.0), (0.5, 1.5, 2.0), [1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1.0, 0.0])
 
 
 def _volume(channels: int = 2, dtype: type = np.float32) -> np.ndarray:

--- a/tests/unit/test_dataset_streaming.py
+++ b/tests/unit/test_dataset_streaming.py
@@ -60,17 +60,14 @@ from konfai.utils import dataset as dataset_module
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import ConfigError
 from konfai.utils.runtime import State
+from oracle_support import geometry
 
 SimpleITK = pytest.importorskip("SimpleITK")
 h5py = pytest.importorskip("h5py")
 
 
 def _image_attributes(origin: list[float], spacing: list[float]) -> Attribute:
-    attributes = Attribute()
-    attributes["Origin"] = np.asarray(origin, dtype=np.float64)
-    attributes["Spacing"] = np.asarray(spacing, dtype=np.float64)
-    attributes["Direction"] = np.eye(len(origin), dtype=np.float64).reshape(-1)
-    return attributes
+    return geometry(origin, spacing)
 
 
 def test_dataset_read_data_slice_h5_reads_only_requested_region(tmp_path: Path) -> None:

--- a/tests/unit/test_imaging_formats.py
+++ b/tests/unit/test_imaging_formats.py
@@ -30,14 +30,11 @@ from konfai.utils.utils import (
     split_path_spec,
     storage_form,
 )
+from oracle_support import geometry
 
 
 def _image_attributes() -> Attribute:
-    attributes = Attribute()
-    attributes["Origin"] = np.asarray([10.0, 20.0, 30.0])
-    attributes["Spacing"] = np.asarray([0.5, 1.5, 2.0])
-    attributes["Direction"] = np.eye(3, dtype=np.float64).flatten()
-    return attributes
+    return geometry((10.0, 20.0, 30.0), (0.5, 1.5, 2.0))
 
 
 def test_flatten_transforms_recurses_into_nested_composites() -> None:

--- a/tests/unit/test_itk_transform_backend.py
+++ b/tests/unit/test_itk_transform_backend.py
@@ -31,17 +31,14 @@ pytest.importorskip("h5py")
 
 from konfai.utils.dataset import Attribute, Dataset  # noqa: E402
 from konfai.utils.errors import DatasetManagerError  # noqa: E402
+from oracle_support import geometry  # noqa: E402
 
 _ORIGIN, _SPACING = [7.0, -3.0, 10.0], [1.5, 1.5, 2.0]
 _DIRECTION = [0.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]
 
 
 def _attributes() -> Attribute:
-    attributes = Attribute()
-    attributes["Origin"] = np.asarray(_ORIGIN)
-    attributes["Spacing"] = np.asarray(_SPACING)
-    attributes["Direction"] = np.asarray(_DIRECTION)
-    return attributes
+    return geometry(_ORIGIN, _SPACING, _DIRECTION)
 
 
 def _field(seed: int = 0) -> np.ndarray:

--- a/tests/unit/test_materialize_driver.py
+++ b/tests/unit/test_materialize_driver.py
@@ -28,16 +28,13 @@ from konfai.data.materialize import CaseMaterializer, Verdict
 from konfai.data.patching import DatasetManager
 from konfai.data.transform import Clip, Permute, Save, Standardize, Transform
 from konfai.utils.dataset import Attribute, Dataset
+from oracle_support import geometry
 
 pytest.importorskip("SimpleITK")
 
 
 def _image_attributes() -> Attribute:
-    attributes = Attribute()
-    attributes["Origin"] = np.asarray([10.0, 20.0, 30.0])
-    attributes["Spacing"] = np.asarray([0.5, 1.5, 2.0])
-    attributes["Direction"] = np.eye(3, dtype=np.float64).reshape(-1)
-    return attributes
+    return geometry((10.0, 20.0, 30.0), (0.5, 1.5, 2.0))
 
 
 def _source(tmp_path: Path) -> Dataset:

--- a/tests/unit/test_ome_zarr_data_surface.py
+++ b/tests/unit/test_ome_zarr_data_surface.py
@@ -39,6 +39,7 @@ from konfai.data import (
 from konfai.data.transform import Transform
 from konfai.utils.dataset import Attribute, Dataset, _store_chunks
 from konfai.utils.errors import DatasetManagerError
+from oracle_support import geometry
 
 
 def _volume(dtype: str = "<f4") -> np.ndarray:
@@ -263,11 +264,7 @@ def test_a_writer_that_declares_nothing_leaves_the_store_its_own_default() -> No
 
 
 def _attributes() -> Attribute:
-    attribute = Attribute()
-    attribute["Origin"] = np.asarray([0.0, 0.0, 0.0])
-    attribute["Spacing"] = np.asarray([1.0, 1.0, 1.0])
-    attribute["Direction"] = np.eye(3, dtype=np.float64).reshape(-1)
-    return attribute
+    return geometry()
 
 
 # ---------------------------------------------------------------- what a declared read plan buys

--- a/tests/unit/test_remote_dataset.py
+++ b/tests/unit/test_remote_dataset.py
@@ -28,6 +28,7 @@ import pytest
 from konfai.utils import uri
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import DatasetManagerError
+from oracle_support import geometry
 
 pytest.importorskip("zarr")
 pytest.importorskip("ngff_zarr")
@@ -45,11 +46,7 @@ def memory_root() -> str:
 
 
 def _attributes() -> Attribute:
-    attribute = Attribute()
-    attribute["Origin"] = np.asarray([0.0, 0.0, 0.0])
-    attribute["Spacing"] = np.asarray([1.0, 1.0, 1.0])
-    attribute["Direction"] = np.eye(3, dtype=np.float64).reshape(-1)
-    return attribute
+    return geometry()
 
 
 def _publish(memory_root: str, case: str, group: str, volume: np.ndarray) -> None:

--- a/tests/unit/test_resample.py
+++ b/tests/unit/test_resample.py
@@ -29,6 +29,7 @@ from konfai.data.transform import (
     Resample,
 )
 from konfai.utils.dataset import Attribute
+from oracle_support import geometry
 
 sitk = pytest.importorskip("SimpleITK")
 
@@ -37,11 +38,7 @@ _SHAPE = (24, 30, 32)
 
 
 def _attributes(origin=None, spacing=None, direction=None) -> Attribute:
-    attribute = Attribute()
-    attribute["Origin"] = np.asarray(_ORIGIN if origin is None else origin, dtype=np.float64)
-    attribute["Spacing"] = np.asarray(_SPACING if spacing is None else spacing, dtype=np.float64)
-    attribute["Direction"] = (np.eye(3) if direction is None else direction).reshape(-1)
-    return attribute
+    return geometry(_ORIGIN if origin is None else origin, _SPACING if spacing is None else spacing, direction)
 
 
 def _volume(shape=_SHAPE, seed: int = 0) -> np.ndarray:

--- a/tests/unit/test_resample_to_reference.py
+++ b/tests/unit/test_resample_to_reference.py
@@ -39,6 +39,7 @@ from konfai.data.sampling import source_window
 from konfai.data.transform import LocalityKind, Reduce, Resample, Write
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import ConfigError, TransformError
+from oracle_support import geometry
 
 pytest.importorskip("SimpleITK")
 import SimpleITK as sitk
@@ -54,11 +55,7 @@ _FILL = -777.0
 
 
 def _attributes(origin: list[float], spacing: list[float], direction: np.ndarray | None = None) -> Attribute:
-    attributes = Attribute()
-    attributes["Origin"] = np.asarray(origin)
-    attributes["Spacing"] = np.asarray(spacing)
-    attributes["Direction"] = (np.eye(3) if direction is None else direction).reshape(-1)
-    return attributes
+    return geometry(origin, spacing, direction)
 
 
 def _volume(shape: tuple[int, ...], seed: int = 0) -> np.ndarray:

--- a/tests/unit/test_save_streaming.py
+++ b/tests/unit/test_save_streaming.py
@@ -27,16 +27,13 @@ import torch
 from konfai.data.patching import DatasetManager, DatasetPatch
 from konfai.data.transform import Clip, Permute, Save, Standardize, Transform
 from konfai.utils.dataset import Attribute, Dataset
+from oracle_support import geometry
 
 pytest.importorskip("SimpleITK")
 
 
 def _image_attributes() -> Attribute:
-    attributes = Attribute()
-    attributes["Origin"] = np.asarray([10.0, 20.0, 30.0])
-    attributes["Spacing"] = np.asarray([0.5, 1.5, 2.0])
-    attributes["Direction"] = np.eye(3, dtype=np.float64).reshape(-1)
-    return attributes
+    return geometry((10.0, 20.0, 30.0), (0.5, 1.5, 2.0))
 
 
 def _source(tmp_path: Path) -> Dataset:

--- a/tests/unit/test_sweep_pipeline.py
+++ b/tests/unit/test_sweep_pipeline.py
@@ -43,6 +43,7 @@ from konfai.data.patching import (
 from konfai.data.transform import Clip, LocalityKind, PatchLocality, RegionContext, Resample, Save, Transform
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import TransformError
+from oracle_support import geometry
 
 pytest.importorskip("SimpleITK")
 
@@ -185,11 +186,7 @@ def test_write_behind_raises_what_the_write_raised() -> None:
 
 
 def _attributes() -> Attribute:
-    attribute = Attribute()
-    attribute["Origin"] = np.asarray([10.0, 20.0, 30.0])
-    attribute["Spacing"] = np.asarray([0.5, 1.5, 2.0])
-    attribute["Direction"] = np.eye(3, dtype=np.float64).reshape(-1)
-    return attribute
+    return geometry((10.0, 20.0, 30.0), (0.5, 1.5, 2.0))
 
 
 def _manager(source: Dataset, transforms: list, out: Path) -> DatasetManager:

--- a/tests/unit/test_sweep_tiling.py
+++ b/tests/unit/test_sweep_tiling.py
@@ -43,6 +43,7 @@ from konfai.data.patching import (
 from konfai.data.transform import OneHot, Resample, Save
 from konfai.utils.dataset import Attribute, Dataset, _store_chunks
 from konfai.utils.errors import DatasetManagerError
+from oracle_support import geometry
 
 pytest.importorskip("SimpleITK")
 
@@ -50,11 +51,7 @@ SPACING = (1.0, 1.0, 1.0)  # (x, y, z) SimpleITK order
 
 
 def _attributes(direction: np.ndarray | None = None) -> Attribute:
-    attribute = Attribute()
-    attribute["Origin"] = np.asarray([0.0, 0.0, 0.0])
-    attribute["Spacing"] = np.asarray(list(SPACING))
-    attribute["Direction"] = (np.eye(3) if direction is None else direction).astype(np.float64).reshape(-1)
-    return attribute
+    return geometry(spacing=SPACING, direction=direction)
 
 
 #: The landing, and the height rule these tests pin, chosen so the two decompositions are far apart:

--- a/tests/unit/test_transformer_workflow.py
+++ b/tests/unit/test_transformer_workflow.py
@@ -28,6 +28,7 @@ from konfai.data.transform import Reduce
 from konfai.utils.budget import BUDGET_SHARES, format_bytes, set_per_rank_budget
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import ConfigError, TransformerError
+from oracle_support import geometry
 
 pytest.importorskip("SimpleITK")
 
@@ -51,11 +52,7 @@ def _workflow_environment(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _image_attributes() -> Attribute:
-    attributes = Attribute()
-    attributes["Origin"] = np.asarray([10.0, 20.0, 30.0])
-    attributes["Spacing"] = np.asarray([0.5, 1.5, 2.0])
-    attributes["Direction"] = np.eye(3, dtype=np.float64).reshape(-1)
-    return attributes
+    return geometry((10.0, 20.0, 30.0), (0.5, 1.5, 2.0))
 
 
 def _write_source(tmp_path: Path, cases: int = 2) -> Path:

--- a/tests/unit/test_warp.py
+++ b/tests/unit/test_warp.py
@@ -30,6 +30,7 @@ from konfai.data.transform import LocalityKind, Resample, Save
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import TransformError
 from konfai.utils.ome_zarr import _zarr_v3_available
+from oracle_support import geometry
 
 pytest.importorskip("SimpleITK")
 
@@ -44,11 +45,7 @@ SPACING = (2.0, 1.0, 1.0)  # (x, y, z) SimpleITK order
 
 
 def _attributes() -> Attribute:
-    attribute = Attribute()
-    attribute["Origin"] = np.asarray([0.0, 0.0, 0.0])
-    attribute["Spacing"] = np.asarray(list(SPACING))
-    attribute["Direction"] = np.eye(3, dtype=np.float64).reshape(-1)
-    return attribute
+    return geometry(spacing=SPACING)
 
 
 def _fixture(


### PR DESCRIPTION
Eighteen files each built the same Attribute triple by hand;
oracle_support.geometry builds it, and each file keeps a one-line wrapper
with its own origin, spacing and direction.

Stacked on #153: merge that one first.