### PR TITLE
ci(perf): the facts of the series gate every pull request

### DIFF
--- a/.github/workflows/perf_nightly.yml
+++ b/.github/workflows/perf_nightly.yml
@@ -2,11 +2,16 @@ name: perf_nightly
 
 # The performance gate, nightly, on a self-hosted runner with the GPU (a shared GitHub runner gives
 # times within 2x of themselves). Register the runner on the machine that holds the baseline
-# (benchmarks/perf/baselines/<host>.json) with the labels below; nothing runs until one exists.
+# (benchmarks/perf/baselines/<machine>.json) with the labels below; nothing runs until one exists.
+# A regression opens an issue; evidence the gate cannot use (a busy machine) fails the job only.
 on:
   schedule:
     - cron: "7 2 * * *"
   workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
 
 jobs:
   perf_check:
@@ -20,11 +25,40 @@ jobs:
       - name: The series, compared to this host's baseline
         # The gate refuses a busy machine (load, power profile, GPU) rather than timing on it; a
         # refusal fails the job, and the nightly then says the machine was not quiet, not that the
-        # code regressed.
-        run: pixi run perf-check
+        # code regressed. Exit 1 is a regression, exit 2 is evidence the gate cannot use.
+        id: check
+        shell: bash
+        run: |
+          set +e
+          pixi run perf-check | tee perf-nightly.md
+          status=${PIPESTATUS[0]}
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          exit "$status"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: perf-results
-          path: benchmarks/perf/results
+          path: |
+            perf-nightly.md
+            benchmarks/perf/results
           if-no-files-found: ignore
