### PR TITLE
fix(mcp): name a component by the package that re-exports it

### DIFF
--- a/konfai-mcp/konfai_mcp/capabilities.py
+++ b/konfai-mcp/konfai_mcp/capabilities.py
@@ -34,6 +34,7 @@ import inspect
 import types
 from typing import Any, Union, get_args, get_origin
 
+from konfai_mcp.classpaths import public_classpath
 from konfai_mcp.workflows import WORKFLOW_SPECS
 
 # Workflow -> (root YAML key, module, class name).
@@ -154,7 +155,7 @@ def _nested_config_classpath(annotation: Any) -> str | None:
     # nested config object the agent can drill into with inspect_object_signature (unwrap Optional first).
     resolved = _unwrap_annotation(annotation)
     if inspect.isclass(resolved) and getattr(resolved, "_key", None) is not None:
-        return f"{resolved.__module__}:{resolved.__qualname__}"
+        return public_classpath(resolved)
     return None
 
 
@@ -229,7 +230,7 @@ def describe_config_schema(workflow: str, path: str | None = None) -> dict[str, 
         "workflow": canonical,
         "root_key": root_key,
         "yaml_path": yaml_path,
-        "classpath": f"{cls.__module__}:{cls.__qualname__}",
+        "classpath": public_classpath(cls),
         "fields": _field_payloads(cls),
         "reference_hint": (
             f"These are the keys under {':'.join(yaml_path)}:. Each field's yaml_key is the literal key to write. "

--- a/konfai-mcp/konfai_mcp/catalog.py
+++ b/konfai-mcp/konfai_mcp/catalog.py
@@ -32,6 +32,8 @@ import os
 import types
 from typing import Any
 
+from konfai_mcp.classpaths import public_module
+
 # Kinds backed by "concrete subclasses of a base class defined in a single module".
 _SUBCLASS_KINDS: dict[str, tuple[str, str]] = {
     "criterion": ("konfai.metric.measure", "Criterion"),
@@ -129,8 +131,8 @@ def _list_subclasses(module_path: str, base_name: str) -> list[dict[str, Any]]:
             {
                 "name": name,
                 "config_reference": name,
-                "inspect_classpath": f"{obj.__module__}:{name}",
-                "module": obj.__module__,
+                "inspect_classpath": f"{public_module(obj)}:{name}",
+                "module": public_module(obj),
                 "doc": _doc_summary(obj),
             }
         )

--- a/konfai-mcp/konfai_mcp/classpaths.py
+++ b/konfai-mcp/konfai_mcp/classpaths.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+"""The classpath an agent should reference a class by: the outermost package that re-exports it."""
+
+import importlib
+
+
+def public_module(cls: type) -> str:
+    """The shortest module path under which ``cls`` is reachable by its own name: a class defined in
+    ``konfai.data.transform.intensity`` and re-exported by ``konfai.data.transform`` is named by the
+    package, which is what configs and the documentation name."""
+    module = cls.__module__
+    parts = module.split(".")
+    for depth in range(1, len(parts)):
+        candidate = ".".join(parts[:depth])
+        try:
+            if getattr(importlib.import_module(candidate), cls.__name__, None) is cls:
+                return candidate
+        except ImportError:
+            continue
+    return module
+
+
+def public_classpath(cls: type) -> str:
+    """``<public module>:<qualified name>``."""
+    return f"{public_module(cls)}:{cls.__qualname__}"

--- a/konfai-mcp/konfai_mcp/runner.py
+++ b/konfai-mcp/konfai_mcp/runner.py
@@ -228,7 +228,7 @@ def _apply_single_process_patches() -> None:
     Only safe in a throwaway child; never call in a real training run.
     """
     import konfai.trainer as konfai_trainer
-    import konfai.utils.runtime as konfai_runtime
+    import konfai.utils.runtime.distributed as konfai_runtime
 
     konfai_runtime.setup_gpu = lambda world_size, rank=None, process_group=True: (0, 0)  # type: ignore[assignment,misc]
     konfai_runtime.mp.spawn = (  # type: ignore[assignment]

--- a/konfai-mcp/konfai_mcp/server_support.py
+++ b/konfai-mcp/konfai_mcp/server_support.py
@@ -28,6 +28,7 @@ from typing import Any
 
 import numpy as np
 
+from .classpaths import public_module
 from .config_io import YAML_DUMP as YAML_DUMP
 from .config_io import YAML_SAFE
 from .config_io import _lint_config_data as _lint_config_data
@@ -809,7 +810,7 @@ def _imported_object_extras(obj: Any) -> dict[str, Any]:
     extras: dict[str, Any] = {"bases": [], "forward": None, "konfai_base": None, "integration_hint": None}
     if not inspect.isclass(obj):
         return extras
-    mro = [f"{cls.__module__}.{cls.__qualname__}" for cls in obj.__mro__ if cls is not object]
+    mro = [f"{public_module(cls)}.{cls.__qualname__}" for cls in obj.__mro__ if cls is not object]
     extras["bases"] = mro
     extras["konfai_base"] = next(
         (_KONFAI_COMPONENT_BASES[name] for name in mro if name in _KONFAI_COMPONENT_BASES), None


### PR DESCRIPTION
The catalog, the config schema and the imported-object summary named a
class by its defining module; with the split packages that is a
submodule nobody references. classpaths.public_module walks up to the
outermost package that re-exports the class. The single-process runner
patches konfai.utils.runtime.distributed, where mp.spawn and setup_gpu
now live.

Stacked on #163: merge that one first.