### PR TITLE
test: one manager builder for the unit tests

### DIFF
--- a/tests/unit/oracle_support.py
+++ b/tests/unit/oracle_support.py
@@ -40,6 +40,7 @@ from konfai.data import augmentation as augmentation_module
 from konfai.data import transform as transform_module
 from konfai.data.augmentation import DataAugmentation
 from konfai.data.augmentation import Flip as FlipAugmentation
+from konfai.data.data_manager import DatasetManager, DatasetPatch
 from konfai.data.transform import (
     Argmax,
     Canonical,
@@ -329,6 +330,27 @@ def _field(geometry: Geometry) -> np.ndarray:
         shape[axis] = geometry.field_extents[axis]
         components.append(amplitude * wave.reshape(shape) * np.ones(geometry.field_extents))
     return np.stack(components).astype(np.float32)
+
+
+def manager(
+    dataset: Dataset,
+    transforms: list[Transform],
+    group: str = "CT",
+    name: str = CASE_NAME,
+    patch: DatasetPatch | None = None,
+    index: int = 0,
+) -> DatasetManager:
+    """One case's manager over ``dataset``: the same group in and out, no augmentation."""
+    return DatasetManager(
+        index=index,
+        group_src=group,
+        group_dest=group,
+        name=name,
+        dataset=dataset,
+        patch=patch,
+        transforms=transforms,
+        data_augmentations_list=[],
+    )
 
 
 def geometry(

--- a/tests/unit/test_case_expansion.py
+++ b/tests/unit/test_case_expansion.py
@@ -35,7 +35,7 @@ from konfai.data.patching import DatasetManager
 from konfai.data.transform import Clip, Expand, Mask, Resample, Save, TensorCast, Transform, Write, split_expand
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import PatchError, TransformError
-from oracle_support import geometry
+from oracle_support import geometry, manager
 
 pytest.importorskip("SimpleITK")
 
@@ -64,16 +64,7 @@ def _drawn_scales(augmentation: Scale, index: int = 0) -> list[torch.Tensor]:
 
 
 def _manager(source: Dataset, transforms: list[Transform], name: str = "CASE_000", index: int = 0) -> DatasetManager:
-    return DatasetManager(
-        index=index,
-        group_src="CT",
-        group_dest="CT",
-        name=name,
-        dataset=source,
-        patch=None,
-        transforms=transforms,
-        data_augmentations_list=[],
-    )
+    return manager(source, transforms, name=name, index=index)
 
 
 # --------------------------------------------------------------------- the marker

--- a/tests/unit/test_materialize_driver.py
+++ b/tests/unit/test_materialize_driver.py
@@ -28,7 +28,7 @@ from konfai.data.materialize import CaseMaterializer, Verdict
 from konfai.data.patching import DatasetManager
 from konfai.data.transform import Clip, Permute, Save, Standardize, Transform
 from konfai.utils.dataset import Attribute, Dataset
-from oracle_support import geometry
+from oracle_support import geometry, manager
 
 pytest.importorskip("SimpleITK")
 
@@ -48,16 +48,7 @@ def _source(tmp_path: Path) -> Dataset:
 def _manager(source: Dataset, transforms: list[Transform]) -> DatasetManager:
     # No patch declared: this is exactly the TRANSFORM case, where get_data would cut one
     # whole-volume patch and read back what materialize just wrote.
-    return DatasetManager(
-        index=0,
-        group_src="CT",
-        group_dest="CT",
-        name="CASE_000",
-        dataset=source,
-        patch=None,
-        transforms=transforms,
-        data_augmentations_list=[],
-    )
+    return manager(source, transforms, name="CASE_000")
 
 
 def test_streamed_branch_writes_without_holding_the_volume(tmp_path: Path) -> None:

--- a/tests/unit/test_per_component_statistic.py
+++ b/tests/unit/test_per_component_statistic.py
@@ -34,6 +34,7 @@ from konfai.data import Attribute, LocalityKind, PatchLocality, Transform, Write
 from konfai.data.materialize import CaseMaterializer, Verdict
 from konfai.data.patching import DatasetManager
 from konfai.utils.dataset import Dataset
+from oracle_support import manager
 
 pytest.importorskip("SimpleITK")
 
@@ -77,16 +78,7 @@ def _field(tmp_path: Path) -> Dataset:
 
 
 def _manager(source: Dataset, transforms) -> DatasetManager:
-    return DatasetManager(
-        index=0,
-        group_src="DVF",
-        group_dest="DVF",
-        name="CASE_000",
-        dataset=source,
-        patch=None,
-        transforms=transforms,
-        data_augmentations_list=[],
-    )
+    return manager(source, transforms, group="DVF", name="CASE_000")
 
 
 def test_the_statistic_is_per_component(tmp_path: Path) -> None:

--- a/tests/unit/test_read_region_sweeps_pending_saves.py
+++ b/tests/unit/test_read_region_sweeps_pending_saves.py
@@ -29,10 +29,10 @@ optimisation of memory, never of meaning.
 import numpy as np
 import pytest
 import torch
-from konfai.data.patching import DatasetManager
 from konfai.data.transform import Clip, Save, Standardize
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.ome_zarr import write_ome_zarr
+from oracle_support import manager
 
 
 def _source(tmp_path):
@@ -44,16 +44,7 @@ def _source(tmp_path):
 
 
 def _manager(tmp_path, transforms):
-    return DatasetManager(
-        index=0,
-        group_src="CT",
-        group_dest="CT",
-        name="CASE_000",
-        dataset=Dataset(tmp_path / "src", "omezarr"),
-        patch=None,
-        transforms=transforms,
-        data_augmentations_list=[],
-    )
+    return manager(Dataset(tmp_path / "src", "omezarr"), transforms, name="CASE_000")
 
 
 def test_a_region_read_through_an_unwritten_save_matches_the_whole_volume(tmp_path):

--- a/tests/unit/test_save_streaming.py
+++ b/tests/unit/test_save_streaming.py
@@ -27,7 +27,7 @@ import torch
 from konfai.data.patching import DatasetManager, DatasetPatch
 from konfai.data.transform import Clip, Permute, Save, Standardize, Transform
 from konfai.utils.dataset import Attribute, Dataset
-from oracle_support import geometry
+from oracle_support import geometry, manager
 
 pytest.importorskip("SimpleITK")
 
@@ -45,15 +45,8 @@ def _source(tmp_path: Path) -> Dataset:
 
 
 def _manager(source: Dataset, transforms: list[Transform], patch_size: list[int] | None = None) -> DatasetManager:
-    return DatasetManager(
-        index=0,
-        group_src="CT",
-        group_dest="CT",
-        name="CASE_000",
-        dataset=source,
-        patch=DatasetPatch(patch_size if patch_size is not None else [4, 5, 4]),
-        transforms=transforms,
-        data_augmentations_list=[],
+    return manager(
+        source, transforms, name="CASE_000", patch=DatasetPatch(patch_size if patch_size is not None else [4, 5, 4])
     )
 
 

--- a/tests/unit/test_streamed_oracle.py
+++ b/tests/unit/test_streamed_oracle.py
@@ -80,6 +80,7 @@ from oracle_support import (
     StageCase,
     attributes,
     build_case,
+    manager,
     seeded_geometry,
     streamable_cases,
     volumes,
@@ -157,16 +158,7 @@ def _sweep_height(manager: DatasetManager, segments: Sequence[SweepSegment]) -> 
 
 
 def _manager(dataset: Dataset, group: str, chain: list[Transform], name: str = CASE_NAME) -> DatasetManager:
-    return DatasetManager(
-        index=0,
-        group_src=group,
-        group_dest=group,
-        name=name,
-        dataset=dataset,
-        patch=None,
-        transforms=chain,
-        data_augmentations_list=[],
-    )
+    return manager(dataset, chain, group=group, name=name)
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_sweep_pipeline.py
+++ b/tests/unit/test_sweep_pipeline.py
@@ -43,7 +43,7 @@ from konfai.data.patching import (
 from konfai.data.transform import Clip, LocalityKind, PatchLocality, RegionContext, Resample, Save, Transform
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import TransformError
-from oracle_support import geometry
+from oracle_support import geometry, manager
 
 pytest.importorskip("SimpleITK")
 
@@ -191,16 +191,7 @@ def _attributes() -> Attribute:
 
 def _manager(source: Dataset, transforms: list, out: Path) -> DatasetManager:
     del out
-    return DatasetManager(
-        index=0,
-        group_src="CT",
-        group_dest="CT",
-        name="CASE_000",
-        dataset=source,
-        patch=DatasetPatch([4, 5, 4]),
-        transforms=transforms,
-        data_augmentations_list=[],
-    )
+    return manager(source, transforms, name="CASE_000", patch=DatasetPatch([4, 5, 4]))
 
 
 def _sweep_into(tmp_path: Path, name: str, monkeypatch: pytest.MonkeyPatch, depth: int) -> np.ndarray:

--- a/tests/unit/test_sweep_tiling.py
+++ b/tests/unit/test_sweep_tiling.py
@@ -43,7 +43,7 @@ from konfai.data.patching import (
 from konfai.data.transform import OneHot, Resample, Save
 from konfai.utils.dataset import Attribute, Dataset, _store_chunks
 from konfai.utils.errors import DatasetManagerError
-from oracle_support import geometry
+from oracle_support import geometry, manager
 
 pytest.importorskip("SimpleITK")
 
@@ -88,16 +88,7 @@ def _sweep_plans(manager: DatasetManager):
 
 
 def _manager(source: Dataset, transforms: list) -> DatasetManager:
-    return DatasetManager(
-        index=0,
-        group_src="CT",
-        group_dest="CT",
-        name="CASE_000",
-        dataset=source,
-        patch=DatasetPatch([4, 5, 4]),
-        transforms=transforms,
-        data_augmentations_list=[],
-    )
+    return manager(source, transforms, name="CASE_000", patch=DatasetPatch([4, 5, 4]))
 
 
 # ---------------------------------------------------------------- the block itself

--- a/tests/unit/test_transform_locality_contract.py
+++ b/tests/unit/test_transform_locality_contract.py
@@ -66,6 +66,7 @@ from oracle_support import (
     builtin_transforms,
     cases_of,
     kind_of,
+    manager,
     stage_cases,
     streamable_cases,
 )
@@ -91,16 +92,7 @@ def _manager(dataset: Dataset, case: StageCase) -> DatasetManager:
     # What a run does before it builds a manager (Data.prepare): a stage that reads a SECOND entry --
     # a mask, a field, a reference grid: is handed the roots to find it in.
     case.transform.set_datasets([dataset])
-    return DatasetManager(
-        index=0,
-        group_src=case.group,
-        group_dest=case.group,
-        name=CASE_NAME,
-        dataset=dataset,
-        patch=DatasetPatch(list(_PATCH_SIZE)),
-        transforms=[case.transform],
-        data_augmentations_list=[],
-    )
+    return manager(dataset, [case.transform], group=case.group, patch=DatasetPatch(list(_PATCH_SIZE)))
 
 
 def test_every_builtin_transform_is_covered() -> None:

--- a/tests/unit/test_transform_materialize_contract.py
+++ b/tests/unit/test_transform_materialize_contract.py
@@ -41,7 +41,16 @@ from konfai.data.materialize import CaseMaterializer, Verdict
 from konfai.data.patching import DatasetManager
 from konfai.data.transform import Write
 from konfai.utils.dataset import Dataset
-from oracle_support import CASE_NAME, FIXED_GEOMETRY, StageCase, attributes, build_case, streamable_cases, volumes
+from oracle_support import (
+    CASE_NAME,
+    FIXED_GEOMETRY,
+    StageCase,
+    attributes,
+    build_case,
+    manager,
+    streamable_cases,
+    volumes,
+)
 
 
 @pytest.fixture(scope="session")
@@ -87,16 +96,7 @@ def _cases() -> list[StageCase]:
 
 def _manager(dataset: Dataset, case: StageCase, out: Path, fmt: str) -> DatasetManager:
     case.transform.set_datasets([dataset])
-    return DatasetManager(
-        index=0,
-        group_src=case.group,
-        group_dest=case.group,
-        name=CASE_NAME,
-        dataset=dataset,
-        patch=None,
-        transforms=[case.transform, Write(f"{out}:{fmt}")],
-        data_augmentations_list=[],
-    )
+    return manager(dataset, [case.transform, Write(f"{out}:{fmt}")], group=case.group)
 
 
 @pytest.mark.parametrize("fmt", ["mha", "omezarr"])

--- a/tests/unit/test_warp.py
+++ b/tests/unit/test_warp.py
@@ -30,7 +30,7 @@ from konfai.data.transform import LocalityKind, Resample, Save
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.errors import TransformError
 from konfai.utils.ome_zarr import _zarr_v3_available
-from oracle_support import geometry
+from oracle_support import geometry, manager
 
 pytest.importorskip("SimpleITK")
 
@@ -67,16 +67,7 @@ def _fixture(
 
 
 def _manager(source: Dataset, transforms: list) -> DatasetManager:
-    return DatasetManager(
-        index=0,
-        group_src="CT",
-        group_dest="CT",
-        name="CASE_000",
-        dataset=source,
-        patch=None,
-        transforms=transforms,
-        data_augmentations_list=[],
-    )
+    return manager(source, transforms, name="CASE_000")
 
 
 def _recorded(warp: Resample, attribute: Attribute | None = None, shape: tuple[int, ...] = (10, 12, 14)) -> Resample:


### PR DESCRIPTION
Eleven files built the same one-case DatasetManager by hand;
oracle_support.manager builds it.

Stacked on #154: merge that one first.