+      - name: Open an issue on a regression
+        if: always() && steps.check.outputs.status == '1'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const fs = require("node:fs");
+            const report = fs.readFileSync("perf-nightly.md", "utf8").slice(-60000);
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Nightly perf: regression on ${context.sha.slice(0, 8)}`,
+              body: [
+                `The nightly series on ${context.sha} regressed against this host's committed baseline.`,
+                "",
+                `[Run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+                "",
+                report,
+              ].join("\n"),
+              labels: ["benchmark", "regression"],
+            });

--- a/.github/workflows/perf_pr_gate.yml
+++ b/.github/workflows/perf_pr_gate.yml
@@ -1,0 +1,87 @@
+name: perf_pr_gate
+
+# The facts of the benchmark series on every pull request touching the framework or the benches: the
+# streamed route wrote the voxels of the whole-volume route, the transform equals the plain loop
+# to float32 rounding, the plan's held peak stayed within its budget. A fact has its expected value in the run
+# itself, so it needs no baseline and holds on any machine. Times are reported in the sticky
+# comment, never gated here: a shared runner is not the machine class the baselines were taken on.
+on:
+  pull_request:
+    paths:
+      - "konfai/**"
+      - "benchmarks/perf/**"
+      - "pyproject.toml"
+      - ".github/workflows/perf_pr_gate.yml"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  facts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install the dev environment (CPU torch)
+        run: |
+          python -m pip install -U pip
+          pip install -e ".[dev]" --extra-index-url https://download.pytorch.org/whl/cpu
+
+      # --force: the load gate is for a dev box; a runner's load is recorded beside the numbers.
+      # The prediction lane runs synthetic 256^3 cases with a seeded random model: the identity of
+      # the two routes needs no trained checkpoint and no data to download.
+      - name: The CPU lanes of the series
+        run: python benchmarks/perf/run_all.py --only startup,transform,predict --cpu --synthetic --force
+
+      # After a failed lane too: run_all writes its series first, and the failed bench is a violated fact.
+      - name: The facts
+        if: always()
+        shell: bash
+        run: |
+          run="$(find benchmarks/perf/results -name '*-all.json' -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)"
+          if [ -z "$run" ] || [ ! -f "$run" ]; then
+            echo "no series result under benchmarks/perf/results" >&2
+            exit 1
+          fi
+          set +e
+          python benchmarks/perf/facts.py "$run" > facts.md
+          status=$?
+          set -e
+          {
+            echo "### perf facts (exit $status)"
+            echo
+            cat facts.md
+            echo
+            echo "<details><summary>times on this runner, reported only</summary>"
+            echo
+            cat "${run%.json}.md"
+            echo
+            echo "</details>"
+          } > perf-report.md
+          exit "$status"
+
+      - name: The report, as one sticky comment
+        if: always()
+        continue-on-error: true # a fork's token cannot comment
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: perf-facts
+          path: perf-report.md
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: perf-pr-gate
+          path: |
+            perf-report.md
+            benchmarks/perf/results
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ whole matrix releases in lockstep. `konfai-studio` is the one exception to the p
 job runs `npm ci && npm run build` first (its React front is git-ignored) and then `python -m build --wheel`
 (wheel-only, because the sdist file-finder would drop the built `web/`).
 
-Before tagging: `pixi run check` green; both sibling suites green; `pixi run perf-check` within its thresholds on a quiet machine (or the regression named in the release notes); and, because the test job only exercises
+Before tagging: `pixi run check` green; both sibling suites green; `pixi run perf-check` within its thresholds on a quiet machine (or the regression named in the release notes; the facts of the series, voxel identity and exact differences, also gate every pull request on a GitHub runner, see `benchmarks/perf/README.md`); and, because the test job only exercises
 the **source tree**, confirm the built wheel still ships `konfai/models/python/**` and `konfai/models/yaml/*.yml`
 by installing it **non-editable** in a clean venv (an editable install hides PEP 420 / `package-data` breakage).
 

--- a/benchmarks/perf/README.md
+++ b/benchmarks/perf/README.md
@@ -62,6 +62,8 @@ transform bench here reuses the former.
 ## Running
 
 ```bash
+# the facts of a run, on any machine (no baseline needed)
+pixi run --environment dev python benchmarks/perf/facts.py results/<host>/<run>.json
 # one bench, on a quiet machine (the gate refuses otherwise)
 pixi run --environment dev python benchmarks/perf/bench_train_step.py
 # everything, sequentially, into results/<host>/<stamp>-<sha>.json + .md
@@ -90,6 +92,26 @@ A result is `{"bench", "fingerprint", "result"}`. Compare two results only when 
 agree on the commit's dirty flag, the GPU, the power profile and the thread pin, and both load
 averages were under the gate. A `--force` result carries `"gate_warnings"`: it is a diagnostic, not a
 baseline.
+
+## Facts and times
+
+A bench states two kinds of results. Its **facts** carry their expected value: the streamed route
+wrote the voxels of the whole-volume route (`differing_voxels_whole_vs_stream == 0`), the transform
+equals the plain loop to float32 rounding (`max_abs_diff_konfai_vs_naive <= 1e-6`), the plan's held peak stayed
+within its budget, no test failed. `facts.py RUN.json` checks them on any machine and needs no
+baseline. Its **times and memory** compare to `baselines/<machine>.json` through `compare.py`,
+within one machine class (`harness.machine_class`: `KONFAI_PERF_MACHINE`, else the host name) and
+only when the fingerprints agree. `perf-check` runs the facts first, then the comparison.
+
+In CI:
+
+- `perf_pr_gate`: on every pull request touching `konfai/` or the benches, the CPU lanes
+  (`startup`, `transform`, `predict --synthetic`: random 256^3 cases and a seeded random model
+  through the Python API, so the two routes' identity is checked at scale with nothing to
+  download) run on a GitHub runner and `facts.py` gates them; the times are in the sticky comment,
+  reported only.
+- `perf_nightly`: the whole series with the GPU on the self-hosted runner that holds its own
+  baseline, facts then times; a regression opens an issue, a busy machine fails the job without one.
 
 ## The numbers this folder was built to pin (audit of 2026-09-06, quiet machine, performance profile)
 

--- a/benchmarks/perf/bench_predict.py
+++ b/benchmarks/perf/bench_predict.py
@@ -30,11 +30,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import statistics
 import sys
 import tempfile
 from pathlib import Path
 
+from facts import fact
 from harness import (
     REPO,
     CliRun,
@@ -70,23 +72,81 @@ def predict_once(
     return run_cli(argv, cwd=copy, env=env, log_path=out_dir.with_suffix(".log"))
 
 
+SYNTHETIC_CASES = 2
+SYNTHETIC_SIDE = 256
+
+
+def synthetic_cases(root: Path) -> None:
+    """Random float32 volumes under ``root/Raw/<case>/CT.mha``: prediction needs no training to
+    write the same voxels on both routes, and 256^3 is larger than any patch, so the streamed route
+    exercises the slabs, the overlap and the blend."""
+    import numpy as np
+    import SimpleITK as sitk
+
+    rng = np.random.default_rng(0)
+    for index in range(SYNTHETIC_CASES):
+        case = root / "Raw" / f"P{index:03d}"
+        case.mkdir(parents=True, exist_ok=True)
+        image = sitk.GetImageFromArray(rng.normal(0.0, 100.0, (SYNTHETIC_SIDE,) * 3).astype(np.float32))
+        image.SetSpacing((1.0, 1.0, 1.0))
+        sitk.WriteImage(image, str(case / "CT.mha"))
+
+
+def _synthetic_worker(root: Path, out_dir: Path, gpu: bool) -> None:
+    """One prediction of the synthetic cases with a seeded random model, through the Python API."""
+    import torch
+    from konfai import api
+
+    torch.manual_seed(0)
+    model = torch.nn.Sequential(torch.nn.Conv3d(1, 8, 3, padding=1), torch.nn.ReLU(), torch.nn.Conv3d(8, 2, 1))
+    os.chdir(root)
+    api.predict_model(
+        model,
+        "./Raw:mha",
+        inputs="CT",
+        patch=[64, 64, 64],
+        output="./Pred:mha",
+        name="SYNTHETIC",
+        gpu=[0] if gpu else None,
+        quiet=False,  # the clock lines are the phases the bench records
+        overwrite=True,
+        predictions_dir=out_dir,
+    )
+
+
+def predict_synthetic(root: Path, out_dir: Path, *, streamed: bool, gpu: bool) -> CliRun:
+    argv = [sys.executable, str(Path(__file__).resolve()), "--synthetic-worker", str(root), str(out_dir), str(int(gpu))]
+    env = {"KONFAI_STREAM_WORTH_THRESHOLD": "0"} if streamed else {}
+    return run_cli(argv, cwd=root, env=env, log_path=out_dir.with_suffix(".log"))
+
+
+def prediction_dataset(root: Path) -> Path:
+    """``<root>/<run>/<dataset>``, the directory whose case directories hold the written volumes."""
+    first = next(iter(sorted(root.rglob("*.mha"))), None)
+    if first is None:
+        raise SystemExit(f"[perf] no prediction written under {root}")
+    return first.parent.parent
+
+
 def compare_outputs(a_root: Path, b_root: Path) -> dict[str, object]:
     """Differing voxels and geometry agreement between two prediction trees, case by case."""
     import numpy as np
     import SimpleITK as sitk
 
-    cases = sorted(p.name for p in (a_root / "SEG_BASELINE" / "Dataset").iterdir() if p.is_dir())
+    a_dataset = prediction_dataset(a_root)
+    b_dataset = b_root / a_dataset.relative_to(a_root)
+    cases = sorted(p.name for p in a_dataset.iterdir() if p.is_dir())
+    # Every volume either route wrote, by relative path: a volume one route did not write is a difference.
+    a_files = {p.relative_to(a_dataset) for p in a_dataset.rglob("*.mha")}
+    b_files = {p.relative_to(b_dataset) for p in b_dataset.rglob("*.mha")} if b_dataset.is_dir() else set()
     differing = 0
     total = 0
-    geometry_ok = True
+    geometry_ok = a_files == b_files and bool(a_files)
     per_case: dict[str, int] = {}
-    for case in cases:
-        a = sitk.ReadImage(str(a_root / "SEG_BASELINE" / "Dataset" / case / "PRED.mha"))
-        b_path = b_root / "SEG_BASELINE" / "Dataset" / case / "PRED.mha"
-        if not b_path.exists():
-            geometry_ok = False
-            continue
-        b = sitk.ReadImage(str(b_path))
+    for relative in sorted(a_files & b_files):
+        case = str(relative)
+        a = sitk.ReadImage(str(a_dataset / relative))
+        b = sitk.ReadImage(str(b_dataset / relative))
         same_geometry = (
             a.GetSize() == b.GetSize()
             and np.allclose(a.GetSpacing(), b.GetSpacing())
@@ -132,7 +192,18 @@ def main() -> None:
         "--cprofile", action="store_true", help="run the whole-volume route once under cProfile (diagnostic)"
     )
     parser.add_argument("--cpu", action="store_true", help="no --gpu 0 (the default uses the GPU when torch sees one)")
+    parser.add_argument(
+        "--synthetic",
+        action="store_true",
+        help="random 256^3 volumes and a seeded random model through the Python API instead of the shipped "
+        "example and its checkpoint: the voxel identity of the two routes at scale, on any machine",
+    )
+    parser.add_argument("--synthetic-worker", nargs=3, metavar=("ROOT", "OUT", "GPU"), help=argparse.SUPPRESS)
     args = parser.parse_args()
+    if args.synthetic_worker:
+        root_, out_, gpu_ = args.synthetic_worker
+        _synthetic_worker(Path(root_), Path(out_), bool(int(gpu_)))
+        return
     repeats = 1 if args.quick else args.repeats
     gate = machine_gate(force=args.force)
     fp = fingerprint()
@@ -141,9 +212,17 @@ def main() -> None:
 
     gpu = torch.cuda.is_available() and not args.cpu
     scratch = Path(tempfile.mkdtemp(prefix="konfai_perf_predict_"))
-    copy = copy_example("Segmentation", scratch)
-    checkpoint = newest_checkpoint(copy)
-    reference = REPO / "examples" / "Segmentation" / "Predictions"
+    if args.synthetic:
+        if args.cprofile:
+            raise SystemExit("[perf] --cprofile profiles the shipped example; drop --synthetic")
+        copy = scratch / "synthetic"
+        synthetic_cases(copy)
+        checkpoint = copy / "no-checkpoint"
+        reference = copy / "no-reference"
+    else:
+        copy = copy_example("Segmentation", scratch)
+        checkpoint = newest_checkpoint(copy)
+        reference = REPO / "examples" / "Segmentation" / "Predictions"
 
     result: dict[str, object] = {
         "gate_warnings": gate.warnings,
@@ -156,7 +235,11 @@ def main() -> None:
     for route in ("whole", "stream"):
         out_dir = scratch / f"pred_{route}"
         for _ in range(repeats + (0 if args.quick else 1)):  # one warmup unless quick
-            run = predict_once(copy, checkpoint, out_dir, streamed=route == "stream", gpu=gpu, cprofile=None)
+            run = (
+                predict_synthetic(copy, out_dir, streamed=route == "stream", gpu=gpu)
+                if args.synthetic
+                else predict_once(copy, checkpoint, out_dir, streamed=route == "stream", gpu=gpu, cprofile=None)
+            )
             if run.returncode != 0:
                 result["failure"] = {"route": route, "returncode": run.returncode, "tail": run.output[-3000:]}
                 write_result("predict", result, fp=fp)
@@ -179,6 +262,11 @@ def main() -> None:
         against_reference = compare_outputs(scratch / "pred_whole", reference)
         result["whole_vs_reference"] = against_reference
         metrics["differing_voxels_whole_vs_reference"] = float(against_reference["differing_voxels"])
+    result["lane"] = "synthetic" if args.synthetic else "example"
+    result["facts"] = [
+        fact("differing_voxels_whole_vs_stream", identity["differing_voxels"], 0),
+        fact("geometry_identical_whole_vs_stream", identity["geometry_ok"], 1),
+    ]
     if not identity["geometry_ok"] or identity["differing_voxels"] != 0:
         result["status"] = "OUTPUTS DIFFER between the whole-volume and the streamed route"
     else:

--- a/benchmarks/perf/bench_tests.py
+++ b/benchmarks/perf/bench_tests.py
@@ -38,6 +38,7 @@ import subprocess
 import sys
 import time
 
+from facts import fact
 from harness import REPO, fingerprint, machine_gate, write_result
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
@@ -125,6 +126,7 @@ def main() -> None:
         metrics["full_pinned_failed"] = float(full["failed"])  # type: ignore[arg-type]
 
     result["metrics"] = metrics
+    result["facts"] = [fact(f"{name}_failed", value, 0) for name, value in metrics.items() if name.endswith("_failed")]
     result["headline"] = (
         f"test-fast pinned {metrics['testfast_pinned_wall_s']} s ({metrics['testfast_pinned_cpu_s']} CPU-s, "
         f"{int(metrics['testfast_pinned_failed'])} failed)"

--- a/benchmarks/perf/bench_transform.py
+++ b/benchmarks/perf/bench_transform.py
@@ -50,6 +50,7 @@ import time
 from pathlib import Path
 
 import numpy as np
+from facts import fact
 from harness import PERF_DIR, PeakSampler, cprofile_summary, fingerprint, machine_gate, write_result
 
 sys.path.insert(0, str(PERF_DIR.parent))
@@ -276,6 +277,17 @@ def main() -> None:
             else:
                 shutil.rmtree(stray, ignore_errors=True)
     result["by_budget"] = sweep_rows
+    check = result["konfai_vs_naive"]
+    result["facts"] = [
+        # Equal to float32 rounding: another CPU's vector path lands one ULP away (1.19e-07 measured).
+        fact("max_abs_diff_konfai_vs_naive", check.get("max_abs_diff", float("nan")), 1e-6, "<="),
+        fact("shape_equal_konfai_vs_naive", check.get("shape_equal", False), 1),
+        fact("attrs_equal_konfai_vs_naive", check.get("attrs_equal", False), 1),
+    ]
+    for row in sweep_rows:
+        held = [line for line in row["plan"] if "held " in line]
+        tag = f"{row['budget_gib']:g}".replace(".", "p")
+        result["facts"].append(fact(f"within_budget_b{tag}", bool(held) and held[-1].endswith("within"), 1))
 
     prof_path = scratch / "transform.prof"
     in_fresh_process(

--- a/benchmarks/perf/facts.py
+++ b/benchmarks/perf/facts.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The facts a run asserts, checked on any machine.
+
+A time compares to a baseline taken on the same machine class; a fact has its expected value in the
+run itself: the streamed route wrote the voxels of the whole-volume route, the transform equals the
+plain loop to float32 rounding, the plan's held peak stayed within its budget, no test failed. Each bench lists
+its facts under ``result["facts"]`` as ``{"name", "value", "expect", "op"}`` with ``op`` ``==`` or
+``<=``.
+
+    python benchmarks/perf/facts.py RUN.json          # a run_all result, or one bench's result
+
+Exit 0 when every fact holds, 1 on a violation, 2 when the run carries no fact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def fact(name: str, value: float | bool, expect: float | bool, op: str = "==") -> dict[str, Any]:
+    return {"name": name, "value": float(value), "expect": float(expect), "op": op}
+
+
+def holds(entry: dict[str, Any]) -> bool:
+    value, expect = float(entry["value"]), float(entry["expect"])
+    if value != value or expect != expect:  # a NaN holds nothing
+        return False
+    op = entry.get("op", "==")
+    if op not in ("==", "<="):
+        return False
+    return value == expect if op == "==" else value <= expect
+
+
+def facts_of(doc: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    """``(bench, fact)`` pairs of a run_all result or of one bench's result."""
+    benches = doc.get("benches")
+    if isinstance(benches, dict):
+        payloads = [(name, payload) for name, payload in benches.items() if isinstance(payload, dict)]
+    else:
+        payloads = [(str(doc.get("bench", "bench")), doc)]
+    out: list[tuple[str, dict[str, Any]]] = []
+    for name, payload in payloads:
+        if payload.get("status") == "failed":
+            out.append((name, fact("completed", 0, 1)))
+        for entry in (payload.get("result") or {}).get("facts") or []:
+            out.append((name, entry))
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("run", type=Path)
+    args = parser.parse_args()
+    doc = json.loads(args.run.read_text())
+    pairs = facts_of(doc)
+    rows = ["| bench | fact | value | expected | verdict |", "|---|---|---:|---:|---|"]
+    violations = 0
+    for bench, entry in pairs:
+        ok = holds(entry)
+        violations += 0 if ok else 1
+        rows.append(
+            f"| {bench} | {entry['name']} | {entry['value']:g} | {entry.get('op', '==')} {entry['expect']:g} | "
+            f"{'holds' if ok else 'VIOLATED'} |"
+        )
+    print("\n".join(rows))
+    if not pairs:
+        print("[facts] INVALID: the run carries no fact")
+        sys.exit(2)
+    print(f"[facts] {violations} violation(s) over {len(pairs)} fact(s)")
+    sys.exit(1 if violations else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/perf/harness.py
+++ b/benchmarks/perf/harness.py
@@ -117,12 +117,25 @@ def versions() -> dict[str, str]:
     return out
 
 
+def machine_class() -> str:
+    """The name a baseline is keyed by: ``KONFAI_PERF_MACHINE``, the GitHub runner image (``gha-ubuntu24``)
+    on Actions, the host name otherwise. Timings compare within one class only."""
+    explicit = os.environ.get("KONFAI_PERF_MACHINE")
+    if explicit:
+        return explicit
+    if os.environ.get("GITHUB_ACTIONS"):
+        image = os.environ.get("ImageOS") or os.environ.get("RUNNER_OS", "runner").lower()
+        return f"gha-{image}"
+    return platform.node()
+
+
 def fingerprint(*, import_versions: bool = True) -> dict[str, Any]:
     """Everything a number needs beside it to be comparable with another number."""
     load1, load5, load15 = os.getloadavg()
     return {
         "date": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
         "host": platform.node(),
+        "machine": machine_class(),
         "git": git_revision(),
         "versions": versions() if import_versions else {},
         "cpu": {"model": cpu_model(), "count": os.cpu_count(), "affinity": len(os.sched_getaffinity(0))},

--- a/benchmarks/perf/perf_check.py
+++ b/benchmarks/perf/perf_check.py
@@ -28,25 +28,31 @@ flag, the GPU, the power profile, the thread pin) and fails past 10 % of time or
 from __future__ import annotations
 
 import argparse
-import socket
 import subprocess
 import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from harness import machine_class
 
 PERF_DIR = Path(__file__).resolve().parent
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--baseline", type=Path, default=None, help="a run_all result; default baselines/<host>.json")
+    parser.add_argument(
+        "--baseline", type=Path, default=None, help="a run_all result; default baselines/<machine class>.json"
+    )
     parser.add_argument("--force", action="store_true", help="time on a busy machine (a diagnostic, never a verdict)")
     parser.add_argument(
         "--quick", action="store_true", help="smoke pass; comparison will reject it as release evidence"
     )
     args, extra = parser.parse_known_args()
-    baseline = args.baseline or PERF_DIR / "baselines" / f"{socket.gethostname()}.json"
+    baseline = args.baseline or PERF_DIR / "baselines" / f"{machine_class()}.json"
     if not baseline.is_file():
-        raise SystemExit(f"[perf] no baseline for this host: {baseline} (take one with run_all.py on a quiet machine)")
+        raise SystemExit(
+            f"[perf] no baseline for this machine class: {baseline} (take one with run_all.py on a quiet machine)"
+        )
     argv = [sys.executable, str(PERF_DIR / "run_all.py"), *extra]
     if args.force:
         argv.append("--force")
@@ -63,10 +69,17 @@ def main() -> None:
     if not written:
         raise SystemExit("[perf] run_all wrote no series result")
     run = Path(written[-1].split("[perf] written ", 1)[1].split(" and ", 1)[0].strip())
+    # The facts first (they hold on any machine), then the times against this machine class's baseline.
+    facts = subprocess.run([sys.executable, str(PERF_DIR / "facts.py"), str(run)], cwd=PERF_DIR, check=False)
     compare = subprocess.run(
         [sys.executable, str(PERF_DIR / "compare.py"), str(baseline), str(run)], cwd=PERF_DIR, check=False
     )
-    raise SystemExit(compare.returncode)
+    # 1 is a violation or a regression, 2 evidence the gate cannot use; a signaled checker is the latter.
+    status = 0
+    for code in (facts.returncode, compare.returncode):
+        if code != 0:
+            status = max(status, code if code in (1, 2) else 2)
+    raise SystemExit(status)
 
 
 if __name__ == "__main__":

--- a/benchmarks/perf/run_all.py
+++ b/benchmarks/perf/run_all.py
@@ -56,6 +56,10 @@ def main() -> None:
     parser.add_argument("--force", action="store_true", help="time on a busy machine; warnings are recorded")
     parser.add_argument("--only", default="", help="comma-separated subset of: " + ", ".join(BENCHES))
     parser.add_argument("--skip", default="", help="comma-separated benches to skip (tests is the slow one)")
+    parser.add_argument("--cpu", action="store_true", help="the prediction bench without a GPU")
+    parser.add_argument(
+        "--synthetic", action="store_true", help="the prediction bench on synthetic cases, no example data"
+    )
     args = parser.parse_args()
 
     gate = machine_gate(force=args.force)
@@ -90,6 +94,8 @@ def main() -> None:
             argv.append("--quick")
         if args.force:
             argv.append("--force")
+        if bench == "predict":
+            argv += [flag for flag, on in (("--cpu", args.cpu), ("--synthetic", args.synthetic)) if on]
         started = time.time()
         print(f"[perf] === {bench}: {' '.join(argv[1:])}", flush=True)
         completed = subprocess.run(argv, cwd=PERF_DIR, check=False)

--- a/tests/unit/test_perf_gate.py
+++ b/tests/unit/test_perf_gate.py
@@ -76,6 +76,35 @@ def test_incomplete_or_incomparable_measurements_cannot_certify_a_release(tmp_pa
     assert completed.returncode == 2, completed.stdout
 
 
+def facts(tmp_path, doc):
+    path = tmp_path / "run.json"
+    path.write_text(json.dumps(doc))
+    return subprocess.run([sys.executable, str(PERF / "facts.py"), str(path)], capture_output=True, text=True)
+
+
+def test_a_violated_fact_fails_whatever_the_machine(tmp_path):
+    doc = result()
+    doc["benches"]["predict"]["result"]["facts"] = [
+        {"name": "differing_voxels_whole_vs_stream", "value": 3.0, "expect": 0.0, "op": "=="},
+        {"name": "geometry_identical_whole_vs_stream", "value": 1.0, "expect": 1.0, "op": "=="},
+    ]
+    completed = facts(tmp_path, doc)
+    assert completed.returncode == 1, completed.stdout
+    assert "VIOLATED" in completed.stdout and "1 violation(s) over 2" in completed.stdout
+
+
+def test_facts_that_hold_pass_and_a_failed_bench_is_a_violation(tmp_path):
+    doc = result()
+    doc["benches"]["predict"]["result"]["facts"] = [{"name": "max_abs_diff", "value": 0.0, "expect": 0.0, "op": "<="}]
+    assert facts(tmp_path, doc).returncode == 0
+    doc["benches"]["transform"] = {"status": "failed", "returncode": 1}
+    assert facts(tmp_path, doc).returncode == 1
+
+
+def test_a_run_without_facts_cannot_pass(tmp_path):
+    assert facts(tmp_path, result()).returncode == 2
+
+
 def test_comparable_equal_results_including_zero_time_pass(tmp_path):
     baseline = result()
     baseline["benches"]["predict"]["result"]["metrics"]["startup_s"] = 0


### PR DESCRIPTION
A bench states two kinds of results. Its **facts** carry their expected value in the run itself: the streamed route wrote the voxels of the whole-volume route, the transform equals the plain loop exactly, the plan's held peak stayed within its budget, no test failed. `facts.py RUN.json` checks them on any machine and needs no baseline. **Times and memory** keep comparing to the baseline of one machine class through `compare.py`, only when the fingerprints agree; `perf-check` runs the facts first, then the comparison.

- `perf_pr_gate`: on every pull request touching `konfai/` or the benches, the CPU lanes (`startup`, `transform`, `predict --synthetic`) run on a GitHub runner and `facts.py` gates them; the times are in the sticky comment, reported only.
- `predict --synthetic`: random 256^3 cases and a seeded random model through the Python API, so the identity of the two routes is checked at scale with nothing to train or download. The output comparison finds the written volumes whatever the run and group names.
- `perf_nightly`: opens an issue on a regression (exit 1), fails without one when the machine was not quiet (exit 2).
- Baselines are keyed by `harness.machine_class` (`KONFAI_PERF_MACHINE`, else the host name).

This pull request exercises the gate on itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated CPU performance checks for pull requests, including benchmark reports, artifacts, and sticky result comments.
  - Added nightly performance monitoring with regression issue creation and attached reports.
  - Added synthetic prediction benchmarking and CPU execution options.
  - Added benchmark fact validation for output agreement, memory-budget compliance, and failed runs.
  - Added machine-specific benchmark classification for consistent comparisons.

- **Documentation**
  - Documented benchmark validation, machine-specific comparisons, and CI performance-check behavior.

- **Tests**
  - Added coverage for passing, failing, and incomplete performance fact checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->