### PR TITLE
test: reset the declared per-rank budget around every unit test

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -25,6 +25,7 @@ import torch
 from konfai.data.augmentation import DataAugmentationsList
 from konfai.data.data_manager import DatasetIter
 from konfai.predictor import Mean, OutputDataset, Reduction
+from konfai.utils import budget as budget_module
 from konfai.utils.dataset import Attribute, Dataset
 from konfai.utils.utils import get_patch_slices_from_shape
 
@@ -93,6 +94,15 @@ class StreamingDatasetStub:
     def is_dataset_exist(self, group_src: str, name: str) -> bool:
         del group_src, name
         return True  # the one entry it serves is always there
+
+
+@pytest.fixture(autouse=True)
+def _no_declared_budget():
+    """A per-rank budget one test declares never reaches the next: the walk's default budget is
+    probed only when nothing is declared."""
+    budget_module.set_per_rank_budget(None)
+    yield
+    budget_module.set_per_rank_budget(None)
 
 
 @pytest.fixture


### PR DESCRIPTION
A test that declared a budget left it for the next one on the same
worker, where the walk's default budget was then never probed.

Stacked on #156: merge that one first.