### PR TITLE
docs(core): cut the prose of the package by a quarter

### DIFF
--- a/konfai/__init__.py
+++ b/konfai/__init__.py
@@ -31,9 +31,7 @@ except ImportError:
     _PYNVML_AVAILABLE = False
 
 # ``torch`` (device-name lookup only) is imported lazily at its point of use so that
-# ``import konfai`` stays light: CLI paths that never touch a GPU (``--help``/``--version``,
-# light apps helpers) avoid the ~1s torch import. The remote-server helpers speak plain HTTP
-# over the stdlib (urllib), so they cost no dependency at all.
+# ``import konfai`` stays light. The remote-server helpers speak plain HTTP over the stdlib.
 from konfai.utils.errors import KonfAIError
 
 try:
@@ -163,9 +161,8 @@ def get_available_devices(
         from torch.cuda import get_device_name
 
         devices_index = cuda_visible_devices()
-        # Torch reindexes devices after CUDA_VISIBLE_DEVICES masking, so the
-        # visible names must be resolved through local ordinals (0..N-1) while
-        # we keep returning the original user-facing device ids.
+        # Torch reindexes devices after CUDA_VISIBLE_DEVICES masking: the names are resolved
+        # through local ordinals (0..N-1), the returned ids stay the user-facing ones.
         return devices_index, [get_device_name(local_index) for local_index in range(len(devices_index))]
 
 
@@ -382,8 +379,8 @@ def assert_konfai_install() -> None:
         raise KonfAIPackagesError("\n".join(lines))
 
 
-#: The Python workflow API (:mod:`konfai.api`), re-exported lazily: ``konfai.transform(...)``
-#: works, and ``import konfai`` stays light: torch and the engines load on first use only.
+#: The Python workflow API (:mod:`konfai.api`), re-exported lazily: torch and the engines load
+#: on first use only.
 _API_EXPORTS = (
     "transform",
     "plan_transform",

--- a/konfai/api.py
+++ b/konfai/api.py
@@ -16,25 +16,18 @@
 
 """KonfAI in Python: the workflows as callables.
 
-The four CLI commands, callable: :func:`transform` (with :func:`plan_transform`, its dry-run
-twin), :func:`evaluate`, :func:`predict` and :func:`train`. One engine, two spellings: everything
-here builds the same config tree the YAML file would hold and hands it to the same binder: a
-chain is a list of live stage objects (their constructor arguments are recorded as given, see
-``record_given_arguments``), or the equivalent mapping, or a whole tree loaded from an existing
-YAML and modified in place.
+:func:`transform` (with :func:`plan_transform`, its dry-run twin), :func:`evaluate`,
+:func:`predict` and :func:`train` build the config tree the YAML file would hold and hand it to
+the same binder: a chain is a list of live stage objects (constructor arguments recorded as given,
+see ``record_given_arguments``), the equivalent mapping, or a tree loaded from a YAML and modified.
 
-The contract, and how it differs from the CLI:
+The contract:
 
-- **A designed refusal raises** ``KonfAIError``: the message and the remedy are the exception;
-  the caller decides. Only the CLI catches and exits.
-- **Results come back structured**: what a run wrote and where, read from the run's own record
-  (``outputs.json``, ``Metric_*.json``) instead of leaving the caller to fish files out.
-- **The process is left as found**: the ``KONFAI_*`` environment is restored around every call,
-  and one workflow runs at a time per process: a second concurrent call is refused with the
-  remedy (subprocesses), not allowed to corrupt the first.
-- **The record remains.** Every call materializes the resolved YAML in the run's workspace: a
-  notebook run is promoted to a versioned experiment by copying ``result.config``: nothing to
-  rewrite.
+- A designed refusal raises ``KonfAIError``; only the CLI catches and exits.
+- Results come back structured, read from the run's own record (``outputs.json``, ``Metric_*.json``).
+- The ``KONFAI_*`` environment is restored around every call; one workflow runs at a time per
+  process, a second concurrent call is refused.
+- Every call materializes the resolved YAML in the run's workspace, the record of the experiment.
 """
 
 import importlib
@@ -70,12 +63,9 @@ _ACTIVE = threading.Lock()
 
 @contextmanager
 def _one_workflow_at_a_time(ranks: int) -> Iterator[None]:
-    """Serialize workflows within the process and leave the environment as found.
-
-    The engine keys its state on process-wide ``KONFAI_*`` variables, so two in-process runs would
-    corrupt each other: refused with the remedy rather than allowed. ``ranks`` is exported as
-    ``KONFAI_LOCAL_RANKS`` for build-time budget sizing, exactly as the CLI launcher does.
-    """
+    """Serialize workflows within the process and leave the environment as found. Two in-process runs
+    would corrupt the process-wide ``KONFAI_*`` state, so a second is refused. ``ranks`` is exported
+    as ``KONFAI_LOCAL_RANKS`` for build-time budget sizing."""
     if not _ACTIVE.acquire(blocking=False):
         raise ConfigError(
             "A KonfAI workflow is already running in this process.",
@@ -125,12 +115,8 @@ def _launch(
     overwrite: bool,
     quiet: bool,
 ) -> _T:
-    """Take the workflow lock, build, execute, and read the result out through ``finish``.
-
-    ``finish`` runs inside the lock on purpose: the workspace lives in ``KONFAI_*`` variables the
-    lock's exit restores to the caller's. ``ranks`` sizes the lock and stays the caller's own
-    expression: the entry points do not all derive it from ``gpu``/``cpu`` the same way.
-    """
+    """Take the workflow lock, build, execute, and read the result out through ``finish``, which runs
+    inside the lock: the workspace lives in ``KONFAI_*`` variables the lock's exit restores."""
     from konfai.utils.clock import restart_startup_clock
     from konfai.utils.runtime import execute_distributed_object
 
@@ -143,7 +129,7 @@ def _launch(
 
 def _yaml_safe(value: object, where: str) -> object:
     """``value`` as the config file could hold it: or a refusal that names the argument."""
-    # Before the Python scalars: np.float64 IS a float subclass, and ruamel refuses it.
+    # Before the Python scalars: np.float64 is a float subclass, and ruamel refuses it.
     if isinstance(value, np.generic):
         return value.item()
     if value is None or isinstance(value, (bool, int, float, str)):
@@ -212,13 +198,9 @@ def _stage_entry(stage: object, default_modules: tuple[str, ...], where: str) ->
 
 
 def _chain_tree(stages: object, default_modules: tuple[str, ...], where: str) -> dict[str, object]:
-    """A chain (a sequence of stages), as the mapping the config tree holds, in order.
-
-    The tree is a mapping keyed by class name: the second occurrence of a class is written
-    module-qualified (which resolves to the same class), and from the third on under an occurrence
-    key (``Clip#3``), the identity a list-spelled chain binds under; the resolver drops the suffix.
-    An already-qualified classpath keeps its module in every occurrence key.
-    """
+    """A chain (a sequence of stages), as the mapping the config tree holds, in order: the second
+    occurrence of a class is written module-qualified, from the third on under an occurrence key
+    (``Clip#3``); an already-qualified classpath keeps its module in every occurrence key."""
     if isinstance(stages, Mapping):  # a chain already spelled as its tree
         return {str(key): _yaml_safe(value, f"{where}.{key}") for key, value in stages.items()}
     tree: dict[str, object] = {}
@@ -250,10 +232,8 @@ def _stage_sequence(stages: object, where: str) -> Sequence[object]:
 def list_components(kind: str) -> "list[Component]":
     """Enumerate the shipped components of one kind, spelled as a YAML config references them.
 
-    ``kind`` is ``transform``, ``augmentation``, ``criterion``, ``reduction``, ``model`` or
-    ``block`` (plural spellings accepted): the vocabulary the config trees above are written in.
-    Records carry ``name``, ``config_reference``, ``module`` and the one-line ``doc``. The catalog
-    imports the component families (torch included), hence the lazy import.
+    ``kind`` is ``transform``, ``augmentation``, ``criterion``, ``reduction``, ``model`` or ``block``
+    (plural spellings accepted). Records carry ``name``, ``config_reference``, ``module`` and ``doc``.
     """
     from konfai.utils.catalog import list_components as _list_components
 
@@ -277,8 +257,7 @@ def _dataset_filenames(datasets: str | Path | Sequence[str | Path]) -> list[str]
 class TransformResult:
     """What a TRANSFORM run produced, in the run's own terms."""
 
-    #: The run directory (``Transforms/<name>``): logs (the plan opens them), the resolved config,
-    #: ``outputs.json``: never the deliverable, which each ``Write`` placed in the caller's tree.
+    #: The run directory (``Transforms/<name>``): logs, the resolved config, ``outputs.json``; never the data.
     workspace: Path
     #: Every chain's terminal ``Write``: ``{group_src, group_dest, dataset, path, group, format}``
     #: (``dataset`` as a config names the root, ``path`` as it is on disk: the ``.h5`` file itself).
@@ -336,8 +315,7 @@ def transform(
 
     ``chains`` maps ``group_src -> group_dest -> chain``, where a chain is a list of stage objects
     (``[Resample(...), Write(dataset='./Out:mha')]``), of one-entry mappings, or the equivalent
-    mapping tree. Every chain ends in a ``Write``: the same rule, message and plan as the CLI,
-    which is this function with a YAML file. GPU is opt-in (``gpu=[0]``), as it is on the CLI.
+    mapping tree. Every chain ends in a ``Write``. GPU is opt-in (``gpu=[0]``).
     """
     tree = _transform_tree(name, datasets, chains, memory_budget, on_fallback, manual_seed, dataset_options)
     from konfai.transformer import build_transform
@@ -373,11 +351,8 @@ def plan_transform(
     quiet: bool = False,
     transforms_dir: Path | str = Path("./Transforms"),
 ) -> "TransformPlan":
-    """:func:`transform`'s dry-run twin: build, plan, print, return the plan: the run never starts.
-
-    Same arguments, same verdicts: the returned ``TransformPlan`` is the run's own routing
-    (STREAM/LOAD/WHOLE-VOLUME/SKIP/REDUCE), measured, not estimated.
-    """
+    """:func:`transform`'s dry-run twin: build, plan, print, return the plan; the run never starts.
+    The ``TransformPlan`` is the run's own routing (STREAM/LOAD/WHOLE-VOLUME/SKIP/REDUCE)."""
     tree = _transform_tree(name, datasets, chains, memory_budget, on_fallback, manual_seed, dataset_options)
     from konfai.transformer import plan_transform as _plan_transform
 
@@ -423,21 +398,18 @@ def evaluate(
 
     ``metrics`` maps ``output_group -> target_group -> criteria``, where criteria is a list of
     :class:`~konfai.metric.measure.Criterion` instances (``[MAE(), Dice(labels=[1, 2])]``) or
-    one-entry mappings. ``transforms`` optionally names a pre-metric chain per group (a cast, a
-    clip): the groups themselves are derived from ``metrics``, declared once, not twice.
+    one-entry mappings. ``transforms`` optionally names a pre-metric chain per group; the groups
+    themselves are derived from ``metrics``.
     """
-    # A composite target ("Seg;Mask") is one metric key over several dataset groups: split it here,
-    # as the Evaluator does, so each named group is actually loaded.
+    # A composite target ("Seg;Mask") names several dataset groups: split it so each is loaded.
     groups = sorted(
         {str(group) for group in metrics}
         | {part for targets in metrics.values() for target in targets for part in str(target).split(";")}
     )
     groups_src: dict[str, object] = {}
     for group in groups:
-        # An undeclared chain is spelled None, never left out: the binder materializes its own
-        # default (Normalize) for an absent key, and each group rescaled to [-1, 1] by its own
-        # extrema erases the very difference the metrics measure (MAE 1.9e-8 instead of 0.025 on a
-        # pair related by 0.9x + 0.05). ``transforms`` is the only key GroupTransformMetric reads.
+        # An undeclared chain is spelled None, never left out: the binder materializes its own default
+        # (Normalize) for an absent key, which erases the difference the metrics measure.
         declared = None if transforms is None else transforms.get(group)
         chain: object = "None" if declared is None else _chain_tree(declared, _STAGE_MODULES, f"transforms.{group}")
         groups_src[group] = {"groups_dest": {group: {"transforms": chain}}}
@@ -478,18 +450,14 @@ def evaluate(
 def _config_copy(config: "Mapping[str, object] | Path | str") -> "dict[str, object] | Path":
     """The caller's config, in a form this call may consume.
 
-    Reading a KonfAI config resolves and REWRITES it: the record the workspace keeps. A tree is
-    passed through; a caller's FILE is not this call's to rewrite, so the write-back lands on a
-    scratch copy instead (released when the API call returns).
-
-    Both land in a scratch directory, and a model YAML named by a relative path resolves next to
-    the config file that names it (``ModelLoader._yaml_path``): so the path is made absolute here,
-    against the caller's file for a file and the working directory for a tree, or the shipped
-    examples' ``classpath: UNet.yml`` would be looked for in the scratch directory.
+    Reading a KonfAI config resolves and REWRITES it. A tree is passed through; a caller's FILE is
+    copied to scratch (released when the API call returns), so the write-back never lands on it. A
+    model YAML named by a relative path resolves next to the config file that names it
+    (``ModelLoader._yaml_path``), so the path is made absolute first: against the caller's file for
+    a file, the working directory for a tree.
     """
     if isinstance(config, Mapping):
-        # Through _yaml_safe so the documented sweep idiom (np.float64 learning rates from
-        # np.logspace, Path values) fails as a named refusal here, not a raw ruamel error at dump.
+        # Through _yaml_safe: an np.float64 or Path value fails as a named refusal, not a ruamel error.
         tree = _yaml_safe(dict(config), "config")
         _anchor_model_paths(tree, Path.cwd())
         return tree  # type: ignore[return-value]
@@ -543,9 +511,8 @@ _LIVE_MODELS: dict[str, object] = {}
 
 def live_model(token: str) -> object:
     """The model a caller built in Python and registered under ``token`` (:func:`train_model`,
-    :func:`predict_model`). The classpath ``konfai.api:live_model`` names it in the run's config,
-    so the run record says a live model was trained, by its token; the model itself lives in the
-    process that registered it, which is why such a run stays on one rank, inline."""
+    :func:`predict_model`). The classpath ``konfai.api:live_model`` names it in the run's config; the
+    model lives in the process that registered it, so such a run stays on one rank, inline."""
     try:
         return _LIVE_MODELS[token]
     except KeyError:
@@ -636,12 +603,10 @@ def train_model(
     """Train a model built in Python (any ``nn.Module`` with one tensor in and one out) on a KonfAI
     dataset; return the checkpoint workspace.
 
-    Ten lines, no YAML: the model is registered for this process and the config tree KonfAI would
-    read is built from the arguments (``inputs`` and ``targets`` are the dataset's groups, ``loss``
-    a criterion object or a list of them, ``augmentations`` a list of draws applied to every case,
-    ``patch`` the patch the model is fed, ``dim`` its spatial rank: the patch's non-unit axes by default, so a 2D model fed ``[1, 256, 256]`` slices is 2D).
-    The workspace keeps the resolved config as every run does; it names the model by its token, and
-    a RESUME must come from this same process. One rank, inline.
+    ``inputs`` and ``targets`` are the dataset's groups, ``loss`` a criterion object or a list of
+    them, ``augmentations`` a list of draws applied to every case, ``patch`` the patch the model is
+    fed, ``dim`` its spatial rank (the patch's non-unit axes by default). The workspace names the
+    model by its token, and a RESUME must come from this same process. One rank, inline.
     """
     from konfai.trainer import build_train
     from konfai.utils.runtime import State
@@ -757,11 +722,9 @@ def predict_model(
     blending, the output written slab by slab next to each case; return the workspace.
 
     ``checkpoints`` are KonfAI checkpoints of this model (what :func:`train_model` wrote); left
-    ``None``, the weights the module holds in memory are used, so a model loaded any other way
-    (a library's pretrained weights, a foreign checkpoint) predicts as it stands. ``output`` is a
-    dataset root the way the YAML spells one (``./Pred:mha``), relative to the run's workspace
-    (``Predictions/<name>/``) unless absolute; the prediction lands under ``group`` with the input's
-    own geometry. One rank, inline.
+    ``None``, the weights the module holds in memory are used. ``output`` is a dataset root the way
+    the YAML spells one (``./Pred:mha``), relative to the run's workspace (``Predictions/<name>/``)
+    unless absolute; the prediction lands under ``group`` with the input's geometry. One rank, inline.
     """
     from konfai.predictor import build_predict
     from konfai.utils.runtime.environment import register_scratch_config
@@ -874,13 +837,11 @@ def predict(
 ) -> Path:
     """Run a PREDICTION workflow; return its workspace (``Predictions/<name>``).
 
-    ``config`` is a ``Prediction.yml`` path or the same tree as a dict: a prediction's substance
-    (checkpoints, patching, TTA, ensembling) is wiring, and the tree is its honest spelling.
+    ``config`` is a ``Prediction.yml`` path or the same tree as a dict.
     """
     from konfai.predictor import build_predict
 
-    # A bare str IS a Sequence[str]: without this, "best.pt" expands per character into
-    # [Path('b'), Path('e'), ...] and fails far downstream as missing models.
+    # A bare str is a Sequence[str]: "best.pt" would expand per character.
     if isinstance(models, (str, Path)):
         models = [models]
     return _launch(
@@ -913,9 +874,8 @@ def train(
 ) -> Path:
     """Run a TRAIN (or RESUME) workflow; return its checkpoint workspace.
 
-    ``config`` is a ``Config.yml`` path or the same tree as a dict. The Python idiom for a sweep
-    is the tree: load the YAML once, change the keys under study, call this: the resolved config
-    each run keeps IS the record of what was tried.
+    ``config`` is a ``Config.yml`` path or the same tree as a dict; for a sweep, load the YAML once,
+    change the keys under study, and call this per run.
     """
     from konfai.trainer import build_train
     from konfai.utils.runtime import State

--- a/konfai/bundle.py
+++ b/konfai/bundle.py
@@ -18,18 +18,16 @@
 becomes a bundle.
 
 A `MONAI Bundle <https://docs.monai.io/en/stable/mb_specification.html>`_ is a directory:
-``metadata.json`` (the model's card), ``configs/inference.json`` (the network under ``network_def``
-as a ``_target_`` class and its arguments, the preprocessing, the inferer), ``models/model.pt``
-(the network's plain state dict) and, optionally, ``models/model.ts`` (the network traced). What
-KonfAI needs of it is the network and its weights: :func:`import_bundle` reads them into the
-``Model`` block a ``Prediction.yml`` holds (``classpath: monai.networks.nets:UNet`` with the
-arguments the bundle resolved) and a checkpoint in KonfAI's own format. The bundle's
-preprocessing and inferer are MONAI transforms on MONAI's runtime; they are reported, not
-translated, and the caller spells the equivalent ``transforms:`` in KonfAI's own stages.
+``metadata.json``, ``configs/inference.json`` (the network under ``network_def`` as a ``_target_``
+class and its arguments, the preprocessing, the inferer), ``models/model.pt`` (the network's plain
+state dict) and, optionally, ``models/model.ts``. :func:`import_bundle` reads the network and its
+weights into the ``Model`` block a ``Prediction.yml`` holds and a checkpoint in KonfAI's own
+format; the bundle's preprocessing and inferer are reported, not translated, and the caller spells
+the equivalent ``transforms:`` in KonfAI's own stages.
 
 :func:`export_bundle` goes the other way: a KonfAI checkpoint's inference head traced to
 ``models/model.ts``, with a ``metadata.json`` and an ``inference.json`` that load that TorchScript
-module, so any bundle consumer (``monai.bundle.load``, MONAI Label, MONAI Deploy) runs it.
+module.
 """
 
 from __future__ import annotations
@@ -124,8 +122,7 @@ def import_bundle(
     ``config`` is the bundle config holding the network (``configs/inference.json`` by
     convention); ``network_key`` its entry; ``weights`` the state dict to convert. The checkpoint
     is written to ``out`` (default: ``<bundle>/models/konfai_model.pt``) in the format
-    ``Network.load`` reads for a wrapped foreign class, so ``konfai PREDICTION --models`` takes it
-    as it takes any KonfAI checkpoint. Nothing of the bundle is modified.
+    ``Network.load`` reads for a wrapped foreign class. Nothing of the bundle is modified.
     """
     monai_bundle = _require_monai()
     root = Path(bundle)
@@ -151,7 +148,7 @@ def import_bundle(
             f"'{weights_path}' is not a state dict.", "KonfAI converts the plain state dict a bundle ships as model.pt."
         )
     # The wrapped class is loaded by the wrapper's name (the class's), each key under the module
-    # the wrapper adds: what predict_model writes for a live model, and what Network.load reads.
+    # the wrapper adds: what Network.load reads.
     checkpoint = Path(out) if out is not None else root / "models" / "konfai_model.pt"
     checkpoint.parent.mkdir(parents=True, exist_ok=True)
     torch.save({"Model": {class_name: {f"Model.{key}": value for key, value in state.items()}}}, checkpoint)
@@ -181,8 +178,7 @@ def export_bundle(
     one patch of the shape it is fed (``[1, C, *patch]``); the head is the last floating-point
     output in execution order unless ``output_module`` names one. The bundle carries
     ``models/model.ts``, a ``metadata.json`` and a ``configs/inference.json`` that loads the traced
-    module, which is what ``monai.bundle.load(..., load_ts_module=True)`` and the bundle runtimes
-    read. Preprocessing is not exported: the traced module expects what the KonfAI chain fed the
+    module. Preprocessing is not exported; the traced module expects what the KonfAI chain fed the
     network, which the bundle's metadata states.
     """
     import monai

--- a/konfai/data/augmentation/base.py
+++ b/konfai/data/augmentation/base.py
@@ -102,10 +102,8 @@ def _rotation_3d_matrix(rotation: torch.Tensor, center: torch.Tensor | None = No
 def _axis_rotation_matrix(theta: torch.Tensor, axis: torch.Tensor) -> torch.Tensor:
     """Rodrigues rotation of a colour vector about ``axis`` by ``theta``, as a 4x4 homogeneous matrix.
 
-    Hue rotation is a rotation of the RGB vector about the luma axis (1, 1, 1)/sqrt(3): it preserves luma
-    (a grey pixel stays grey) and is identity at theta = 0. The 4th (alpha) channel is left untouched.
-    Using Euler XYZ angles about the coordinate axes instead (as ``_rotation_3d_matrix(theta.repeat(3), v)``
-    did) is not a rotation about the luma axis and recolours grey pixels.
+    About the luma axis (1, 1, 1)/sqrt(3) it preserves luma and is the identity at theta = 0. The
+    4th (alpha) channel is left untouched.
     """
     k = (axis[:3] / torch.linalg.norm(axis[:3])).to(torch.float32)
     cross = torch.zeros((3, 3))
@@ -158,12 +156,12 @@ class DataAugmentationsList:
         self.data_augmentations = []
         for augmentation, prob in self.data_augmentationsLoader.items():
             module, name = get_module(augmentation, "konfai.data.augmentation")
-            # A key is read as a dotted path, and a classpath naming its module carries dots of its own.
+            # A key is read as a dotted path, and a classpath carries dots of its own.
             drawn = apply_config(
                 f"{konfai_root()}.Dataset.augmentations.{key}.data_augmentations.{_escape_key_component(augmentation)}"
             )(getattr(module, name))()
-            # A foreign class is handed over wrapped, and the wrapper reads its own parameters from
-            # the same subtree the class read its arguments from, as MinimalModel does for a model.
+            # A foreign class is handed over wrapped, the wrapper reading its own parameters from
+            # the subtree the class read its arguments from.
             data_augmentation: DataAugmentation = (
                 drawn
                 if isinstance(drawn, DataAugmentation)
@@ -172,9 +170,7 @@ class DataAugmentationsList:
                     f".data_augmentations.{_escape_key_component(augmentation)}"
                 )(partial(Foreign, drawn, augmentation))()
             )
-            # A foreign class brings all of its randomness, including whether it applies at all, and
-            # names that gate itself (`prob`, `p`). A second gate here would compose with it, so a
-            # probability of one half would be one quarter. The one it declares is the one that runs.
+            # A foreign class brings its own gate (`prob`, `p`), which a second gate would compose with.
             data_augmentation.load(1.0 if isinstance(data_augmentation, Foreign) else prob.prob)
             self.data_augmentations.append(data_augmentation)
 
@@ -184,18 +180,16 @@ class DataAugmentationsList:
 
 
 class DataAugmentation(NeedDevice, ABC):
-    #: Tier-1 declaration, exactly as :attr:`konfai.data.transform.Transform.locality`: the one
-    #: :class:`LocalityKind` every draw of this class makes, when it is unconditional. The base
-    #: ``_patch_locality`` answers from it; ``None`` (the default) keeps the fail-safe
-    #: ``WHOLE_VOLUME``. A declaration that depends on the draw overrides the method instead.
+    #: The one :class:`LocalityKind` every draw of this class makes, when it is unconditional.
+    #: ``None`` keeps the fail-safe ``WHOLE_VOLUME``; a declaration that depends on the draw
+    #: overrides ``_patch_locality``.
     locality: LocalityKind | None = None
 
-    #: Tier-1 companion to a ``HALO`` :attr:`locality`: per-spatial-axis radius in array order.
+    #: Companion to a ``HALO`` :attr:`locality`: per-spatial-axis radius in array order.
     halo: tuple[int, ...] = ()
 
     def __init_subclass__(cls, **kwargs: object) -> None:
-        # A draw is a chain stage too: record its constructor arguments as given, so konfai.api can
-        # write the config tree back from live objects (see Transform.__init_subclass__).
+        # A draw is a chain stage too: konfai.api writes the config tree back from live objects.
         super().__init_subclass__(**kwargs)
         record_given_arguments(cls)
 
@@ -215,16 +209,9 @@ class DataAugmentation(NeedDevice, ABC):
     def reset_state(self, index: int | None = None) -> None:
         """Drop the cached sampling for *index* so the next ``state_init`` re-samples.
 
-        Augmentation parameters are drawn once per case index and cached so that
-        every patch of that case shares a consistent transform within an epoch
-        (see ``state_init``). They must, however, be re-drawn at the start of each
-        epoch; otherwise a case keeps identical augmentation parameters for the
-        whole run. ``DatasetManager.reset_augmentation`` calls this before
-        ``state_init`` on every epoch reset. Subclass-specific caches (e.g.
-        ``matrix``/``flip``) are keyed by the same index and are overwritten by
-        the subsequent ``_state_init``; when the re-draw selects nothing they are
-        left untouched but never read (``__call__``/``inverse`` gate on
-        ``who_index``). Passing ``None`` clears every cached index.
+        Augmentation parameters are drawn once per case index and cached, so every patch of that
+        case shares one transform within an epoch, and re-drawn at each epoch reset, which
+        ``DatasetManager.reset_augmentation`` calls this from. ``None`` clears every cached index.
         """
         if index is None:
             self.who_index.clear()
@@ -266,17 +253,14 @@ class DataAugmentation(NeedDevice, ABC):
 
     def _slot(self, index: int, a: int) -> int:
         """The slot copy *a*'s draw is kept at: state is stored for the selected copies only, in
-        selection order, and the ``_``-prefixed methods are all handed that slot."""
+        selection order, and the ``_``-prefixed methods are handed that slot."""
         return self.who_index[index].index(a)
 
     def patch_locality(self, index: int, a: int, cache_attribute: Attribute) -> PatchLocality:
         """Declare how the draw of copy *a* makes its output depend on its input, for patch streaming.
 
         The same contract as :meth:`konfai.data.transform.Transform.patch_locality` (read-only, no
-        I/O, total, ``WHOLE_VOLUME`` by default) asked of one copy of one case, because that is the
-        grain an augmentation is parameterised at: the halo of a geometric draw is the draw's own, so
-        two copies of the same case answer differently and the same copy answers differently next
-        epoch. A copy the draw did not select is the identity, which the base answers for.
+        I/O, total, ``WHOLE_VOLUME`` by default), asked of one copy of one case.
         """
         if a not in self.who_index[index]:
             return PatchLocality(LocalityKind.POINTWISE)
@@ -298,9 +282,8 @@ class DataAugmentation(NeedDevice, ABC):
         return self._stream_region_source(index, self._slot(index, a), target_slices, source_spatial_shape)
 
     def stream_shape(self, index: int, a: int, shape: list[int]) -> list[int]:
-        """The spatial shape copy *a*'s draw produces from ``shape`` (the shape-fold counterpart of
-        ``Transform.transform_shape``). The identity default covers every draw but a shape-changing
-        one, which restates here what its ``state_init`` did to the copy's grid."""
+        """The spatial shape copy *a*'s draw produces from ``shape``, the counterpart of
+        ``Transform.transform_shape``. A shape-changing draw restates what ``state_init`` did."""
         return self._stream_shape(index, self._slot(index, a), shape)
 
     def _stream_shape(self, index: int, a: int, shape: list[int]) -> list[int]:
@@ -328,9 +311,8 @@ class DataAugmentation(NeedDevice, ABC):
         self, name: str, index: int, a: int, tensor: torch.Tensor, context: RegionContext
     ) -> torch.Tensor:
         """Apply the draw of copy *a* to one region, told where it sits (the same contract as
-        :meth:`konfai.data.transform.Transform.stream_region`). The default is the draw itself: a
-        per-voxel draw gives the same answer wherever its input came from; a draw parameterised by
-        the place (a noise field, a cutout box, a resample) overrides ``_stream_region``."""
+        :meth:`konfai.data.transform.Transform.stream_region`). The default is the draw itself; a
+        draw parameterised by the place overrides ``_stream_region``."""
         if a not in self.who_index[index]:
             return tensor
         return self._stream_region(name, index, self._slot(index, a), tensor, context)
@@ -353,9 +335,7 @@ class DataAugmentation(NeedDevice, ABC):
     def _compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
         """Copy ``a`` of case ``index`` drawn from ``tensor``: a fresh tensor or a view of it.
 
-        ``tensor`` is the case itself, or another draw's output, and every copy the draw did not
-        select aliases it: nothing may be written into it. A draw that must work in place clones
-        first, as ``Foreign`` does.
+        Every copy the draw did not select aliases ``tensor``, so nothing may be written into it.
         """
 
     def inverse(self, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
@@ -372,9 +352,7 @@ def _hashed_normal_field(
     seed: int, shape: tuple[int, ...], offsets: tuple[int, ...], full: tuple[int, ...], device: torch.device
 ) -> torch.Tensor:
     """A standard-normal field over ``shape`` (channel first) whose value at a voxel is a function of
-    ``(seed, channel, position in the full volume)``: what lets a region hold exactly its part of the
-    volume's field. splitmix64 over the voxel's linear index (int64 arithmetic wraps, on every
-    device), two uniforms, one Box-Muller draw."""
+    ``(seed, channel, position in the full volume)``, so a region holds its part of the field."""
     channels, spatial = int(shape[0]), tuple(int(extent) for extent in shape[1:])
     positions = [
         torch.arange(start, start + extent, device=device, dtype=torch.int64)
@@ -410,9 +388,8 @@ def _hashed_normal_field(
 
 
 def _reflect_interval(low: float, high: float, span: float) -> tuple[float, float]:
-    """The interval ``[low, high]`` after ``padding_mode='reflection'`` folds it into ``[0, span]``
-    (mirrors at 0 and at ``span``, repeated). Every fold inside the interval lands on 0 or on
-    ``span``, so the image is the hull of the folded endpoints and those."""
+    """The interval ``[low, high]`` after ``padding_mode='reflection'`` folds it into ``[0, span]``:
+    the hull of the folded endpoints and the fold points inside the interval."""
     if span <= 0:
         return 0.0, 0.0
 
@@ -439,18 +416,13 @@ class Foreign(DataAugmentation):
             args: {prob: 1.0, std: 12.0}
             groups: [CT]
 
-    The class must be callable on one tensor, return the transformed tensor, and keep its shape --
-    which is what torchvision's transforms, TorchIO's and MONAI's array transforms all do.
+    The class must be callable on one tensor, return the transformed tensor, and keep its shape. A
+    draw belongs to the case, and each group of the case is handed the same copy of it: the seed is
+    drawn once and the global state is set from it before every group.
 
-    A draw belongs to the case, and each group of the case is handed the same copy of it. The seed
-    of the copy is drawn once and the global state is set from it before every group, so the class
-    draws the same way for the label as for the image.
-
-    Name the ONE group a foreign draw belongs to. A single draw suits several groups only when the
-    class consumes its random state identically whatever it is given and the draw does not SAMPLE:
-    a rotation of the image is a rotation of the label, but a label interpolated between two ids is
-    neither. Subclass ``DataAugmentation`` for a draw that must span groups: the draw is then a
-    value this framework holds, rather than a random state two libraries agree about.
+    Name the one group a foreign draw belongs to: a single draw suits several groups only when the
+    class consumes its random state identically whatever it is given and does not sample values.
+    Subclass ``DataAugmentation`` for a draw that must span groups.
     """
 
     def __init__(self, transform, classpath: str, groups: list[str] | None = None) -> None:
@@ -460,22 +432,14 @@ class Foreign(DataAugmentation):
         self.seeds: dict[int, list[int]] = {}
 
     def _state_init(self, index: int, shapes: list[list[int]], caches_attribute: list[Attribute]) -> list[list[int]]:
-        # One seed per copy, drawn once for the case: every group of it is handed these same seeds.
+        # One seed per copy, drawn once for the case: every group is handed these same seeds.
         self.seeds[index] = torch.randint(0, 2**31 - 1, (len(shapes),)).tolist()
         return shapes
 
     @contextmanager
     def _seeded(self, seed: int):
         """Put the class's random state where the seed says, and give the process back what it had.
-
-        A class draws either from the interpreter's global state, which torchvision's transforms and
-        TorchIO's draw from, or from a state of its own, which MONAI's Randomizable holds and reaches
-        through ``set_random_state``. Both are set: which one a class uses is not something it says.
-
-        The global state belongs to the run, not to this draw. Left where the class stopped, the two
-        groups of one case would leave it in the same place and whatever drew next would draw twice
-        the same, and torch's seed reaches the devices, where the model draws its own.
-        """
+        Both the interpreter's global state and the class's own ``set_random_state`` are set."""
         with preserved_rng():
             seed_all(seed)
             set_random_state = getattr(self.transform, "set_random_state", None)
@@ -484,8 +448,7 @@ class Foreign(DataAugmentation):
             yield
 
     def _compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
-        # A class from another framework may write into what it is handed. The tensor is the
-        # case's own, shared by every copy, so the class alone is handed a copy of it.
+        # A class from another framework may write into what it is handed, and the tensor is shared.
         with self._seeded(self.seeds[index][a]):
             result = self.transform(tensor.clone())
         if not isinstance(result, torch.Tensor):
@@ -498,8 +461,6 @@ class Foreign(DataAugmentation):
         return result
 
     def _inverse(self, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
-        # Undoing a draw is a second thing a class must expose, and the convention this reads covers
-        # applying one alone.
         raise AugmentationError(
             f"'{self.classpath}' cannot be undone.",
             "Subclass DataAugmentation and implement _inverse(), or drop the augmentation from a"

--- a/konfai/data/augmentation/color.py
+++ b/konfai/data/augmentation/color.py
@@ -27,8 +27,7 @@ from konfai.utils.errors import AugmentationError
 
 
 class ColorTransform(DataAugmentation):
-    # The draw is a colour matrix applied to each voxel on its own: no neighbour, no coordinate,
-    # no extent. Whatever region a voxel is read in, it comes out the same.
+    # The draw is a colour matrix applied to each voxel on its own: no neighbour, no coordinate.
     locality = LocalityKind.POINTWISE
 
     def __init__(self, groups: list[str] | None = None) -> None:
@@ -106,9 +105,7 @@ class Saturation(ColorTransform):
     def _state_init(self, index: int, shapes: list[list[int]], caches_attribute: list[Attribute]) -> list[list[int]]:
         saturation = torch.exp2(torch.randn(len(shapes)) * self.s_std)
         # Keep the luma component (v vT) at unit gain and scale only the orthogonal chroma component
-        # (I - v vT) by the saturation factor. Scaling the whole matrix instead, (v vT + (I - v vT)) * s
-        # = I * s, is a uniform per-channel gain (contrast) that never mixes toward luma. With this form
-        # s=1 is identity, s=0 collapses to greyscale, s>1 boosts saturation.
+        # (I - v vT) by the saturation factor: s=1 is the identity, s=0 collapses to greyscale.
         self.matrix[index] = [
             (self.v.ger(self.v) + (torch.eye(4) - self.v.ger(self.v)) * value).unsqueeze(0) for value in saturation
         ]

--- a/konfai/data/augmentation/placed.py
+++ b/konfai/data/augmentation/placed.py
@@ -35,8 +35,7 @@ from konfai.utils.errors import AugmentationError
 class PlacedDraw(DataAugmentation):
     """A per-voxel draw whose value at a voxel is a function of the voxel's place in the volume.
 
-    POINTWISE: a region computes exactly its part, given where it sits (``offsets``) and the volume's
-    spatial extent (``full``), which the whole volume passes as zeros and its own shape.
+    A region computes its part from where it sits (``offsets``) and the volume's extent (``full``).
     """
 
     locality = LocalityKind.POINTWISE
@@ -58,7 +57,7 @@ class PlacedDraw(DataAugmentation):
         return self._apply(index, a, tensor, offsets, tuple(int(extent) for extent in context.source_shape))
 
     def _inverse(self, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
-        # A value draw moves no voxel: the inverse a TTA applies to a prediction is the tensor itself.
+        # A value draw moves no voxel: the inverse a TTA applies is the tensor itself.
         return tensor
 
 
@@ -122,10 +121,8 @@ class Noise(PlacedDraw):
 class CutOUT(PlacedDraw):
     """Cut a box out of the copy and fill it with ``value``.
 
-    ``cutout_size`` is the box's edge as a FRACTION of the volume's extent per axis, in (0, 1]:
-    the box is placed in normalised coordinates, so a 0.34 box cuts about ``0.34**rank`` of the
-    volume. An integer count of voxels is not a size this draw takes: through the YAML binder it
-    once bound silently and erased the whole copy.
+    ``cutout_size`` is the box's edge as a fraction of the volume's extent per axis, in (0, 1], never
+    a count of voxels: a 0.34 box cuts about ``0.34**rank`` of the volume.
     """
 
     def __init__(
@@ -164,8 +161,7 @@ class CutOUT(PlacedDraw):
         result = masks[0]
         for mask in masks[1:]:
             result = torch.logical_or(result, mask)
-        # The bool mask broadcasts over the channels: repeated C times and re-tested against 1 it
-        # was a copy and a pass over C times the volume (measured 54-60 ms at 8x128^3, 34-40 without).
+        # The bool mask broadcasts over the channels, never repeated C times and re-tested.
         return torch.where(result.unsqueeze(0).to(tensor.device), tensor, torch.tensor(self.value).to(tensor.device))
 
 
@@ -201,8 +197,8 @@ class Mask(DataAugmentation):
         # The mask's own grid, the extent state_init gave the copy: the draw crops or pads to it.
         return list(self.mask_shape)
 
-    # WHOLE_VOLUME on purpose: the output grid is the mask's, and the mask volume is already resident
-    # at that extent: there is no whole-volume read left for a declaration to save.
+    # WHOLE_VOLUME on purpose: the output grid is the mask's, and the mask volume is already
+    # resident at that extent.
     def _compute(self, name: str, index: int, a: int, tensor: torch.Tensor) -> torch.Tensor:
         mask = self._load_mask()
         position = self.positions[index][a]

--- a/konfai/data/augmentation/spatial.py
+++ b/konfai/data/augmentation/spatial.py
@@ -50,17 +50,11 @@ class EulerTransform(DataAugmentation):
     """A draw that resamples the copy through an affine map about the volume's centre.
 
     The map is stated in the normalised coordinates ``affine_grid`` spans over the whole extent
-    (``[-1, 1]`` per axis, ``align_corners=True``), output to source. Sampling goes through
-    :meth:`_sample_region`: the whole volume is the region that covers everything, so a streamed
-    region and the whole-volume copy run the very same arithmetic and agree to float rounding.
-
-    A REGRID by default, and the declared kind is what routes a streamed region: a REGRID samples
-    the target region out of the source box it pulled; any other kind (a HALO shift, an ORIENTATION
-    quarter turn) is handed the block its declaration asked for and applies the draw to it whole.
+    (``[-1, 1]`` per axis, ``align_corners=True``), output to source. A REGRID samples the target
+    region out of the source box it pulled; any other declared kind is handed the block it asked for.
     """
 
-    # A map about the centre displaces a voxel by an amount that grows with its distance to it,
-    # so no constant halo bounds the read: each target region pulls the source box it maps to.
+    # A map about the centre displaces a voxel by an amount that grows with its distance to it.
     locality = LocalityKind.REGRID
 
     def __init__(self) -> None:
@@ -72,9 +66,7 @@ class EulerTransform(DataAugmentation):
         return self.matrix[index][a]
 
     #: How far inside the grid a mapped box must lie, in voxels, for the float32 coordinates built
-    #: from it to lie inside too: the GEMM and the scaling to voxels err by a few float32 ulps of
-    #: the extent (under 2e-6 of it), and a coordinate within an ulp of the far face folds to its
-    #: mirror. The larger of the two margins applies.
+    #: from it to lie inside too. The larger of the two margins applies.
     _INTERIOR_MARGIN = 1e-3
     _INTERIOR_MARGIN_RELATIVE = 1e-5
 
@@ -82,16 +74,15 @@ class EulerTransform(DataAugmentation):
     def _mapped_box(
         matrix: torch.Tensor, target: tuple[slice, ...], full: tuple[int, ...]
     ) -> list[tuple[float, float]]:
-        """Where the region's corners map to, per array axis, in source voxel indices of the full
-        grid: the hull of the affine image of the region's box, in float64."""
+        """The hull of the affine image of the region's box, per array axis, in source voxel indices."""
         n = len(full)
         affine = matrix[0].to(torch.float64).numpy()
 
         def normalised(position: int, extent: int) -> float:
-            # affine_grid's coordinate of a voxel of the FULL extent (a singleton axis sits at 0).
+            # affine_grid's coordinate of a voxel of the full extent (a singleton axis sits at 0).
             return -1.0 + 2.0 * position / (extent - 1) if extent > 1 else 0.0
 
-        # The region's first and last voxel per axis, in (x, y, z): affine_grid's order.
+        # The region's first and last voxel per axis, in (x, y, z).
         ends = np.array(
             [
                 [normalised(part.start, extent), normalised(part.stop - 1, extent)]
@@ -121,20 +112,12 @@ class EulerTransform(DataAugmentation):
     def _source_coordinates(
         matrix: torch.Tensor, target: tuple[slice, ...], full: tuple[int, ...], device: torch.device | None = None
     ) -> torch.Tensor:
-        """Where each target voxel samples from, in source VOXEL indices of the full grid, per axis in
-        array order: ``[*region_shape, n]``, on ``device``. Reflected into the volume as
-        ``padding_mode='reflection'`` would (``align_corners=True``: mirrored about the outer voxel
-        centres) and clipped.
-
-        In place past the affine map: each step is the op it always was, rounded once, on the one
-        tensor, where a chain of full-grid temporaries moved ~200 bytes per voxel for a 12-byte
-        result (measured 867 MiB of growth for an 81 MiB result at 192^3). A region whose mapped
-        box is interior skips the reflection and the clip: both are the identity on ``[0, n - 1]``.
-        """
+        """Where each target voxel samples from, in source voxel indices of the full grid, per axis in
+        array order: ``[*region_shape, n]``, on ``device``. Reflected as ``padding_mode='reflection'``
+        would and clipped, both skipped for a region whose mapped box is interior."""
         n = len(full)
-        # affine_grid's own base grid, restricted to the region: linspace over the FULL extent (a
-        # singleton axis sits at 0, as affine_grid places it). Built on the host and moved, so every
-        # device meshes the same bits.
+        # affine_grid's base grid restricted to the region, built on the host so every device meshes
+        # the same bits.
         axes = [
             (torch.linspace(-1.0, 1.0, extent, dtype=torch.float32) if extent > 1 else torch.zeros(1))[part].to(device)
             for extent, part in zip(full, target, strict=True)
@@ -146,8 +129,7 @@ class EulerTransform(DataAugmentation):
         if device is None or device.type == "cpu":
             source = homogeneous.reshape(-1, n + 1) @ weights.to(torch.float32)
         else:
-            # In float64 on a device: a float32 matmul there follows the process's TF32 setting,
-            # ten bits of mantissa, a thousandth of a voxel on a 512 axis. Sixteen flops per voxel.
+            # In float64 on a device: a float32 matmul there follows the process's TF32 setting.
             source = (homogeneous.reshape(-1, n + 1).to(torch.float64) @ weights.to(device, torch.float64)).to(
                 torch.float32
             )
@@ -178,13 +160,8 @@ class EulerTransform(DataAugmentation):
         target: tuple[slice, ...],
         full: tuple[int, ...],
     ) -> torch.Tensor:
-        """Sample the target region from ``block`` (the source region ``source`` of the full grid).
-
-        Integer tensors are label maps: interpolating them blends class ids into non-existent labels,
-        so they are resampled with nearest-neighbour instead. The coordinates are the full grid's,
-        re-expressed on the block: every one lies inside it, since the pull kept what a reflection
-        reads back from.
-        """
+        """Sample the target region from ``block``, the source region ``source`` of the full grid.
+        Integer tensors are label maps and are resampled with nearest-neighbour."""
         mode = "nearest" if not block.dtype.is_floating_point else "bilinear"
         coordinates = self._source_coordinates(matrix, target, full, block.device)
         starts = torch.tensor([float(part.start) for part in source], dtype=torch.float32, device=block.device)
@@ -214,9 +191,8 @@ class EulerTransform(DataAugmentation):
     def _stream_region_source(
         self, index: int, a: int, target_slices: tuple[slice, ...], source_spatial_shape: list[int]
     ) -> list[slice]:
-        """The source box a target region samples from: the affine image of the region's box,
-        widened by one voxel for the interpolation taps and to what a reflection at the border
-        reads back from, clamped to the volume."""
+        """The source box a target region samples from: the affine image of the region's box, widened
+        for the interpolation taps and the border reflection, clamped to the volume."""
         full = tuple(int(extent) for extent in source_spatial_shape)
         box = self._mapped_box(self._grid_matrix(index, a, list(full)), tuple(target_slices), full)
         pull: list[slice] = []
@@ -260,16 +236,13 @@ class Translate(EulerTransform):
         return shapes
 
     def _grid_matrix(self, index: int, a: int, shape: list[int]) -> torch.Tensor:
-        # The draw is a shift in VOXELS, in (x, y, z). ``affine_grid`` spans [-1, 1] over whatever
-        # extent it is given, so the same shift is a different matrix on a patch than on the volume:
-        # normalise it against the extent it is about to be applied to, never against a fixed one.
+        # The draw is a shift in voxels, in (x, y, z). ``affine_grid`` spans [-1, 1] over whatever
+        # extent it is given, so the shift is normalised against that extent.
         sizes = torch.tensor(list(reversed(shape)), dtype=torch.float32)
         return torch.unsqueeze(_translate_matrix(self.translate[index][a] * 2.0 / (sizes - 1)), dim=0)
 
     def _patch_locality(self, index: int, a: int, cache_attribute: Attribute) -> PatchLocality:
-        # A uniform shift sends a target patch to that same patch displaced by the draw, so the source
-        # is a bounded neighbourhood of it. One voxel past the ceiling covers the far tap a fractional
-        # shift interpolates from. The draw is in (x, y, z); a halo is in array order.
+        # One voxel past the ceiling covers the far tap. The draw is in (x, y, z), a halo in array order.
         radius = (torch.ceil(self.translate[index][a].abs()).to(torch.int64) + 1).tolist()
         return PatchLocality(LocalityKind.HALO, halo=tuple(int(r) for r in reversed(radius)))
 
@@ -277,10 +250,8 @@ class Translate(EulerTransform):
 class Rotate(EulerTransform):
     """Rotate a copy of the case about its centre.
 
-    A quarter draw is a signed permutation of the axes: an exact index remap (permute + flip), never an
-    interpolation, and it transposes the extents it swaps, so the copy is cut on its own grid. A free
-    angle resamples: it streams as a REGRID, each target region pulling the source box its corners map
-    to (a slab of a rotated volume pulls a wide band, which the plan prices).
+    A quarter draw is a signed permutation of the axes, an exact index remap that transposes the
+    extents it swaps, so the copy is cut on its own grid. A free angle resamples as a REGRID.
     """
 
     def __init__(self, a_min: float = 0, a_max: float = 360, is_quarter: bool = False):
@@ -304,27 +275,19 @@ class Rotate(EulerTransform):
             )
 
         self.matrix[index] = [torch.unsqueeze(func(value), dim=0) for value in angles]
-        # A quarter turn transposes the extents it swaps, so a copy whose draw is one is cut on the grid
-        # that draw lands on. A sampled draw keeps the grid it was applied to.
+        # A quarter turn transposes the extents it swaps; a sampled draw keeps its grid.
         return [Rotate._draw_shape(self.matrix[index][a], shape) for a, shape in enumerate(shapes)]
 
     @classmethod
     def _index_remap(cls, matrix: torch.Tensor) -> AxisRemap | None:
-        """The exact index remap this draw is, or ``None`` if it must be sampled.
-
-        ``matrix`` maps an output coordinate onto the input it comes from, so it is a signed
-        permutation exactly for a quarter turn: the shared predicate decides, at the tolerance of
-        the float32 cosines the matrix is composed from.
-        """
+        """The exact index remap this draw is, or ``None`` if it must be sampled: ``matrix`` is a
+        signed permutation exactly for a quarter turn."""
         return signed_permutation(matrix[0, :-1, :-1], SIGNED_PERMUTATION_ATOL_FLOAT32)
 
     @classmethod
     def _draw_shape(cls, matrix: torch.Tensor, shape: list[int]) -> list[int]:
-        """The spatial extents a draw lands on, given the ones it is applied to.
-
-        A quarter turn carries each extent with the axis it reads; a sampled draw spans the extent
-        it is given.
-        """
+        """The spatial extents a draw lands on: a quarter turn carries each extent with the axis it
+        reads, a sampled draw spans the extent it is given."""
         remap = cls._index_remap(matrix)
         if remap is None:
             return list(shape)
@@ -344,16 +307,12 @@ class Rotate(EulerTransform):
         return self._reorient(index, a, self._grid_matrix(index, a, list(tensor.shape[1:])).inverse(), tensor)
 
     def _patch_locality(self, index: int, a: int, cache_attribute: Attribute) -> PatchLocality:
-        # Permuting and mirroring voxels is a bijection on them, which is what ORIENTATION promises and
-        # what LocalityKind.preserves_statistics lets a later stage trust. Only the draw can say whether
-        # this one is that, and the draw is a property of the copy rather than of the case. Any other
-        # angle resamples: a REGRID whose target region pulls the source box its corners map to.
+        # Permuting and mirroring voxels is the bijection ORIENTATION promises; any angle is a REGRID.
         if Rotate._index_remap(self.matrix[index][a]) is None:
             return PatchLocality(LocalityKind.REGRID)
         return PatchLocality(LocalityKind.ORIENTATION)
 
     def _stream_shape(self, index: int, a: int, shape: list[int]) -> list[int]:
-        # The same extent carry state_init applied to the copy's grid.
         return Rotate._draw_shape(self.matrix[index][a], list(shape))
 
     def _stream_region_source(
@@ -400,21 +359,17 @@ class Flip(DataAugmentation):
 
     def _flip(self, tensor: torch.Tensor, dims: list[int]) -> torch.Tensor:
         result = torch.flip(tensor, dims=dims)
-        # A displacement/vector field (one channel per spatial axis, channel-first [C=(dx,dy,dz),(D),H,W])
-        # is not mirror-invariant: flipping a spatial axis must also negate its component channel
-        # (channel = tensor.dim() - 1 - dim, as channels are in (x,y,z) order and axes are reversed).
-        # Enable ``vector_field`` only in configs whose augmented tensors are single-channel (scalars/masks,
-        # left untouched) or genuine vector fields: any OTHER multi-channel tensor whose channel count
-        # equals the spatial rank (e.g. a 3-contrast volume in 3D) would be wrongly negated by this guard.
+        # Flipping a spatial axis also negates its component channel (channel = tensor.dim() - 1 -
+        # dim, channels being in (x, y, z) order). Enable ``vector_field`` only where the tensors are
+        # single-channel or genuine vector fields.
         if self.vector_field and tensor.shape[0] == tensor.dim() - 1:
             for dim in dims:
                 result[tensor.dim() - 1 - dim] = -result[tensor.dim() - 1 - dim]
         return result
 
     def _patch_locality(self, index: int, a: int, cache_attribute: Attribute) -> PatchLocality:
-        # A mirror is a bijection on the voxels (ORIENTATION). Negating a component channel is not: it
-        # maps values, so a later GLOBAL_STAT could no longer seed from the stored volume, and only
-        # the tensor's channel count says whether it fires, which a header-time declaration cannot see.
+        # A mirror is a bijection on the voxels (ORIENTATION), but negating a component channel maps
+        # values, so a later GLOBAL_STAT could no longer seed from the stored volume.
         if self.vector_field:
             return PatchLocality(
                 LocalityKind.WHOLE_VOLUME,
@@ -430,8 +385,7 @@ class Flip(DataAugmentation):
         target_slices: tuple[slice, ...],
         source_spatial_shape: list[int],
     ) -> list[slice]:
-        # A mirror moves no axis: the remap is the identity permutation, mirrored on the flipped
-        # axes. ``flip`` holds channel-first tensor dims, so spatial axis k is dim k + 1.
+        # ``flip`` holds channel-first tensor dims, so spatial axis k is dim k + 1.
         dims = self.flip[index][a]
         remap: AxisRemap = [(k, (k + 1) in dims) for k in range(len(target_slices))]
         return remap_region(target_slices, source_spatial_shape, remap)
@@ -476,8 +430,7 @@ class Permute(DataAugmentation):
             axes = [axes[dim - 1] for dim in permute[1:]]
         return axes
 
-    # Reordering axes moves every voxel and touches none, so the multiset of values is the input's:
-    # a bijection, which is what ORIENTATION promises.
+    # Reordering axes moves every voxel and touches none: a bijection, which ORIENTATION promises.
     locality = LocalityKind.ORIENTATION
 
     def _remap(self, index: int, a: int) -> AxisRemap:
@@ -485,7 +438,6 @@ class Permute(DataAugmentation):
         return [(axis, False) for axis in self._source_axes(index, a)]
 
     def _stream_shape(self, index: int, a: int, shape: list[int]) -> list[int]:
-        # The same reorder state_init applied to the copy's grid.
         return remap_shape(shape, self._remap(index, a))
 
     def _stream_region_source(
@@ -509,8 +461,7 @@ class Permute(DataAugmentation):
 
 
 #: Voxels one chunk of an Elastix warp evaluates at once: the float64 corner walk holds tens of
-#: bytes per voxel it evaluates, so the sampling grid is filled in chunks and only the grid (12
-#: bytes per voxel of the region) stands at the peak.
+#: bytes per voxel, so the sampling grid is filled in chunks and only the grid stands at the peak.
 _ELASTIX_CHUNK_VOXELS = 1 << 21
 
 
@@ -524,12 +475,10 @@ class Elastix(DataAugmentation):
     ``grid_spacing`` and ``max_displacement`` are in the case's world units (its header spacing; a
     headerless case counts voxels). Control values are uniform in ``[-max_displacement,
     max_displacement]`` and the kernel is a convex combination of them, so no voxel's displacement
-    exceeds ``max_displacement``: what bounds the source box a target region pulls.
+    exceeds ``max_displacement``.
     """
 
-    # A warp through a bounded field: each target region pulls its own box, widened by the field's
-    # reach, and samples it. The bound is constant, but REGRID (not HALO) keeps the pull exactly
-    # the mapped box and prices the sampling grid the warp builds beside its block.
+    # REGRID rather than HALO keeps the pull exactly the mapped box.
     locality = LocalityKind.REGRID
 
     def __init__(self, grid_spacing: int = 16, max_displacement: int = 16) -> None:
@@ -551,10 +500,8 @@ class Elastix(DataAugmentation):
         for shape, cache_attribute in zip(shapes, caches_attribute, strict=False):
             dim = len(shape)
             grid, _missing = Grid.from_header(list(shape), cache_attribute, "the case this draw warps")
-            # The transform domain covers the volume's physical footprint (voxel edges). The
-            # coefficient grid is what sitk.BSplineTransform(order=3) stores for that domain: one
-            # node's spacing before its origin, mesh + 3 nodes per axis (verified against
-            # GetCoefficientImages; the parity test holds it to TransformToDisplacementFieldFilter).
+            # The transform domain covers the volume's physical footprint (voxel edges), and the
+            # coefficient grid is what sitk.BSplineTransform(order=3) stores for it.
             physical_xyz = np.array(list(reversed(shape)), dtype=np.float64) * grid.spacing_xyz
             mesh_xyz = np.maximum(1, (physical_xyz / float(self.grid_spacing) + 0.5).astype(np.int64))
             node_spacing_xyz = physical_xyz / mesh_xyz
@@ -577,10 +524,8 @@ class Elastix(DataAugmentation):
         target_slices: tuple[slice, ...],
         source_spatial_shape: list[int],
     ) -> list[slice]:
-        # |displacement| <= max_displacement per world component by convexity. An index axis
-        # combines the components through its row of the inverse affine (an oblique direction
-        # mixes them), so its reach is that row's L1 norm times the bound (which reduces to
-        # 1/spacing on an axis-aligned grid), plus one voxel for the far interpolation tap.
+        # |displacement| <= max_displacement per world component by convexity, so an index axis
+        # reaches that row's L1 norm times the bound, plus one voxel for the far interpolation tap.
         _stage, grid = self.draws[index][a]
         rank = len(source_spatial_shape)
         row_reach_xyz = np.abs(grid.world_to_index.matrix).sum(axis=1)
@@ -603,9 +548,7 @@ class Elastix(DataAugmentation):
         """Where each target voxel samples from, normalised on the source block for ``grid_sample``.
 
         Per target voxel: its world point, plus the lattice's displacement there, back to a
-        continuous index, re-expressed on the block. Filled slab by slab along the first target
-        axis: the corner walk's float64 temporaries then stay chunk-sized while the float32 grid is
-        the one region-sized tensor held.
+        continuous index. Filled slab by slab along the first target axis.
         """
         target_shape = tuple(int(part.stop - part.start) for part in target)
         rank = len(target_shape)
@@ -638,9 +581,7 @@ class Elastix(DataAugmentation):
         source: tuple[slice, ...],
         target: tuple[slice, ...],
     ) -> torch.Tensor:
-        # Integer tensors are label maps: nearest-neighbour keeps class ids intact. The whole
-        # volume is the region that covers everything, so a streamed region and the whole-volume
-        # copy run the same arithmetic and agree to grid_sample's own float rounding.
+        # Integer tensors are label maps: nearest-neighbour keeps class ids intact.
         mode = "nearest" if not tensor.dtype.is_floating_point else "bilinear"
         sampling = self._sampling_grid(stage, grid, target, source, tensor.device).unsqueeze(0)
         return (

--- a/konfai/data/case_reduction.py
+++ b/konfai/data/case_reduction.py
@@ -16,15 +16,10 @@
 
 """Reducing a group's cases into one entry, one region at a time.
 
-A :class:`~konfai.data.patching.DatasetManager` IS one case: its name is the name it reads, the name
-it writes, and the name every stage is handed. A reduction has no case name, so it is not a manager
--- it is a consumer of them, which is why it lives here and not in the patching module.
-
-The loop is the per-case loop turned inside out. Instead of walking cases and, within a case, its
-regions, it walks the OUTPUT's regions and, within a region, the cases: each reads that region
-through its own chain (:meth:`~konfai.data.patching.DatasetManager.read_region`) and the operator
-folds them. Peak memory is N regions, never N volumes, and two regions, whatever N, once the
-operator can accumulate.
+The loop walks the OUTPUT's regions and, within a region, the cases: each reads that region through
+its own chain (:meth:`~konfai.data.patching.DatasetManager.read_region`) and the operator folds them.
+Peak memory is N regions, never N volumes, and two regions, whatever N, once the operator can
+accumulate.
 """
 
 from __future__ import annotations
@@ -54,32 +49,25 @@ from konfai.utils.dataset import Attribute, Dataset, DataStream
 from konfai.utils.dataset.statistics import _finalize_running_statistics, _update_running_statistics
 from konfai.utils.errors import ReductionError
 
-#: Geometry keys compared between cases under ``grid: strict``. Direction is in because a flipped
-#: axis shows in neither extent nor spacing: averaging two volumes that disagree on it mirrors half
-#: the cases into the other half, silently, and the result still looks like a volume.
+#: Geometry keys compared between cases under ``grid: strict``. Direction is in: a flipped axis
+#: shows in neither extent nor spacing.
 _GEOMETRY_KEYS = ("Spacing", "Origin", "Direction")
 
 #: What a stage placed AFTER the reduction may declare. Voxel-local is exact on a region; a
-#: whole-volume statistic is exact too, because the engine seeds it with a pass of its own.
+#: whole-volume statistic is seeded by a pass of its own.
 _POST_KINDS = frozenset({LocalityKind.POINTWISE, LocalityKind.GLOBAL_STAT})
 
 #: Bytes per sample assumed when sizing regions from headers alone, before a dtype is known.
 _ASSUMED_ITEMSIZE = 4
 
 #: How much of the regions' own share the folds a stat pass KEEPS may take, the regions getting the
-#: rest. Not a share of the declaration: they sit beside the regions for the whole write pass, so
-#: they come out of what the regions were given (:data:`~konfai.utils.budget.BUDGET_SHARES`).
+#: rest (:data:`~konfai.utils.budget.BUDGET_SHARES`).
 _KEPT_FOLDS_SHARE_OF_REGIONS = 0.5
 
 
 @contextlib.contextmanager
 def _awaited(phase: str) -> Iterator[None]:
-    """A phase the fold both performs and stands still for.
-
-    The fold has no pipeline: every member's region is read, and every slab written, on its own
-    thread. So the store's own seconds ARE the seconds the loop waits, which is what
-    :meth:`~konfai.utils.clock.SweepClock.report` prints on either side of its bar.
-    """
+    """A phase the fold both performs and stands still for: the store's seconds are the loop's."""
     with SWEEP_CLOCK.phase(f"wait({phase})"), SWEEP_CLOCK.phase(phase):
         yield
 
@@ -95,31 +83,23 @@ class ReductionPlan:
     slab_rows: int
     incremental: bool
     stat_pass: bool
-    #: Channels a MEMBER's region carries. Separate from ``channels``, the output's, because an
-    #: operator may change the count: ``Concat`` writes ``N x C`` where each member holds ``C``, so
-    #: charging the members at the output's width over-states the peak by the cohort's size.
+    #: Channels a MEMBER's region carries, separate from ``channels``, the output's: an operator may
+    #: change the count (``Concat`` writes ``N x C`` where each member holds ``C``).
     source_channels: int = 0
     working_multiple: float = 0.0
     #: Volumes-worth the MEMBER CHAIN allocates beside the region it is producing
     #: (``DatasetManager.working_multiple()``, the largest ``Transform.working_multiple`` on the
-    #: chain: ``Resample`` declares 6.5 for its sampling grid, plus what the case's own field costs
-    #: through ``case_working_multiple``). Distinct from ``working_multiple``,
-    #: which is the OPERATOR's: a fold is a chain replay per member and then an accumulate, and
-    #: pricing only the second half under-states a resampling cohort by the first. Charged ONCE
-    #: whatever the cohort's size, because ``_fold`` accumulates the members one after another, so
-    #: only one chain is ever replaying.
+    #: chain). Distinct from ``working_multiple``, the OPERATOR's. Charged ONCE whatever the
+    #: cohort's size: ``_fold`` accumulates the members one after another, so one chain replays.
     chain_multiple: float = 0.0
     #: The source window ONE member's region pulls (:attr:`~konfai.data.patching.BlockReads`
-    #: ``widest_pull``). For a chain that resamples, a region's source is not the region -- a
-    #: rotated or scaled map reaches a box around it -- and the chain holds that box while it
-    #: produces the region. Charged ONCE, like the reads below: the members are folded in turn, so
-    #: one chain is pulling at a time. Zero for a chain whose region is its own source.
+    #: ``widest_pull``). Charged ONCE: the members are folded in turn, so one chain pulls at a time.
+    #: Zero for a chain whose region is its own source.
     pull_bytes: int = 0
     #: What ONE member's region makes the store decode ABOVE the window it asked for
     #: (:meth:`~konfai.data.patching.DatasetManager.region_reads`). A chunked backend decodes whole
-    #: blocks, so below one stored block this is the SAME figure at every height: it is charged flat
-    #: and never divided by the rows: measured on the prep's cohort at 4.51 GiB for a 17-row region
-    #: whose own tensor was 70 MiB, and 4.57 GiB for a 4-row one.
+    #: blocks, so below one stored block this is the same figure at every height: charged flat,
+    #: never divided by the rows.
     read_bytes: int = 0
     #: Members read from a store that cannot serve a bounded region read (a gzipped NIfTI, a
     #: compressed MetaImage, NRRD), by name, with the store's format: every region asked of such a
@@ -145,10 +125,8 @@ class ReductionPlan:
     def read_factor(self) -> float:
         """How many times a member's source is read in full, priced from the plan alone.
 
-        A store serving bounded region reads is read once per pass. One that cannot decodes the
-        whole volume behind every region asked of it: once per region and per pass, so a budget
-        that lowers ``slab_rows`` raises the count. The figure of the worst member, which the run is
-        paced by; ``unbounded`` names the members it applies to.
+        A store serving bounded region reads is read once per pass; one that cannot, once per region
+        and per pass. The figure of the worst member; ``unbounded`` names the members it applies to.
         """
         return float(self.passes * (self.regions if self.unbounded else 1))
 
@@ -159,9 +137,8 @@ class ReductionPlan:
 
     @property
     def resident_regions(self) -> float:
-        """Regions held at the peak, in member regions: the buffer, what the operator builds over
-        it (``working_multiple`` buffers-worth), what the one replaying chain holds beside the
-        region it is producing (``chain_multiple``), and the output's own. A count for
+        """Regions held at the peak, in member regions: the buffer, ``working_multiple`` buffers-worth
+        over it, ``chain_multiple`` for the replaying chain, and the output's own. A count for
         ``describe``; ``peak_bytes`` is the figure the plan sizes by."""
         return self.buffered_regions * (1 + self.working_multiple) + self.chain_multiple + 1
 
@@ -176,17 +153,12 @@ class ReductionPlan:
     @property
     def peak_bytes(self) -> int:
         # Members at their own width, the output at its, and whatever the operator builds over the
-        # buffer it is handed, which is member-sized, since that is what it was handed.
-        #
-        # A statistics pass is a second traversal, not a second working set: it holds exactly what
-        # one region holds, so the peak is the same whether there are one or two passes.
+        # buffer. A statistics pass is a second traversal, not a second working set.
         member_bytes = self._region_bytes(self.source_channels or self.channels)
         members = self.buffered_regions * member_bytes
-        # Beside the buffered regions, the one replaying chain holds three things at once: the
-        # source window it pulled, its own working buffers, and what the store decoded above that
-        # window. The buffers are built over the larger of the window and the region it lands, the
-        # sweep prices its blocks the same way, and all three are charged once because the members
-        # are folded in turn -- one chain pulls, allocates and decodes at a time.
+        # Beside the buffered regions, the one replaying chain holds the source window it pulled,
+        # its own working buffers (over the larger of the window and the region it lands) and what
+        # the store decoded above that window. All three are charged once: one chain runs at a time.
         return int(
             members * (1 + self.working_multiple)
             + self.chain_multiple * max(member_bytes, self.pull_bytes)
@@ -230,8 +202,8 @@ class ReductionPlan:
 class _RunningStatistics:
     """Min/Max/Mean/Std accumulated over regions, so the volume is never resident.
 
-    The store-scan recurrence (:func:`konfai.utils.dataset.statistics._update_running_statistics`) is the one
-    Welford kernel; this feeds it blocks and writes the keys in KonfAI's own spelling.
+    Feeds blocks to :func:`konfai.utils.dataset.statistics._update_running_statistics` and writes the
+    keys in KonfAI's own spelling.
     """
 
     _state: dict | None = None
@@ -240,9 +212,8 @@ class _RunningStatistics:
         self._state = _update_running_statistics(self._state, block.detach().cpu().numpy().reshape(1, -1))
 
     def write_into(self, attribute: Attribute) -> None:
-        """Seed the attribute the way the rest of KonfAI already spells these keys: Min/Max bare
-        scalars, Mean/Std one-element arrays. A second convention reads back as a string and fails
-        inside whichever transform consumed it."""
+        """Seed the attribute the way the rest of KonfAI spells these keys: Min/Max bare scalars,
+        Mean/Std one-element arrays."""
         if self._state is None or not self._state["count"]:
             raise ReductionError("Statistics were requested over an empty volume.", "Check the output extent.")
         statistics = _finalize_running_statistics(self._state)
@@ -264,15 +235,12 @@ def split_chain(transforms: list[Transform]) -> tuple[list[Transform], Reduce | 
 def check_post_stages(post: list[Transform], output: str) -> None:
     """What may follow a ``Reduce`` in the same chain.
 
-    Each stage after the reduction is handed ONE REGION of the result. A stage reading across space (a halo, a
-    resample, a reorientation) would take that region for the whole volume and seam
-    at every boundary: a plausible result, and a wrong one. Those are deferred, not forbidden:
-    end the chain, and read the written volume back in a second chain where the ordinary planner can
-    pull regions through it.
+    Each stage after the reduction is handed ONE REGION of the result, so only voxel-local stages may
+    follow: a stage reading across space would seam at every region boundary. End the chain and read
+    the written volume back in a second one instead.
 
     A statistic may follow the reduction, but only over stages that leave the values alone: the stat
-    pass measures the FOLD, so an earlier stage that changes the values makes the seed describe a
-    volume nobody wrote (``stat_seed_valid``, the per-case planner's rule).
+    pass measures the FOLD (``stat_seed_valid``, the per-case planner's rule).
     """
     localities: list[PatchLocality] = []
     for index, stage in enumerate(post):
@@ -302,9 +270,8 @@ def check_post_stages(post: list[Transform], output: str) -> None:
 class CaseReduction:
     """Fold every case of a group into one entry, region by region.
 
-    It uses only the public read side of each case's manager (the streaming machinery already
-    planned, accepted or refused per case), and owns the write side itself, under the output name
-    the chain declared.
+    It uses only the public read side of each case's manager and owns the write side itself, under
+    the output name the chain declared.
     """
 
     managers: list[DatasetManager]
@@ -334,33 +301,25 @@ class CaseReduction:
         """Size the FIRST region so the resident ones fit ``budget_bytes``; the rest follow what
         the regions hold (:meth:`_folds`).
 
-        The default region height is safe for one case and not for N: a reduction holds one region
-        PER CASE, so the constant that bounds a per-case sweep is off by the number of cases here.
-        The first region starts at ``_START_SHARE`` of the regions' share (the price is a model,
-        and the recorded incident is a first region at 1.5x its price on a host that kills before
-        anything is measured); ``cap`` bounds the growth, ``GROWTH_CAP_UNITS`` slabs by default.
-        Below one row nothing fits; the plan then reports a peak above the budget and the workflow
-        refuses, which is the only honest answer: there is no whole-volume path to fall back to.
+        The first region starts at ``_START_SHARE`` of the regions' share; ``cap`` bounds the
+        growth, ``GROWTH_CAP_UNITS`` slabs by default. Below one row nothing fits, the plan then
+        reports a peak above the budget and the workflow refuses: there is no whole-volume path.
 
-        The budget also goes to the cases' own managers, because a chain crossing a ``Save`` sweeps
-        that cache when first read, and ``read_region`` carries no budget of its own.
+        The budget also goes to the cases' own managers: a chain crossing a ``Save`` sweeps that
+        cache when first read, and ``read_region`` carries no budget of its own.
         """
         self._budget_bytes = budget_bytes
         self._cap = None if cap is None else max(1, int(cap))
-        # THE REMAINDER, not the whole figure. A member's chain holds what it holds WHILE the fold
-        # is holding its regions -- its own sweeps fire from inside the fold loop, when the operator
-        # already has earlier members in its buffer -- so handing it the full budget six lines above
-        # spending half of it on the regions declared the same bytes twice.
+        # THE REMAINDER, not the whole figure: a member's chain holds what it holds WHILE the fold
+        # is holding its regions.
         chains = budget_share("chains", budget_bytes)
         for manager in self.managers:
             manager.set_memory_budget(budget_bytes if chains is None else chains)
         if not budget_bytes or budget_bytes <= 0:
             return
         plan = self.plan()
-        # What the fold's own share leaves the regions: the folds it keeps live beside them, for the
-        # whole write pass, so they come out of the same half rather than out of nothing. Decided
-        # here and not at the stat pass, because the regions cannot be sized against a decision that
-        # has not been taken yet.
+        # What the fold's own share leaves the regions: the folds it keeps live beside them for the
+        # whole write pass. Decided here, since the regions are sized against it.
         allowance = budget_share("regions", budget_bytes) or 0.0
         if self.keeps_folds(plan):
             allowance -= self._folded_output_bytes(plan)
@@ -375,14 +334,7 @@ class CaseReduction:
     def _start_rows(self, plan: ReductionPlan, allowance: float) -> int:
         """Where the growth starts: the tallest height up to the cap whose PRICED plan fits
         ``_START_SHARE`` of ``allowance``, failing that ``allowance`` itself; one row when nothing
-        fits.
-
-        Bisected on the price itself rather than extrapolated from one height, because none of what
-        a region costs scales with its rows: a chain's source window is not its region (a halo is a
-        constant, a rotated map's box grows with the diagonal), and what a chunked store decodes
-        does not fall with the height at all. A straight line through one sample sized a fold at
-        2.6x the budget it printed.
-        """
+        fits. Bisected on the price itself: none of what a region costs scales with its rows."""
         ceiling = self._cap_rows(plan.spatial)
         for share in (_START_SHARE, 1.0):
             allowed = allowance * share
@@ -400,11 +352,7 @@ class CaseReduction:
 
     def _priced_peak(self, plan: ReductionPlan, rows: int) -> int:
         """What ``plan`` prices at ``rows``, leaving the height the sizing is working from alone.
-
-        Only the read fields depend on the height, so only they are recomputed per probe: the rest
-        of the plan (refusal walks, filesystem stats, channel maps) is height-independent, and a
-        sizing re-deriving all of it once put 96% of plan time into the members' geometry walks.
-        """
+        Only the read fields depend on the height, so only they are recomputed per probe."""
         held = self.slab_rows
         try:
             self.slab_rows = rows
@@ -417,9 +365,7 @@ class CaseReduction:
         """Whether the stat pass hands its folds to the write pass instead of re-folding them.
 
         One rule, two callers: the sizing subtracts what they will hold, the stat pass fills them.
-        Two rules would let the regions be cut for folds nobody keeps, or folds be kept the regions
-        made no room for. They may take their share of what the FOLD holds, never of the whole
-        declaration: a member's chain is holding the rest of it at the same moment.
+        They may take their share of what the FOLD holds, never of the whole declaration.
         """
         if not plan.stat_pass or not self._budget_bytes or self._budget_bytes <= 0:
             return False
@@ -445,17 +391,12 @@ class CaseReduction:
     def check_grid(self) -> str | None:
         """Whether the cases agree enough to be folded, or why they do not.
 
-        Compared on the grid each case's chain LANDS on (the folded shape and the plan-evolved
-        geometry), not the stored one: the chain exists precisely to bring disagreeing members onto
-        one grid (a ``Resample`` before the ``Reduce``), and comparing what is on disk would refuse
-        the very cohorts the reduction is for. Read from headers and plans alone, so it costs
-        nothing and happens before the first byte. Nothing anywhere can verify that the members
-        truly share a space, only that they claim to.
+        Compared on the grid each case's chain LANDS on, not the stored one, and from headers and
+        plans alone, before the first byte. Nothing can verify that the members truly share a space,
+        only that they claim to.
 
-        Compared against :attr:`reference`, the case whose geometry the output adopts, and only
-        ``strict`` compares geometry at all: naming a reference is how a cohort says its members
-        disagree on their headers and which one to believe, so demanding they agree would refuse
-        every cohort the policy exists for.
+        Compared against :attr:`reference`, the case whose geometry the output adopts; only
+        ``strict`` compares geometry at all.
         """
         reference = self.reference
         others = [manager for manager in self.managers if manager is not reference]
@@ -472,9 +413,7 @@ class CaseReduction:
             attribute = manager.landed_attributes()
             for key in _GEOMETRY_KEYS:
                 # ``strict`` is a promise that the geometries WERE compared, and a key nobody
-                # recorded cannot be. Skipping it is quietest exactly where it costs most: a
-                # Direction missing from one header is a flip that shows in neither extent nor
-                # spacing. Fold on extent alone with 'grid: shape_only' if that is what is meant.
+                # recorded cannot be. Fold on extent alone with 'grid: shape_only' instead.
                 absent = [
                     name for name, side in ((reference.name, expected), (manager.name, attribute)) if key not in side
                 ]
@@ -513,10 +452,8 @@ class CaseReduction:
 
     def _unbounded_members(self) -> dict[str, str]:
         """The members whose region reads decode their whole volume, with their store's format.
-
-        Only an entry on disk is asked: a cache the run has still to write is swept onto a store
-        that serves region writes, and every such store serves bounded region reads.
-        """
+        Only an entry on disk is asked: a cache still to write lands on a store serving bounded
+        reads."""
         unbounded: dict[str, str] = {}
         for manager in self.managers:
             dataset, group = self._member_source(manager)
@@ -525,12 +462,9 @@ class CaseReduction:
         return unbounded
 
     def _needs_stat_pass(self) -> bool:
-        """Whether a stage after the reduction wants whole-volume statistics OF THE RESULT.
-
-        Those cannot be seeded from disk the usual way: the reduced volume is stored nowhere yet --
-        so the engine computes them with a pass of its own. Twice the reads, no intermediate volume,
-        and the reduction is deterministic so both passes see the same values.
-        """
+        """Whether a stage after the reduction wants whole-volume statistics OF THE RESULT. The
+        reduced volume is stored nowhere yet, so the engine computes them with a pass of its own:
+        twice the reads, no intermediate volume."""
         return any(stage.patch_locality(Attribute()).kind is LocalityKind.GLOBAL_STAT for stage in self.post)
 
     def plan(self) -> ReductionPlan:
@@ -540,15 +474,14 @@ class CaseReduction:
             output=self.reduce.output,
             cases=[manager.name for manager in self.managers],
             spatial=reference.spatial_shape,
-            # The operator's own channel map, because only it knows the result's leading axis: a
-            # Concat over N cases writes N times the channels, and the plan must probe and size the
-            # shape the run will actually open.
+            # The operator's own channel map: a Concat over N cases writes N times the channels,
+            # and the plan must size the shape the run will open.
             channels=self.operator.output_channels(int(reference.base_shape[0]), len(self.managers)),
             source_channels=int(reference.base_shape[0]),
             slab_rows=self.slab_rows,
             incremental=self.operator.incremental,
             working_multiple=float(self.operator.working_multiple_for(len(self.managers))),
-            # The worst member's, because the fold is paced by whichever chain holds the most.
+            # The worst member's: the fold is paced by whichever chain holds the most.
             chain_multiple=max((float(manager.working_multiple()) for manager in self.managers), default=0.0),
             pull_bytes=pull_bytes,
             read_bytes=read_bytes,
@@ -559,13 +492,8 @@ class CaseReduction:
 
     def _member_read_bytes(self, channels: int) -> tuple[int, int]:
         """What one member's region costs its store at the current height, in bytes: the source
-        window it pulls, and what the store decodes above that window.
-
-        The fold is paced by whichever member costs the most, and one read is in flight at a time,
-        so both are the widest member's and both are charged once. ``None`` from a manager (a chain
-        that cannot answer) contributes nothing: the peak then says what it did before, which is
-        what the run-time probe is there to correct.
-        """
+        window it pulls, and what the store decodes above that window. Both are the widest member's
+        and both are charged once; ``None`` from a manager contributes nothing."""
         from konfai.data.patching.budget import _SWEEP_ELEMENT_BYTES
 
         reads = [manager.region_reads(self.slab_rows) for manager in self.managers]
@@ -579,18 +507,13 @@ class CaseReduction:
 
     def _fold(self, region: tuple[slice, ...]) -> torch.Tensor:
         """One region of the reduced volume: every case reads that region, the operator folds them.
-
-        Each region is presented as ``[1, C, *spatial]`` (the stack-axis layout every operator is
-        written against (see :class:`~konfai.data.reduction.Reduction`)), and the result comes back
-        without it. The axis matters to any operator that places things side by side.
-        """
+        Each region is presented as ``[1, C, *spatial]``, the stack-axis layout every operator is
+        written against (:class:`~konfai.data.reduction.Reduction`); the result comes back without it."""
         with SWEEP_CLOCK.phase("chain"):
             self.operator.start()
         for manager in self.managers:
             # No name holds the region past its accumulate: one that did would keep a second member
-            # region resident, which the plan does not price (1162 MiB against 778 on a 5 x 384 MiB
-            # float32 cohort folded whole). The read stays outside the phase, and the argument dies
-            # with the frame that times the fold of it.
+            # region resident, which the plan does not price.
             self._accumulate(self._member_region(manager, region))
         with SWEEP_CLOCK.phase("chain"):
             return self.operator.finalize().squeeze(0)
@@ -607,19 +530,9 @@ class CaseReduction:
             return manager.read_region(region).unsqueeze(0)
 
     def _folds(self, spatial: list[int]):
-        """Every region's fold, in order, the height following what the regions HOLD.
-
-        The first region is the one the sizing priced (:meth:`fit_budget`); every one after it is
-        cut by :class:`RegionGrowth` from what the last one held, read by the instrument the route
-        has (:func:`open_held_meter`: the allocator on a device, the resident peak on the host).
-        What the plan priced is a model, and a model of what a chain holds has to be right about
-        every stage, every store and every bridge it crosses; what the region actually held is a
-        fact, and it costs one counter read on work the fold had to do anyway.
-
-        Judged against the declaration LESS the chunk cache's share, because that is what the
-        reading covers: the meter does not count the decoded-chunk cache (it outlives the region),
-        so the cache's bytes come off the other side of the comparison too.
-        """
+        """Every region's fold, in order, the height following what the regions HOLD: the first is
+        the one the sizing priced (:meth:`fit_budget`), each one after it is cut by
+        :class:`RegionGrowth` from what the last held, judged against the budget less the cache's share."""
         budget = self._budget_bytes if self._budget_bytes and self._budget_bytes > 0 else None
         allowed = None if budget is None else budget - (budget_share("cache", budget) or 0.0)
         growth = RegionGrowth(self.slab_rows, self._cap_rows(spatial), allowed)
@@ -671,22 +584,17 @@ class CaseReduction:
 
     def _output_attributes(self, plan: ReductionPlan) -> Attribute:
         # The header is the geometry the reference's chain LANDS on, not the geometry it was stored
-        # with: a cohort resampled onto a template grid by its pre-chain must publish that grid --
-        # seeding the source's own Spacing here would stamp a wrong header on every round of an
-        # atlas build, and nothing about the volume would look wrong.
+        # with: a cohort resampled onto a template grid must publish that grid.
         attribute = self.reference.landed_attributes()
         if self.reduce.provenance:
-            # The deliverable carries its own recipe. A set of cases that changed between two runs
-            # would otherwise write a different volume under the same name: the worst way this can
-            # fail, because nothing about the output looks wrong.
+            # The deliverable carries its own recipe: a case list that changed between two runs
+            # would otherwise write a different volume under the same name.
             attribute["konfai_reduce_operator"] = self.reduce.operator_classpath
             attribute["konfai_reduce_cases"] = "|".join(plan.cases)
         if plan.stat_pass:
             statistics = _RunningStatistics()
             # The folds this pass computes ARE the folds the write pass needs: keep them when they
-            # fit their share of what the fold holds (:meth:`keeps_folds`, the same rule the sizing
-            # subtracted them by), and the write pass then only applies the post stages. Otherwise
-            # the second pass re-folds, as before: correctness never depends on the keep.
+            # fit their share (:meth:`keeps_folds`). Correctness never depends on the keep.
             self._kept_folds = [] if self.keeps_folds(plan) else None
             # The region is kept beside its fold: the growth changes the height along the pass, so
             # regions re-derived at any one height would misalign with the folds cut at another.
@@ -720,35 +628,28 @@ class CaseReduction:
     def materialize(self, rewrite: bool = False, device: torch.device | None = None) -> bool:
         """Write the reduced entry, or raise saying why it cannot be written this way.
 
-        There is no whole-volume fallback: assembling every case is exactly what this exists to
-        avoid, and doing it silently would turn a bounded run into an unannounced OOM. A finished
-        output is left alone unless ``rewrite``, which is the resume.
-
-        ``device`` is where the fold runs: each member replays its region there, the operator folds
-        there, and only the finished block comes back to the host for the write.
+        There is no whole-volume fallback. A finished output is left alone unless ``rewrite``, which
+        is the resume. ``device`` is where the fold runs: each member replays its region there, the
+        operator folds there, and only the finished block comes back to the host for the write.
         """
         if not rewrite and self.destination.is_dataset_exist(self.group, self.reduce.output):
             return True
         for manager in self.managers:
             manager.set_chain_device(device)
             # --overwrite must reach the MEMBERS, not just this output: each member's read_region
-            # resolves satisfied Saves from the previous run's caches unless told to rewrite, and a
-            # reduction folding stale caches writes a wrong volume whose provenance looks correct.
+            # resolves satisfied Saves from the previous run's caches unless told to rewrite.
             manager._set_rewrite(rewrite)
         if device is not None and device.type == "cuda":
-            # The member regions this fold accumulates live in VRAM: the slabs are sized against
-            # the card, not against a budget declared in host bytes -- a host-sized region set on a
-            # 16 GB card is an OOM mid-fold, after the stat pass already paid.
+            # The member regions this fold accumulates live in VRAM: the slabs are sized against the
+            # card, not against a budget declared in host bytes.
             declared = self._budget_bytes
             capped = device_capped_budget(declared, device)
             if capped is not None and capped != declared:
                 self.fit_budget(capped)
                 # The slabs are the card's; the KEEP decision is the host's: kept folds live in host
-                # memory (``.cpu()``), and judging them against VRAM/2 re-folded outputs the host
-                # could have held whole -- a second full pass for nothing.
+                # memory (``.cpu()``).
                 self._budget_bytes = declared
-                # Said once, because the PLAN printed the host figure: the run must say which
-                # budget it actually worked under, or every future OOM is diagnosed off a lie.
+                # The PLAN printed the host figure, so the run says which budget it worked under.
                 print(
                     f"[Reduce] '{self.reduce.output}': regions re-sized for {device} --"
                     f" {self.slab_rows} row(s) under {capped / 2**30:.2f} GiB"
@@ -757,8 +658,7 @@ class CaseReduction:
                 )
         plan = self.plan()
         if not plan.streams:
-            # A grid disagreement gets its own remedy: a Save changes nothing about the grids, so
-            # the generic advice would send the reader in a circle.
+            # A grid disagreement gets its own remedy: a Save changes nothing about the grids.
             remedy = (
                 "The members do not land on one grid: resample them onto a common grid before the"
                 " Reduce, or declare grid: reference:<case> / shape_only if the cohort is already"
@@ -778,8 +678,7 @@ class CaseReduction:
         spatial = plan.spatial
         attribute = self._output_attributes(plan)
         rank = len(spatial) + 1
-        # The folds a stat pass kept (when the folded output fits half the budget) are written as
-        # they are; otherwise every region is folded here, once.
+        # The folds a stat pass kept are written as they are; otherwise every region is folded here.
         kept = self._kept_folds
         self._kept_folds = None
         folds = iter(kept) if kept is not None else self._folds(spatial)

--- a/konfai/data/data_manager/groups.py
+++ b/konfai/data/data_manager/groups.py
@@ -35,10 +35,9 @@ from konfai.utils.runtime import State
 def _check_patch_transform_locality(transform: Transform, group_src: str, group_dest: str) -> None:
     """Reject a transform whose per-patch result cannot equal its case-level result.
 
-    Only POINTWISE and GLOBAL_STAT are correct on one patch (per-patch GLOBAL_STAT means: derive the
-    statistic from this patch; use ``lazy=True`` case-level to feed it the volume's). The messages in
-    ``reasons`` below say why each other kind is rejected. Probed with an empty ``Attribute`` (config
-    time has no case), so an image-decided kind answers WHOLE_VOLUME: the right answer here.
+    Only POINTWISE and GLOBAL_STAT are correct on one patch; per-patch GLOBAL_STAT derives the statistic
+    from that patch. The probe passes an empty ``Attribute``, so a kind decided by the image answers
+    WHOLE_VOLUME.
     """
     kind = transform.patch_locality(Attribute()).kind
     if kind in (LocalityKind.POINTWISE, LocalityKind.GLOBAL_STAT):
@@ -77,18 +76,9 @@ def _check_patch_transform_locality(transform: Transform, group_src: str, group_
 def _check_patch_transform_shape(transform: Transform, group_src: str, group_dest: str) -> None:
     """Reject a patch_transform that resizes the patch it is handed.
 
-    The patch grid is folded from the CASE-level ``transforms`` only (``DatasetManager``), so a
-    patch_transform that changes the spatial shape hands back a patch the batch cannot collate and the
-    ``Accumulator`` cannot write onto the grid. ``_check_patch_transform_locality`` above takes the
-    transform at its word; this is the structural check, and it is asked of ``transform_shape`` (the
-    contract every transform already owes the patch planner), with distinct extents, so a swap or a
-    resize of any single axis shows up. Only the SPATIAL shape is at stake: patching hands
-    ``transform_shape`` the channel-stripped shape, so a transform that changes only the channel count
-    (``OneHot``) is not caught here, and must not be: the grid it feeds is spatial.
-
-    Runs after the locality check, which is what makes the bare probe attribute safe: by here the
-    transform is POINTWISE or GLOBAL_STAT, and the kinds whose ``transform_shape`` needs real geometry
-    (``Resample`` reads ``Spacing``) have already been rejected.
+    The patch grid is folded from the CASE-level ``transforms`` only, so a patch_transform must be spatially
+    shape-preserving. Only the spatial shape is checked: ``transform_shape`` is asked with the
+    channel-stripped shape, so a transform that changes only the channel count is not caught here.
     """
     spatial_shape = [7, 11, 13]
     shape = list(transform.transform_shape(group_src, "", list(spatial_shape), Attribute()))
@@ -109,22 +99,10 @@ def _check_patch_transform_invertible(
 ) -> None:
     """Reject a per-patch global statistic at prediction, whose inverse cannot be reconstructed.
 
-    A ``GLOBAL_STAT`` transform is allowed in ``patch_transforms`` (see
-    ``_check_patch_transform_locality``): run per patch it standardizes each patch by that patch's OWN
-    statistic, which is what asking for it per-patch means: correct, and the deliberate training use.
-    But the per-patch statistic lives in the per-patch attribute scope and never reaches the case
-    attribute, so at prediction the finalize inverse, which seeds every patch from the CASE attribute
-    and pops the statistic: has nothing to pop. Nor could it: the reassembled volume was normalised
-    patch by patch with different coefficients, so a single case-level inverse cannot un-apply it. Refuse
-    here, at config time, rather than fail deep in the inverse with a lookup error.
-
-    A case-level ``transforms`` entry that derives the SAME statistic rescues it: run once on the whole
-    volume it caches that statistic on the case attribute (``Standardize(lazy=True)`` caches Mean/Std and
-    applies nothing), which the per-patch inverse then inherits and pops. So the patch transform is only
-    un-invertible when nothing case-level captures its statistic.
-
-    Training-only use stays valid: the check is gated on the prediction state, where the inverse actually
-    runs (``RESUME``/``TRAIN`` never invert patch_transforms, and evaluation drops them entirely).
+    A per-patch statistic never reaches the case attribute, so the finalize inverse, seeded from the case
+    attribute, has nothing to pop. A case-level ``transforms`` entry deriving the same statistic
+    (``Standardize(lazy=True)`` caches Mean/Std and applies nothing) rescues it. Gated on the prediction
+    state, the only one that inverts patch_transforms.
     """
     if konfai_state() != str(State.PREDICTION):
         return
@@ -171,10 +149,8 @@ class GroupTransform:
         self._prepared = False
 
     def prepare(self, group_src: str, group_dest: str) -> None:
-        # Binds ONCE. A workflow that inspects its chains before handing over to Data.prepare() calls
-        # this first, and Data.prepare() calls it again for every group, so without the guard every
-        # stage is constructed twice, and anything the workflow attached to the first set is silently
-        # thrown away with it. A stage's __init__ is user code and may not be run twice for free.
+        # Binds ONCE: a workflow may inspect its chains before Data.prepare() calls this for every group,
+        # and a stage's __init__ is user code that may not be run twice.
         if self._prepared:
             return
         self._prepared = True
@@ -185,8 +161,8 @@ class GroupTransform:
                 transform = transform_loader.get_transform(
                     classpath,
                     konfai_args=f"{konfai_root()}.Dataset.groups_src.{group_src}.groups_dest.{group_dest}.transforms",
-                    # Past an Expand marker the chain is the copies' draws: a name both packages
-                    # have (Flip, Mask, Permute) is the draw there, the transform before it.
+                    # Past an Expand marker the chain is the copies' draws: a name both packages have
+                    # (Flip, Mask, Permute) is the draw there, the transform before it.
                     prefer_augmentation=any(isinstance(stage, Expand) for stage in self.transforms),
                 )
                 self.transforms.append(transform)
@@ -237,9 +213,7 @@ class GroupTransformMetric(GroupTransform):
 class GroupTransformOut(GroupTransform):
     """Transform-workflow group: a plain chain, no patch-time transforms, no ``is_input``.
 
-    Every group of a dataset-preparation workflow is an input, so the flag is not a question to ask; and the
-    patch grid is an execution detail the planner owns, so a per-patch transform would make the
-    OUTPUT a function of the declared budget."""
+    Every group of a dataset-preparation workflow is an input."""
 
     def __init__(
         self,

--- a/konfai/data/data_manager/sources.py
+++ b/konfai/data/data_manager/sources.py
@@ -63,8 +63,7 @@ class DataSources(ABC):
     Which cases, from which file, under which destination group: the ``dataset_filenames`` roots,
     the case names common to every source group and kept by ``subset``, and one
     :class:`~konfai.data.patching.DatasetManager` per (destination group, case), all resolved by
-    :meth:`prepare`. :class:`Data` adds the batch-loading mechanics; :class:`DataTransform` builds
-    on this alone.
+    :meth:`prepare`. :class:`Data` adds the batch-loading mechanics.
     """
 
     @abstractmethod
@@ -107,14 +106,9 @@ class DataSources(ABC):
         return groups_dest
 
     def _check_destination_groups_are_unique(self) -> None:
-        """A destination group names ONE chain, whatever source group it reads.
-
-        It is the key everything downstream indexes by: the prepared managers, the sample handed to
-        a model, the plan's lines. Two source groups declaring the same destination name would
-        silently keep only the last one: the first chain built, then dropped, with nothing
-        anywhere looking wrong. Naming the chain is free: what a chain WRITES is the ``Write``'s own ``group``,
-        which is a separate word for a separate thing.
-        """
+        """A destination group names ONE chain, whatever source group it reads. It is the key
+        everything downstream indexes by: the prepared managers, the sample handed to a model, the
+        plan's lines. What a chain WRITES is the ``Write``'s own ``group``, a separate word."""
         owner: dict[str, str] = {}
         for group_src, group_dest, _chain in _chains(self.groups_src):
             if group_dest in owner:
@@ -165,15 +159,12 @@ class DataSources(ABC):
 
     def _resolve_dataset_sources(self, requested: set[str] | None = None) -> dict[str, list[tuple[str, bool]]]:
         """The roots holding each source group, as ``(filename, append)`` in declaration order.
-
-        ``requested`` is what the subset can name (:meth:`Subset.required_names`), asked of a root
-        in place of its whole listing; ``None`` lists every case.
-        """
+        ``requested`` is what the subset can name (:meth:`Subset.required_names`), asked of a root in
+        place of its whole listing; ``None`` lists every case."""
         datasets: dict[str, list[tuple[str, bool]]] = {}
         if self.dataset_filenames is None or len(self.dataset_filenames) == 0:
             raise DatasetManagerError("No dataset filenames were provided")
-        # A resolve after the first (the evaluation's sizing pass, an OOM re-plan) keeps each root's
-        # Dataset, and with it the listing it took and the headers it parsed.
+        # A resolve after the first keeps each root's Dataset, its listing and its parsed headers.
         kept = self.datasets
         self.datasets = {}
         for dataset_filename in self.dataset_filenames:
@@ -237,8 +228,7 @@ class DataSources(ABC):
             roots = sorted({filename for entries in datasets.values() for filename, _ in entries})
             print(f"[KonfAI] listing every case of {', '.join(sorted(datasets))} under {', '.join(roots)}")
         cohort: dict[str, set[str]] = {}
-        # Seeded from the first group, whatever it holds: an empty first group is a fact of the
-        # walk, not a walk that has not started, and it empties the intersection.
+        # Seeded from the first group, whatever it holds: an empty first group empties the intersection.
         names: set[str] | None = None
         for group in self.groups_src:
             names_by_group = set()
@@ -320,7 +310,6 @@ class DataSources(ABC):
                     first = source_filename_by_group[group_src].setdefault(name, filename)
                     if first != filename:
                         # Two roots hold the same case of the same group: the first declared is read.
-                        # Said out loud, because a stale copy left in one root would be read in silence.
                         warnings.warn(
                             f"Case '{name}' of group '{group_src}' is in '{first}' and in '{filename}':"
                             f" reading '{first}' (dataset_filenames order).",
@@ -377,10 +366,8 @@ class DataSources(ABC):
 class Data(DataSources):
     """The batch-loading layer over :class:`DataSources`, shared by training, prediction and
     evaluation: a patch grid, an optional RAM cache, a train/validation split, augmentation copies,
-    and one torch DataLoader per rank and partition (:meth:`get_data`).
-
-    ``case_names``/``managers`` hold the first partition (the training cases); the validation split
-    has its own.
+    and one torch DataLoader per rank and partition (:meth:`get_data`). ``case_names``/``managers``
+    hold the first partition (the training cases); the validation split has its own.
     """
 
     @staticmethod
@@ -435,9 +422,7 @@ class Data(DataSources):
 
         # A window keeps ``shuffle_window`` cases resident, so the FIFO buffer must be at least that
         # large or a window would evict its own cases before their patches are consumed. Unwindowed,
-        # one batch plus the case being read is all a loader ever holds at once. A one-pass workflow
-        # serves a case's patches in order and never reads it again: its FIFO holds the case being
-        # finished and the next one, whatever the batch size.
+        # one batch plus the case being read is all a loader holds; a one-pass workflow holds two.
         window = subset.shuffle_window
         if self._reads_each_case_once:
             self._buffer_size = 2
@@ -447,8 +432,7 @@ class Data(DataSources):
         self._pin_memory = pin_memory
         self._prefetch_factor = prefetch_factor
         self._persistent_workers = persistent_workers
-        # ``memory_budget`` may later override ``use_cache`` (once the dataset size is known, in
-        # ``get_data``), which reshapes the loader; both paths funnel through the same builder.
+        # ``memory_budget`` may later override ``use_cache`` in ``get_data``; one builder for both.
         self._configure_data_loading(use_cache)
         self.data: list[list[dict[str, list[DatasetManager]]]] = []
         self.mapping: list[list[list[tuple[int, int, int]]]] = []
@@ -460,9 +444,8 @@ class Data(DataSources):
     def _configure_data_loading(self, use_cache: bool) -> None:
         """Build the loader from the cache regime: the DatasetIter factory and the worker settings.
 
-        Called once from ``__init__`` with the declared ``use_cache``, again from ``prepare`` once
-        the managers say how each case is read, and, when a ``memory_budget`` overrides it, again
-        from ``get_data`` with the derived value.
+        Called from ``__init__`` with the declared ``use_cache``, from ``prepare`` once the managers
+        say how each case is read, and from ``get_data`` when a ``memory_budget`` overrides it.
         """
         self.use_cache = use_cache
         self.datasetIter = partial(
@@ -489,9 +472,8 @@ class Data(DataSources):
         }
         if resolved_num_workers > 0:
             self.dataLoader_args["prefetch_factor"] = 2 if self._prefetch_factor is None else self._prefetch_factor
-            # Persistent workers keep a fork-time copy of the dataset and never see the main process's
-            # per-epoch reset_augmentation redraw, so inline augmentations freeze at their first-epoch draw.
-            # An explicit persistent_workers=True cannot override that: correctness wins over the request.
+            # Persistent workers hold a fork-time copy of the dataset and never see the per-epoch
+            # redraw, so inline augmentations freeze; an explicit persistent_workers=True cannot win.
             inline_augmentation_active = self.inline_augmentations and len(self.data_augmentations_list) > 0
             if inline_augmentation_active:
                 persistent_workers = False
@@ -502,20 +484,10 @@ class Data(DataSources):
             self.dataLoader_args["persistent_workers"] = persistent_workers
 
     def _default_num_workers(self, use_cache: bool) -> int:
-        """The worker count when the config names none.
-
-        A cache preloads every case up front and leaves the loader nothing to do. A one-pass
-        workflow walks each case once in grid order, and shipping a batch through shared memory
-        costs more than reading it in place. Workers pay for themselves in one place, where a
-        patch read decodes more than the patch it asks for, and the decodes then run in parallel.
-
-        Measured on a quiet 24-core host, three cases, whole PREDICTION runs, best of two
-        (``CUDA_VISIBLE_DEVICES=``), zero workers against four:
-        patches streaming off an uncompressed MetaImage 0.24 s / 0.34 s (2.5-D, patch
-        [1, 192, 192]), 0.14 s / 0.27 s (3-D, [32, 32, 32]), and 4.26 s / 4.89 s on the 2.5-D grid
-        with a five-layer convolutional net; the case buffered whole 0.17 s / 0.44 s; and, where
-        every patch decodes the volume, 18.1 s / 5.7 s.
-        """
+        """The worker count when the config names none. A cache preloads every case up front and
+        leaves the loader nothing to do, and a one-pass workflow walks each case once in grid order,
+        where shipping a batch through shared memory costs more than reading it in place. Workers pay
+        for themselves where a patch read decodes more than the patch it asks for."""
         if use_cache:
             return 0
         if self._reads_each_case_once and not self._patch_read_decodes_the_volume():
@@ -523,15 +495,9 @@ class Data(DataSources):
         return max(1, min(os.cpu_count() or 1, 4))
 
     def _patch_read_decodes_the_volume(self) -> bool:
-        """Whether reading one patch costs a whole-volume decode, on any case of any group.
-
-        Only where the patches are read from the store one by one AND the store cannot serve a
-        region (a compressed MetaImage, an NRRD, a gzipped NIfTI). A chain that cannot stream is
-        not that: it reads the case once into the loader's buffer and cuts its patches from RAM.
-
-        ``False`` before ``prepare``, where no manager can answer yet: only the worker default
-        reads this, and only ``get_data`` reads the default.
-        """
+        """Whether reading one patch costs a whole-volume decode, on any case of any group: only
+        where the patches are read from the store one by one AND the store cannot serve a region (a
+        compressed MetaImage, an NRRD, a gzipped NIfTI). ``False`` before ``prepare``."""
         if self._managers is None:
             return False
         return any(
@@ -546,16 +512,11 @@ class Data(DataSources):
         self._configure_data_loading(self.use_cache)
 
     def _estimate_cached_bytes(self) -> int:
-        """Raw in-RAM size of the whole prepared dataset, from headers alone (no voxel read).
-
-        Sums ``prod(shape) x 4`` over every case of every source group, once per COPY the cache holds:
-        a cached case is its base tensor PLUS one per augmentation draw, which validation only makes
-        when ``validation_augmentations``. See ``_CACHE_ELEMENT_BYTES``: this is an honest header-only
-        estimate that ignores size-changing transforms (an augmentation's ``Mask`` included). It also
-        counts the tensors themselves, not the allocator's arenas around them: those settle about a
-        third higher (measured), which is over the "auto" safety fraction, so a dataset landing within
-        a few percent of an "auto" budget can still be caching more than the budget names.
-        """
+        """Raw in-RAM size of the whole prepared dataset, from headers alone (no voxel read). Sums
+        ``prod(shape) x 4`` over every case of every source group, once per COPY the cache holds (see
+        ``_CACHE_ELEMENT_BYTES``): the base tensor plus one per augmentation draw, which validation
+        only makes when ``validation_augmentations``. It ignores size-changing transforms and the
+        allocator's arenas, which settle about a third higher than the tensors counted here."""
         total = 0
         for prepared, copies in (
             (self._managers, Data._get_nb_augmentation(self._get_data_augmentations(True))),
@@ -569,25 +530,21 @@ class Data(DataSources):
                     total += int(np.prod(manager.base_shape, dtype=np.int64)) * _CACHE_ELEMENT_BYTES * copies
         return total
 
-    #: Whether the workflow reads each case exactly once. False for training, whose epochs
-    #: re-read every case; True for prediction and evaluation. A one-pass workflow never re-reads
-    #: a cache, so a fitting ``memory_budget`` does not choose one, and its loader has one region
-    #: read per patch to do, which costs less in place than through a worker.
+    #: Whether the workflow reads each case exactly once. False for training, whose epochs re-read
+    #: every case; True for prediction and evaluation. A one-pass workflow never re-reads a cache, so
+    #: a fitting ``memory_budget`` does not choose one.
     _reads_each_case_once = False
 
     def _resolve_cache_regime(self, world_size: int) -> None:
         """Derive ``use_cache`` from ``memory_budget``. ``None`` means ``"auto"``.
 
-        The cache is chosen iff the per-rank dataset (``dataset / world_size``: ``Data._split``
-        shards cases across ranks) fits the per-rank budget: an explicit budget is taken as declared
-        per rank; ``"auto"``: also what an absent key means: divides the detected node memory
-        (cgroup-capped) by the ranks sharing THAT node, so on a single node the two divisions cancel
-        and the test reduces to "does the whole dataset fit the node". The decision is logged once
-        here: ``get_data`` runs on the launcher alone, before any worker is spawned.
+        The cache is chosen iff the per-rank dataset (``Data._split`` shards cases across ranks) fits
+        the per-rank budget: an explicit budget is taken as declared per rank; ``"auto"`` divides the
+        detected node memory (cgroup-capped) by the ranks sharing THAT node, so on a single node the
+        two divisions cancel. Logged once here, on the launcher.
         """
         if self._reads_each_case_once:
-            # One-pass workflows (prediction, evaluation) read each case exactly once: a cache is
-            # never re-read, so the regime is always stream/buffer and there is nothing to derive.
+            # One-pass workflows never re-read a cache: the regime is always stream/buffer.
             return
         world_size = max(1, world_size)
         n_cases = len(self.case_names) + len(self._validation_names)
@@ -659,12 +616,10 @@ class Data(DataSources):
         self, dataset_name: dict[str, dict[str, list[str]]], managers: dict[str, list[DatasetManager]] | None = None
     ) -> None:
         """(Re)build the managers and patch mappings of both partitions from ``case_names`` and
-        ``_validation_names``; the validation indices continue the training ones. Nothing is
-        assigned until both are built, so a failure leaves the dataset unprepared.
-
-        ``managers`` are every selected case's, built in run order with the training draws: the
-        training partition is their head and, when validation keeps the draws, the validation
-        partition their tail, indices included. Unaugmented validation is built without them.
+        ``_validation_names``; the validation indices continue the training ones. Nothing is assigned
+        until both are built, so a failure leaves the dataset unprepared. ``managers`` are every
+        selected case's, built in run order with the training draws: the training partition is their
+        head and, when validation keeps the draws, the validation partition their tail.
         """
         split = len(self.case_names)
         training = validation = None
@@ -686,11 +641,9 @@ class Data(DataSources):
         self._validation_managers, self._prepared_validation_mapping = validation, validation_mapping
 
     def worst_case_shape(self) -> list[int] | None:
-        """Per-axis maximum spatial extent over every prepared case and augmentation copy.
-
-        A provisional auto-patch grid starts from this worst case at full extent: one GLOBAL patch
-        size, which smaller cases clamp to fewer (or single whole-volume) patches for free.
-        """
+        """Per-axis maximum spatial extent over every prepared case and augmentation copy. A
+        provisional auto-patch grid starts from this worst case at full extent: one GLOBAL patch
+        size, which smaller cases clamp to fewer (or single whole-volume) patches for free."""
         shapes = [
             shape
             for prepared in (self._managers, self._validation_managers)
@@ -703,22 +656,18 @@ class Data(DataSources):
         return [max(int(shape[axis]) for shape in shapes) for axis in range(len(shapes[0]))]
 
     def set_free_axis_multiple(self, multiple: list[int] | None) -> None:
-        """Record the model's per-axis downsampling factor on the shared patch BEFORE ``prepare()`` cuts
-        the grids, so every case's free (``0``) axis rounds up to a valid model input. A no-op without a
-        patch (evaluation) or without a free axis; harmless once a re-plan has made the sizes concrete.
-        """
+        """Record the model's per-axis downsampling factor on the shared patch BEFORE ``prepare()``
+        cuts the grids, so every case's free (``0``) axis rounds up to a valid model input. A no-op
+        without a patch (evaluation) or without a free axis."""
         if self.patch is not None:
             self.patch.free_axis_multiple = multiple
 
     def replan_patch(self, patch_size: list[int]) -> None:
-        """Re-cut every prepared grid for a new GLOBAL patch size (the OOM-restart path).
-
-        The managers are rebuilt against the already-resolved sources and the SAME case lists --
-        NOT through ``prepare()`` (its idempotence guard would skip the rebuild): so a later
-        ``get_data`` shards cases identically across the restart: only the grids and the patch mapping change.
-        The new sizes are written into the shared ``patch_size`` list IN PLACE because the loader
-        factory holds a reference to it; each rebuilt manager then takes its own copy of them.
-        """
+        """Re-cut every prepared grid for a new GLOBAL patch size (the OOM-restart path). The managers
+        are rebuilt against the already-resolved sources and the SAME case lists, NOT through
+        ``prepare()``, whose idempotence guard would skip the rebuild, so a later ``get_data`` shards
+        cases identically. The new sizes are written into the shared ``patch_size`` list IN PLACE
+        because the loader factory holds a reference to it."""
         if self.patch is None or self._managers is None:
             raise DatasetManagerError(
                 "replan_patch requires a prepared dataset with a patch definition.",
@@ -741,12 +690,9 @@ class Data(DataSources):
 
     @staticmethod
     def _check_cross_group_patch_counts(managers: dict[str, list[DatasetManager]], nb_augmentation: int) -> None:
-        """Refuse destination groups whose grids disagree, before a single patch is read.
-
-        The mapping is counted on ONE group (``_patch_counts``) and every group is then read with
-        the same patch index: a group with more patches never has its tail enumerated, one with
-        fewer raises an IndexError deep in a loader worker.
-        """
+        """Refuse destination groups whose grids disagree, before a single patch is read. The mapping
+        is counted on ONE group (``_patch_counts``) and every group is then read with the same patch
+        index: a group with more patches never has its tail enumerated, one with fewer raises."""
         grouped = list(managers.items())
         if len(grouped) < 2:
             return
@@ -811,9 +757,8 @@ class Data(DataSources):
                 "\t• str  → list of sample names, file paths, slices ('0:10') or '~' exclusions",
                 f"Received list: {self.validation}",
             )
-        # One selector grammar for 'subset:' and 'validation:': names, case-list files, slices
-        # (negative ends included) and '~' exclusions all resolve through the subset's machinery,
-        # against the RUN-ORDER names, so a slice keeps its positional meaning.
+        # One selector grammar for 'subset:' and 'validation:': names, case-list files, slices and
+        # '~' exclusions all resolve through the subset's machinery, against the RUN-ORDER names.
         return self.subset._resolve_selectors(cast("list[str | int]", selectors), subset_names)
 
     def _split_train_validation_names(
@@ -867,8 +812,7 @@ class Data(DataSources):
         mapping: list[tuple[int, int, int]] = []
         # PREDICTION walks the mapping in order, and the copies of a TTA case must advance together
         # along the slab axis for the streamed write to hold a bounded window (see
-        # ``_interleaved_case_entries``). TRAIN shuffles the mapping anyway and keeps the plain
-        # order, as does a dataset prepared outside any workflow, where no state is set at all.
+        # ``_interleaved_case_entries``). TRAIN shuffles the mapping anyway and keeps the plain order.
         interleave = nb_augmentation > 1 and os.environ.get("KONFAI_STATE") == str(State.PREDICTION)
         for x, counts in enumerate(self._patch_counts(managers, nb_augmentation)):
             entries = [(y, z) for y in range(nb_augmentation) for z in range(counts[y])]
@@ -883,18 +827,16 @@ class Data(DataSources):
             return [[] for _ in range(world_size)]
 
         mappings: list[list[tuple[int, int, int]]] = []
-        # One-pass workflows shard by CASE; the default branch below is the TRAIN one, whose
-        # duplicate-padding (for DDP) would hand the same case to two ranks: two concurrent writers
-        # of the same output file for a workflow that writes per case.
+        # One-pass workflows shard by CASE; the TRAIN branch below pads duplicates for DDP, which
+        # would hand the same case to two ranks, two concurrent writers of one per-case output.
         if konfai_state() in (str(State.PREDICTION), str(State.EVALUATION), str(State.TRANSFORM)):
             mapping_by_index: dict[int, list[tuple[int, int, int]]] = {}
             for entry in mapping:
                 mapping_by_index.setdefault(entry[0], []).append(entry)
             # Balanced by patch LOAD, not case count: an equal-count contiguous split lands a
-            # [1000, 10, 10, 10]-patch cohort as 1010 against 20 on two ranks, and every rank waits
-            # for the slowest at the end-of-run barrier. Deterministic (sorted cases, stable greedy),
-            # so a restart shards identically; within a shard each case keeps its entries in mapping
-            # order, walked in ascending case order.
+            # [1000, 10, 10, 10]-patch cohort as 1010 against 20 on two ranks. Deterministic (sorted
+            # cases, stable greedy), so a restart shards identically; within a shard each case keeps
+            # its entries in mapping order, walked in ascending case order.
             case_loads = {case: len(mapping_by_index[case]) for case in sorted(mapping_by_index)}
             for shard in _balanced_case_partitions(case_loads, world_size):
                 mappings.append([entry for case in sorted(shard) for entry in mapping_by_index[case]])
@@ -905,15 +847,10 @@ class Data(DataSources):
                 end = (size * (rank + 1)) // world_size
                 mappings.append(mapping[start:end])
             # TRAIN/RESUME wraps the model in DDP(static_graph=True): every rank must run the same
-            # number of backward all-reduces per epoch. Contiguous shards can differ by one sample,
-            # which desynchronises the collective and hangs NCCL, so equalise their length. PAD the
-            # shorter shards (wrapping their own head) rather than truncating: truncation permanently
-            # drops the tail sample of the longer shards (it is outside every rank's shard, and _split
-            # runs once at setup so the sampler's per-epoch shuffle never reaches it), whereas padding
-            # keeps every sample training with only a harmless duplicate. world_size == 1 is a no-op.
-            # A shard fills itself from its own head, and one that holds nothing has no head to fill
-            # from: fewer entries than ranks leaves it empty, and an empty rank runs no backward at
-            # all: the very hang this equalises against. It takes the mapping's head instead.
+            # number of backward all-reduces per epoch, so the shards are equalised in length. PAD
+            # the shorter shards (wrapping their own head) rather than truncating, which would
+            # permanently drop the tail sample of the longer shards. A shard that holds nothing has
+            # no head to fill from and takes the mapping's head. world_size == 1 is a no-op.
             max_len = max(len(shard) for shard in mappings)
             mappings = [shard + (shard if shard else mapping)[: max_len - len(shard)] for shard in mappings]
         return mappings
@@ -960,8 +897,7 @@ class Data(DataSources):
             data_loaders.append([])
             for loader_index, (dataset_items, mapping) in enumerate(zip(datas, mappings, strict=False)):
                 # Windowing is a training-order knob, so it reaches the shuffled training loader only
-                # (loader_index == 0). Validation is scored over the whole subset whatever the order,
-                # and ``None`` keeps it on the plain global one.
+                # (loader_index == 0). Validation is scored over the whole subset whatever the order.
                 window = self.subset.shuffle_window if loader_index == 0 else None
                 dataset_iter = self.datasetIter(
                     rank=i,
@@ -1087,26 +1023,22 @@ class DataMetric(Data):
     """Dataset configuration used by the evaluation workflow.
 
     Evaluation never exposes a patch: each run sizes its own from ``memory_budget`` (a missing key
-    means ``"auto"``): a case that fits the budget is evaluated whole (exact); one
-    that does not is cut into the largest DISJOINT patches that fit (overlap 0, no padding) and the
-    reducible metrics combine their running partials into the exact whole-case value. A metric
-    scoring through a window declares a halo, and every patch is then read that much wider than its
-    slot. The evaluator disables this sizing when any of its metrics is not reducible, so a metric
-    that needs the whole volume always gets it.
+    means ``"auto"``). A case that fits the budget is evaluated whole; one that does not is cut into
+    the largest DISJOINT patches that fit (overlap 0, no padding) and the reducible metrics combine
+    their running partials into the exact whole-case value. A metric scoring through a window
+    declares a halo, and every patch is read that much wider than its slot. The sizing is disabled
+    when any metric is not reducible.
     """
 
     _reads_each_case_once = True
 
-    #: Working copies a metric makes of the patch pair (float casts, the difference, a masked select):
-    #: measured ~<= 2x the resident tensors; the sizing keeps this conservative and the 0.8 safety
-    #: fraction absorbs the rest.
+    #: Working copies a metric makes of the patch pair (float casts, the difference, a masked
+    #: select): ~<= 2x the resident tensors, the 0.8 safety fraction absorbing the rest.
     _METRIC_INTERMEDIATE_FACTOR = 2.0
 
-    # The evaluator clears this when any of its metrics is not reducible: that metric needs whole
-    # volumes, so the budget sizing must not cut the case.
+    # Cleared by the evaluator when a metric is not reducible: that metric needs whole volumes.
     auto_patch_allowed = True
-    # The widest halo among the evaluator's metrics: the context every patch is read with past its
-    # slot, and what the sizing reserves on each face.
+    # The widest halo among the evaluator's metrics: what the sizing reserves on each face.
     patch_halo = 0
 
     def _maybe_auto_patch(self) -> None:
@@ -1115,9 +1047,8 @@ class DataMetric(Data):
             return
         requested = self.subset.required_names()
         sources = self._resolve_dataset_sources(requested)
-        # Header-only scan: for each case, its resident bytes per spatial voxel is the sum of its
-        # groups' channels (output + targets + masks all arrive as groups); the WORST case sizes the
-        # one patch every case then shares (a smaller case simply yields fewer patches).
+        # Header-only scan: each case's resident bytes per spatial voxel is the sum of its groups'
+        # channels; the WORST case sizes the one patch every case then shares.
         channels_by_name: dict[str, int] = {}
         spatial_by_name: dict[str, list[int]] = {}
         for group, entries in sources.items():
@@ -1138,9 +1069,8 @@ class DataMetric(Data):
         budget = self.resolved_budget().per_rank_bytes(node_local_ranks())
         extent = spatial_by_name[worst]
         halo = self.patch_halo
-        # What the budget bounds is the READ: a slot plus the halo past each face. Sized as one
-        # patch; an axis the budget cuts thinner than its two halos is spanned whole instead, since
-        # the halo there would cost more than the axis, and the other axes absorb it.
+        # What the budget bounds is the READ: a slot plus the halo past each face. An axis the
+        # budget cuts thinner than its two halos is spanned whole, the other axes absorbing it.
         template = [0] * len(extent)
         while True:
             sized = resolve_patch(
@@ -1201,16 +1131,14 @@ class DataMetric(Data):
             subset,
             memory_budget,
             patch=None,
-            # Evaluation reads each case exactly once (no augmentations, one pass): a cache is never
-            # re-read, it only fronts the whole dataset's RAM. Stream.
+            # Evaluation reads each case exactly once: a cache is never re-read. Stream.
             use_cache=False,
             batch_size=1,
             validation=validation,
             num_workers=num_workers,
             pin_memory=pin_memory,
             prefetch_factor=prefetch_factor,
-            # One pass: workers are never reused across epochs, and persistent workers race the
-            # process teardown (the terminated worker trips torch's failure handler at exit).
+            # One pass: persistent workers race the process teardown at exit.
             persistent_workers=False if persistent_workers is None else persistent_workers,
         )
 
@@ -1223,8 +1151,7 @@ class DataTransform(DataSources):
     :class:`~konfai.data.materialize.CaseMaterializer` over the managers, never a DataLoader. So no
     patch (the planner cuts slabs, never the user), no batch, no validation split, no shuffle, and
     no ``augmentations`` section: a draw is a stage, declared IN the chain, at the place it applies,
-    after an :class:`~konfai.data.transform.Expand` marker. Everything decidable from the config
-    alone is refused here, before a single byte is read.
+    after an :class:`~konfai.data.transform.Expand` marker.
     """
 
     def __init__(
@@ -1241,8 +1168,7 @@ class DataTransform(DataSources):
 
     def prepare(self) -> None:
         # The chains are bound first and the cardinality checked BEFORE any manager exists: a draw
-        # declared outside a copy has no shape map, so the manager's own fold would die on an
-        # AttributeError naming a method instead of refusing with the place to move the draw to.
+        # declared outside a copy has no shape map, and the manager's fold would die on it.
         for group_src, group_dest, chain in _chains(self.groups_src):
             chain.prepare(group_src, group_dest)
         self._validate_expansion()
@@ -1251,13 +1177,10 @@ class DataTransform(DataSources):
         self._validate_write_chains()
 
     def _seed_expansions(self) -> None:
-        """Hand the run's seed to every ``Expand`` that did not declare one of its own.
-
-        Done before ``super().prepare()``, which is where the managers are built and the copies
-        drawn. Every chain inheriting the same number is what makes an image chain and its mask
-        chain agree: they never meet, they derive from one seed they both hold. A chain that
-        declares ``seed`` keeps it, which is how two chains are asked for different copies.
-        """
+        """Hand the run's seed to every ``Expand`` that did not declare one of its own, before
+        ``super().prepare()`` builds the managers and draws the copies. Every chain inheriting the
+        same number is what makes an image chain and its mask chain agree; a chain that declares
+        ``seed`` keeps it, which is how two chains are asked for different copies."""
         for _group_src, _group_dest, chain in _chains(self.groups_src):
             for transform in chain.transforms:
                 if isinstance(transform, Expand) and transform.seed is None:

--- a/konfai/data/geometry.py
+++ b/konfai/data/geometry.py
@@ -16,14 +16,12 @@
 
 """Grids, boxes and affine maps in world coordinates: the value vocabulary a resample shares.
 
-Two axis orders coexist in every KonfAI header, and the classic failure is a confusion between
-them: array data is ``(Z, Y, X)``, physical geometry (``Origin``,
-``Spacing``, ``Direction``) is ``(x, y, z)``. The types here carry the order in the field name (``size_zyx``,
-``origin_xyz``), so a mixed expression reads as wrong at the call site instead of
-resampling perfectly onto the wrong place.
+Two axis orders coexist in every KonfAI header: array data is ``(Z, Y, X)``, physical geometry
+(``Origin``, ``Spacing``, ``Direction``) is ``(x, y, z)``. The types here carry the order in the
+field name (``size_zyx``, ``origin_xyz``), so a mixed expression reads as wrong at the call site.
 
-Everything is plain float64 numpy: no torch, no SimpleITK. A value built here crosses the
-``mp.spawn`` pickle boundary as data, and the SimpleITK plumbing that produces it lives in
+Everything is plain float64 numpy: no torch, no SimpleITK, so a value built here crosses the
+``mp.spawn`` pickle boundary as data. The SimpleITK plumbing that produces it lives in
 ``konfai.utils.ITK`` behind its import guard.
 """
 
@@ -75,13 +73,10 @@ class AffineMap:
         return bool(np.array_equal(self.matrix, np.eye(self.rank)) and not self.translation.any())
 
     def apply(self, points_xyz: np.ndarray) -> np.ndarray:
-        """Map points of shape ``(..., rank)``, accumulating exactly as ITK does.
-
-        ``translation + Σ_j column_j · p_j`` with ``j`` ascending: the association of
-        ``TransformIndexToPhysicalPoint``. A matmul sums in whatever order BLAS picks, which is
-        one ULP away on an oblique grid, and one ULP of origin is the difference between a
-        streamed slab that is bit-identical to the whole volume and one that is merely close.
-        """
+        """Map points of shape ``(..., rank)``, accumulating exactly as ITK does:
+        ``translation + Σ_j column_j · p_j`` with ``j`` ascending, the association of
+        ``TransformIndexToPhysicalPoint``. A matmul sums in whatever order BLAS picks, one ULP away
+        on an oblique grid, and one ULP of origin costs a streamed slab its bit-identity."""
         points = np.asarray(points_xyz, dtype=np.float64)
         out = np.broadcast_to(self.translation, points.shape).copy()
         for j in range(self.rank):
@@ -93,11 +88,8 @@ class AffineMap:
         return AffineMap(outer.matrix @ self.matrix, outer.matrix @ self.translation + outer.translation)
 
     def inverted(self) -> AffineMap:
-        """The inverse map, or a refusal when the matrix is singular.
-
-        Refused rather than returned as garbage: a singular matrix here means a degenerate grid or
-        transform, and ``pinv`` would hand back a map that resamples plausibly from the wrong place.
-        """
+        """The inverse map, or a refusal when the matrix is singular: that means a degenerate grid
+        or transform, and ``pinv`` would hand back a map resampling plausibly from the wrong place."""
         try:
             inverse = np.linalg.inv(self.matrix)
         except np.linalg.LinAlgError:
@@ -121,25 +113,18 @@ class WorldBox:
         return WorldBox(self.low_xyz - radius, self.high_xyz + radius)
 
     def extended(self, low_xyz: np.ndarray, high_xyz: np.ndarray) -> WorldBox:
-        """This box plus a per-component interval: each end moved by its own end of it.
-
-        The asymmetric form of :meth:`grown`, and the one a signed displacement bound needs. An
-        interval that does not straddle zero MOVES the box instead of widening it, which is the
-        difference between a field's reach and twice its largest value.
-        """
+        """This box plus a per-component interval: each end moved by its own end of it. The
+        asymmetric form of :meth:`grown`, and the one a signed displacement bound needs. An interval
+        that does not straddle zero MOVES the box instead of widening it."""
         return WorldBox(
             self.low_xyz + np.asarray(low_xyz, dtype=np.float64),
             self.high_xyz + np.asarray(high_xyz, dtype=np.float64),
         )
 
     def image_under(self, affine: AffineMap) -> WorldBox:
-        """The axis-aligned hull of this box's image under ``affine``.
-
-        Centre and half-extents: the image of centre ``c`` is ``A c + b``, and the largest reach of
-        ``A h`` over the corners is ``|A| h`` because each corner coordinate is ``±h_k``. Equal to
-        the hull of the ``2^rank`` mapped corners (pinned by a test against that enumeration) in
-        O(rank²) and with no corner loop to get wrong.
-        """
+        """The axis-aligned hull of this box's image under ``affine``, from centre and half-extents:
+        the image of centre ``c`` is ``A c + b``, and the largest reach of ``A h`` over the corners is
+        ``|A| h``. Equal to the hull of the ``2^rank`` mapped corners, in O(rank²)."""
         centre = (self.low_xyz + self.high_xyz) / 2.0
         half = (self.high_xyz - self.low_xyz) / 2.0
         mapped = affine.apply(centre)
@@ -147,10 +132,9 @@ class WorldBox:
         return WorldBox(mapped - reach, mapped + reach)
 
 
-#: How close to a whole number a voxel count must be before it is taken to BE that number. A
-#: spacing of 0.7 mm is not representable in binary, so 90 voxels of it re-cut at 1.5 mm come to
-#: 41.999999999999997 and truncate to 41, one slice of anatomy dropped, and a spacing recorded
-#: that no longer covers what was read. The band is far narrower than any density a header states.
+#: How close to a whole number a voxel count must be before it is taken to BE that number. A spacing
+#: of 0.7 mm is not representable in binary, so 90 voxels of it re-cut at 1.5 mm come to
+#: 41.999999999999997 and would truncate to 41. The band is narrower than any density a header states.
 _COUNT_TOLERANCE = 1e-6
 
 
@@ -170,27 +154,17 @@ class Grid:
 
     @classmethod
     def identity(cls, spatial_shape: list[int]) -> Grid:
-        """The grid of a volume with no geometry: unit spacing, origin zero, axes as stored.
-
-        What a header carrying no ``Origin``/``Spacing``/``Direction`` means when the question is
-        only a change of extent. Under it a world coordinate IS an index, so a resample onto another
-        grid degenerates to the size ratio it always was, which is how one engine serves a case
-        whose geometry is known and one whose is not, instead of a physical path and a ratio path
-        that have to be kept agreeing.
-        """
+        """The grid of a volume with no geometry: unit spacing, origin zero, axes as stored, which is
+        what a header carrying no ``Origin``/``Spacing``/``Direction`` means. Under it a world
+        coordinate IS an index, so a resample onto another grid degenerates to the size ratio."""
         rank = len(spatial_shape)
         return cls(tuple(int(extent) for extent in spatial_shape), np.zeros(rank), np.ones(rank), np.eye(rank))
 
     @classmethod
     def from_header(cls, spatial_shape: list[int], attribute: Attribute, what: str) -> tuple[Grid, frozenset[str]]:
-        """The grid a header describes AND which of its keys it did not say, never a refusal.
-
-        The identity stands in for what is absent, and the caller is told what it stood in for: what
-        a missing key costs depends on the question. An extent change needs none of them; a density
-        change needs the ``Spacing`` and nothing else; a reference grid or a stored map needs a real
-        physical space and so needs all three. Deciding that here, once, for every caller would
-        either refuse a resample that was answerable or answer one that was not.
-        """
+        """The grid a header describes AND which of its keys it did not say, never a refusal. The
+        identity stands in for what is absent and the caller is told what it stood in for: an extent
+        change needs no key, a density change the ``Spacing`` alone, a reference grid all three."""
         rank = len(spatial_shape)
         identity = cls.identity(spatial_shape)
         missing = frozenset(key for key in _GEOMETRY_KEYS if key not in attribute)
@@ -242,12 +216,9 @@ class Grid:
 
     @cached_property
     def index_to_world(self) -> AffineMap:
-        """Continuous index ``(x, y, z)`` to world: ``p = O + D S i``: ITK's own association.
-
-        Cached (the grid is frozen): a streamed walk asks per SLAB, and rebuilding the product --
-        and, for :attr:`world_to_index`, re-INVERTING it -- thousands of times per region was
-        measurable wall time. The cache returns the same floats it always returned, only once.
-        """
+        """Continuous index ``(x, y, z)`` to world: ``p = O + D S i``, ITK's own association. Cached
+        (the grid is frozen): a streamed walk asks per SLAB, and rebuilding the product, and for
+        :attr:`world_to_index` re-INVERTING it, thousands of times per region was measurable."""
         return AffineMap(self.direction_xyz @ np.diag(self.spacing_xyz), np.asarray(self.origin_xyz, dtype=np.float64))
 
     @cached_property
@@ -256,12 +227,8 @@ class Grid:
 
     def _index_box(self, region_zyx: tuple[slice, ...] | None) -> tuple[np.ndarray, np.ndarray]:
         """The region's outer faces as continuous indices ``(x, y, z)``: ``start - 0.5 .. stop - 0.5``.
-
-        Outer faces and not voxel centres, deliberately: a sample is inside a grid while its
-        continuous index lies in ``[-0.5, n - 0.5)`` (the sampler rule of
-        ``Resample._resample_offset_region``), so a bound built on centres is short by the half
-        voxel that rule reaches.
-        """
+        Outer faces and not voxel centres: a sample is inside a grid while its continuous index lies
+        in ``[-0.5, n - 0.5)``, so a bound built on centres is short by that half voxel."""
         if region_zyx is None:
             region_zyx = tuple(slice(0, extent) for extent in self.size_zyx)
         low = np.array([float(part.start) - 0.5 for part in reversed(region_zyx)])
@@ -279,13 +246,9 @@ class Grid:
         return image.low_xyz, image.high_xyz
 
     def index_window(self, box: WorldBox, margin: int) -> tuple[slice, ...]:
-        """The clamped array-order window a world box needs, grown by ``margin`` whole voxels.
-
-        ``floor``/``ceil`` on the continuous-index box, plus the margin the interpolation taps
-        reach; clamped to a non-empty window, exactly as ``Resample._offset_window`` clamps: a region entirely
-        off the grid is a real place for a regrid (every sample takes the
-        fill) and a zero-width read is not something every backend serves.
-        """
+        """The clamped array-order window a world box needs, grown by ``margin`` whole voxels:
+        ``floor``/``ceil`` on the continuous-index box plus the margin the interpolation taps reach,
+        clamped to a non-empty window exactly as ``Resample._offset_window`` clamps."""
         low, high = self.continuous_box(box)
         window: list[slice] = []
         for axis in range(self.rank - 1, -1, -1):
@@ -305,20 +268,16 @@ class Grid:
         """The same anatomy at another sampling density: give a spacing, or give a count.
 
         A component left at zero keeps that axis as it is. Whichever is given, the other follows,
-        and ``align`` decides where the new grid SITS: the one real choice here, worth a quarter
-        of a voxel of anatomy, and made silently by every library that offers only one of them:
+        and ``align`` decides where the new grid SITS:
 
         - ``extent``: the outer faces coincide, so both grids cover exactly the same box and a
-          target index reads ``scale * (i + 0.5) - 0.5`` of the source. What ``F.interpolate`` does,
-          and what KonfAI has always done.
+          target index reads ``scale * (i + 0.5) - 0.5`` of the source. What ``F.interpolate`` does.
         - ``origin``: voxel zero's CENTRE stays put, so a target index reads ``scale * i`` and the
-          far edge moves by whatever the count rounded away. What resampling onto a grid that
-          shares an origin does.
+          far edge moves by whatever the count rounded away.
 
         Under ``extent`` the spacing is derived from the counts and not from the request: a count is
         a whole number, so the density that actually covers the box is ``n_src / n_dst`` times the
-        source's, and recording the requested one instead is a header that describes a grid nobody
-        sampled (up to a millimetre of drift across a volume, measured).
+        source's, and recording the requested one describes a grid nobody sampled.
         """
         if (spacing_xyz is None) == (size_zyx is None):
             raise TransformError("A resampled grid is defined by a spacing or by a count, and by exactly one of them.")
@@ -355,13 +314,9 @@ class Grid:
         )
 
     def sub_grid(self, region_zyx: tuple[slice, ...]) -> Grid:
-        """The grid of a region: same spacing and direction, the origin of its first voxel.
-
-        The load-bearing line of every streamed regrid: a region left at the volume's origin
-        replays the volume's first slab wherever it lands, and the output still looks like an
-        image. The origin is ``index_to_world`` of the region's start, one application of the
-        parent's own map, never a second association that could land a slab origin apart from it.
-        """
+        """The grid of a region: same spacing and direction, the origin of its first voxel. A region
+        left at the volume's origin replays the volume's first slab wherever it lands. The origin is
+        ``index_to_world`` of the region's start, one application of the parent's own map."""
         start_xyz = np.array([float(part.start) for part in reversed(region_zyx)])
         return Grid(
             tuple(int(part.stop - part.start) for part in region_zyx),
@@ -374,18 +329,16 @@ class Grid:
 # ---------------------------------------------------------------------------------- index remaps
 # A signed permutation of the axes is the one map that is an exact index remap: values only change
 # place, so an ORIENTATION stage's bijection promise (and everything preserves_statistics lets a
-# later stage trust) rests on the predicate below. It is written once, here, because two copies of
-# it (a draw's quarter turn, a header's reorientation) is exactly where a silent divergence starts.
+# later stage trust) rests on the predicate below. It is written once, here.
 
-#: Whether a matrix entry stands for exactly 0 or +/-1, by the matrix's provenance. Two tolerances,
-#: because the matrices come at two precisions: a draw's quarter-turn affine is composed from
-#: float32 cosines, so an entry lands within ~1e-7 of the value it stands for; a header
-#: reorientation is a float64 product of orthonormal matrices and lands within a few double ulps.
+#: Whether a matrix entry stands for exactly 0 or +/-1, by the matrix's provenance. Two tolerances:
+#: a draw's quarter-turn affine is composed from float32 cosines and lands within ~1e-7 of the value
+#: it stands for; a header reorientation is a float64 product and lands within a few double ulps.
 #: One shared 1e-6 would remap a float64 direction whose obliqueness is real, not rounding.
 SIGNED_PERMUTATION_ATOL_FLOAT32 = 1e-6
 SIGNED_PERMUTATION_ATOL_FLOAT64 = 1e-9
 
-#: Per output SPATIAL axis in array order: ``(source_axis, mirrored)`` — which source axis it reads,
+#: Per output SPATIAL axis in array order: ``(source_axis, mirrored)``, which source axis it reads
 #: and whether it reads it backwards.
 AxisRemap = list[tuple[int, bool]]
 
@@ -395,10 +348,8 @@ def signed_permutation(matrix: object, atol: float) -> AxisRemap | None:
 
     ``matrix`` maps an output coordinate onto the input it comes from, in physical ``(x, y, z)``
     order: it is a signed permutation exactly when every column holds a single +/-1 and every row
-    carries unit weight. The three tests together admit exactly those: unit column sums alone also
-    pass an axis-averaging matrix, unit peaks alone a superposing one, and columns alone a
-    rank-deficient one that reads the same axis twice. The answer is in array order, where physical
-    axis ``k`` is array axis ``n - 1 - k``.
+    carries unit weight, which is what the three tests together admit. The answer is in array order,
+    where physical axis ``k`` is array axis ``n - 1 - k``.
     """
     linear = np.asarray(matrix, dtype=np.float64)
     n = int(linear.shape[0])
@@ -426,12 +377,9 @@ def remap_shape(shape: list[int], remap: AxisRemap) -> list[int]:
 
 
 def remap_region(target_slices: tuple[slice, ...], source_shape: list[int], remap: AxisRemap) -> list[slice]:
-    """The source region a target region reads under a remap.
-
-    Output axis ``k``'s slice lands on the source axis it reads; a MIRRORED axis reads the mirror
-    region ``[n - stop, n - start)`` of it, because a flip restricted to a contiguous region is that
-    region reversed. The remap covers every axis exactly once, so every source axis is assigned.
-    """
+    """The source region a target region reads under a remap. Output axis ``k``'s slice lands on the
+    source axis it reads; a MIRRORED axis reads the mirror region ``[n - stop, n - start)`` of it.
+    The remap covers every axis exactly once, so every source axis is assigned."""
     source_slices: list[slice] = [slice(0, int(extent)) for extent in source_shape]
     for target, (source, mirrored) in zip(target_slices, remap, strict=True):
         extent = int(source_shape[source])
@@ -451,12 +399,9 @@ def invert_remap(remap: AxisRemap) -> AxisRemap:
 
 
 def apply_remap(tensor: torch.Tensor, remap: AxisRemap) -> torch.Tensor:
-    """The remap, materialised on a tensor whose trailing axes are the spatial ones.
-
-    Leading axes (channel, and anything before it) are left in place. ``flip`` materialises the
-    permuted view even for an empty mirror list, so the result never aliases the tensor it was
-    read from: a remapped copy may be handed on while the source tensor lives its own life.
-    """
+    """The remap, materialised on a tensor whose trailing axes are the spatial ones. Leading axes are
+    left in place. ``flip`` materialises the permuted view even for an empty mirror list, so the
+    result never aliases the tensor it was read from."""
     offset = tensor.dim() - len(remap)
     dims = list(range(offset)) + [offset + source for source, _ in remap]
     flips = [offset + axis for axis, (_, mirrored) in enumerate(remap) if mirrored]
@@ -469,18 +414,13 @@ class TransformBound:
 
     ``T(p)`` lies in ``affine(p) + [low_xyz, high_xyz]`` for every ``p``, per world component. For a
     linear transform the interval is empty and the statement is exact; for a BSpline it is the range
-    of the coefficients (non-negative basis functions summing to one make every displacement a
-    convex combination of them, so it lies between their smallest and largest); for a dense field it
-    is the range of its values. The affine part is read structurally off the transform, never
-    probed: a probe measures a local gradient and extrapolates it, which under-bounds (measured).
+    of the coefficients; for a dense field the range of its values. The affine part is read
+    structurally off the transform, never probed: a probe under-bounds.
 
     SIGNED, NOT A RADIUS. A displacement field solved between two frames carries the offset between
     them in its values, and an interval that does not straddle zero MOVES a region's window rather
-    than widening it. Measured on an ExaSPIM field whose z component runs [-28.1, -22.2] mm on a
-    volume 20.6 mm thick: as a radius it reaches 28.1 mm either way, so every region pulls the whole
-    volume and the fold refuses (23.57 GiB held against a 19.01 GiB budget); as an interval it
-    reaches 5.9 mm, and a 24-row region pulls 175 source rows of 514. The same two reductions
-    produce either (:attr:`DisplacementStage.range_xyz`), so the tighter one is free.
+    than widening it. The same two reductions produce either
+    (:attr:`DisplacementStage.range_xyz`), so the tighter one is free.
     """
 
     affine: AffineMap
@@ -499,11 +439,9 @@ class TransformBound:
 
     @staticmethod
     def shift(residual_xyz: np.ndarray) -> TransformBound:
-        """A pure displacement bounded in magnitude only, ``± residual_xyz``.
-
-        For a caller that knows a radius and not a range. Anything that can state both ends should
-        say so with :meth:`interval`: this one is twice as wide wherever the range is one-sided.
-        """
+        """A pure displacement bounded in magnitude only, ``± residual_xyz``, for a caller that knows
+        a radius and not a range. Anything that can state both ends should say so with
+        :meth:`interval`: this one is twice as wide wherever the range is one-sided."""
         radius = np.asarray(residual_xyz, dtype=np.float64)
         return TransformBound.interval(-radius, radius)
 
@@ -513,15 +451,11 @@ class TransformBound:
         return np.maximum(np.abs(self.low_xyz), np.abs(self.high_xyz))
 
     def after(self, inner: TransformBound) -> TransformBound:
-        """The bound of ``self(inner(p))``: interval arithmetic through the outer affine.
-
-        NOT ``|A| @ residual``. That is right for an interval centred on zero and wrong for one that
-        is not: a negative entry of ``A`` sends the inner interval's low end to the outer's high,
-        and taking absolute values first loses which end went where -- so a rotation folded onto a
-        one-sided field would be bounded by a box that does not contain it. Splitting the matrix
-        into its non-negative and non-positive parts is the same arithmetic written to hold either
-        way, and it reduces to ``|A| @ r`` when ``low = -high``.
-        """
+        """The bound of ``self(inner(p))``: interval arithmetic through the outer affine. NOT
+        ``|A| @ residual``, which is right only for an interval centred on zero: a negative entry of
+        ``A`` sends the inner interval's low end to the outer's high. Splitting the matrix into its
+        non-negative and non-positive parts holds either way and reduces to ``|A| @ r`` when
+        ``low = -high``."""
         matrix = self.affine.matrix
         rise, fall = np.maximum(matrix, 0.0), np.minimum(matrix, 0.0)
         return TransformBound(
@@ -546,9 +480,8 @@ class AffineStage:
 
 
 #: The B-spline orders KonfAI evaluates: the linear hat a dense field is read through, and the cubic
-#: ITK writes a BSplineTransform with. ITK will happily write orders 0 and 2, which decode as
-#: readily as any other and have no kernel here, so the refusal belongs where the value is built,
-#: not where it is finally sampled, which is mid-run and per region.
+#: ITK writes a BSplineTransform with. ITK also writes orders 0 and 2, which have no kernel here, so
+#: the refusal belongs where the value is built, not mid-run and per region where it is sampled.
 SUPPORTED_SPLINE_ORDERS = (1, 3)
 
 
@@ -556,25 +489,20 @@ SUPPORTED_SPLINE_ORDERS = (1, 3)
 class DisplacementStage:
     """One displacement step: ``p + d(p)``, with ``d`` interpolated off a value grid.
 
-    One shape for the two non-linear things a stored transform can be. A BSpline is order-3
-    coefficients on a coarse control grid; a dense field is order-1 samples on its own grid. Both
-    kernels are non-negative and sum to one, so the displacement anywhere is a convex combination
-    of ``values`` and ``sup |values|`` per component bounds it at every point: the bound that
-    replaces walking a region's boundary, which under-bounds a wiggle narrower than the region
-    and costs more than the resample it serves (both measured).
+    One shape for the two non-linear things a stored transform can be: a BSpline is order-3
+    coefficients on a coarse control grid, a dense field order-1 samples on its own grid. Both
+    kernels are non-negative and sum to one, so ``sup |values|`` per component bounds the
+    displacement at every point, which is what replaces walking a region's boundary.
 
     ``values`` is ``(rank, Z, Y, X)`` float64, components in physical ``(x, y, z)`` order, world
-    units. ITK applies no direction matrix to them (verified in ``itkBSplineTransform.hxx``).
-    Outside the grid's reach the displacement is zero: ITK returns the identity there.
+    units. ITK applies no direction matrix to them. Outside the grid's reach the displacement is zero.
     """
 
     grid: Grid
     values: np.ndarray
     order: int
-    #: The values as a tensor, per (device, dtype), built on first use and living exactly as long
-    #: as the stage does: a stage is evaluated once per region per case, and re-uploading a whole
-    #: field for each was the copy the arithmetic never saw. Frozen dataclass, so a mutable field
-    #: hides behind object.__setattr__ once; it is excluded from equality and pickling by name.
+    #: The values as a tensor, per (device, dtype), built on first use and living exactly as long as
+    #: the stage does. Excluded from equality, hashing and pickling.
     _tensors: dict = field(default_factory=dict, init=False, repr=False, compare=False, hash=False)
 
     def __post_init__(self) -> None:
@@ -616,17 +544,10 @@ class DisplacementStage:
     def range_xyz(self) -> tuple[np.ndarray, np.ndarray]:
         """``(min, max)`` per component: one pass over the field, kept for the stage's life.
 
-        Every pull map asks for it (per patch, per plan block, per pushed slab), so it is kept:
-        a thousand patches recomputing one constant 3-vector cost 73 s on a 3x160x256x256 field.
+        Every pull map asks for it (per patch, per plan block, per pushed slab), so it is kept.
         ``cached_property`` writes through ``__dict__``, which a frozen dataclass allows; the entry
-        is dropped from the pickle beside ``_tensors``.
-
-        Two reductions and no temporary, which is what the pair costs and what its magnitude cost
-        before it: ``np.abs(...).max()`` would first write a values-sized copy and then walk it
-        again. On the 31 M-voxel field that copy is 72 ms and 250 MiB; on a native ExaSPIM field
-        window (3 x 141 x 1331 x 1775) it is 4 GiB, and the fold spent 26.4 s of its 179 s here.
-        Keeping both ends instead of the larger magnitude measured 79 ms against 80 on a 184
-        M-value window: the range is free, and it is the one a region can be sized from.
+        is dropped from the pickle beside ``_tensors``. Two reductions and no temporary:
+        ``np.abs(...).max()`` would first write a values-sized copy and then walk it again.
         """
         flat = self.values.reshape(self.values.shape[0], -1)
         return flat.min(axis=1), flat.max(axis=1)
@@ -638,8 +559,8 @@ class DisplacementStage:
         return np.maximum(np.abs(low), np.abs(high))
 
     def bound(self) -> TransformBound:
-        # The interval is clamped to include zero: the stage applies NO displacement outside its
-        # grid, so a target region past the field's edge still needs its identity-mapped samples.
+        # Clamped to include zero: the stage applies NO displacement outside its grid, so a target
+        # region past the field's edge still needs its identity-mapped samples.
         low, high = self.range_xyz
         return TransformBound.interval(np.minimum(low, 0.0), np.maximum(high, 0.0))
 

--- a/konfai/data/materialize.py
+++ b/konfai/data/materialize.py
@@ -16,15 +16,10 @@
 
 """The TRANSFORM materialization engine: writes one case's chain over the manager's plan/replay API.
 
-A :class:`~konfai.data.patching.DatasetManager` plans and replays a case's chain (the patch and
-region reads training, prediction and evaluation share). :class:`CaseMaterializer` is the write
-side of that same machinery for the dataset-preparation workflow: it drives one case's ``Save``
-outputs to disk by the cheapest route the plan allows (the streamed slab sweep, the whole-volume
-load, or one shared read pass across the copies of an ``Expand``), prices those routes for the plan
-(peak bytes, working set, predicted source re-reads), and answers why a copy sweeps alone. It
-holds no read state of its own: the rewrite flag, the swept-entry ledger and the sweep-failure
-reason live on the manager, because a streamed read of a pending ``Save`` sweeps it there too
-(``DatasetManager._stream_ready``), training included.
+:class:`CaseMaterializer` drives one case's ``Save`` outputs to disk by the cheapest route the plan
+allows (the streamed slab sweep, the whole-volume load, or one shared read pass across the copies of
+an ``Expand``) and prices those routes for the plan. It holds no read state of its own: the rewrite
+flag, the swept-entry ledger and the sweep-failure reason live on the manager.
 """
 
 import contextlib
@@ -86,12 +81,9 @@ class CopyRoute:
 
 
 class CaseMaterializer:
-    """Write one case's chain to disk over its manager's plan/replay API, and price the routes.
-
-    Built per case (a :class:`~konfai.data.patching.DatasetManager`) and kept for the run: the
-    peak-bytes fold is memoized here, so the plan, the shards and the run all read the same figure
-    without re-folding the chain.
-    """
+    """Write one case's chain to disk over its manager's plan/replay API, and price the routes. Built
+    per case and kept for the run: the peak-bytes fold is memoized here, so the plan, the shards and
+    the run read the same figure."""
 
     def __init__(self, manager: DatasetManager) -> None:
         self.manager = manager
@@ -105,9 +97,7 @@ class CaseMaterializer:
     ) -> Iterator[None]:
         """What every materialization sets up on the manager: the rewrite mode, the budget its
         sweeps size their slabs against, and the device the chain runs on for this call (opt-in,
-        and only here: this same machinery loads training cases inside DataLoader workers, where a
-        CUDA default would be wrong; the transformer's rank is the one caller that knows its
-        device)."""
+        and only here: the transformer's rank is the one caller that knows its device)."""
         self.manager._set_rewrite(rewrite)
         self.manager.set_memory_budget(fallback_budget_bytes)
         with self.manager._chain_device_scope(device):
@@ -124,12 +114,10 @@ class CaseMaterializer:
     ) -> Verdict:
         """Write this case's chain to disk by the cheapest path that can, and say which it took.
 
-        The streamed path sweeps every unsatisfied :class:`Save` slab by slab; when the plan refuses
-        (a WHOLE_VOLUME stage, a destination without region writes, a failed sweep) the whole-volume
-        load writes the same caches, same bytes, more memory. ``allow_fallback=False`` raises instead
-        of loading; ``prefer_whole`` is the plan's LOAD choice (no fallback, no refusal);
-        ``rewrite=True`` recomputes the case and renames over the old entries (``--overwrite``). A
-        chain whose caches all exist writes nothing (the per-case resume).
+        The streamed path sweeps every unsatisfied :class:`Save` slab by slab, the whole-volume load
+        writes the same caches with more memory. ``allow_fallback=False`` raises instead of loading;
+        ``prefer_whole`` is the plan's LOAD choice; ``rewrite=True`` recomputes the case and renames
+        over the old entries (``--overwrite``). A chain whose caches all exist writes nothing.
         """
         with self._materialization(rewrite, fallback_budget_bytes, device):
             verdict = self._write_case(a, fallback_budget_bytes, allow_fallback, prefer_whole)
@@ -141,8 +129,7 @@ class CaseMaterializer:
     ) -> Verdict:
         """One case or copy, inside a materialization: streamed if it can, else the whole volume."""
         manager = self.manager
-        # A chain with an Expand materializes a COPY, whose draw must be part of the plan; without
-        # one it materializes the case itself, and augmentations have nothing to do with writing.
+        # With an Expand this materializes a COPY, whose draw must be part of the plan.
         apply_augmentations = manager._expand is not None and a > 0
         if not prefer_whole:
             if manager._stream_ready(a, apply_augmentations=apply_augmentations):
@@ -155,8 +142,7 @@ class CaseMaterializer:
                     or "the chain cannot stream.",
                     "Nothing was written for this case; the caller forbids the whole-volume fallback.",
                 )
-        # The plan's promise holds at run time too: a case that fell back here (a refusal the probe
-        # could not see) must not assemble a volume the budget cannot hold.
+        # A case that fell back here must not assemble a volume the budget cannot hold.
         self._enforce_fallback_budget(fallback_budget_bytes)
         self._assemble_and_write(a)
         return Verdict.LOAD if prefer_whole else Verdict.WHOLE_VOLUME
@@ -174,13 +160,9 @@ class CaseMaterializer:
             )
 
     def _assemble_and_write(self, a: int) -> None:
-        """The whole-volume fallback: assemble and write every Save. The caller releases.
-
-        Without an :class:`Expand` this is the classic load of the full chain. With one, the shared
-        part is assembled once (``load`` keeps it, so the copies of one case reuse the same tensor
-        across calls) and only the copy's draw and the per-copy stages run per copy, writing their
-        Saves under the copy's name.
-        """
+        """The whole-volume fallback: assemble and write every Save. The caller releases. With an
+        :class:`Expand`, the shared part is assembled once and only the copy's draw and the per-copy
+        stages run per copy, writing their Saves under the copy's name."""
         with _stage_failures_explained():
             self._assemble_and_write_chain(a)
 
@@ -202,14 +184,10 @@ class CaseMaterializer:
         allow_fallback: bool = True,
         device: "torch.device | None" = None,
     ) -> dict[int, tuple[Verdict, Regime | None]]:
-        """Write the :class:`Expand` copies of this case; returns what each took, as the plan lines
-        it: the verdict and, for a streamed copy, whether it rode the shared pass or its own.
-
-        Copies whose per-copy stages are all pointwise share ONE read pass (each slab is read and
-        carried through the shared prefix once, then every copy applies its draw into its own
-        stream); a copy whose draw reads regions sweeps its own pass; a copy that cannot stream falls
-        back to the whole volume, whose shared part is assembled once for all such copies.
-        """
+        """Write the :class:`Expand` copies of this case; returns what each took: the verdict and,
+        for a streamed copy, whether it rode the shared pass or its own. Copies whose per-copy stages
+        are all pointwise share ONE read pass; a copy whose draw reads regions sweeps its own; a copy
+        that cannot stream falls back to the whole volume."""
         manager = self.manager
         if manager._expand is None:
             raise PatchError(
@@ -222,8 +200,7 @@ class CaseMaterializer:
             if not copies:
                 return outcomes
             # The caches the copies share (pre-Expand Saves) are swept once, first: every copy's
-            # plan reads through them, and sweeping them inside each copy's own pass would redo
-            # the work.
+            # plan reads through them.
             first = manager._resolve_patch_stream_source(copies[0], apply_augmentations=True)
             if first is not None:
                 manager._sweep_pending([sweep for sweep in first.pending_sweeps if sweep.entry == manager.name])
@@ -260,14 +237,10 @@ class CaseMaterializer:
             return outcomes
 
     def classify_copies(self, copies: Iterable[int]) -> dict[int, CopyRoute]:
-        """How each copy streams, decided once for the run and the plan alike.
-
-        A copy joins the shared read pass when its per-copy segment is one Save whose stages are all
-        pointwise (its pull is exactly the slab the shared prefix landed on); it sweeps alone when a
-        per-copy stage reads regions, when it crosses several per-copy Saves, or when a cache the
-        copies share is still to write; and a shared pass with one member is that copy's own sweep.
-        A copy the planner refuses has no regime.
-        """
+        """How each copy streams, decided once for the run and the plan alike. A copy joins the
+        shared read pass when its per-copy segment is one Save whose stages are all pointwise; it
+        sweeps alone when a per-copy stage reads regions, when it crosses several per-copy Saves, or
+        when a cache the copies share is still to write. A copy the planner refuses has no regime."""
         manager = self.manager
         routes: dict[int, CopyRoute] = {}
         for a in copies:
@@ -294,8 +267,7 @@ class CaseMaterializer:
     @staticmethod
     def _pointwise_tail(plans: Sequence[_ReadStagePlan]) -> bool:
         """Whether a copy's per-copy stages are pure value maps on their slab: a pointwise tail pulls
-        exactly the slab the shared prefix landed on, so every such copy can consume one read; a
-        region draw pulls its own geometry and a GLOBAL_STAT reads a statistic of ITS input."""
+        exactly the slab the shared prefix landed on, so every such copy can consume one read."""
         return all(plan.kind is LocalityKind.POINTWISE for plan in plans)
 
     @staticmethod
@@ -313,16 +285,13 @@ class CaseMaterializer:
         return "the copy's plan is incomplete; it sweeps its own pass."
 
     def _materialize_shared_pass(self, shared: list[tuple[int, _PendingSweep]]) -> set[int]:
-        """One read pass, N write streams: each slab is read and computed through the shared prefix
-        once, each copy applies its pointwise tail to a clone and writes into its own stream (peak:
-        the pulled slab plus one block). On failure every stream is aborted and the copies take
-        their own passes; returns the copies written.
-        """
+        """One read pass, N write streams: each slab is computed through the shared prefix once, and
+        each copy applies its pointwise tail to a clone and writes into its own stream. On failure
+        the copies take their own passes; returns the copies written."""
         manager = self.manager
         reference = shared[0][1]
-        # Defensive: the regime only holds when every copy lands the same grid from the same source
-        # and writes into the same store. Built that way, but a draw that lies about its shape map
-        # would corrupt N entries at once here, so the mismatch is checked rather than assumed.
+        # The regime only holds when every copy lands the same grid from the same source and writes
+        # into the same store; the mismatch is checked rather than assumed.
         shared = [
             (a, sweep)
             for a, sweep in shared
@@ -334,8 +303,7 @@ class CaseMaterializer:
         ]
         if not shared:
             return set()
-        # The shared prefix is planned once, and replayed once per slab; each copy's header is its
-        # OWN full-segment plan state, since the tail's geometry and inversion keys are the copy's.
+        # The shared prefix is planned once and replayed per slab; each copy's header is its own.
         source, prefix_evolved, _refusal = manager._replan_sweep(
             reference, list(reference.stages[: reference.copy_stage_start])
         )
@@ -348,8 +316,7 @@ class CaseMaterializer:
                 continue
             tail_plans = planned.stage_plans[sweep.copy_stage_start :]
             # Re-planned against the materialized source, so re-checked here: the shared block is a
-            # tail stage's region only while every one of them is pointwise. A copy left out takes
-            # its own pass, where its tail reads its own geometry.
+            # tail stage's region only while every one of them is pointwise.
             if self._pointwise_tail(tail_plans):
                 members.append(_SweepMember(a, sweep, evolved, sweep.tail_stages, tail_plans))
         if not members:
@@ -366,12 +333,9 @@ class CaseMaterializer:
     # ---------------------------------------------------------------- what the plan asks
 
     def write_targets(self, a: int = 0) -> list[tuple[Save, list[int], Attribute]]:
-        """Every ``Save`` copy ``a`` writes, with the extent and case state it lands at.
-
-        What a write probe must open to be the run's own verdict: behind an ``Expand`` the stages
-        after the marker fold the COPY's grid, so probing the chain with the marker left in it
-        would validate the pre-draw extent and call a destination good for a shape it never sees.
-        """
+        """Every ``Save`` copy ``a`` writes, with the extent and case state it lands at: what a write
+        probe must open to be the run's own verdict. Behind an ``Expand`` the stages after the marker
+        fold the COPY's grid."""
         manager = self.manager
         spatial = [int(extent) for extent in manager.base_shape[1:]]
         attributes = Attribute(manager.cache_attributes_bak[0])
@@ -384,9 +348,8 @@ class CaseMaterializer:
 
     def sub_cap_sweep(self) -> bool:
         """Whether this case's landing is swept in more than one block AND a stage of its chain can
-        show it in the values: a resample whose map does not factorise, or a draw that samples
-        through an affine (a free rotation, a scale). Pointwise and separable chains land the same
-        bytes whatever the decomposition."""
+        show it in the values: a resample whose map does not factorise, or a draw sampling through
+        an affine. Pointwise and separable chains land the same bytes whatever the decomposition."""
         manager = self.manager
         if not any(
             extent < segment.landing[axis]
@@ -406,9 +369,8 @@ class CaseMaterializer:
 
     def plan_notes(self, group_dest: str) -> list[str]:
         """The notes the chain's transforms ask the plan to print (``Transform.plan_note``), each
-        stage asked about ITS OWN input: the case state folded through the stages before it, as
-        the streamed planner folds it. Only as far as a ``Reduce``: past it the grid is the
-        cohort's, and what the reduction writes is its own plan line."""
+        stage asked about ITS OWN input. Only as far as a ``Reduce``: past it the grid is the
+        cohort's."""
         manager = self.manager
         shape = [int(extent) for extent in manager.base_shape[1:]]
         attributes = Attribute(manager.stored_attributes)
@@ -426,18 +388,14 @@ class CaseMaterializer:
 
     def peak_case_bytes(self) -> int:
         """The largest single tensor the whole-volume path holds: the chain's shapes folded through
-        each stage's own map (a pad or an upsample holds its largest intermediate), at
-        ``CASE_ELEMENT_BYTES`` per element. Headers only, so a floor for a stage that widens the
-        dtype beyond what it declares."""
+        each stage's own map, at ``CASE_ELEMENT_BYTES`` per element. Headers only."""
         if self._peak_case_bytes is None:
             manager = self.manager
             channels = int(manager.base_shape[0])
             peak = int(np.prod(manager.base_shape, dtype=np.int64))
 
             # Copy 0 carries no draw, copy 1 carries them all, and a draw widens the grid as readily
-            # as a transform does (the augmentation Mask pads to the mask's own extent), so both
-            # walks run from the stored state and the peak is the largest either one holds. Copy 1
-            # exists only where the chain has copies at all.
+            # as a transform does, so the peak is the largest either walk holds.
             copies = [0]
             if manager._expand is not None or any(group.nb for group in manager.data_augmentations_list):
                 copies.append(1)
@@ -457,9 +415,8 @@ class CaseMaterializer:
 
     def reads_its_source_whole(self, a: int = 0, apply_augmentations: bool = False) -> bool | None:
         """Whether a sweep of this case would decode its stored source whole for every region: the
-        store serves no bounded region read (a gzipped NIfTI). ``None`` when the chain cannot
-        stream. A Save cache the run has still to write lands on a region-write store, and every
-        one of those serves bounded reads, so it never counts."""
+        store serves no bounded region read (a gzipped NIfTI). ``None`` when the chain cannot stream;
+        a Save cache still to write lands on a store serving bounded reads, so it never counts."""
         segments = self.manager.sweep_segments(a, apply_augmentations)
         if segments is None:
             return None

--- a/konfai/data/materialize.py
+++ b/konfai/data/materialize.py
@@ -115,7 +115,8 @@ class CaseMaterializer:
         """Write this case's chain to disk by the cheapest path that can, and say which it took.
 
         The streamed path sweeps every unsatisfied :class:`Save` slab by slab, the whole-volume load
-        writes the same caches with more memory. ``allow_fallback=False`` raises instead of loading;
+        writes the same caches with more memory. ``allow_fallback=False`` raises instead of
+        loading when streaming is unavailable, but a planned ``prefer_whole`` route still loads;
         ``prefer_whole`` is the plan's LOAD choice; ``rewrite=True`` recomputes the case and renames
         over the old entries (``--overwrite``). A chain whose caches all exist writes nothing.
         """

--- a/konfai/data/patching/accumulate.py
+++ b/konfai/data/patching/accumulate.py
@@ -38,17 +38,13 @@ class Accumulator:
         batch: bool = True,
         sweep_axis: int = 0,
     ) -> None:
-        # Which spatial axis the window slides along. The patch grid is emitted with this axis
-        # outermost, so a patch's arrival finalizes everything behind it on that axis and nothing
-        # else. 0 is what get_patch_slices_from_shape produces today.
+        # Which spatial axis the window slides along: the patch grid is emitted with this axis outermost.
         self.sweep_axis = sweep_axis
         self.patch_slices: list[tuple[slice, ...]] = []
         self.shape = max([[v.stop for v in patch] for patch in patch_slices])
 
         if patch_size is not None and not all(p == 0 for p in patch_size):
-            # The last patch of an axis is padded up to the patch size for the model, then cropped; a
-            # free axis (0) spans the full extent, so concretise it here or ``s.start + 0`` would
-            # collapse the axis to a zero-width slice.
+            # A free axis (0) spans the full extent: concretise it, or ``s.start + 0`` is a zero-width slice.
             concrete = [size if size > 0 else self.shape[dim] for dim, size in enumerate(patch_size)]
             for patch in patch_slices:
                 slices = [slice(s.start, s.start + concrete[dim]) for dim, s in enumerate(patch)]
@@ -62,33 +58,23 @@ class Accumulator:
         self._count = len(patch_slices)
         self._filled = 0
         self._done = [False] * self._count
-        # Patches are blended into this running buffer as they arrive (see add_layer), instead of
-        # being kept until assembly: holding every patch of a large multi-class case (e.g. ~70 patches
-        # of a 122-channel whole-body segmentation ≈ tens of GB) was the dominant reassembly RAM cost.
+        # Patches are blended into this running buffer as they arrive (add_layer), never kept.
         self._result: torch.Tensor | None = None
         self._weighted: torch.Tensor | None = None
-        # Blend-weight geometry: fixed for the accumulator's life, so it survives _reset. The grid,
-        # the shares and the kept spans are all per (axis, start): sum(n_d) entries for a grid of
-        # prod(n_d) patches, and one dict lookup per patch and axis to find them.
+        # Blend-weight geometry, fixed for the accumulator's life (it survives _reset), per (axis, start).
         self._geometry: tuple[list[list[torch.Tensor]], list[torch.Tensor]] | None = None
         self._grid: list[dict[int, int]] | None = None
         self._shares: dict[tuple[int, int, int, torch.dtype, torch.device], torch.Tensor | None] = {}
         self._kept: dict[tuple[int, int], slice] = {}
 
     def add_layer(self, index: int, layer: torch.Tensor) -> list[tuple[slice, torch.Tensor]]:
-        """Blend one patch in; returns the slabs this completes (none for the whole-volume base)."""
-        # Blend each patch straight into the running accumulator and drop the patch, rather than
-        # storing all patches for a single assemble() at the end. The overlap blend is a weighted sum,
-        # so accumulating incrementally is equivalent; re-adding an index is a no-op (last-write wins is
-        # not possible once blended, and the prediction pipeline adds each patch exactly once).
+        """Blend one patch in; returns the slabs this completes (none for the whole-volume base).
+        Re-adding an index is a no-op."""
         if self._done[index]:
             return []
         if self._result is None:
-            # Allocate to the ACTUAL volume extent (self.shape), not the patch-size-extended grid. The
-            # last patch of each axis is padded up to patch_size for the model, but that padded tail lies
-            # OUTSIDE the volume; blending it would over-allocate the accumulator by up to
-            # (patch_size - overlap) per axis (then get cropped away). We crop each patch to its in-volume
-            # part at blend time instead, so nothing outside the volume is ever allocated.
+            # Allocated to the ACTUAL volume extent (self.shape): each patch is cropped to its in-volume
+            # part at blend time.
             n = self._n
             self._result = torch.zeros(list(layer.shape[:n]) + list(self.shape), dtype=layer.dtype, device=layer.device)
         self._blend(layer, self.patch_slices[index])
@@ -104,9 +90,7 @@ class Accumulator:
         for dim, s in enumerate(patch_slice):
             if s.stop - s.start == 1:
                 data = data.unsqueeze(dim=dim + n)
-        # Clamp each spatial destination to the volume and crop the patch to it, BEFORE weighting: the
-        # padded tail of a border patch lies outside the volume, so it has no share of the blend weight
-        # to compute and every index in _weighted_patch stays in range.
+        # Clamp each spatial destination to the volume and crop the patch to it, BEFORE weighting.
         dest = [slice(s.start, min(s.stop, self.shape[dim])) for dim, s in enumerate(patch_slice)]
         data = data[tuple([slice(None)] * n + [slice(0, d.stop - d.start) for d in dest])]
         sweep = self.sweep_axis
@@ -117,13 +101,9 @@ class Accumulator:
         if self.patch_combine is None:
             result[slices_dest] = data
         elif self.patch_combine.selects:
-            # The kept regions partition the volume: nothing to weight, nothing to sum. Writing the box
-            # this patch owns IS the operation, and it is what carries a discrete output through,
-            # where a weighting would invent values between its classes.
-            # Cut to the patch's in-volume part like the data above: the last patch of an axis is
-            # padded past the volume, and its kept run may end in that padding. The whole-volume
-            # buffer clipped that implicitly; the streaming window, wider than the volume's tail,
-            # does not, and wrote a [1, 4] destination from a [3] source.
+            # The kept regions partition the volume: the box this patch owns is written, not summed.
+            # Cut to the patch's in-volume part like the data above: the kept run of the last patch
+            # of an axis may end in its padding.
             box = [
                 slice(min(b.start, d.stop - d.start), min(b.stop, d.stop - d.start))
                 for d, b in zip(dest, self._kept_box(patch_slice), strict=True)
@@ -134,12 +114,8 @@ class Accumulator:
             result[slices_dest] += self._weighted_patch(data, patch_slice)
 
     def _kept_box(self, patch_slice: tuple[slice, ...]) -> tuple[slice, ...]:
-        """The sub-box a selection keeps of this patch: the run of ones in its window, per axis.
-
-        Pure geometry, so it is read once from the host-side windows and cached per grid position
-        along each axis. Deriving it from the share instead would read a device tensor: a host sync
-        on every patch, which costs more than the weighting it replaces.
-        """
+        """The sub-box a selection keeps of this patch: the run of ones in its window, per axis, read
+        from the host-side windows and cached per grid position."""
         return tuple(self._kept_span(dim, s.start) for dim, s in enumerate(patch_slice))
 
     def _kept_span(self, dim: int, start: int) -> slice:
@@ -153,16 +129,11 @@ class Accumulator:
     def _weight_geometry(self) -> tuple[list[list[torch.Tensor]], list[torch.Tensor]]:
         """Per axis: the blend window, and its sum over the patch grid.
 
-        The outer product of those sums is the total weight covering each voxel. It factorises because
-        the patch grid is a full per-axis product and the window is itself separable
-        (``sum_p prod_d w_d == prod_d sum_k w_d``), so the total is one vector per axis and never exists
-        as a volume, on a 320-row window of a 1331x1775 volume, 13 KB instead of 2.8 GB.
-
-        The patch extent comes from the slices, not from the window: a free axis carries a single
-        broadcast entry (the ModelPatch blend-window contract) that must cover the whole extent.
-
-        The window is asked for per grid position, because a selection opens its border patches to the
-        volume edge (see Trim); a weighting returns the same window everywhere.
+        The outer product of those sums is the total weight covering each voxel
+        (``sum_p prod_d w_d == prod_d sum_k w_d``), so the total is one vector per axis. The patch
+        extent comes from the slices, not from the window: a free axis carries a single broadcast
+        entry that must cover the whole extent. The window is asked for per grid position: a
+        selection opens its border patches to the volume edge (Trim).
         """
         if self._geometry is None:
             combine = cast(PathCombine, self.patch_combine)
@@ -184,11 +155,7 @@ class Accumulator:
 
     def _positions(self) -> list[dict[int, int]]:
         """Per axis, the patch grid's starts in order, each mapped to its position along the axis.
-
-        One pass over the slices for the accumulator's life. Rebuilding the sorted starts per patch
-        made every lookup O(P): 0.07 ms per patch at P = 1331 and 15.6 s over a case of 18,000
-        thin 2.5D patches, against 16 ms for that case here.
-        """
+        One pass over the slices for the accumulator's life."""
         if self._grid is None:
             self._grid = [
                 {
@@ -205,10 +172,8 @@ class Accumulator:
     def _share(self, dim: int, start: int, data: torch.Tensor) -> torch.Tensor | None:
         """This patch's fraction of the blend weight along one axis, ``w / sum_k w``, cached per axis.
 
-        ``None`` where that fraction is exactly one on every voxel of the axis, which is what an axis
-        holding a single grid position gives (the patch is the whole of the weight there, so the total
-        IS its own window): the blend then skips a full pass over the patch, bit for bit the same
-        values. A patch grid that tiles one axis and spans the other two is that case twice over.
+        ``None`` where that fraction is exactly one on every voxel of the axis (an axis holding a
+        single grid position): the blend then skips a pass over the patch.
         """
         extent = data.shape[self._n + dim]
         key = (dim, start, extent, data.dtype, data.device)
@@ -223,17 +188,9 @@ class Accumulator:
     def _weighted_patch(self, data: torch.Tensor, patch_slice: tuple[slice, ...]) -> torch.Tensor:
         """``data`` scaled by its SHARE of the blend weight at each voxel, one axis at a time.
 
-        Normalising per patch rather than dividing the assembled volume by an accumulated weight drops
-        both the spatial-sized weight buffer and the final division pass over every channel. The shares
-        sum to one per voxel by construction (the total is the sum over the same grid), so the blend
-        stays exact, and each factor is a ratio of comparable quantities, so it lives in [0, 1] where
-        the raw product underflows fp16 and needed a floor.
-
-        Only the axes whose share is not identically one are applied (see ``_share``), each one pass
-        over the patch: a grid tiled along one axis and spanning the other two hands the patch back
-        untouched. Into a staging buffer the patches share otherwise, one patch-sized allocation per
-        accumulator instead of per blend, and out of place: the caller's tensor is never touched, so
-        the OOM retry (which re-blends the same patch on the CPU) never re-weights it.
+        The shares sum to one per voxel, and each factor lives in [0, 1]. Only the axes whose share
+        is not identically one are applied (``_share``). Out of place, into a staging buffer the
+        patches share: the caller's tensor is never touched, so the OOM retry never re-weights it.
         """
         shares = []
         for dim, s in enumerate(patch_slice):
@@ -276,8 +233,6 @@ class Accumulator:
         return self.shape
 
     def is_full(self) -> bool:
-        # O(1): a running counter avoids re-scanning every slot after each added patch
-        # (re-scanning per patch would be O(P^2) per case).
         return self._filled == self._count
 
     def assemble(self) -> torch.Tensor:
@@ -288,8 +243,7 @@ class Accumulator:
                 "Add at least one patch (and check is_full()) before calling assemble().",
             )
         result = self._result
-        # Nothing to normalise: each patch was blended in with its share of the weight, so the shares
-        # already sum to one per voxel. No final crop either: patches are cropped at blend time.
+        # Nothing to normalise or crop: both happened at blend time.
         self._reset()
         return result
 
@@ -301,14 +255,13 @@ class Accumulator:
 
 
 class StreamingAccumulator(Accumulator):
-    """Accumulator holding only the active window along the first spatial axis; it yields each finalized
-    slab as its patches complete, so peak memory is two patch extents (the window and its slide room).
+    """Accumulator holding only the active window along the sweep axis; it yields each finalized slab
+    as its patches complete.
 
-    The patch-grid order (``get_patch_slices_from_shape`` iterates ``itertools.product`` with the first
-    spatial axis outermost) has patch starts along that axis never decreasing, so when a patch starting
-    at ``z`` arrives, every voxel before ``z`` has already received all of its patches and the region up
-    to ``z`` is final. ``add_layer`` returns those finalized slabs (``assemble()``'s values, from the
-    same blend and weight arithmetic applied slab by slab), and ``finalize()`` flushes the tail.
+    Patches must arrive with non-decreasing starts along the sweep axis (the order
+    ``get_patch_slices_from_shape`` emits): a patch starting at ``z`` finalizes every row before
+    ``z``. ``add_layer`` returns those slabs (``assemble()``'s values, slab by slab) and
+    ``finalize()`` flushes the tail.
     """
 
     def __init__(
@@ -340,11 +293,8 @@ class StreamingAccumulator(Accumulator):
             return []
         n = self._n
         patch_slice = self.patch_slices[index]
-        # Correctness rests on patches ARRIVING in non-decreasing axis-0-start order, not just on the
-        # slice list being sorted: a patch whose start is already flushed would write at a negative
-        # window offset (dest[0] below), which torch silently reads from the end -> misplaced data, no
-        # error. Fail loud instead. The prediction loop preserves per-case order (shuffle=False), so
-        # this only guards a future misuse (e.g. a shuffling sampler).
+        # A patch whose start is already flushed would write at a negative window offset, which torch
+        # reads from the end without an error.
         if patch_slice[self.sweep_axis].start < self._flushed:
             raise PatchError(
                 f"StreamingAccumulator received patch start {patch_slice[self.sweep_axis].start} after flushing to "
@@ -372,10 +322,7 @@ class StreamingAccumulator(Accumulator):
 
     @property
     def footprint_shape(self) -> list[int]:
-        # Only the window is resident, so the blend-device budget is the window's: a huge volume streams
-        # on the GPU within bounded VRAM. Blend and IEEE-correctly-rounded finalize ops (+, *, /, argmax,
-        # cast) are bit-identical CPU/CUDA; only a transcendental-terminated float output (Softmax/Sigmoid)
-        # can differ by ~1 ULP between a window on the GPU and a whole-volume reference on the CPU.
+        # Only the window is resident, so the blend-device budget is the window's.
         return self._sweep_shape(self._window)
 
     def assemble(self) -> torch.Tensor:
@@ -396,8 +343,7 @@ class StreamingAccumulator(Accumulator):
                 f"StreamingAccumulator asked to finalize {length} rows at once with a {self._window}-row window.",
                 "Patch starts may advance by at most one patch extent per step (checked at construction).",
             )
-        # Cloned: the window slides over these rows right after, so the slab handed out must not be a
-        # view of it. Nothing else to do: the blend weights already sum to one over these voxels.
+        # Cloned: the window slides over these rows right after, so the slab handed out must not be a view.
         slab = self._result[self._along_sweep(slice(0, length), n)].clone()
         keep = self._window - length
         # .clone(): source and destination views overlap when length < window.
@@ -411,23 +357,19 @@ class StreamingAccumulator(Accumulator):
 
 
 class SlabRegionStream:
-    """Slab in → slab out through one region stage, with bounded lookahead.
+    """Slab in, slab out through one region stage, with bounded lookahead.
 
-    The write mirror of the read dispatcher's single-region rule: finalized slabs arrive in order along
-    the first spatial axis (the :class:`StreamingAccumulator`'s order), and each output region is
-    emitted as soon as the input region it pulls has arrived, so only a sliding window of the input is
-    ever resident. The stage itself is two injected callables, both pure region arithmetic + tensor
-    work, so no stage kind has streaming code of its own:
+    Finalized slabs arrive in order along the first spatial axis (the :class:`StreamingAccumulator`'s
+    order), and each output region is emitted as soon as the input region it pulls has arrived, so
+    only a sliding window of the input is resident. The stage is two callables:
 
     - ``pull(target_slices) -> source_slices``: the clamped input region an output region is computed
-      from (a transform's ``stream_region_target``/``stream_region_source``, or a halo enlargement).
+      from.
     - ``produce(window, target_slices, source_slices) -> tensor``: the output block for
       ``target_slices``, given exactly the pulled window.
 
     The schedule is derived from ``pull`` alone: a probe finds which output axis the input slab axis
-    feeds and in which direction (a mirrored or permuted axis streams too, through the sink's
-    random-access region writes), and emission advances along that axis as far as the arrived input
-    allows. Any per-axis monotone map works; nothing here names a stage.
+    feeds and in which direction. Any per-axis monotone map works.
     """
 
     def __init__(
@@ -447,13 +389,9 @@ class SlabRegionStream:
         self._emitted = 0
 
     def _probe_axis(self) -> tuple[int, bool]:
-        """Which output axis the input slab axis feeds, and whether in ascending order.
-
-        Probing one output row per axis against the full-region pull identifies the axis whose region
-        controls input axis 0; comparing the first and last rows' pulls gives the direction. A wrong
-        pick can never corrupt the output (emission is gated on the pull of the real regions); it only
-        buffers more, so a map no probe can tell apart falls back to axis 0 ascending.
-        """
+        """Which output axis the input slab axis feeds, and whether in ascending order. A wrong pick
+        cannot corrupt the output (emission is gated on the pull of the real regions), it only
+        buffers more; a map no probe can tell apart falls back to axis 0 ascending."""
         full = tuple(slice(0, n) for n in self._out_shape)
         baseline = self._pull(full)[0]
         for axis, extent in enumerate(self._out_shape):
@@ -501,9 +439,8 @@ class SlabRegionStream:
 
     def _emit(self) -> list[tuple[tuple[slice, ...], torch.Tensor]]:
         extent = self._out_shape[self._axis]
-        # The pull of an iteration prefix grows monotonically with it, so the furthest emittable row is
-        # a binary search. O(log rows) pull calls per push, and a pull may be more than slice
-        # arithmetic (a declaration may copy the attribute it reads).
+        # The pull of an iteration prefix grows monotonically with it: the furthest emittable row is a
+        # binary search.
         low, high = self._emitted, extent
         while low < high:
             middle = (low + high + 1) // 2
@@ -556,13 +493,9 @@ class SlabRegionStream:
 class SlabAligner:
     """Merge several slab streams over the same axis into jointly finalized intervals.
 
-    The cross-stream mirror of :class:`StreamingAccumulator`: each stream (a TTA copy's accumulator)
-    emits finalized slabs in non-decreasing order along the shared first spatial axis, and a consumer
-    that needs every stream's rows together (a cross-copy reduction) can only advance to the
-    slowest frontier. ``push`` takes one stream's new slabs and returns the intervals that just
-    became complete, each carrying every stream's rows; only the inter-stream skew is ever buffered,
-    and a single stream passes through untouched. Nothing here knows what a stream is: it is pure
-    interval arithmetic over ``nb_streams`` ordered emitters.
+    Each stream emits finalized slabs in non-decreasing order along the shared first spatial axis;
+    ``push`` takes one stream's new slabs and returns the intervals complete on every stream, each
+    carrying every stream's rows. Only the inter-stream skew is buffered.
     """
 
     def __init__(self, nb_streams: int, lead_dims: int = 1) -> None:

--- a/konfai/data/patching/blend.py
+++ b/konfai/data/patching/blend.py
@@ -41,16 +41,9 @@ class PathCombine(ABC):
         overlaps = [overlap] * len(patch_size) if isinstance(overlap, int) else list(overlap)
         self.overlap = max(overlaps)
         self.overlaps = overlaps
-        # The per-patch weight is the outer product of one 1-D window per axis. It is separable by
-        # construction, so a per-axis partition of unity stays a partition of unity in N-D and overlapping
-        # patches blend without darkening: no distance map or explicit renormalisation loop is needed, and
-        # the trailing normalisation in Accumulator.assemble stays exact at the volume borders.
-        # Each axis tapers over its own overlap, so anisotropic overlaps blend correctly per axis.
-        #
-        # The factors are kept, not just their product: Accumulator normalises by a per-axis sum rather
-        # than a volume-sized buffer (see _weight_factors). Stored rather than re-derived, because the
-        # all-flat case below never calls _window_1d: re-deriving would turn its uniform count into a
-        # tapered weighting.
+        # The per-patch weight is the outer product of one 1-D window per axis, each axis tapering over its
+        # own overlap. The factors are kept: Accumulator normalises by a per-axis sum (_weight_factors),
+        # and the all-flat case below never calls _window_1d.
         if all(o <= 0 for o in overlaps):
             self.windows_1d = [torch.ones(size) for size in patch_size]
             return
@@ -63,10 +56,8 @@ class PathCombine(ABC):
     def data(self) -> torch.Tensor:
         """The per-voxel window: the outer product of the per-axis factors.
 
-        Derived, not stored: it is a patch of floats that ``Network.init`` builds before the spawn and
-        every rank then unpickles (a 128^3 ModelPatch at overlap 16 pickles to 8 391 775 bytes with it,
-        1355 without), while assembly goes through the factors themselves (see ``_weight_factors``).
-        :meth:`weight` caches what it builds per device and dtype.
+        Derived, not stored: the object is pickled to every rank, and assembly goes through the factors
+        themselves (``_weight_factors``). :meth:`weight` caches what it builds per device and dtype.
         """
         data = self.windows_1d[0]
         for window in self.windows_1d[1:]:
@@ -77,8 +68,8 @@ class PathCombine(ABC):
     def selects(self) -> bool:
         """Whether the window picks ONE patch per voxel (values 0 or 1) rather than weighting several.
 
-        A selection makes the kept regions a partition of the volume, so assembly writes each one
-        instead of accumulating a weighted sum: see Accumulator._blend.
+        A selection is a partition of the volume: assembly writes each region instead of accumulating
+        a weighted sum (``Accumulator._blend``).
         """
         return False
 
@@ -92,22 +83,17 @@ class PathCombine(ABC):
         return self.windows_1d[dim]
 
     def weight(self, tensor: torch.Tensor) -> torch.Tensor:
-        """The raw per-voxel window on ``tensor``'s device and dtype (cached per pair).
+        """The raw per-voxel window on ``tensor``'s device and dtype (cached per pair), unnormalised.
 
-        The window UNNORMALISED, as declared. Assembly does not go through it: Accumulator divides each
-        window by the total over the patches covering a voxel and applies that share instead, so the
-        quantity it multiplies by is always in [0, 1]. This stays for a caller that wants the window
-        itself.
+        Assembly does not go through it: Accumulator divides each window by the total over the patches
+        covering a voxel, so what it multiplies by is always in [0, 1].
         """
         key = (tensor.device, tensor.dtype)
         if key not in self._data_per_device:
-            # Match the tensor dtype: the weight has no reason to carry more precision than the data it
-            # scales, and a float64 weight would upcast the whole (channels x volume) blend.
+            # Match the tensor dtype: a float64 weight would upcast the whole blend.
             weight = self.data.to(device=tensor.device, dtype=tensor.dtype)
             if weight.is_floating_point():
-                # A Gaussian tail underflows the target dtype (a 96^3 patch corner is ~6e-11: zero in
-                # fp16). Floor it at the smallest normal so a caller scaling by this window on its own
-                # does not silently drop those voxels.
+                # A Gaussian tail underflows fp16 (a 96^3 patch corner is ~6e-11): floor at the smallest normal.
                 weight = weight.clamp(min=torch.finfo(weight.dtype).tiny)
             self._data_per_device[key] = weight
         return self._data_per_device[key]
@@ -124,9 +110,7 @@ def blend_axes(patch_size: list[int]) -> list[int]:
     """The blend window's axes for a ``patch_size``: every axis kept, a free (0) or singleton (1) axis
     as a single broadcast entry.
 
-    ``Accumulator`` reads one window per spatial axis of the volume, and the window has to broadcast
-    against the patch at any axis position. Dropping the untiled axes shortens the list, so the
-    window is looked up on the wrong axis (or not at all).
+    ``Accumulator`` reads one window per spatial axis of the volume, so the list must not drop an axis.
     """
     return [size if size > 1 else 1 for size in patch_size]
 
@@ -134,8 +118,7 @@ def blend_axes(patch_size: list[int]) -> list[int]:
 def blend_overlap(overlap: "int | float | str | list[int | float | str]", patch_size: list[int]) -> list[int]:
     """Per-axis blend overlap for a concrete ``patch_size`` (int broadcast, ``%``/fraction resolved).
 
-    The blend has no volume extent: every axis whose patch is longer than one voxel is treated as tiled
-    (the untiled-axis-0 rule is already applied by the slicing plan), so an int is the same voxel
+    Every axis whose patch is longer than one voxel is treated as tiled, so an int is the same voxel
     overlap on every such axis.
     """
     if isinstance(overlap, int):
@@ -161,8 +144,7 @@ class Cosinus(PathCombine):
     def _window_1d(self, size: int, overlap: int) -> torch.Tensor:
         window = torch.ones(size)
         # sin**2 ramp over the overlap; the neighbouring patch's cos**2 ramp is its complement, so the two
-        # sum to exactly one across the overlap. The +0.5 phase keeps the very edge > 0 so a single-patch
-        # border, whose share is then the whole of the weight there, recovers the raw value.
+        # sum to one. The +0.5 phase keeps the very edge > 0.
         ramp = torch.sin((torch.arange(overlap, dtype=torch.float32) + 0.5) / overlap * (torch.pi / 2)) ** 2
         window[:overlap] = ramp
         window[size - overlap :] = ramp.flip(0)
@@ -173,13 +155,9 @@ class Trim(PathCombine):
     """Selection instead of weighting: each voxel comes from the patch that holds it most centrally.
 
     An interior patch keeps its central ``patch - overlap`` band, so the kept bands tile the axis
-    exactly and the weights already sum to one; the first and last patch of an axis open to the volume
-    edge. Every kept voxel therefore carries at least half the overlap of context on each side, where
-    the unweighted default keeps whichever patch wrote last: possibly one holding that voxel on its
-    own border with no context behind it, which is what a seam is.
-
-    The values are 0 or 1, so the patch is selected rather than averaged: a discrete output (a label
-    map, an argmax) survives reassembly, where any weighting would invent values between its classes.
+    exactly; the first and last patch of an axis open to the volume edge. The values are 0 or 1, so
+    the patch is selected rather than averaged: a discrete output (a label map, an argmax) survives
+    reassembly.
     """
 
     @property
@@ -188,9 +166,7 @@ class Trim(PathCombine):
 
     def _window_1d(self, size: int, overlap: int) -> torch.Tensor:
         if overlap >= size:
-            # Nothing central left to keep: trimming both sides would leave an empty band, and a patch
-            # that keeps nothing has no box to write. Keep the patch whole instead: the axis stops
-            # being a partition and falls back to last-write-wins on it, which is what it was before.
+            # Nothing central left to keep: the patch stays whole and the axis falls back to last-write-wins.
             return torch.ones(size)
         window = torch.zeros(size)
         # Split an odd overlap so consecutive kept bands abut: k*stride + hi == (k+1)*stride + lo.
@@ -213,9 +189,7 @@ class Trim(PathCombine):
 class Gaussian(PathCombine):
     """nnU-Net-style Gaussian importance weighting.
 
-    Favours patch centres (where the model sees the most surrounding context), and down-weights the
-    borders, which suppresses seam artefacts. Not a partition of unity: the accumulator blends each
-    patch in with its share of the total weight, so overlapping patches still form a weighted average.
+    Not a partition of unity: the accumulator blends each patch in with its share of the total weight.
     """
 
     def __init__(self, sigma_scale: float = 0.125) -> None:

--- a/konfai/data/patching/budget.py
+++ b/konfai/data/patching/budget.py
@@ -25,9 +25,7 @@ import torch
 from konfai.utils.budget import peak_resident_bytes, reset_resident_peak, resident_bytes, resident_floor
 
 #: The whole-volume statistics every store can serve (``Dataset.read_data_statistics``), by the key a
-#: GLOBAL_STAT stage declares: what the plan checks against without reading a voxel, and what the
-#: seed reads. The per-channel figures are what a vector-valued quantity needs, where pooling the
-#: components into one number describes nothing.
+#: GLOBAL_STAT stage declares.
 _STREAM_STATS = {
     "Min": "min",
     "Max": "max",
@@ -41,16 +39,13 @@ _STREAM_STATS = {
 _STREAM_STAT_KEYS = frozenset(_STREAM_STATS)
 
 # The unit a region grows by on a store without a block grid, and the height a sweep keeps without
-# a budget: with one, the first region is priced (SegmentSizer.growth) and the next ones follow
-# what the last held (RegionGrowth), up to GROWTH_CAP_UNITS of it.
+# a budget.
 SWEEP_SLAB_ROWS = 64
 
 
-# "not looked up yet", where None is itself an answer (a store with no read granularity to state).
-# A class with a by-name ``__reduce__`` rather than a bare ``object()``: the manager is pickled into
-# every DataLoader worker (spawn), and a plain ``object()`` unpickles as a NEW instance, so the
-# ``is _UNRESOLVED`` test failed in the worker and the sentinel itself got indexed
-# (``'object' object is not subscriptable`` in ``_sweep_rows``).
+# "not looked up yet", where None is itself an answer. A by-name ``__reduce__``, not a bare
+# ``object()``: the manager is pickled into every DataLoader worker, and a plain ``object()``
+# unpickles as a new instance.
 class _Unresolved:
     __slots__ = ()
 
@@ -63,46 +58,29 @@ class _Unresolved:
 
 _UNRESOLVED = _Unresolved()
 
-# The bytes each element travels as through a sweep (float32). What a sweep holds in those elements
-# is _sweep_resident_regions, and DatasetManager.sweep_block_bytes prices it.
-#
-# What a streamed case holds beside its regions, whatever they are: the manager's state, the chain's
-# stage objects, the store handles, the allocator's slack. Measured as the resident set above the
-# interpreter floor that the priced regions do not account for, on the memory-limit cohort: 25 MiB
-# (a bare Write), 8 (Gradient), 11 (Resample), 27 (Resample then Gradient). A floor the sizing cannot
-# lower, so the TRANSFORM plan's header states it instead of leaving it to be found in a resident set.
+# What a streamed case holds beside its regions: the manager's state, the chain's stage objects, the
+# store handles, the allocator's slack. Measured at up to 27 MiB above the interpreter floor. The
+# TRANSFORM plan's header states it.
 SWEEP_ENGINE_FLOOR_BYTES = 32 << 20
 #: How many units a region grows to at most, a unit being the store's block along the sweep axis
-#: (``SWEEP_SLAB_ROWS`` on a store without one). Measured on a 2 GiB h5 volume chunked at 64
-#: rows (``benchmarks/perf/bench_transform.py``, 2026-09-07): the wall halves from a sub-chunk
-#: region to four-to-eight chunk rows (15.6 -> 7.6 s) and is flat past that; on the 513-row
-#: ExaSPIM store chunked at 256 rows the knee sits at one chunk row (24 s under 1 GiB, 5.9 s
-#: under 8 GiB, flat at 16), and a region under the chunk runs, slower, where a refusal would not.
+#: (``SWEEP_SLAB_ROWS`` on a store without one). The wall is flat past four to eight chunk rows.
 GROWTH_CAP_UNITS = 8
-#: The share of the budget the first region is priced against. The price is a model of what a
-#: chain holds, and the worst overshoot on record is a first region at 1.5x its price (a fold over
-#: registration fields), on a host that kills without a MemoryError: from a half, that lands at
-#: 0.75 of the budget, and the growth finds the rest in one doubling. An eighth was measured to
-#: cost a 513-row store two of its three regions (12.2 s against 5.9 under 8 GiB).
+#: The share of the budget the first region is priced against. The worst overshoot on record is a
+#: first region at 1.5x its price; from a half that lands at 0.75 of the budget, and the growth finds
+#: the rest in one doubling.
 _START_SHARE = 0.5
-#: A region measured under this share of the budget doubles the next. A third, not a half: what
-#: a doubled region holds is not double (the landing buffers, the chain's temporaries and the
-#: allocator's slack grow with it), measured at 2.4x on a 2 GiB h5 sweep whose 128-row regions
-#: held 0.42 GiB and whose 256-row ones held 1.00; doubled from under a third, the next lands under
-#: the budget at that ratio. One measured over the budget halves the next.
+#: A region measured under this share of the budget doubles the next. A third, not a half: a doubled
+#: region holds up to 2.4x (the landing buffers, the chain's temporaries and the allocator's slack
+#: grow with it). One measured over the budget halves the next.
 _GROW_BELOW = 1.0 / 3.0
 #: How much less a cubic block must read for the sweep to take it (``DatasetManager._sweep_tile``).
-#: A sheared map measures 0.61 on a 513x1331x1776 rigid+affine; an unsheared one, the margin alone.
 _SWEEP_TILE_MARGIN = 0.8
+#: The bytes each element travels as through a sweep (float32).
 _SWEEP_ELEMENT_BYTES = 4
 
 #: What a whole-volume fallback holds while a case is in flight (the assembled tensor plus one
-#: transform output), and the bytes each element travels as.
-#:
-#: Public because two callers must agree on the figure and neither owns it: the run-time budget check
-#: (``CaseMaterializer._enforce_fallback_budget``) refuses a case against it, and the TRANSFORM plan
-#: prints and enforces the same number before a byte is written. A plan estimating differently from
-#: the run it describes is worse than no plan.
+#: transform output), and the bytes each element travels as. Public: the run-time budget check
+#: (``CaseMaterializer._enforce_fallback_budget``) and the TRANSFORM plan must agree on the figure.
 FALLBACK_INFLIGHT_FACTOR = 2
 CASE_ELEMENT_BYTES = 4
 
@@ -111,11 +89,10 @@ CASE_ELEMENT_BYTES = 4
 class RegionGrowth:
     """The height of the regions a route cuts, decided by what the last one HELD.
 
-    The price starts the first region small (``_START_SHARE``); every region measured under a third of
-    the budget doubles the next, one measured over the budget halves it, never above ``cap`` and
-    never below the first, so every region starts on a multiple of the first and the output's
-    chunk grid, cut on the first, is never straddled. Without a budget, or without an instrument
-    to read, the height stands.
+    Every region measured under ``_GROW_BELOW`` of the budget doubles the next, one measured over the
+    budget halves it, never above ``cap`` and never below the first, so every region starts on a
+    multiple of the first and the output's chunk grid is never straddled. Without a budget, or
+    without an instrument to read, the height stands.
     """
 
     rows: int
@@ -123,9 +100,7 @@ class RegionGrowth:
     budget_bytes: float | None
     #: Regions measured at the current height before it may double again: a pipelined sweep holds
     #: ``depth + 2`` regions in flight, and a reading taken before that many have run at a height
-    #: says what the previous height cost. Doubled twice on such readings, a sweep of a 2 GiB
-    #: volume reached 340-row regions and 1.52 GiB held under a 1 GiB budget before the meter
-    #: caught up, and the high-water mark then held it at the first height for the rest.
+    #: says what the previous height cost.
     settle: int = 1
     first: int = field(init=False)
     _at_height: int = field(init=False, default=0)
@@ -137,9 +112,8 @@ class RegionGrowth:
         self.first = self.rows
 
     def halve_below_first(self) -> int:
-        """Half the height, the first region's included: the answer to a region the device could not
-        hold at all (an OutOfMemoryError), where the measured rule only ever halves down to the
-        first. The new height is the floor from here on."""
+        """Half the height, the first region's included: the answer to an OutOfMemoryError. The new
+        height is the floor from here on."""
         self.rows = max(1, self.rows // 2)
         self.first, self._at_height = self.rows, 0
         return self.rows
@@ -162,27 +136,17 @@ class RegionGrowth:
 
 
 def device_signals_oom(device: "torch.device | None") -> bool:
-    """Whether a region ``device`` cannot hold is a catchable ``OutOfMemoryError``: a CUDA device
-    raises one, the host gets no signal (the kernel kills). What the halve-on-OOM retry asks."""
+    """Whether a region ``device`` cannot hold raises a catchable ``OutOfMemoryError``: a CUDA device
+    does, the host gets no signal (the kernel kills)."""
     return device is not None and device.type == "cuda"
 
 
 def device_capped_budget(budget_bytes: float | None, device: "torch.device | None") -> float | None:
-    """The budget, capped at what ``device`` can actually hold.
+    """The budget, capped at what ``device`` can hold.
 
-    The memory budget is declared in HOST bytes -- ``auto`` measures node RAM -- but on a GPU
-    chain the working sets it sizes (swept slabs, whole-volume fallbacks, a reduction's member
-    regions) live in VRAM. A 64G budget on a 16 GB card is then not a budget, it is a promise of
-    an OOM. Half of what the card can give THIS process: the halving is the slack that covers
-    allocations arriving after the reading, since a fold sized once can run for hours.
-
-    What the card can give this process is the free memory plus what this process's own allocator
-    is already sitting on, because a cached block is memory the next allocation reuses rather than
-    asks the driver for. Reading the free memory alone made the answer depend on WHEN it was read:
-    the same fold, on the same idle card, sized its regions at 47 rows under 4.99 GiB in one run
-    and 65 rows under 11.58 GiB in another, the difference being how much the process had already
-    reserved by the time the fit ran. Region height decides the whole read plan, so a sizing that
-    moves with the moment is a run whose cost cannot be reproduced or reasoned about.
+    The memory budget is declared in HOST bytes, but on a GPU chain the working sets it sizes live
+    in VRAM. The cap is half of what the card can give THIS process: the free memory plus what the
+    process's own allocator already holds, so the figure does not move with when it is read.
     """
     if device is None or device.type != "cuda" or not torch.cuda.is_available():
         return budget_bytes
@@ -195,12 +159,9 @@ def device_capped_budget(budget_bytes: float | None, device: "torch.device | Non
 class HeldMeter:
     """What one scope of work HELD, read by the instrument the route it runs on has.
 
-    A GPU chain has the device allocator, which counts what is in use; a host chain has the kernel's
-    resident high-water mark, which counts what the allocator is sitting on as well -- and that is
-    the better figure of the two here, since the kernel kills on resident memory. Both answer the
-    same question, so a caller asks one thing and never branches on which it got. On the host the
-    baseline is the run's resident floor when the workflow recorded one
-    (:func:`~konfai.utils.budget.record_resident_floor`), else where the scope started.
+    A GPU chain reads the device allocator; a host chain reads the kernel's resident high-water mark,
+    above the run's resident floor when the workflow recorded one
+    (:func:`~konfai.utils.budget.record_resident_floor`), else above where the scope started.
     """
 
     _peak: Callable[[], int | None]
@@ -213,12 +174,8 @@ class HeldMeter:
 
 
 def open_held_meter(device: "torch.device | None") -> HeldMeter | None:
-    """Start measuring what the next scope holds, or ``None`` where nothing can measure it.
-
-    Reading is a high-water mark either way, so what comes back bounds the NEXT scope of the same
-    shape from above -- which is what makes a measured figure usable for sizing the ones that follow
-    (:meth:`Predictor._accumulate_device` reads a forward the same way).
-    """
+    """Start measuring what the next scope holds, or ``None`` where nothing can measure it. The reading
+    is a high-water mark, so it bounds the NEXT scope of the same shape from above."""
     if device is not None and device.type == "cuda" and torch.cuda.is_available():
         try:
             torch.cuda.synchronize(device)
@@ -237,18 +194,12 @@ def open_held_meter(device: "torch.device | None") -> HeldMeter | None:
         return HeldMeter(device_peak, baseline)
     if not reset_resident_peak():
         return None
-    # Above the run's resident floor where the workflow recorded one, else above where the scope
-    # starts: a region reusing the pages an earlier one freed holds them all the same, and only
-    # a baseline taken before any region was read counts them.
+    # Above the run's resident floor where the workflow recorded one, else above where the scope starts.
     resident = resident_floor() if resident_floor() is not None else resident_bytes()
     if resident is None:
         return None
-    # THE CACHE IS NOT THE SCOPE'S. A host peak is the whole process's high-water mark, and the
-    # decoded-chunk cache sits inside it: a scope that reads from a store fills the cache on its
-    # way, and the cache keeps what it decoded past the scope, for the next one. Charging the scope
-    # for that is charging it for a budget line that has its own share (BUDGET_SHARES['cache']).
-    # Measured on a fold's probe over ten native members: 24.4 GiB read, 13.2 of it the cache
-    # filling from empty, and the fold cut to 78 % of the height its regions actually needed.
+    # The decoded-chunk cache sits inside the host peak and has its own budget line
+    # (BUDGET_SHARES['cache']): what it took during the scope is not the scope's.
     from konfai.utils.ome_zarr import chunk_cache_held_bytes
 
     cache_at_start = chunk_cache_held_bytes()

--- a/konfai/data/patching/grid.py
+++ b/konfai/data/patching/grid.py
@@ -72,21 +72,19 @@ class Patch(ABC):
         self._grids: dict[int, _PatchGrid] = {}
         self.pad_value = pad_value
         self.extend_slice = extend_slice
-        # Models need every patch at the declared size, so the last patch of an axis is padded up to it.
-        # A consumer that REDUCES patches instead (streamed evaluation) must see only in-volume voxels:
-        # padded ones would pollute its running sums, so it turns this off and takes the cropped patch.
+        # The last patch of an axis is padded up to the patch size for a model. A consumer that REDUCES
+        # patches (streamed evaluation) must see only in-volume voxels and turns this off.
         self.pad_to_patch = True
         #: Voxels of context read past each face of a grid patch, clamped to the volume, for a consumer
-        #: that reduces patches but scores through a window (a metric's halo). The grid keeps its
-        #: disjoint slots (``get_patch_slices``); ``core_in_read`` says where a slot sits in its read.
-        #: Unpadded only (``pad_to_patch`` False): a model input padded to the patch has no core.
+        #: that reduces patches through a window (a metric's halo). The grid keeps its disjoint slots
+        #: (``get_patch_slices``); ``core_in_read`` says where a slot sits in its read.
+        #: Unpadded only (``pad_to_patch`` False).
         self.halo = 0
         # The model's per-axis downsampling factor a FREE (``0``) axis rounds up to, set before the grids
-        # are cut so each case's whole-axis extent lands on a valid model input. ``None`` outside a model
-        # (evaluation) or for a network that never downsamples.
+        # are cut. ``None`` outside a model or for a network that never downsamples.
         self.free_axis_multiple: list[int] | None = None
-        # Whether a free (``0``) axis was DECLARED. Captured now because the OOM re-plan later pins
-        # ``patch_size`` to a concrete size in place, erasing the ``0`` the overlap default keys on.
+        # Whether a free (``0``) axis was DECLARED, captured before the OOM re-plan pins ``patch_size``
+        # in place.
         self._declared_free_axis: bool = (
             patch_size is not None and any(p == 0 for p in patch_size) and not all(p == 0 for p in patch_size)
         )
@@ -97,14 +95,11 @@ class Patch(ABC):
         self._grids.pop(a, None)
 
     def _grid(self, a: int) -> _PatchGrid:
-        """Copy ``a``'s cut, made once. A pure function of the recorded shape and this patch's own
-        configuration, so a rank rebuilds it instead of unpickling it (``__getstate__``)."""
+        """Copy ``a``'s cut, made once from the recorded shape (``__getstate__`` drops it)."""
         grid = self._grids.get(a)
         if grid is None:
             shape = self._shapes[a]
-            # The grid decides its own sweep axis and the reassembly reads it back (get_sweep_axis): one
-            # source of truth, because a grid emitted for one axis and reassembled along another hands out
-            # regions that are not final, with nothing to report it.
+            # The grid decides its own sweep axis and the reassembly reads it back (get_sweep_axis).
             sweep_axis = best_sweep_axis(concretize_patch_size(self.patch_size, shape, self.free_axis_multiple), shape)
             slices = get_patch_slices_from_shape(
                 self.patch_size,
@@ -118,15 +113,8 @@ class Patch(ABC):
         return grid
 
     def __getstate__(self) -> dict[str, Any]:
-        """The cuts stay out of the pickle: ``mp.spawn`` pickles the configured object once per
-        rank, and every manager's per-case grids dominated its bytes. Only the shapes travel, and
-        each rank cuts the same grids back from them on first use.
-
-        Cutting costs more than unpickling would have (100 cases of 2048 patches: 31 ms against 81
-        ms in process); it is the transfer, paid once per rank, that dominates. On a 2-rank CPU
-        spawn of 1000 such cases the payload goes from 35.2 to 0.44 MiB and the second rank holds
-        every grid 3.0 s after the launcher's stamp instead of 4.8 s.
-        """
+        """The cuts stay out of the pickle: only the shapes travel, and each rank cuts the same grids
+        back from them on first use."""
         return {**self.__dict__, "_grids": {}}
 
     def get_sweep_axis(self, a: int = 0) -> int:
@@ -188,9 +176,7 @@ class Patch(ABC):
                 if declared != 0:
                     target = declared
                 else:
-                    # A FREE axis pads up to THIS case's extent rounded to the model's downsampling
-                    # multiple, so a small heterogeneous case still reaches the network at a valid input
-                    # size (the up-front worst-case sizing only guarantees the largest case).
+                    # A FREE axis pads up to THIS case's extent rounded to the model's downsampling multiple.
                     m = free_axis_rounding(self.free_axis_multiple, axis, nspatial)
                     target = ((extent + m - 1) // m) * m if m > 1 else extent
                 p = 0 if _slice.start + target <= extent else target - (extent - _slice.start)
@@ -221,12 +207,8 @@ class Patch(ABC):
 
     def _pad_constant(self, data: torch.Tensor, padding: tuple[int, ...]) -> torch.Tensor:
         """``data`` padded (``F.pad`` pair order) with the configured value, a uint8 map with zero,
-        and anything else with its own minimum when no value is configured.
-
-        That minimum never leaves the device: the bands are filled from the 0-d tensor after a zero
-        pad, so a padded patch costs no host round trip (37 of the 64 patches of a 100^3 case at
-        32^3 are padded, measured).
-        """
+        and anything else with its own minimum when no value is configured. The minimum never leaves
+        the device."""
         if data.dtype == torch.uint8:
             return F.pad(data, padding, "constant", 0)
         if self.pad_value is not None:

--- a/konfai/data/patching/manager.py
+++ b/konfai/data/patching/manager.py
@@ -185,10 +185,9 @@ class DatasetManager:
         # for a patch replay (_refold_copy_records), or None once any fold or whole-volume call
         # moved them.
         self._records_source: _PatchStreamSource | None = None
-        # A GLOBAL_STAT stage's whole-volume statistic is read on the process that runs the chain,
-        # at first data access, never by a plan probe: the plan checks the source can provide it
-        # (headers only) and the run reads it once. ``_statistics_deferred`` remembers that a plan
-        # was resolved without its seed, so the run replans before reading.
+        # A GLOBAL_STAT stage's whole-volume statistic is read on the process that runs the chain, at
+        # first data access, never by a plan probe. ``_statistics_deferred`` remembers that a plan was
+        # resolved without its seed, so the run replans before reading.
         self._statistics_seeded = False
         self._statistics_deferred = False
         # Why a Save sweep gave up for this case, or None. One field rather than a flag beside a
@@ -247,10 +246,9 @@ class DatasetManager:
 
     def _draw_expand_copies(self, reset_state: bool) -> None:
         """Draw the :class:`Expand` copies by walking the per-copy tail stage by stage: each draw is
-        parameterised on the grid and case state the stages before it leave (``T, draw, T, draw``
-        means what it reads like). Each draw is seeded from ``(Expand.seed, case name, draw class,
-        rank among its class)``: what two chains of one case agree on, and not the draw's position
-        in the tail, so an intensity draw one chain lacks does not shift the geometric ones.
+        parameterised on the grid and case state the stages before it leave. Each draw is seeded from
+        ``(Expand.seed, case name, draw class, rank among its class)``, not the draw's position in
+        the tail, so an intensity draw one chain lacks does not shift the geometric ones.
         """
         expand = self._expand
         assert expand is not None  # nosec B101 - the caller checked
@@ -268,10 +266,8 @@ class DatasetManager:
                 occurrence = drawn.get(kind, 0)
                 drawn[kind] = occurrence + 1
                 # One draw, every copy at once: state_init IS the per-copy sampler, and it wants the
-                # copies' current grids, which the stages before it just folded.
-                # Keyed by the case's NAME, not its index: the index is a position in the run's
-                # case list, and a different `subset` (or a second run over image and mask with
-                # different subsets) must not hand a case other copies.
+                # copies' current grids. Keyed by the case's NAME, not its index: a different
+                # `subset` must not hand a case other copies.
                 with _drawn_from(expand.draw_seed, self.name, kind, occurrence):
                     shapes = stage.state_init(self.index, shapes, foldings)
                 continue
@@ -353,9 +349,8 @@ class DatasetManager:
     ) -> torch.Tensor:
         """Apply stages in order on an assembled tensor, writing each Save's cache under ``entry``.
 
-        The one whole-volume applicator: ``_load`` drives it with the case's own name, and the
-        expansion fallback with a copy's name: the entry is the only thing that differs between
-        assembling a case and assembling one of its copies.
+        The one whole-volume applicator: ``_load`` drives it with the case's own name, the expansion
+        fallback with a copy's name.
         """
         self._records_source = None  # a stage re-records the case it is called on
         for transform_function in transforms:
@@ -381,10 +376,9 @@ class DatasetManager:
             return
 
         # The case tensor itself, once per copy. A draw hands back a fresh tensor or a view of what
-        # it was given and writes nothing into it (Foreign clones for a class that might), so a
-        # copy a draw did not select IS the case, as copy 0 already is. A clone per copy was a
-        # memcpy of the case dropped unread: 640 MiB and 0.22 s for 10 copies of a 64 MiB case,
-        # per group, per case, per epoch under inline augmentation (measured).
+        # it was given and writes nothing into it (Foreign clones for a class that might), so a copy
+        # a draw did not select IS the case. A clone per copy was 640 MiB and 0.22 s for 10 copies of
+        # a 64 MiB case, per group, per case, per epoch under inline augmentation.
         a_data = [self.data[0] for _ in range(data_augmentations.nb)]
         for data_augmentation in data_augmentations.data_augmentations:
             if data_augmentation.groups is None or self.group_dest in data_augmentation.groups:
@@ -407,8 +401,8 @@ class DatasetManager:
         """The augmentations copy *a* is made of, each bound to it.
 
         Copy 0 is made of none: it is the tensor the transforms produced, which is why it is the one
-        copy that has a counterpart on disk to stream from at all. The rest carry their list's draw,
-        minus whatever that draw does not address to this group.
+        copy with a counterpart on disk to stream from. The rest carry their list's draw, minus
+        whatever that draw does not address to this group.
         """
         if a == 0:
             return []
@@ -423,8 +417,8 @@ class DatasetManager:
         """The per-copy tail of an :class:`Expand` chain, as copy ``a`` runs it.
 
         The tail IS the declared order: a transform stays itself, a draw is bound to this copy. The
-        two kinds are the same species to everything downstream (the planner reads one contract,
-        the replay calls one signature), which is why they can be written in any order.
+        two kinds are one species downstream (one contract to plan, one signature to call), so they
+        can be written in any order.
         """
         if a == 0:
             # Copy 0 is the case itself: it carries no draw, so the tail is its transforms alone --
@@ -442,8 +436,7 @@ class DatasetManager:
     def copy_entry(self, a: int) -> str:
         """The entry name copy ``a`` writes (and resumes) under, behind this chain's ``Expand``.
 
-        Copy 0 is the case itself (the un-augmented tensor has no draw of its own to name), and so
-        is every copy of a chain with no ``Expand``, where nothing per-copy is ever written.
+        Copy 0 is the case itself, and so is every copy of a chain with no ``Expand``.
         """
         if self._expand is None or a == 0:
             return self.name
@@ -459,12 +452,10 @@ class DatasetManager:
     ) -> dict[str, float]:
         """Read (and memoise) the whole-volume statistics of one on-disk group for this case.
 
-        ``read_data_statistics`` scans the stored volume without materialising it, but it is still a
-        full pass: memoise it per (dataset, group, entry, channels) so a per-patch consumer (whose
-        ``inverse()`` pops the seeded keys back out of the cache attribute at prediction time) does
-        not re-scan the volume once per patch. ``keys`` is what the stage asked for (the public
-        ``min``/``max_per_channel``/... names): a request without a moment is scanned for its
-        extrema only, in the stored dtype.
+        ``read_data_statistics`` scans the stored volume without materialising it, but it is a full
+        pass: memoised per (dataset, group, entry, channels) so a per-patch consumer does not re-scan
+        once per patch. ``keys`` is what the stage asked for (``min``, ``max_per_channel``, ...): a
+        request without a moment is scanned for its extrema only, in the stored dtype.
         """
         selected = tuple(channels) if channels is not None else None
         # A scan that folded the moments serves every request; an extrema-only one serves only
@@ -517,10 +508,8 @@ class DatasetManager:
         """Whether a halo of this radius still buys copy *a* anything over loading the volume.
 
         Every patch pays the halo on every side and the patches tile the volume, so streaming a case
-        reads ``prod(1 + 2 * halo_k / patch_k)`` times its bytes: the multiple streaming pays to keep
-        one volume off the heap. Half a patch doubles every axis: 8x the reads in 3D. Past that the
-        multiple runs away: a halo of one whole patch is 27x, while the saving is still just the
-        one volume.
+        reads ``prod(1 + 2 * halo_k / patch_k)`` times its bytes. Half a patch doubles every axis: 8x
+        the reads in 3D; a halo of one whole patch is 27x, while the saving is still one volume.
         """
         patch_size = self.patch.patch_size
         extent = (
@@ -548,13 +537,12 @@ class DatasetManager:
         """Validate a chain's locality declarations and plan its region stages, which compose.
 
         Returns ``(streamable, stage_plans, evolved, refusal)``: ``refusal`` names the stage and the
-        reason when the chain cannot stream; ``evolved`` is the case state the plan leaves (a
-        :class:`Save` sweep writes it as its cache header). The chain streams when every stage is
-        pointwise, a region kind (``HALO``/``ORIENTATION``/``CROP``/``REGRID``, each pulling through
-        the one before it) or a ``GLOBAL_STAT`` the source can serve; each stage declares against
-        the geometry the stages before it left, and a shape fold that does not land on
-        ``landing_shape`` refuses. ``seed_statistics=False`` defers a statistic to the sweep of a
-        cache not materialized yet. A transform and a draw are planned alike: by declaration.
+        reason when the chain cannot stream; ``evolved`` is the case state the plan leaves. The chain
+        streams when every stage is pointwise, a region kind (``HALO``/``ORIENTATION``/``CROP``/
+        ``REGRID``, each pulling through the one before it) or a ``GLOBAL_STAT`` the source can serve;
+        each stage declares against the geometry the stages before it left, and a shape fold that does
+        not land on ``landing_shape`` refuses. ``seed_statistics=False`` defers a statistic to the
+        sweep of a cache not materialized yet. A transform and a draw are planned alike.
         """
         evolved = Attribute(cache_attribute)
         shape = [int(extent) for extent in source_spatial_shape]
@@ -573,8 +561,7 @@ class DatasetManager:
             if loc.kind in (LocalityKind.WHOLE_VOLUME, LocalityKind.SLAB):
                 # SLAB is a write-side contract: its side effect needs the slab's place in the
                 # OUTPUT, which a patch read has no notion of. A stage that is whole-volume only
-                # because something was left undeclared says so itself (PatchLocality.reason), so
-                # the reader is told what to change instead of what happened.
+                # because something was left undeclared says so itself (PatchLocality.reason).
                 return refuse(f"{label} declares {loc.kind.name}: {loc.reason or 'it needs the whole volume'}.")
             if loc.kind is LocalityKind.GLOBAL_STAT:
                 # The seed is the STORED volume's statistic; otherwise ([Clip(-200, 400), Standardize()])
@@ -624,8 +611,7 @@ class DatasetManager:
     ) -> "_ReadStagePlan":
         """One stage's slot in the composed plan: its shapes, its pull map, and the case state it
         leaves for the stages after it and for the header the sweep ships
-        (``write_stream_cache_attribute``, stated by every stage, region or not: a fold of the
-        channel axis consumes a key that describes an input the output no longer has)."""
+        (``write_stream_cache_attribute``, stated by every stage, region or not)."""
         if not loc.kind.is_region:
             plan = _ReadStagePlan(loc.kind, tuple(shape), tuple(shape), None)
         elif loc.kind is LocalityKind.HALO:
@@ -649,9 +635,9 @@ class DatasetManager:
     def _stage_out_shape(self, stage: Stage, shape: list[int], attribute: Attribute) -> list[int]:
         """The spatial shape one stage folds ``shape`` to: a transform's map or a draw's own.
 
-        The one dispatch between the two Stage species' shape vocabularies: a ``Transform`` restates
-        its fold as ``transform_shape``, an :class:`AugmentedStage` as its draw's ``stream_shape``.
-        Shape only: the geometry transition is :meth:`_fold_case_state`'s half.
+        The one dispatch between the two Stage species: a ``Transform`` restates its fold as
+        ``transform_shape``, an :class:`AugmentedStage` as its draw's ``stream_shape``. Shape only:
+        the geometry transition is :meth:`_fold_case_state`'s half.
         """
         self._records_source = None  # transform_shape records the case state it is handed
         if isinstance(stage, Transform):
@@ -660,11 +646,10 @@ class DatasetManager:
 
     def _fold_case_state(self, stage: Stage, shape: list[int], attribute: Attribute) -> list[int]:
         """Fold one stage over the evolving case state: the shape through its map, the geometry
-        through its stated transition: the idiom :meth:`_plan_read_stage` runs per region stage.
+        through its stated transition, the idiom :meth:`_plan_read_stage` runs per region stage.
 
         Every landing fold goes through here, so a stage is judged on the state the stages before it
-        left rather than on the stored header: a ``Resample`` behind a ``Canonical`` records the
-        reoriented grid, and a second ``Resample`` sees the first one's spacing.
+        left rather than on the stored header: a second ``Resample`` sees the first one's spacing.
         """
         out = self._stage_out_shape(stage, shape, attribute)
         if isinstance(stage, Transform):
@@ -673,19 +658,18 @@ class DatasetManager:
 
     @staticmethod
     def _adopt_case_facts(folding: Attribute, case: Attribute) -> None:
-        """Keep what a landing fold computed about the CASE (Crop's content-derived box) off its
-        walk state. The geometry the fold evolved is the walk's own (the run re-makes those
-        transitions); the box is expensive, immutable per case, and read by every later fold, the
-        streamed replays and the run itself."""
+        """Keep what a landing fold computed about the CASE (Crop's content-derived box) off its walk
+        state. The geometry the fold evolved is the walk's own; the box is expensive, immutable per
+        case, and read by every later fold, the streamed replays and the run."""
         if "box" in folding and "box" not in case:
             case["box"] = folding["box"]
 
     def chain_stages(self, a: int = 0) -> list[Stage]:
         """The ordered stages copy ``a`` is made of: the one definition of what a copy IS.
 
-        Behind an :class:`Expand`, the shared prefix, then the copy's own draw at the marker's
-        position, then the per-copy tail. Without one, the chain itself, with any draw appended
-        last: the training order, where an augmentation is a copy of the chain's whole result.
+        Behind an :class:`Expand`, the shared prefix, the copy's own draw at the marker's position,
+        then the per-copy tail. Without one, the chain itself with any draw appended last: the
+        training order, where an augmentation is a copy of the chain's whole result.
         """
         if self._expand is None:
             return [*self.transforms, *self._augmentation_stages(a)]
@@ -701,9 +685,8 @@ class DatasetManager:
         source_entry = self.name
         source_shape = list(self.base_shape)
         # Plan from the case as STORED (the pristine backup), never from the live attribute: the live
-        # one carries what earlier patches or epochs wrote (a Resample's target Spacing, a Canonical's
-        # canonical Direction), and planning from it would hand a stage its own output as the
-        # description of its input on every epoch after the first.
+        # one carries what earlier patches or epochs wrote, and planning from it would hand a stage
+        # its own output as the description of its input on every epoch after the first.
         stream_cache_attribute = Attribute(self.cache_attributes_bak[0])
         pending: list[_PendingSweep] = []
         trailing_transforms: list[Stage] = []
@@ -773,10 +756,9 @@ class DatasetManager:
                     sweep_refusal = planned_refusal
             trailing_transforms.append(transform)
 
-        # What copy `a` is. Without an Expand, the training order: the trailing transforms, then
-        # its own draw appended last. With one, the draw was spliced at the marker above, and the
-        # whole thing is planned as one chain either way: a region transform and a region
-        # augmentation are then two regions, which is exactly what they are.
+        # What copy `a` is. Without an Expand, the training order: the trailing transforms, then its
+        # own draw appended last. With one, the draw was spliced at the marker above. Either way the
+        # whole thing is planned as one chain.
         if self._expand is None:
             stages = trailing_transforms + (self._augmentation_stages(a) if apply_augmentations else [])
         else:
@@ -808,11 +790,10 @@ class DatasetManager:
             self._patch_stream_sources[key] = _PatchStreamSource(
                 source_dataset, source_group, source_entry, source_shape, stages, stage_plans
             )
-        # The state the whole plan lands on, kept for consumers that need the LANDED geometry (a
-        # reduction seeding its output header) without re-walking the chain. Recorded only when the
-        # plan HOLDS: a refused plan folded as far as the stage that refused and no further, and half
-        # a fold is not a geometry: it is a Spacing from before the resample meant to change it.
-        # An unset key is what lets ``landed_attributes`` answer with the stored state instead.
+        # The state the whole plan lands on, kept for consumers that need the LANDED geometry without
+        # re-walking the chain. Recorded only when the plan HOLDS: a refused plan folded as far as the
+        # stage that refused, and half a fold is a Spacing from before the resample meant to change
+        # it. An unset key is what lets ``landed_attributes`` answer with the stored state.
         if streamable:
             self._stream_evolved[key] = Attribute(evolved)
         return self._patch_stream_sources[key]
@@ -833,10 +814,8 @@ class DatasetManager:
     ) -> tuple[_PendingSweep | None, Attribute | None, str | None]:
         """Plan the materialization of one unsatisfied :class:`Save`, or refuse with the reason and
         leave it on the whole-volume path: the segment feeding it must itself stream, and the
-        destination must serve region writes (probed by capability, so a refusal costs nothing).
-        Returns ``(sweep, evolved, None)`` on success (the pending sweep and the case state its
-        cache will carry, which the stages after the Save plan against), and ``(None, None,
-        reason)`` on refusal."""
+        destination must serve region writes (probed by capability). Returns ``(sweep, evolved,
+        None)`` on success and ``(None, None, reason)`` on refusal."""
         if self._sweep_failure is not None:
             return (
                 None,
@@ -889,11 +868,11 @@ class DatasetManager:
 
     def sweep_segments(self, a: int = 0, apply_augmentations: bool = False) -> list[SweepSegment] | None:
         """Every segment the streamed route sweeps: one per unsatisfied ``Save`` (each sweeps ITS
-        source) plus the head past the last boundary, which is read only if stages follow it.
-        ``None`` when the chain cannot stream at all.
+        source) plus the head past the last boundary, read only if stages follow it. ``None`` when the
+        chain cannot stream at all.
 
-        Public because three consumers ask the same question of one plan: what the run will sweep,
-        what the plan prices it at, and whether the budget holds a region of it.
+        Public because three consumers ask it of one plan: what the run will sweep, what the plan
+        prices it at, and whether the budget holds a region of it.
         """
         source = self._resolve_patch_stream_source(a, apply_augmentations)
         if source is None:
@@ -930,11 +909,10 @@ class DatasetManager:
     def stream_refusal(self, a: int = 0, apply_augmentations: bool = True) -> str | None:
         """Why this copy cannot stream (the reified refusal) or ``None`` when it can.
 
-        Resolves the plan (a probe, never a write) and hands back the first stage-level reason the
-        planner met, or, past that, the budget one: a chain whose smallest region does not fit is
-        not a chain that streams, and routing it away here is what makes the whole-volume pass
-        price and refuse it before a byte is written, instead of the sweep meeting it at its first
-        slab. The whole-volume fallback stays available, but neither refusal is silent."""
+        Resolves the plan (a probe, never a write) and hands back the first stage-level reason, or,
+        past that, the budget one: a chain whose smallest region does not fit is not a chain that
+        streams. Routing it away here is what lets the whole-volume pass price and refuse it before a
+        byte is written. The fallback stays available, but neither refusal is silent."""
         key = (a, apply_augmentations)
         if key in self._stream_ok:
             return None
@@ -959,18 +937,16 @@ class DatasetManager:
         """The case as STORED: the geometry of the entry on disk, before any stage ran.
 
         A copy, and pristine on purpose: the live attribute carries what earlier regions or epochs
-        wrote into it, so anything planning against it would be handed a stage's own output as the
-        description of its input.
+        wrote into it.
         """
         return Attribute(self.cache_attributes_bak[0])
 
     def landed_attributes(self, a: int = 0) -> Attribute:
         """The case state the chain LANDS on: stored geometry folded by every stage's rewrite.
 
-        This is what an output built FROM the chain's result must carry as its header (a Resample's
-        target ``Spacing``, a Canonical's direction), where :attr:`stored_attributes` is the source's
-        own. Resolved from the plan (a probe, never a write); a chain that cannot stream answers with
-        the stored state, the only honest one available without assembling the volume.
+        What an output built FROM the chain's result must carry as its header, where
+        :attr:`stored_attributes` is the source's own. Resolved from the plan (a probe, never a
+        write); a chain that cannot stream answers with the stored state.
         """
         self._resolve_patch_stream_source(a, apply_augmentations=False)
         evolved = self._stream_evolved.get((a, False))
@@ -1014,17 +990,17 @@ class DatasetManager:
         """The per-rank budget this case's streamed sweeps size their slabs against.
 
         Public because the budget reaches a manager from more than one door:
-        :meth:`~konfai.data.materialize.CaseMaterializer.materialize` takes it as an argument, while
-        a reduction only ever calls :meth:`read_region`: which sweeps pending Saves as a side effect
-        and must sweep them under the same bound.
+        :meth:`~konfai.data.materialize.CaseMaterializer.materialize` takes it as an argument, while a
+        reduction only calls :meth:`read_region`, which sweeps pending Saves as a side effect and must
+        sweep them under the same bound.
         """
         self._sweep_budget_bytes = budget_bytes
 
     def set_chain_device(self, device: torch.device | None) -> None:
         """The device this case's chain replays on. Public for the same reason as the budget: a
-        reduction never calls :meth:`materialize`, only :meth:`read_region`, and its members must
-        replay where the fold will run. CPU collapses to None: opt-in only, because this same
-        machinery loads training cases inside DataLoader workers, where a CUDA default is wrong."""
+        reduction only calls :meth:`read_region`, and its members must replay where the fold will run.
+        CPU collapses to None: opt-in only, because this machinery also loads training cases inside
+        DataLoader workers, where a CUDA default is wrong."""
         self._chain_device = device if device is not None and device.type != "cpu" else None
 
     def _set_rewrite(self, rewrite: bool) -> None:
@@ -1033,10 +1009,9 @@ class DatasetManager:
         why the flag and the ledger it resets live here and not on the engine)."""
         if rewrite == self._rewrite_saves:
             return
-        # The memoized plans were probed under the other boundary answer: replan. And replan from
-        # the case as STORED: an earlier boundary-based plan wrote the OUTPUT's header into the
-        # backup (its Spacing, its Size), and a rewrite planned from that geometry re-writes
-        # untransformed data over the deliverable without an error.
+        # The memoized plans were probed under the other boundary answer: replan, and replan from the
+        # case as STORED. An earlier boundary-based plan wrote the OUTPUT's header into the backup, and
+        # a rewrite planned from that geometry re-writes untransformed data over the deliverable.
         self._rewrite_saves = rewrite
         self._patch_stream_sources.clear()
         self._stream_refusals.clear()
@@ -1051,9 +1026,8 @@ class DatasetManager:
         """Whether this copy can stream its patches, materializing what that requires.
 
         Resolves the source and, the first time a case whose chain reads through unmaterialized Save
-        caches is actually asked for data, sweeps them and re-resolves from disk: all data then
-        flows through the satisfied-boundary path, exactly as if the caches had always existed. The
-        regime probes (``can_stream_patch``) answer from the plan alone and never write."""
+        caches is asked for data, sweeps them and re-resolves from disk. The regime probes
+        (``can_stream_patch``) answer from the plan alone and never write."""
         self._require_statistics()
         source = self._resolve_patch_stream_source(a, apply_augmentations)
         if source is None:
@@ -1065,9 +1039,8 @@ class DatasetManager:
 
     def _sweep_pending(self, sweeps: Iterable[_PendingSweep]) -> None:
         """Materialize the pending Save caches in order, stopping at the first failure: they are
-        chained (each one's source is the previous one's destination), so past a failure the next
-        would read a cache nobody wrote and record its own symptom over the cause. Every plan is
-        then dropped: they pointed at caches that did not exist yet, or after a failure never will."""
+        chained, so past a failure the next would read a cache nobody wrote and record its own symptom
+        over the cause. Every plan is then dropped."""
         for sweep in sweeps:
             if not self._materialize_save(sweep):
                 break
@@ -1144,11 +1117,10 @@ class DatasetManager:
         members: list[_SweepMember],
     ) -> tuple[set[Any], str | None]:
         """The block loop every sweep runs: each block of REFERENCE's landing is read once through
-        SOURCE (its first block against EVOLVED, so a region stage recording geometry nowhere the
-        case can read refuses here, as the patch path does), then every :class:`_SweepMember`
-        applies its tail to the block and region-writes it into its own stream, opened on the first
-        block with the header the whole-volume pass would leave. Returns the keys written and, when
-        the pass failed, why: every stream is then aborted; an interrupt is re-raised."""
+        SOURCE (its first block against EVOLVED, so a region stage recording geometry nowhere the case
+        can read refuses here), then every :class:`_SweepMember` applies its tail to the block and
+        region-writes it into its own stream. Returns the keys written and, when the pass failed, why:
+        every stream is then aborted; an interrupt is re-raised."""
         spatial = list(reference.out_spatial)
         channels = int(reference.source_shape[0])
         # Keyed to the segment being swept: ITS stages (the re-planned source's) and ITS store.
@@ -1173,9 +1145,8 @@ class DatasetManager:
         # The regions in flight at once: what must have run at a height before its cost is known.
         growth.settle = depth + 2
         # Reading ahead means the reading thread must touch no stage of the chain, so the pull maps
-        # are folded on this thread, a few regions ahead of the reader. A stage that sizes its
-        # window from the data it reads (a displacement field: the sizing read IS the sampling
-        # read) cannot be folded ahead, and that chain reads where it samples.
+        # are folded on this thread, a few regions ahead of the reader. A stage that sizes its window
+        # from the data it reads (a displacement field) cannot be folded ahead.
         folds_ahead = not any(plan.run_pull is not None for plan in source.stage_plans)
         ahead = depth if folds_ahead else 0
         sweeps = {member.key: member.sweep for member in members}
@@ -1185,10 +1156,9 @@ class DatasetManager:
         # The regions, cut one at a time as the growth decides their height, and handed to the
         # reader with their pulls already folded: this thread cuts, the reader reads.
         regions_plan = _RegionPlan(spatial, tile, growth)
-        # The stores and the stages are told the reads to come only where the decomposition is
-        # fixed, which is a sweep with no budget to grow under: declared at the first height, a
-        # growing sweep deviates at its second band and the store keeps what it used last from
-        # there on.
+        # The stores and the stages are told the reads to come only where the decomposition is fixed,
+        # a sweep with no budget to grow under: a growing sweep deviates at its second band and the
+        # store keeps what it used last from there on.
         if not growth.budget_bytes:
             hinted = list(_sweep_targets(spatial, tile))
             if folds_ahead:
@@ -1253,8 +1223,7 @@ class DatasetManager:
                             scope = Attribute(region_attribute)
                             # Dispatched exactly as the stages before the marker are, so a tail stage
                             # reading a companion volume (Mask) or drawing from the voxel's place
-                            # (Noise, CutOUT) is told where its block sits instead of taking it for
-                            # the whole volume.
+                            # (Noise, CutOUT) is told where its block sits.
                             member_tensor = self._run_streamed_stages(
                                 member.stages,
                                 member.stage_plans,
@@ -1332,9 +1301,8 @@ class DatasetManager:
     def _sweep_failed_because(self, sweep: _PendingSweep, reason: str) -> bool:
         """Record why a sweep gave up, warn, and answer ``False``: the one exit for all of them.
 
-        The reason is kept, not only warned: a caller with a whole-volume fallback treats this as
-        information, but one without (a reduction reading through this cache) has to raise, and it
-        can only be as specific as what was kept here.
+        The reason is kept, not only warned: a caller without a whole-volume fallback has to raise,
+        and it can only be as specific as what was kept here.
         """
         self._sweep_failure = f"'{sweep.group}/{sweep.entry}' could not be written region by region: {reason}"
         warnings.warn(f"{self._sweep_failure} Falling back to the whole-volume path.", stacklevel=3)
@@ -1349,15 +1317,13 @@ class DatasetManager:
         return cast(tuple[int, ...] | None, self._read_granularity)
 
     def region_reads(self, rows: int, a: int = 0) -> "BlockReads | None":
-        """What a decomposition into ``rows``-row regions costs this chain in source voxels.
-        ``None`` when the chain cannot stream.
+        """What a decomposition into ``rows``-row regions costs this chain in source voxels. ``None``
+        when the chain cannot stream.
 
-        The same aggregates the sweep sizes against (:class:`BlockReads`): ``widest_pull``, the
-        source window one region materialises -- which for a chain that resamples is not the region
-        and is what a fold must hold while it produces one; ``widest_excess``, what the store
-        decodes above that window, a chunked one serving a window by the block-aligned hull that
-        covers it; and ``total``, what all the regions read together, the figure a caller compares
-        heights on.
+        The same aggregates the sweep sizes against (:class:`BlockReads`): ``widest_pull``, the source
+        window one region materialises, which for a chain that resamples is not the region;
+        ``widest_excess``, what the store decodes above that window, a chunked one serving a window by
+        the block-aligned hull; and ``total``, what all the regions read together.
 
         Closed form, from the chain's own pull maps and the store's metadata: no voxel is read.
         """
@@ -1510,17 +1476,16 @@ class DatasetManager:
     def _region_target(self, index: int, a: int, is_input: bool) -> tuple[slice, ...]:
         """The spatial window the region chain replays for patch ``index`` of copy ``a``: the read
         plan's own slices, which widen the grid slot by the halo AND by the 2.5D slice context
-        (``extend_slice``). The context must come from the volume: ``_finalize_stream_patch``
-        reflects and concatenates the plan on what this hands back, and a slot alone gave it one
-        slice where the model expects ``extend_slice + 1``."""
+        (``extend_slice``). The context must come from the volume: ``_finalize_stream_patch`` reflects
+        and concatenates the plan on what this hands back."""
         plan = self.patch.get_read_plan(self.shapes[a], index, a, is_input)
         spatial = len(self.patch.get_patch_slices(a)[index])
         return tuple(plan.data_slices[len(plan.data_slices) - spatial :])
 
     def _finalize_stream_patch(self, tensor: torch.Tensor, index: int, a: int, is_input: bool) -> torch.Tensor:
         """Pad a streamed patch to ``patch_size`` through the same read plan the whole-volume path
-        applies, so a border patch the overlap tiling left narrower is byte-identical between the
-        two paths. The plan is built on ``self.shapes[a]``, the grid this copy's patches are cut on.
+        applies, so a border patch is byte-identical between the two paths. The plan is built on
+        ``self.shapes[a]``, the grid this copy's patches are cut on.
         """
         plan = self.patch.get_read_plan(self.shapes[a], index, a, is_input)
         return self.patch.apply_read_plan(tensor, plan)
@@ -1567,15 +1532,12 @@ class DatasetManager:
     def _refold_copy_records(self, a: int, stream_source: _PatchStreamSource) -> None:
         """Re-fold copy ``a``'s chain state before replaying a region of it.
 
-        A stage keys its per-case records by the CASE name (a stored transform is looked up by
-        it), so the copies of an Expand share one key and the last WALK's records win. The write
-        sweeps re-plan before sweeping and the whole-volume path re-records at call time; the
-        patch replay is the consumer left over, and reading two copies interleaved would otherwise
-        hand one copy the other's grids. Headers only: no voxel is read.
+        A stage keys its per-case records by the CASE name, so the copies of an Expand share one key
+        and the last WALK's records win. The write sweeps re-plan before sweeping and the whole-volume
+        path re-records at call time; the patch replay is the consumer left over, and reading two
+        copies interleaved would hand one copy the other's grids. Headers only: no voxel is read.
 
-        Once per change of copy, not per patch: consecutive patches nearly always belong to one
-        copy, and ``_records_source`` says whose records the stages hold until a fold or a
-        whole-volume call moves them.
+        Once per change of copy, not per patch: consecutive patches nearly always belong to one copy.
         """
         if not stream_source.stages:
             return
@@ -1608,10 +1570,8 @@ class DatasetManager:
         them: ``entries`` is its ``(copy, patch)`` sequence, from the loader's own order (see
         :class:`~konfai.data.data_manager.PatchReadOrder`). Called once, as the case is entered.
 
-        The reads are named from the plans alone, so nothing is read here and no voxel of a patch
-        still to come is touched. A copy whose Save caches are not materialized yet is left out: the
-        sweep that materializes them declares its own reads, and what the patches then read is the
-        cache, not this source.
+        The reads are named from the plans alone: nothing is read here. A copy whose Save caches are
+        not materialized yet is left out, since the sweep that materializes them declares its own.
         """
         if self.loaded or not entries or not self._stream_ready(entries[0][0], apply_augmentations):
             return
@@ -1641,8 +1601,7 @@ class DatasetManager:
         A store that caches decoded blocks then keeps what a later read asks for again and drops what
         none does (:meth:`~konfai.utils.dataset.Dataset.plan_region_reads`), and a stage reading a
         companion volume beside its region (:class:`~konfai.data.transform.Mask`) declares those reads
-        too. Grouped by the entry read and by the stage handed the region, so the copies of one case
-        interleaved over one store are declared as the single sequence that store will serve.
+        too. Grouped by the entry read and by the stage handed the region.
         """
         by_entry: dict[tuple[Dataset, str, str], list[tuple[slice, ...]]] = {}
         by_stage: dict[int, tuple[Stage, list[RegionContext]]] = {}  # by identity: a Stage need not be hashable
@@ -1665,8 +1624,8 @@ class DatasetManager:
         itself and the first the window to read from the store.
 
         Closed form, from the plans' own pull maps, EXCEPT for a stage that sizes its window from the
-        data (``run_pull``, a displacement field): that one reads, and its sizing read is also its
-        sampling read, so its spans cannot be folded ahead of the chain.
+        data (``run_pull``, a displacement field): its sizing read is also its sampling read, so its
+        spans cannot be folded ahead of the chain.
         """
         spans: list[list[slice]] = [list(target_slices)]
         for plan in reversed(stream_source.stage_plans):
@@ -1701,9 +1660,8 @@ class DatasetManager:
         read returned, then :meth:`_run_streamed_stages` walks the stages over it.
 
         ``cache_attribute`` is the region's scope, evolved by the chain; ``case_attribute``, when
-        given, receives each region stage's case-level geometry (from the full shape). Returns the
-        tensor, the evolved scope, and the keys the scope held before (what the chain added is what
-        the caller may persist).
+        given, receives each region stage's case-level geometry. Returns the tensor, the evolved
+        scope, and the keys the scope held before.
         """
         cache_attribute.update(attributes)
         cache_attribute["StatisticsSeeded"] = 1.0  # same contract as the pointwise route above
@@ -1723,12 +1681,11 @@ class DatasetManager:
         case_attribute: Attribute | None,
     ) -> torch.Tensor:
         """Walk STAGES over a region already read, each on the region pair the fold computed for it:
-        HALO reads the enlarged region and is cropped back, ORIENTATION remaps what it read, a
-        CROP's remap is its action (not re-applied), REGRID interpolates to its target extent, a
-        per-voxel stage is told where its region sits.
+        HALO reads the enlarged region and is cropped back, ORIENTATION remaps what it read, a CROP's
+        remap is its action (not re-applied), REGRID interpolates to its target extent, a per-voxel
+        stage is told where its region sits.
 
-        The one dispatch: a chain read through the store and a member's per-copy tail (which reads
-        on the landing, so its regions are the blocks themselves) both come here.
+        The one dispatch: a chain read through the store and a member's per-copy tail both come here.
         """
         for stage, plan, source, target in zip(stages, plans, spans[:-1], spans[1:], strict=True):
             if not plan.kind.is_region:
@@ -1762,9 +1719,8 @@ class DatasetManager:
 
         A region stage is handed a patch, so what it records about the extent is one patch's answer:
         the scope it records into is thrown away, and ``write_stream_cache_attribute`` is what reaches
-        the case. A stage that records in ``__call__`` alone streams a whole run and leaves the case
-        the geometry it was stored with. Recording in both is what a reorientation does: the check
-        is on recording in neither.
+        the case. A stage that records in ``__call__`` alone leaves the case the geometry it was
+        stored with. The check is on recording in neither.
         """
         recorded = {key for key in scoped.keys() if key not in cache_attribute or scoped[key] != cache_attribute[key]}
         if not recorded:

--- a/konfai/data/patching/manager.py
+++ b/konfai/data/patching/manager.py
@@ -375,10 +375,10 @@ class DatasetManager:
         if all(index in self.augmented_data for index in indices):
             return
 
-        # The case tensor itself, once per copy. A draw hands back a fresh tensor or a view of what
-        # it was given and writes nothing into it (Foreign clones for a class that might), so a copy
-        # a draw did not select IS the case. A clone per copy was 640 MiB and 0.22 s for 10 copies of
-        # a 64 MiB case, per group, per case, per epoch under inline augmentation.
+        # The case tensor itself, once per copy. A draw must not write into the tensor it is handed:
+        # it returns a fresh tensor or a view (Foreign clones for a class that might), so a copy a
+        # draw did not select IS the case. A clone per copy was 640 MiB and 0.22 s for 10 copies of a
+        # 64 MiB case, per group, per case, per epoch under inline augmentation.
         a_data = [self.data[0] for _ in range(data_augmentations.nb)]
         for data_augmentation in data_augmentations.data_augmentations:
             if data_augmentation.groups is None or self.group_dest in data_augmentation.groups:

--- a/konfai/data/patching/sizer.py
+++ b/konfai/data/patching/sizer.py
@@ -16,12 +16,8 @@
 
 """The sweep's pricing engine, keyed to the segment it prices.
 
-The sizing once lived on the :class:`~konfai.data.patching.manager.DatasetManager` and read manager
-state: the WHOLE declared chain's channel folds and the RAW source's read granularity. A segment
-past a ``Save`` boundary was therefore priced with another segment's facts -- channel folds applied
-twice onto a cache that already holds them, the wrong store's chunk grid, and a copy's draws priced
-at zero. A :class:`SegmentSizer` is constructed per segment from explicit inputs, so the price can
-only read the segment's own facts -- and it needs no dataset fixture to be tested.
+A :class:`SegmentSizer` is constructed per segment from explicit inputs, so the price reads only the
+segment's own facts.
 """
 
 from collections.abc import Callable, Sequence
@@ -57,10 +53,8 @@ class SegmentSizer:
 
     ``spatial``/``channels``/``plans``/``stages`` are the segment's own landing, source channels,
     region plans and stage list; ``granularity`` is the segment's OWN store's decode grain (spatial
-    axes, ``None`` when a read costs what it asks for -- including a cache this run has still to
-    write, whose chunks will be the very tile being sized, so its reads align by construction).
-    ``block_reads_memo`` is shared across sizers by the owning manager: the geometry walk is the
-    expensive part and its key already carries everything a sizer varies.
+    axes, ``None`` when a read costs what it asks for, a cache this run has still to write included).
+    ``block_reads_memo`` is shared across sizers by the owning manager.
     """
 
     spatial: list[int]
@@ -81,10 +75,7 @@ class SegmentSizer:
         the channels a block lands with, the widest the segment ever holds, and the volumes-worth
         its widest stage allocates, that one counted on the channels that stage is handed.
 
-        Identity for a segment that keeps the axis. ``OneHot`` is the stage that widens it, and a
-        block priced at the source's would be short by its class count. Every stage of the segment
-        answers -- a copy's draws included: priced at zero, an Expand copy swept under a budget
-        that never heard of its ``grid_sample`` buffers.
+        Every stage of the segment answers, a copy's draws included.
         """
         source = held = landed = peak = max(1, int(self.channels))
         working = 0.0
@@ -101,22 +92,16 @@ class SegmentSizer:
     # ------------------------------------------------------------------ reads
 
     def _source_extents(self) -> list[int]:
-        """The extents the pull spans live in: the first stage's own input, which is the stored
-        volume. The landing is a different grid, and a hull capped against it is under-charged
-        wherever the source is the larger of the two."""
+        """The extents the pull spans live in: the first stage's own input, the stored volume, never
+        the landing."""
         if self.plans:
             return [int(extent) for extent in self.plans[0].in_shape]
         return [int(extent) for extent in self.spatial]
 
     def block_reads(self, tile: Sequence[int]) -> BlockReads:
-        """What a decomposition of the landing into ``tile`` reads, walked once and kept.
-
-        The sizing asks the same question of the same decomposition several times over -- the shape
-        rule prices the slab and the cube, the ladder is priced height by height -- and every one
-        of those goes through the chain's pull maps, which for a ``Resample`` is real geometry per
-        block. Keyed by the decomposition AND by the plans
-        that map it, whose tuple is held so no identity is reused under the key.
-        """
+        """What a decomposition of the landing into ``tile`` reads, walked once and kept, keyed by the
+        decomposition AND by the plans that map it, whose tuple is held so no identity is reused under
+        the key."""
         key = (tuple(self.spatial), tuple(tile), tuple(id(plan) for plan in self.plans), self.granularity)
         held = self.block_reads_memo.get(key)
         if held is not None:
@@ -132,22 +117,16 @@ class SegmentSizer:
         return reads
 
     def decomposition_reads(self, tile: Sequence[int]) -> int:
-        """What sweeping the landing in ``tile`` reads from the store, all blocks together.
-
-        The store's own currency: a chunked backend decodes whole blocks, so what a decomposition
-        reads is the sum of its blocks' hulls, and a shape is judged on the same figure it is later
-        priced with (:meth:`sweep_block_bytes`). Two currencies here and there is how a shape gets
-        chosen for pulling little and then costs what its hull costs.
-        """
+        """What sweeping the landing in ``tile`` reads from the store, all blocks together: the sum of
+        the blocks' hulls, the figure :meth:`sweep_block_bytes` prices."""
         return self.block_reads(tile).total
 
     def sweep_block_bytes(self, tile: list[int], depth: int) -> int:
         """What a sweep decomposed into ``tile`` holds at its peak: the source regions it has pulled
         and the blocks it has landed, both counted by :func:`_sweep_resident_regions`, plus what the
         widest stage of the segment allocates on top of the largest of them. Each term is counted on
-        the channels it actually holds (:meth:`chain_channels`), at ``_SWEEP_ELEMENT_BYTES`` each.
-        Beside this, and outside it, a streamed case holds ``SWEEP_ENGINE_FLOOR_BYTES`` the
-        decomposition cannot lower.
+        the channels it holds (:meth:`chain_channels`), at ``_SWEEP_ELEMENT_BYTES`` each. Outside
+        it, a streamed case holds ``SWEEP_ENGINE_FLOOR_BYTES``.
         """
         pulled, landed = _sweep_resident_regions(depth)
         block = int(np.prod(tile, dtype=np.int64))
@@ -155,11 +134,8 @@ class SegmentSizer:
         pull = reads.widest_pull or block
         source, landed_channels, _peak, working = self.chain_channels()
         held = pulled * pull * source + landed * block * landed_channels + working * max(pull, block)
-        # A chunked store serves a window by decoding the block-aligned hull that covers it, and
-        # assembles the window out of that: one read is in flight at a time, so the hull is resident
-        # ONCE, and the window is the part of it the chain keeps. What a straddling region costs is
-        # exactly this term, and it does not fall when the region does -- below one stored block a
-        # shorter region reads the same bytes and only reads them more often.
+        # A chunked store decodes the block-aligned hull covering a window, one read in flight: the
+        # hull is resident ONCE, and it does not fall when the region does.
         held += reads.widest_excess * source
         return int(held * _SWEEP_ELEMENT_BYTES)
 
@@ -169,11 +145,9 @@ class SegmentSizer:
         """The block ``rows`` rows of the landing become: the slab itself, or the cube of the same
         volume where that pulls less.
 
-        A region pulls the BOUNDING BOX of its own image under the chain's maps, so a slab spanning
-        the trailing plane pays that plane's extent for every degree of shear where a cube pays its
-        side: 1.79x the image against 1.09x on a 513x1331x1776 rigid+affine. Both are priced against
-        the plans' own pull maps, and the cube wins only by ``_SWEEP_TILE_MARGIN``: the decomposition
-        is also the shape a store gets chunked in. Without plans, the slab.
+        A region pulls the BOUNDING BOX of its own image under the chain's maps. Both are priced
+        against the plans' own pull maps, and the cube wins only by ``_SWEEP_TILE_MARGIN``. Without
+        plans, the slab.
         """
         slab, cube = self._slab(rows), self._cube(rows)
         if cube == slab or not self.plans:
@@ -183,8 +157,7 @@ class SegmentSizer:
 
     def unit_rows(self) -> int:
         """What a region grows by: the store's block along the sweep axis, else ``SWEEP_SLAB_ROWS``.
-        A region a whole number of blocks tall reads each stored block once; one that straddles the
-        grid decodes both blocks it touches, for every region."""
+        A region that straddles the grid decodes both blocks it touches."""
         block = int(self.granularity[0]) if self.granularity is not None else 1
         return block if block > 1 else int(budget.SWEEP_SLAB_ROWS)
 
@@ -207,9 +180,7 @@ class SegmentSizer:
 
     def _tallest(self, allowance: float, depth: int, shape: Callable[[int], list[int]]) -> int | None:
         """The tallest height up to the cap whose priced block, in ``shape``, holds inside
-        ``allowance``; ``None`` when one row does not. Bisected on the price itself: none of what a
-        region costs scales with its rows (a halo is a constant, a rotated map's box grows with
-        the diagonal, a chunked store decodes whole blocks whatever the height)."""
+        ``allowance``; ``None`` when one row does not. Bisected on the price itself."""
         if self.sweep_block_bytes(shape(1), depth) > allowance:
             return None
         low, high = 1, self.cap_rows()
@@ -224,20 +195,14 @@ class SegmentSizer:
     def start(self, depth: int | None = None) -> tuple[list[int], RegionGrowth]:
         """The block the first region covers and how the regions grow from it (:class:`RegionGrowth`).
 
-        The shape is decided at the height the whole budget buys (:meth:`sweep_shape`: the slab, or
-        the cube where a sheared map makes it pull less), because the shape is a fact of the pull
-        geometry and not of the memory. A slab then starts at the tallest height whose price holds
-        inside ``_START_SHARE`` of the budget, snapped down to a whole number of the store's blocks
-        when one fits, and grows from there; a cube starts where the budget's own price puts it,
-        since it cannot grow across the plane and would pay a small start for the whole case
-        (measured: 84 cubes of 256^3 against 37 slabs, +25 % of wall on a 513-row store under 8
-        GiB). Without a budget the unit stands, as it always did. The budget is what a sweep may
-        HOLD, so it is the priced block (:meth:`sweep_block_bytes`) that is held to it, never the
-        landed rows alone.
+        The shape is decided at the height the whole budget buys (:meth:`sweep_shape`). A slab starts
+        at the tallest height whose price holds inside ``_START_SHARE`` of the budget, snapped down to
+        a whole number of the store's blocks when one fits, and grows from there; a cube starts where
+        the budget's own price puts it. Without a budget the unit stands. The priced block
+        (:meth:`sweep_block_bytes`) is what is held to the budget, never the landed rows alone.
 
-        A budget one row does not fit is a refusal naming both figures, with the read-ahead given
-        up first: the queue is the one part of the price the sizing chose, and a sweep about to
-        refuse has no clock to buy with it.
+        A budget one row does not fit is a refusal naming both figures, with the read-ahead given up
+        first.
         """
         depth = sweep_module._sweep_pipeline_depth() if depth is None else depth
         budget_bytes = self.budget_bytes
@@ -277,9 +242,7 @@ class SegmentSizer:
     def sweep_depth(self, tile: list[int]) -> int:
         """How many blocks the sweep keeps in flight beside the one it transforms: the rank's
         pipeline depth while the priced block still holds inside the budget with it, none
-        otherwise. The queue is bought, and a sweep that cannot afford it stops buying it: three
-        source regions resident become one, a quarter to a third of the block on a chain whose
-        stage buffers do not dominate."""
+        otherwise."""
         depth = sweep_module._sweep_pipeline_depth()
         budget_bytes = self.budget_bytes
         if not depth or not budget_bytes or budget_bytes <= 0:

--- a/konfai/data/patching/stage.py
+++ b/konfai/data/patching/stage.py
@@ -48,10 +48,9 @@ def _halo_radii(halo: tuple[int, ...], n_axes: int) -> list[int]:
 class Stage(Protocol):
     """One step of what a case's copy is made of, as the patch-streaming dispatcher sees it.
 
-    A copy is its group's transforms followed by the augmentations drawn for it, and streaming asks the
-    same three things of every step: what its output depends on, which source region a target patch
-    needs, and to run on one tensor. A ``Transform`` answers them as itself. An augmentation is
-    parameterised per case and per copy, so it answers them bound to one (see :class:`AugmentedStage`).
+    Streaming asks three things of every step: what its output depends on, which source region a
+    target patch needs, and to run on one tensor. A ``Transform`` answers as itself; an augmentation
+    answers bound to one case and copy (:class:`AugmentedStage`).
     """
 
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality: ...
@@ -78,13 +77,8 @@ class Stage(Protocol):
 
 
 def _spatial(shape: object) -> list[int]:
-    """A folded shape as plain Python ints, whatever the stage returned it as.
-
-    ``transform_shape`` is user-facing: a stage that computes its target grid with torch or numpy
-    hands back that library's scalars, and they travel unnoticed until something outside Python asks
-    for a real int: a zarr store refusing "Expected an iterable of integers", a header holding
-    ``tensor(128)``. Normalising at the fold makes ``shapes`` hold what it is typed as.
-    """
+    """A folded shape as plain Python ints: a stage's ``transform_shape`` may hand back torch or numpy
+    scalars."""
     return [int(extent) for extent in cast("Sequence[Any]", shape)]
 
 
@@ -95,11 +89,9 @@ def _is_draw(stage: object) -> TypeGuard[DataAugmentation]:
 
 @contextlib.contextmanager
 def _drawn_from(*key: object) -> Iterator[None]:
-    """Seed the global RNGs (random, numpy, torch on every device) from ``key`` for the duration,
-    then restore them. Two chains of one case (an image and its mask) hold different draw objects
-    and derive the same copies from the same key (the Expand's seed, the case's name, which draw
-    this is). ``blake2b``, not ``hash()``: string hashing is salted per process.
-    """
+    """Seed the global RNGs (random, numpy, torch on every device) from ``key`` for the duration, then
+    restore them. Two chains of one case derive the same copies from the same key. ``blake2b``, not
+    ``hash()``: string hashing is salted per process."""
     digest = hashlib.blake2b("|".join(str(part) for part in key).encode(), digest_size=4).digest()
     with preserved_rng():
         seed_all(int.from_bytes(digest, "big"))
@@ -107,12 +99,7 @@ def _drawn_from(*key: object) -> Iterator[None]:
 
 
 def _stage_name(stage: Stage) -> str:
-    """What to CALL a stage in a message: a draw's own class, never the adapter that binds it.
-
-    Every refusal and every regime note names the stage that caused it, and 'AugmentedStage' names
-    nothing a user wrote: the point of saying which stage refused is lost if the answer is the
-    wrapper's name for all of them.
-    """
+    """What to CALL a stage in a message: a draw's own class, never the adapter that binds it."""
     if isinstance(stage, AugmentedStage):
         return type(stage.augmentation).__name__
     return type(stage).__name__
@@ -120,11 +107,8 @@ def _stage_name(stage: Stage) -> str:
 
 @dataclass(frozen=True)
 class AugmentedStage:
-    """One augmentation, bound to the case and the copy whose draw it carries.
-
-    An augmentation is parameterised per (case, copy); binding both makes it answer the Stage
-    protocol like a plain transform.
-    """
+    """One augmentation, bound to the case and the copy whose draw it carries, so it answers the Stage
+    protocol like a plain transform."""
 
     augmentation: DataAugmentation
     index: int
@@ -138,13 +122,9 @@ class AugmentedStage:
         return channels
 
     def case_working_multiple(self, name: str) -> float:
-        """What this copy's draw allocates beyond its block, in volumes-worth of it.
-
-        From the draw's locality: a REGRID draw resamples through ``grid_sample``, which builds the
-        pull box's coordinate grid (one volume per spatial axis) beside the landed block; any other
-        draw returns a fresh tensor or a view over a field of its own (one volume). Priced at zero,
-        an Expand copy's draws swept under a budget that never heard of their buffers.
-        """
+        """What this copy's draw allocates beyond its block, in volumes-worth of it: a REGRID draw builds
+        the pull box's coordinate grid through ``grid_sample`` (one volume per spatial axis), any other
+        draw one volume."""
         del name
         kind = self.patch_locality(Attribute()).kind
         return 4.0 if kind is LocalityKind.REGRID else 1.0
@@ -156,8 +136,7 @@ class AugmentedStage:
         source_spatial_shape: list[int],
         cache_attribute: Attribute,
     ) -> list[slice]:
-        # A draw is bound to (case index, copy), not to the case's NAME: the name a region stage
-        # needs to find its own per-case map means nothing to an augmentation.
+        # A draw is bound to (case index, copy), not to the case's NAME.
         del name
         return self.augmentation.stream_region_source(self.index, self.a, target_slices, source_spatial_shape)
 
@@ -183,9 +162,7 @@ class AugmentedStage:
         return self.augmentation.compute(name, self.index, self.a, tensor)
 
 
-# The pull maps are callable dataclasses, not closures, because a plan crosses a process boundary:
-# the launcher plans every case, `mp.spawn` then pickles the workflow object whole, and a local
-# function cannot be pickled. Everything a plan memoizes must survive that trip.
+# The pull maps are callable dataclasses, not closures: a plan is pickled whole by `mp.spawn`.
 
 
 @dataclass(frozen=True)
@@ -206,11 +183,8 @@ class _HaloPull:
 class _RemapPull:
     """An index-remap stage's pull map, bound to the case and the state the stages before it left.
 
-    The case NAME is bound here because a stage instance is shared by every case of a manager
-    (``DatasetManager`` hands the same transforms list to each), while a map read from a stored
-    transform or a reference header is per case. A pull that could not say which case it was for
-    would build one case's window from another case's map, and a window that is short does not
-    raise, it returns the fill.
+    The case NAME is bound: a stage instance is shared by every case of a manager, while a map read
+    from a stored transform or a reference header is per case.
     """
 
     remap: Callable[[str, tuple[slice, ...], list[int], Attribute], list[slice]]
@@ -228,8 +202,7 @@ class _ReadStagePlan:
     on either side, and (for a region stage) the pull map from a region of its output to the region
     of its input it is computed from, bound to the case state the stages before it left.
 
-    ``run_pull``, when set, is the pull the RUN walks instead: a stage that sizes its windows from
-    the data it reads (a declared field) measures there, while ``pull`` stays headers-only for the
+    ``run_pull``, when set, is the pull the RUN walks instead; ``pull`` stays headers-only for the
     plan's pricing: the estimator must never read a voxel."""
 
     kind: LocalityKind

--- a/konfai/data/patching/sweep.py
+++ b/konfai/data/patching/sweep.py
@@ -41,14 +41,10 @@ from konfai.utils.runtime import rank_cpu_share
 
 
 def save_destination(save: Save, default_dataset: Dataset, default_group: str) -> tuple[Dataset, str]:
-    """The dataset and group a :class:`Save` caches into, the manager's own when it names none.
-
-    Public because a planner has to resolve a destination exactly as the engine will: one that probes
-    a store the run does not open has verified nothing.
-    """
+    """The dataset and group a :class:`Save` caches into, the manager's own when it names none. Public:
+    a planner must resolve a destination exactly as the engine will."""
     destination = save.destination
-    # No destination of its own: the Save caches into the manager's dataset, whose write format is
-    # not this stage's to redecorate: a pyramid asked here would silently not happen.
+    # A Save without a destination caches into the manager's dataset, whose write format is not its own.
     if destination is None and save.scale_factors:
         raise ConfigError(
             f"A '{type(save).__name__}' asks for a pyramid but names no dataset of its own.",
@@ -62,16 +58,9 @@ class RegionWriter:
     """Region writes into streams opened at their first block: the one sweep loop of the three
     engines (a Save's sweep, an Expand's shared pass, a Reduce).
 
-    ``write`` opens the stream for a key on its first block (through ``open_stream``, so a refusal
-    surfaces where the caller can say why) and writes the block; ``close`` publishes every stream,
-    ``abort`` drops every partial entry and is safe after a failure or an interrupt.
-
-    Writes here are synchronous. Whether a caller should overlap them with its compute depends on
-    where the compute runs, since the store's encoder competes for the host's cores: measured on a
-    300^3 float32 case to OME-Zarr, a host chain writing one slab behind was 50 % slower than
-    writing in place, and a host resample of a 513x1331x1776 case stayed at 13.0 s either way,
-    where the same resample on a GPU went from 8.2 s to 6.2 s with the write one block behind.
-    :class:`_WriteBehind` is what a sweep wraps this in; nothing here assumes it.
+    ``write`` opens the stream for a key on its first block (through ``open_stream``) and writes the
+    block; ``close`` publishes every stream, ``abort`` drops every partial entry and is safe after a
+    failure or an interrupt. Writes are synchronous; :class:`_WriteBehind` overlaps them.
     """
 
     def __init__(self, open_stream: Callable[[Any, np.ndarray, Attribute], DataStream]) -> None:
@@ -185,11 +174,8 @@ class _SweepMember:
 
 
 def _sweep_targets(spatial: list[int], tile: Sequence[int]) -> Iterator[tuple[slice, ...]]:
-    """The sweep's regions: ``tile``-sized blocks of the landing, innermost axis fastest.
-
-    The order is the source's: consecutive blocks differ on the axis stored contiguously, so the
-    chunks one block decodes are the chunks the next one reads.
-    """
+    """The sweep's regions: ``tile``-sized blocks of the landing, innermost axis fastest (the store's
+    own order)."""
     steps = [max(1, int(step)) for step in tile]
     for corner in itertools.product(*(range(0, extent, step) for extent, step in zip(spatial, steps, strict=True))):
         yield tuple(
@@ -201,13 +187,12 @@ def _cubic_tile(spatial: list[int], voxels: int, align: int) -> list[int]:
     """The block of at most ``voxels`` closest to a cube inside ``spatial``, aligned to ``align``.
 
     ``align`` keeps a block a whole number of store chunks wide, so a region write never becomes a
-    read-modify-write (:func:`konfai.utils.dataset.ome_zarr_file._store_chunks`); an axis shorter than one step is
-    taken whole. Why a cube: :meth:`DatasetManager._sweep_tile`.
+    read-modify-write; an axis shorter than one step is taken whole.
     """
     tile = [max(1, int(extent)) for extent in spatial]
     budget = float(max(1, voxels))
     # Shortest axis first: an axis under the ideal side takes its whole extent and hands its slack
-    # to the others, which only raises the side, so once one axis is over it every later one is too.
+    # to the others.
     free = sorted(range(len(spatial)), key=lambda axis: tile[axis])
     for taken, axis in enumerate(free):
         side = budget ** (1.0 / (len(free) - taken))
@@ -239,13 +224,8 @@ def _span_voxels(span: Sequence[slice]) -> int:
 
 
 class BlockReads(NamedTuple):
-    """What one decomposition's blocks read, in the currencies the sizing spends.
-
-    Every consumer of the enumeration wants an aggregate of it and none wants the blocks, so it is
-    walked once and the aggregates are kept: the widest window one block materialises, the widest
-    hull the store decodes to serve one, and what the whole decomposition reads. Walking it per
-    consumer made the plan spend 96% of its time in ``Resample.stream_region_source``.
-    """
+    """What one decomposition's blocks read: the widest window one block materialises, the widest
+    hull the store decodes to serve one, and what the whole decomposition reads."""
 
     widest_pull: int
     widest_hull: int
@@ -270,8 +250,7 @@ class _RegionPlan:
     The landing is swept in bands along the sweep axis, each band cut on the tile's trailing grid
     (one block per band for a slab, a grid of cubes for a cube). A band is as tall as the growth
     says when it starts, in whole multiples of the first, so every region starts on the chunk grid
-    the output was cut on and the trailing grid never moves: growing one axis of a cube re-cuts
-    nothing, where growing all three would no longer partition the landing.
+    the output was cut on and the trailing grid never moves.
     """
 
     def __init__(self, spatial: Sequence[int], tile: Sequence[int], growth: RegionGrowth) -> None:
@@ -282,14 +261,12 @@ class _RegionPlan:
         self._band: Iterator[tuple[slice, ...]] = iter(())
 
     def rewind(self, start: int) -> None:
-        """Cut again from ``start`` (a band's first row): what a sweep does after a region the device
-        could not hold, at the height the growth was cut to."""
+        """Cut again from ``start`` (a band's first row) at the growth's current height."""
         self._cursor = int(start)
         self._band = iter(())
 
     def next_target(self) -> tuple[slice, ...] | None:
-        """The next region, ``None`` past the last: a new band opens at the growth's CURRENT
-        height, so a height decided after one region is cut is the height of the bands cut after it."""
+        """The next region, ``None`` past the last: a new band opens at the growth's CURRENT height."""
         target = next(self._band, None)
         if target is not None:
             return target
@@ -313,9 +290,8 @@ def _sweep_pipeline_depth() -> int:
 
 def _sweep_resident_regions(depth: int) -> tuple[int, int]:
     """How many pulled source regions and how many landed blocks a sweep of pipeline ``depth`` holds
-    at once: the region the chain is running on, and, pipelined, the ``depth`` queued ahead of it
-    plus the one the reader holds while the queue is full; against the block being landed and,
-    pipelined, the one being written behind it."""
+    at once: the region being run, the ``depth`` queued ahead and the one the reader holds; the
+    block being landed and the one being written behind it."""
     return (1, 1) if depth < 1 else (depth + 2, 2)
 
 
@@ -343,9 +319,8 @@ SWEEP_CLOCK = SweepClock()
 class _ReadAhead:
     """One block's read running while the previous one is transformed and written.
 
-    The consumer drains IN ORDER, so a stage object is touched by one thread at a time: the read
-    stages by the producer, the tail by the consumer, disjoint by construction. At most ``depth``
-    blocks wait, and a consumer that leaves early stops the producer.
+    The consumer drains IN ORDER, so a stage object is touched by one thread at a time. At most
+    ``depth`` blocks wait, and a consumer that leaves early stops the producer.
     """
 
     _DONE = object()
@@ -366,8 +341,7 @@ class _ReadAhead:
     def __exit__(self, exc_type, value, traceback) -> None:
         if self._depth < 1:
             return
-        # To the end marker, whether the consumer stopped early or an error cut it short: a producer
-        # blocked on a full queue cannot reach its own end, and cannot then be joined.
+        # Drain to the end marker: a producer blocked on a full queue cannot be joined.
         self._stop.set()
         while self._queue.get()[0] is not _ReadAhead._DONE:
             pass
@@ -395,16 +369,9 @@ class _ReadAhead:
 
 
 class _HostLanding:
-    """The host buffers a device chain's blocks come home into, reused rather than reallocated.
-
-    A fresh allocation per block pays first-touch on pages the transfer overwrites whole, so the
-    pageable copy faults page by page: measured on a 216 MiB block, 2.4 GiB/s into a new buffer
-    against 10.1 GiB/s into one already resident. Two slots, because the writer holds exactly one
-    block while the sweep fills the next, and that is what the sweep already keeps live.
-
-    A block already on the host is handed over as it is: copying one would cost the host chain
-    exactly what this saves on the device one.
-    """
+    """The host buffers a device chain's blocks come home into, reused rather than reallocated. Two
+    slots: the writer holds one block while the sweep fills the next. A block already on the host is
+    handed over as it is."""
 
     _SLOTS = 2
 
@@ -428,10 +395,9 @@ class _HostLanding:
 class _WriteBehind:
     """A sweep's :class:`RegionWriter`, driven from one thread that is not the sweep's.
 
-    One worker and one outstanding write, so the order stays the sweep's and the store's own
-    encoder keeps its concurrency. EVERY call goes to that thread, not only the writes: the h5
-    backend holds a per-file ``RLock`` across a stream's whole life, and a release from a thread
-    that did not take it raises.
+    One worker and one outstanding write, so the order stays the sweep's. EVERY call goes to that
+    thread, not only the writes: the h5 backend holds a per-file ``RLock`` across a stream's whole
+    life, and a release from another thread raises.
     """
 
     def __init__(self, writer: RegionWriter, depth: int) -> None:
@@ -482,13 +448,8 @@ class _WriteBehind:
 
 
 def _torch_dtype_hint(error: BaseException) -> str | None:
-    """The config change that answers ``error``, when it is a dtype torch has no kernel for.
-
-    torch ships none for several dtypes a store legitimately holds: ``uint16`` is what microscopy
-    writes, and torch implements for it neither comparison, nor flip, nor arithmetic, nor scalar
-    fill. A chain that touches such a payload raises deep inside a stage with nothing but the
-    missing operator's name, where what the reader needs is the dtype and the line that fixes it.
-    """
+    """The config change that answers ``error``, when it is a dtype torch has no kernel for (``uint16``
+    is one)."""
     text = str(error)
     if not isinstance(error, NotImplementedError) or "not implemented for" not in text or text.count("'") < 2:
         return None
@@ -537,11 +498,8 @@ def _sweep_header(evolved: Attribute, scope: Attribute, keys_before: set[str]) -
 
 def _channel_first_block(block: np.ndarray, spatial: list[int], header: Attribute, what: str) -> np.ndarray:
     """The block a region write ships: channel-first, single-channel where the header says so
-    (:func:`as_channel_first`, the rule the whole-volume write applies), else refused.
-
-    Writing another rank anyway is the worst outcome available: the header would take the block's
-    first spatial extent for a channel count and publish a store of that many "channels", raising
-    nothing, while the whole-volume path returns the right rank: the two would silently disagree."""
+    (:func:`as_channel_first`, the rule the whole-volume write applies), else refused: the header
+    would take the block's first spatial extent for a channel count."""
     block = as_channel_first(block, header)
     if block.ndim != len(spatial) + 1:
         raise PatchError(
@@ -558,7 +516,7 @@ def _open_sweep_stream(
     sweep: _PendingSweep, block: np.ndarray, spatial: list[int], tile: Sequence[int], attributes: Attribute
 ) -> DataStream:
     """One region-write stream shaped for the sweep: the store chunks divide the block the sweep
-    writes (channels included), so no region write ever pays a read-modify-write."""
+    writes (channels included), so no region write pays a read-modify-write."""
     stream = sweep.destination.open_data_stream(
         sweep.group,
         sweep.entry,

--- a/konfai/data/reduction.py
+++ b/konfai/data/reduction.py
@@ -16,11 +16,9 @@
 
 """Operators that aggregate several tensors into one, and the contract that lets them stream.
 
-Two callers, one vocabulary: the predictor reduces the copies of one case (an ensemble's models, a
-TTA draw's augmentations), the transform workflow reduces one region across N cases. Both fold a
-leading axis at fixed voxel, region by region.
-
-A reduction is an extension point: subclass :class:`Reduction`, reference it by classpath.
+The predictor reduces the copies of one case (an ensemble, a TTA draw); the transform workflow
+reduces one region across N cases. Both fold a leading axis at fixed voxel, region by region.
+Subclass :class:`Reduction` and reference it by classpath.
 """
 
 from abc import ABC, abstractmethod
@@ -34,19 +32,15 @@ from konfai.utils.errors import ReductionError
 class Reduction(ABC):
     """Aggregate a list of tensors, one per case, into one.
 
-    Implement :meth:`__call__`; override the incremental protocol (:meth:`start`,
-    :meth:`accumulate`, :meth:`finalize`) when the operator can fold cases one at a time.
-
-    Both engines hand over ``[1, K, C, *spatial]``: a singleton stack axis, the axis that
-    distinguishes the folded things (the models of an ensemble; the case's channels for a cohort),
-    then the volume.
+    Implement :meth:`__call__`; override :meth:`start`, :meth:`accumulate` and :meth:`finalize` when
+    the operator can fold cases one at a time. Both engines hand over ``[1, K, C, *spatial]``: a
+    singleton stack axis, the axis distinguishing the folded things, then the volume.
     """
 
     #: ``True`` declares a per-voxel operation over the case axis: every output voxel depends only on
-    #: the SAME voxel of each input (a fold along dim 0 or 1). Anything reading across spatial
-    #: positions must stay ``False``. The streamed gates trust this flag and check nothing else: a
-    #: wrong ``True`` corrupts a streamed output (each region reduced with its own cases only); a
-    #: wrong ``False`` costs the whole-volume path.
+    #: the SAME voxel of each input. Anything reading across spatial positions must stay ``False``.
+    #: The streamed gates check nothing else: a wrong ``True`` corrupts a streamed output, a wrong
+    #: ``False`` costs the whole-volume path.
     voxel_local: bool = False
 
     #: Whether :meth:`accumulate` can fold cases one at a time (working set: two regions, whatever
@@ -60,9 +54,8 @@ class Reduction(ABC):
     def working_multiple_for(self, cases: int) -> float:
         """:attr:`working_multiple` for a fold of ``cases`` members, which is what the plan asks.
 
-        The attribute is the contract and the worst case; an operator whose route depends on the
-        count (``Median`` selects the middle by network up to five members, and sorts past that)
-        answers what THAT route holds, so the plan can cut taller slabs where the cheaper route runs.
+        The attribute is the worst case; an operator whose route depends on the count answers what
+        THAT route holds.
         """
         return float(self.working_multiple)
 
@@ -93,15 +86,12 @@ class Reduction(ABC):
 
 def _averaged_dtype(reference: torch.dtype) -> torch.dtype:
     """The dtype an average of ``reference`` values belongs in: floating inputs keep their own,
-    integer inputs widen to float32 (the mean of 1 and 2 is not an integer)."""
+    integer inputs widen to float32."""
     return reference if reference.is_floating_point else torch.float32
 
 
 class Mean(Reduction):
-    """Average the cases element-wise.
-
-    Accumulated in float32 whatever the inputs are, then returned as :func:`_averaged_dtype` says.
-    """
+    """Average the cases element-wise, accumulated in float32 and returned as :func:`_averaged_dtype` says."""
 
     voxel_local = True
     incremental = True
@@ -123,11 +113,9 @@ class Mean(Reduction):
         if self._total is None:
             self._total, self._dtype = tensor.to(torch.float32, copy=True), tensor.dtype
         else:
-            # Promoted inside the add kernel, whose cast to float32 is the one float() made: the
-            # same bits, without the float32 copy of the member that float() put beside the total
-            # (64 MiB per 32 MiB fp16 member: one allocation per member on CUDA, none here,
-            # measured; the CPU iterator casts into a temporary either way). A member wider than
-            # float32 would be added at its own width and rounded after, so it is narrowed first.
+            # Promoted inside the add kernel: the same bits as float(), without the float32 copy of
+            # the member beside the total. A member wider than float32 would be added at its own
+            # width and rounded after, so it is narrowed first.
             promoted = torch.promote_types(torch.float32, tensor.dtype) is torch.float32
             self._total.add_(tensor if promoted else tensor.float())
         self._count += 1
@@ -143,9 +131,8 @@ class Mean(Reduction):
 class Std(Reduction):
     """The element-wise standard deviation across cases: the ensemble-spread map.
 
-    Welford's running moments, so the peak is two float32 accumulators plus the case being read,
-    whatever N is. Unbiased (N-1), matching ``torch.std``; a single case has no spread and
-    finalizes to zeros.
+    Welford's running moments. Unbiased (N-1), matching ``torch.std``; a single case has no spread
+    and finalizes to zeros.
     """
 
     voxel_local = True
@@ -185,30 +172,19 @@ class Std(Reduction):
 
 class Median(Reduction):
     """The element-wise median across cases, averaging the middle pair on an even count as
-    ``numpy.median`` does (``torch.median`` returns the lower one). Not incremental: every case
-    is resident at one region. Not for label maps: the average of two labels is a third one; fold
-    segmentations with :class:`Vote`.
+    ``numpy.median`` does. Not incremental: every case is resident at one region. Not for label
+    maps; fold segmentations with :class:`Vote`.
     """
 
     voxel_local = True
-    # THE MIDDLE IS SELECTED, NEVER SORTED. A sort along the case axis copies the stack and returns
-    # int64 indices over it -- eight bytes an element whatever the members weigh -- so ten uint16
-    # regions of 33 x 1331 x 1775 (1.45 GiB) sorted at 6.0x their own size, and ten float32 ones
-    # at 4.0x (peak resident above the members, measured). A selection network of element-wise
-    # min/max holds a WINDOW of the k+1 smallest members seen so far, in the averaging dtype, and
-    # inserts each member into it: no stack, no indices, and the members stay in the dtype they
-    # arrived in. Ten uint16 members: 1.8x, against 6.0x. Twice the arithmetic of the sort (3.4 s
-    # against 1.6 on that region) on a fold whose clock is the disk by 40 to 1, and whose regions
-    # the planner may now cut two to three times taller.
-    #
-    # The attribute is the worst case the plan may see; :meth:`working_multiple_for` prices the
-    # network for the count it is handed.
+    # THE MIDDLE IS SELECTED, NEVER SORTED. A selection network of element-wise min/max holds a
+    # window of the k+1 smallest members seen so far, in the averaging dtype: no stack, no int64
+    # indices, and the members stay in the dtype they arrived in. The attribute is the worst case
+    # the plan may see; :meth:`working_multiple_for` prices the network for the count it is handed.
     working_multiple = 2.5
-    #: What the hand-written networks (three to five) hold beside the members they are handed,
-    #: measured on a 24 MiB float32 member.
+    #: What the hand-written networks (three to five) hold beside the members they are handed.
     _NETWORK_MULTIPLE: ClassVar[dict[int, float]] = {1: 1.0, 2: 1.5, 3: 1.0, 4: 2.5, 5: 1.5}
-    #: Past five, the window: k+1 float32 buffers for k = count // 2, and the two it blends,
-    #: measured on a 293 MiB uint16 member at ten.
+    #: Past five, the window: k+1 float32 buffers for k = count // 2, and the two it blends.
     _WINDOW_MULTIPLE = 1.8
 
     def working_multiple_for(self, cases: int) -> float:
@@ -224,9 +200,8 @@ class Median(Reduction):
         dtype = _averaged_dtype(tensors[0].dtype)
         if len(tensors) == 1:
             return tensors[0].to(dtype)
-        # The members are handed over in the dtype they arrived in and widened one at a time as the
-        # network takes them: torch has no integer min/max kernel on the CPU, and widening ten
-        # members up front is what put ten float32 copies beside ten uint16 regions.
+        # The members are widened one at a time as the network takes them: torch has no integer
+        # min/max kernel on the CPU.
         low, high = self._middle_pair(tensors, dtype)
         return low if low is high else torch.lerp(low, high, 0.5)
 
@@ -261,16 +236,9 @@ class Median(Reduction):
 
     @staticmethod
     def _middle_pair_by_window(members: list[torch.Tensor], dtype: torch.dtype) -> tuple[torch.Tensor, torch.Tensor]:
-        """The middle pair of any count, by an insertion window of the ``k + 1`` smallest seen.
-
-        The middle of ``count`` members is rank ``count // 2`` (0-based; the pair ``count // 2 - 1``
-        and ``count // 2`` on an even count). A window that keeps the ``k + 1`` smallest members
-        seen so far, ``k = count // 2``, holds those ranks exactly once every member has passed
-        through it: a member larger than the whole window can be no smaller than rank ``k + 1`` of
-        the members seen, so dropping it off the end loses nothing the answer needs. Each insertion
-        is a chain of element-wise min/max, which is what makes the selection exact -- the same
-        values a full sort returns, to the bit (pinned against ``torch.sort`` in the tests).
-        """
+        """The middle pair of any count, by an insertion window of the ``k + 1`` smallest seen,
+        ``k = count // 2``. Each insertion is a chain of element-wise min/max, and the values are
+        the ones a full sort returns, to the bit."""
         count = len(members)
         keep = count // 2 + 1
         window: list[torch.Tensor] = []
@@ -289,16 +257,13 @@ class Median(Reduction):
 
 class Vote(Reduction):
     """The label the most cases agree on, per voxel: the operator for folding segmentations. It
-    picks and never blends, keeps the input's dtype, and breaks a tie on the smallest label (the
-    same volume on every run and rank). Not incremental.
-    """
+    picks and never blends, keeps the input's dtype, and breaks a tie on the smallest label. Not
+    incremental."""
 
     voxel_local = True
-    # What the running best holds beside the members: two counts, the best label, the mask
-    # deciding it and the comparisons behind it, 2 x itemsize + 6 bytes per voxel (measured 6 to
-    # 9 on uint8 and int16 members, at two and at six members). A fixed set of planes, so as a
-    # share of the cohort it shrinks with the count: 16 bytes over the plan's 4 per member, and
-    # the attribute is the two-member fold, the worst case.
+    # What the running best holds beside the members: two counts, the best label, the mask deciding
+    # it and the comparisons behind it. A fixed set of planes, so as a share of the cohort it
+    # shrinks with the count; the attribute is the two-member fold, the worst case.
     working_multiple = 2.0
 
     def working_multiple_for(self, cases: int) -> float:
@@ -307,15 +272,11 @@ class Vote(Reduction):
     def __call__(self, tensors: list[torch.Tensor]) -> torch.Tensor:
         if len(tensors) == 1:
             return tensors[0]
-        # NOT torch.mode: its tie-break is the smallest label on CPU and the LARGEST on CUDA
-        # (measured: 16% of a six-member fold differed by device), so a --gpu reduce and a CPU
-        # reduce wrote different label maps under one provenance. Every member is a candidate
-        # counted against the others, and the running best keeps a strictly larger count or the
-        # same count on a smaller label: the smallest label with the most votes, on every device
-        # and whatever the members' order. Per voxel this is cases^2 comparisons and nothing else:
-        # no stack sorted along the case axis (whose int64 indices alone were 8 bytes per voxel and
-        # member: a 128-row slab of six 512x512 uint8 members peaked 1920 MiB sorted, 256 MiB
-        # here, 64 -> 11 ms on CUDA, measured), no unique over the volume, no per-label planes.
+        # NOT torch.mode: its tie-break is the smallest label on CPU and the LARGEST on CUDA, so a
+        # --gpu reduce and a CPU reduce would write different label maps. Every member is a
+        # candidate counted against the others, and the running best keeps a strictly larger count
+        # or the same count on a smaller label: the smallest label with the most votes, on every
+        # device and whatever the members' order.
         best, best_votes = tensors[0], self._votes_for(0, tensors)
         for index in range(1, len(tensors)):
             member, votes = tensors[index], self._votes_for(index, tensors)
@@ -326,14 +287,9 @@ class Vote(Reduction):
 
     @staticmethod
     def _votes_for(index: int, tensors: list[torch.Tensor]) -> torch.Tensor:
-        """How many members hold member ``index``'s label, per voxel: its own vote and every
-        equal one.
-
-        Counted in uint8 from the mask viewed as uint8 (a bool is one byte holding 0 or 1): the
-        same dtype on both sides of the add, so the CPU iterator adds in place where a bool into
-        a wider count went through a cast temporary (1156 -> 784 ms per six-member int16 slab on
-        the host, 29 -> 21 ms on CUDA, measured). int16 past 255 members, where uint8 would wrap.
-        """
+        """How many members hold member ``index``'s label, per voxel: its own vote and every equal
+        one. Counted in uint8 from the mask viewed as uint8, the same dtype on both sides of the
+        add; int16 past 255 members, where uint8 would wrap."""
         member = tensors[index]
         votes = torch.ones_like(member, dtype=torch.uint8 if len(tensors) < 256 else torch.int16)
         for other_index, other in enumerate(tensors):

--- a/konfai/data/sampling.py
+++ b/konfai/data/sampling.py
@@ -16,15 +16,11 @@
 
 """Where each target voxel reads from, and the gather that reads it, in torch, on the volume's device.
 
-Two halves, and only the first one varies. The COORDINATE PRODUCER turns a decoded transform into
-one source index per target voxel; the GATHER is ITK's sampler and is written once. A stage that
-resamples onto another grid, one that warps through a field and one that does both differ only in
-what they hand the producer.
+Two halves. The COORDINATE PRODUCER turns a decoded transform into one source index per target
+voxel; the GATHER is ITK's sampler and is written once.
 
 Nothing here calls SimpleITK. A BSpline is evaluated from its coefficient grid and a dense field
-from its samples, with the same tensor-product kernel arithmetic ITK uses (verified to 8e-14
-against ``TransformPoint``), so a chain that resamples through a stored transform stays on the GPU
-from the read to the write.
+from its samples, with the same tensor-product kernel arithmetic ITK uses.
 """
 
 from __future__ import annotations
@@ -48,18 +44,14 @@ from konfai.data.geometry import (
     TransformBound,
 )
 
-#: Coordinates are accumulated in float64 and only the gather runs in the payload's dtype. A world
-#: coordinate is an origin of hundreds of millimetres plus an index of hundreds of voxels, and in
-#: float32 that sum keeps about four digits past the voxel: enough to move a sample across a
-#: voxel boundary on a large grid, which is a visibly different value on anything that is not
-#: smooth. Measured on a 64x512x512 slab: float32 coordinates disagree with SimpleITK by 0.35 on
-#: data in [0, 1], float64 by 3e-05 (which is the gather's own float32 rounding).
+#: Coordinates are accumulated in float64 and only the gather runs in the payload's dtype. In
+#: float32 a world coordinate keeps about four digits past the voxel, enough to move a sample across
+#: a voxel boundary on a large grid.
 _COORDINATE_DTYPE = torch.float64
 
-#: The walk's dtype for the CURRENT context, entered by :func:`coordinate_precision`. A contextvar
-#: and not a parameter threaded through eight signatures: the choice belongs to the stage that
-#: knows its data (an intensity resample can trade the last bits for bandwidth, a label resample
-#: must not), and every helper below reads the same answer without the plumbing.
+#: The walk's dtype for the CURRENT context, entered by :func:`coordinate_precision`. The choice
+#: belongs to the stage that knows its data: an intensity resample may trade the last bits for
+#: bandwidth, a label resample may not.
 _COORDINATE_DTYPE_VAR: contextvars.ContextVar[torch.dtype | None] = contextvars.ContextVar(
     "konfai_coordinate_dtype", default=None
 )
@@ -73,12 +65,10 @@ def _walk_dtype() -> torch.dtype:
 def coordinate_precision(dtype: torch.dtype) -> Iterator[None]:
     """Run the coordinate walk under ``dtype`` for the duration of the block.
 
-    The default (float64) is the BIT-EXACT contract with SimpleITK and stays untouched unless a
-    caller opts out. float32 halves the walk's bytes -- measured ~1.6x on a bandwidth-bound GPU
-    walk, and twice the rows per slab -- at a coordinate error of about |world| / 2^24: a few 1e-4
-    of a voxel on world coordinates of order 1e4-1e5 units, growing with the magnitude. A NEAREST
-    pick within that band of a .5 boundary lands on the other voxel. Intensity chains may take the
-    trade; label chains and anything that must reproduce sitk.Resample bit for bit must not.
+    The default (float64) is the BIT-EXACT contract with SimpleITK. float32 halves the walk's bytes
+    at a coordinate error of about |world| / 2^24, and a NEAREST pick within that band of a .5
+    boundary lands on the other voxel. Intensity chains may take the trade; label chains and
+    anything that must reproduce sitk.Resample bit for bit must not.
     """
     token = _COORDINATE_DTYPE_VAR.set(dtype)
     try:
@@ -88,19 +78,15 @@ def coordinate_precision(dtype: torch.dtype) -> Iterator[None]:
 
 
 # --------------------------------------------------------------------------------------------------
-# The rules every sampler below obeys. There are two gather strategies for one arithmetic: per-axis
-# maps where the coordinate is separable, eight flat corners where a displacement makes it not: and
-# the strategies differ for a measured reason. The RULES must not: written out at each site they
-# drift, and the drift is silent because a resampled volume looks right either way.
+# The rules every sampler below obeys. Two gather strategies for one arithmetic: per-axis maps where
+# the coordinate is separable, eight flat corners where a displacement makes it not.
 
 
 def sampling_dtype(tensor: torch.Tensor) -> torch.dtype:
     """The dtype to accumulate a weighted sum of ``tensor``'s voxels in.
 
-    An integer input has no arithmetic of its own to interpolate with. A CPU half does, and it should
-    not be used: torch's CPU Half kernels are missing from older releases and lossy over a sum of
-    eight terms, at values a scanner actually produces. A CUDA half keeps its own; every mode has a
-    Half kernel there, and upcasting a whole multi-class volume would double its memory for nothing.
+    An integer input has no arithmetic of its own to interpolate with. A CPU half is lossy over a sum
+    of eight terms and is upcast; a CUDA half keeps its own.
     """
     if not tensor.is_floating_point():
         return torch.float32
@@ -110,33 +96,25 @@ def sampling_dtype(tensor: torch.Tensor) -> torch.dtype:
 
 
 def nearest_index(coordinate: torch.Tensor) -> torch.Tensor:
-    """ITK's nearest: round half UP on the continuous source index.
-
-    ``torch.round`` breaks a tie to the even index, and ``F.interpolate``'s nearest is
-    ``floor(o * scale)``: a statement about a size RATIO, which says nothing once the target grid
-    carries an origin of its own. On a label map either wrong rule still yields a label map.
-    """
+    """ITK's nearest: round half UP on the continuous source index. Not ``torch.round``, which ties
+    to the even index, and not ``F.interpolate``'s ``floor(o * scale)``, which is a statement about a
+    size ratio and says nothing once the target grid carries an origin of its own."""
     return torch.floor(coordinate + 0.5).to(torch.long)
 
 
 def window_index(index: torch.Tensor, n_in: int, region_start: int, window: int) -> torch.Tensor:
     """A global source index as an offset into the sub-region that was actually read.
 
-    Clamped twice, and both matter: to the SOURCE first, so a tap past the volume reproduces the
-    border value rather than wrapping, and to the WINDOW second, so it stays inside the buffer on
-    hand. The second clamp is only ever load-bearing where the first already put the sample outside,
-    which the caller masks to fill: or, for a halo'd read, where the declared bound was checked.
+    Clamped twice: to the SOURCE first, so a tap past the volume reproduces the border value rather
+    than wrapping, and to the WINDOW second, so it stays inside the buffer on hand.
     """
     return torch.clamp(torch.clamp(index, 0, n_in - 1) - region_start, 0, window - 1)
 
 
 def _kernel_weights(offset: torch.Tensor, order: int) -> torch.Tensor:
-    """The 1-D B-spline weight at distance ``offset``: ITK's own kernels.
-
-    Order 1 is the linear hat; order 3 is ``itkBSplineKernelFunction``'s cubic. Both are
-    non-negative and sum to one over their support, which is what makes ``sup |values|`` a bound
-    on the displacement at every point rather than at the samples.
-    """
+    """The 1-D B-spline weight at distance ``offset``: ITK's own kernels. Order 1 is the linear hat,
+    order 3 ``itkBSplineKernelFunction``'s cubic. Both are non-negative and sum to one over their
+    support, which makes ``sup |values|`` a bound on the displacement at every point."""
     distance = offset.abs()
     if order == 1:
         return torch.clamp(1.0 - distance, min=0.0)
@@ -149,14 +127,9 @@ def _kernel_weights(offset: torch.Tensor, order: int) -> torch.Tensor:
 
 
 def _cubic_weights(offset: torch.Tensor) -> torch.Tensor:
-    """Keys' cubic convolution at a = -1/2 (Catmull-Rom): the interpolating cubic.
-
-    Four taps per axis, exact through the samples (weight 1 at distance 0, 0 at 1 and 2) and exact
-    on polynomials up to degree two, which is what the a = -1/2 choice buys. NOT the order-3
-    B-spline above: that one smooths unless its input is prefiltered coefficients, which a
-    displacement stage stores and an image does not. The weights go negative between 1 and 2:
-    that is what preserves an edge, and why a blend can overshoot the values it read.
-    """
+    """Keys' cubic convolution at a = -1/2 (Catmull-Rom), four taps per axis, exact through the
+    samples. NOT the order-3 B-spline above, which smooths unless its input is prefiltered
+    coefficients. The weights go negative between 1 and 2, so a blend can overshoot what it read."""
     distance = offset.abs()
     near = 1.0 + distance * distance * (1.5 * distance - 2.5)
     far = 2.0 - distance * (4.0 - distance * (2.5 - 0.5 * distance))
@@ -165,8 +138,7 @@ def _cubic_weights(offset: torch.Tensor) -> torch.Tensor:
 
 def _saturate_overshoot(blended: torch.Tensor, payload_dtype: torch.dtype) -> torch.Tensor:
     """A cubic blend can overshoot the payload's range, and an integer cast WRAPS instead of
-    saturating: the bright rim a negative lobe builds beside an edge would come back as the
-    opposite extreme. Clamping to the dtype's range is the saturating cast ITK performs."""
+    saturating. Clamping to the dtype's range is the saturating cast ITK performs."""
     if payload_dtype.is_floating_point:
         return blended
     info = torch.iinfo(payload_dtype)
@@ -174,13 +146,9 @@ def _saturate_overshoot(blended: torch.Tensor, payload_dtype: torch.dtype) -> to
 
 
 def _apply(points_xyz: torch.Tensor, affine: AffineMap, device: torch.device) -> torch.Tensor:
-    """``translation + Σ_j column_j · p_j``, accumulated in ``j`` order. ITK's own association.
-
-    Not ``points @ matrix.T + offset``. That is the same sum in a different order, which BLAS is
-    free to reassociate, and the two answers differ in the last bit; a continuous index landing on
-    an exact half then rounds to the other voxel. The one matmul saved is not worth a label map
-    that disagrees with ``sitk.Resample`` in whole columns.
-    """
+    """``translation + Σ_j column_j · p_j``, accumulated in ``j`` order: ITK's own association. Not
+    ``points @ matrix.T + offset``, which BLAS is free to reassociate; the two answers differ in the
+    last bit and a continuous index landing on an exact half rounds to the other voxel."""
     matrix = torch.tensor(affine.matrix, dtype=_walk_dtype(), device=device)
     out = torch.tensor(affine.translation, dtype=_walk_dtype(), device=device).expand(points_xyz.shape).clone()
     for j in range(affine.rank):
@@ -189,12 +157,9 @@ def _apply(points_xyz: torch.Tensor, affine: AffineMap, device: torch.device) ->
 
 
 def _to_index(world_xyz: torch.Tensor, grid: Grid, device: torch.device) -> torch.Tensor:
-    """World to continuous index, in ITK's arithmetic: subtract the origin FIRST, then accumulate.
-
-    ``TransformPhysicalPointToContinuousIndex`` sums ``M[i][j] * (p_j - O_j)`` from zero. Folding the
-    origin into a translation instead (which is what a generic inverted affine map is) reassociates
-    a difference of large world coordinates against a small one and moves the last bit.
-    """
+    """World to continuous index, in ITK's arithmetic: subtract the origin FIRST, then accumulate
+    ``M[i][j] * (p_j - O_j)`` from zero, as ``TransformPhysicalPointToContinuousIndex`` does. Folding
+    the origin into a translation instead moves the last bit."""
     matrix = torch.tensor(grid.world_to_index.matrix, dtype=_walk_dtype(), device=device)
     origin = torch.tensor(grid.origin_xyz, dtype=_walk_dtype(), device=device)
     shifted = world_xyz - origin
@@ -205,31 +170,17 @@ def _to_index(world_xyz: torch.Tensor, grid: Grid, device: torch.device) -> torc
 
 
 def _displacement_at(stage: DisplacementStage, world_xyz: torch.Tensor, device: torch.device) -> torch.Tensor:
-    """The stage's displacement at each world point: zero where its grid does not reach.
-
-    ITK returns the identity outside a BSpline's valid region and outside a field's domain, so a
-    point past the values simply moves by nothing. That is also what makes a region of a field a
-    legal stand-in for the whole of it: the part it does not cover was going to be identity here
-    anyway, which is exactly why the region handed in must COVER the target region, and why a
-    short one degrades in silence rather than raising.
-
-    The corner walk is arranged so nothing is computed twice, and ONLY so: each axis's tap weights
-    and clamped positions are built once and the corners read them, and the per-corner gather pulls
-    all components through one ``index_select``. Every float op the original per-corner form ran is
-    still run, on the same values, in the same association, so the result is bit-identical: the
-    weight product multiplies axis 0 first, the corner sum accumulates in ``itertools.product``
-    order, and a gather copies without rounding.
-    """
+    """The stage's displacement at each world point: zero where its grid does not reach, ITK
+    returning the identity outside a BSpline's valid region and outside a field's domain. The region
+    handed in must COVER the target region; a short one degrades in silence rather than raising."""
     rank = stage.grid.rank
     index = _to_index(world_xyz, stage.grid, device)  # continuous index on the value grid, (x, y, z)
     extent_xyz = [int(stage.grid.size_zyx[rank - 1 - axis]) for axis in range(rank)]
 
     if stage.order != 1:
         # ITK admits a continuous index within ~4 ulps of the spline's valid-region END by nudging
-        # it JUST inside (``InsideValidRegion``): the support then fits and the value is the
-        # continuous limit, the outermost tap's weight vanishing at the boundary. Without the nudge
-        # the whole last plane of a grid commensurate with the coefficient mesh is silently the
-        # identity, and a commensurate grid is exactly what a fitted transform domain produces.
+        # it JUST inside (``InsideValidRegion``). Without the nudge the whole last plane of a grid
+        # commensurate with the coefficient mesh is silently the identity.
         for axis in range(rank):
             end = float(extent_xyz[axis] - 2)
             ulp = float(np.spacing(np.float64(max(1.0, end))))
@@ -239,14 +190,11 @@ def _displacement_at(stage: DisplacementStage, world_xyz: torch.Tensor, device: 
     taps = stage.order + 1
     shift = (stage.order - 1) // 2
     # Per axis, per tap, once, on a CONTIGUOUS copy of that axis: ``index[..., axis]`` is a stride-
-    # rank view, and every elementwise op over it ran ~7x slower than over a packed tensor
-    # (measured). The copy holds the very same floats. ``base`` is derived per axis and dropped
-    # with it, and ``index`` is released before the corner loop: the walk's transient peak is made
-    # of tensors that outlive their use.
+    # rank view and every elementwise op over it is far slower than over a packed tensor. The copy
+    # holds the very same floats, and ``index`` is released before the corner loop.
     #
-    # The two domains ITK actually implements, and they differ. A BSpline is the identity unless
-    # its whole support lies in the coefficient grid (``InsideValidRegion``), so its edge falls off
-    # a control point early. A dense field is an ordinary image: it interpolates anywhere in
+    # The two domains ITK implements differ. A BSpline is the identity unless its whole support lies
+    # in the coefficient grid (``InsideValidRegion``). A dense field interpolates anywhere in
     # ``[-0.5, n - 0.5)`` with the taps clamped, which reaches half a voxel past the outermost
     # samples. Using the spline's rule for a field blanks that rim.
     inside = torch.ones(index.shape[:-1], dtype=torch.bool, device=device)
@@ -272,8 +220,7 @@ def _displacement_at(stage: DisplacementStage, world_xyz: torch.Tensor, device: 
     del index
 
     # (voxel, component), contiguous: a gather then lands each voxel's components side by side,
-    # which is the layout the accumulator wants -- the (component, voxel) form needed a strided
-    # transpose per corner, measured at 2.6x the cost for the same numbers.
+    # which is the layout the accumulator wants.
     flat_values = stage.tensor_by_voxel(device, _walk_dtype())
     out = torch.zeros((*inside.shape, rank), dtype=_walk_dtype(), device=device)
     for corner in itertools.product(range(taps), repeat=rank):
@@ -281,22 +228,17 @@ def _displacement_at(stage: DisplacementStage, world_xyz: torch.Tensor, device: 
         for axis in range(1, rank):
             weight = weight * weight_at[axis][corner[axis]]
         # ``values`` is (component, Z, Y, X) and row-major over the spatial axes, so the flat index
-        # runs the ARRAY axes outermost-first with x fastest: the mirror of the physical order the
-        # coordinates arrive in. Running it the other way samples the field transposed, which warps
-        # the anatomy somewhere plausible and wrong.
-        # int64 for the flat index: a full-resolution field window exceeds 2**31 voxels, and the
-        # per-axis int32 positions widen exactly on the first multiply.
+        # runs the ARRAY axes outermost-first with x fastest, the mirror of the physical order the
+        # coordinates arrive in. Running it the other way samples the field transposed. int64 for the
+        # flat index: a full-resolution field window exceeds 2**31 voxels.
         flat_index = position_at[rank - 1][corner[rank - 1]].to(torch.long)
         for array_axis in range(1, rank):
             axis = rank - 1 - array_axis
             flat_index = flat_index * int(stage.grid.size_zyx[array_axis]) + position_at[axis][corner[axis]]
         # One gather for all components; a copy, so the numbers are the stored ones. NOT addcmul_:
-        # a fused multiply-add rounds once where ``out + g * w`` rounds twice, and the last bit is
-        # the contract.
+        # a fused multiply-add rounds once where ``out + g * w`` rounds twice.
         gathered = flat_values[flat_index.reshape(-1)]
-        # In place: the same two roundings as ``out = out + g * w`` (verified bitwise), one fewer
-        # full-size allocation per corner -- and per-corner allocations are what the walk's
-        # transient peak is made of.
+        # In place: the same two roundings as ``out = out + g * w``, one full-size allocation fewer.
         out += gathered.reshape(out.shape) * weight.unsqueeze(-1)
         del gathered, flat_index, weight
     out *= inside.unsqueeze(-1)
@@ -317,19 +259,16 @@ def source_index(
     THE WORLD POINT IS MATERIALISED, never folded away. Target index to world and world to source
     index compose into one affine that is algebraically identical and one matmul cheaper, and it is
     the wrong arithmetic: ITK takes the two steps separately, so the two associations disagree in the
-    last bit, and a continuous index landing EXACTLY on ``k + 0.5`` (which is what a target grid
-    commensurate with its source produces, in whole columns at a time) then rounds to a different
-    voxel. Measured against ``sitk.Resample``: 150 of 1050 voxels of a label map, every one of them
-    a legal-looking label. Consecutive affine STAGES are still folded, that is between two world
-    points, where nothing rounds to an index.
+    last bit, and a continuous index landing EXACTLY on ``k + 0.5`` then rounds to a different voxel.
+    Consecutive affine STAGES are still folded, which is between two world points, where nothing
+    rounds to an index.
     """
     rank = target_grid.rank
     rows_total = int(target_grid.size_zyx[0])
     # The walk holds several float64 tensors per voxel at once (world, index, per-tap weights and
-    # positions, the corner gather), so a large region's TRANSIENTS dwarf its result: ~30 GB beside
-    # a 3.6 GB answer, measured on an ExaSPIM slab. Slabbing the leading array axis bounds them
-    # without touching a value: every op here is per-voxel, and a sub-range arange holds the very
-    # integers the full one holds, so a slab computes bit for bit what the whole region computes.
+    # positions, the corner gather), so a large region's TRANSIENTS dwarf its result. Slabbing the
+    # leading array axis bounds them without touching a value: every op here is per-voxel, and a
+    # sub-range arange holds the very integers the full one holds.
     rows = walk_rows(target_grid, stages, device, budget_bytes)
     if rows >= rows_total:
         return source_index_rows(target_grid, source_grid, stages, device, 0, rows_total)
@@ -342,42 +281,17 @@ def source_index(
     return out
 
 
-#: How long a probed default budget stands before the machine is asked again. The probe reads the
-#: cgroup, /proc and the device's free memory (197-211 us per call, measured) and is asked once per
-#: patch; a budget only sizes a slab, and a slab changes no value, so a second of staleness costs
-#: nothing.
+#: How long a probed default budget stands before the machine is asked again. A budget only sizes a
+#: slab, and a slab changes no value, so a second of staleness costs nothing.
 _BUDGET_TTL_SECONDS = 1.0
 _default_budgets: dict[tuple, tuple[float, float]] = {}
 _now = time.monotonic
 
 
 def _default_walk_budget(device: torch.device) -> float:
-    """The budget for a walk on ``device``, probed once per :data:`_BUDGET_TTL_SECONDS`.
-
-    THE RUN'S DECLARED BUDGET FIRST, and the machine's only when nothing was declared. A walk that
-    sizes itself from free memory is a stage that holds what the machine happens to have rather
-    than what the run promised: measured on an oblique resample, whose map does not factorise so
-    the general walk runs, the stage held 21 volumes-worth of its input against a declaration of 3
-    -- and would have held more on an emptier machine. That is also why the declaration could not
-    be right: what the stage holds was not a property of the stage.
-
-    Undeclared, the machine's own share stands (:func:`~konfai.data.patching.device_capped_budget`):
-    on CUDA half the free VRAM, on CPU a quarter of what this process may still allocate.
-
-    IT IS THE CHAIN SHARE AGAIN, DELIBERATELY, and that reads like double-spending: the sweep takes
-    regions + chains (85%) and the block price already folds in what the chain holds, so a walk
-    asking for chains again could reach 120% of the declaration on paper. It does not, because the
-    two are not independent -- the walk's target grid IS the sweep's region, so it slabs inside a
-    block that ``sweep_block_bytes`` already sized against ``Resample``'s declaration, and the block
-    price binds first. Measured on an oblique resample (verified non-separable, on the card, where
-    the host hands a non-factorising map to ITK and this walk never runs): peak against declaration
-    0.10x at 4 GiB, 0.13 at 2, 0.19 at 1, 0.29 at 512 MiB, 0.42 at 256, monotone and never near 100.
-
-    Bounding it by the stage's own declaration instead (``case_working_multiple`` times the block it
-    was handed) was built and MEASURED WORSE: that product is the LARGER of the two at these region
-    sizes, so it loosens rather than tightens, and the peak went 141 -> 188 MiB at 512 and 103 -> 123
-    at 256 with the seconds unchanged. This share is the tighter bound available. Do not re-derive it.
-    """
+    """The budget for a walk on ``device``, probed once per :data:`_BUDGET_TTL_SECONDS`: the run's
+    declared budget's chain share, and only when nothing was declared the machine's own share
+    (:func:`~konfai.data.patching.device_capped_budget`), half the free VRAM or a quarter of the host."""
     from konfai.data.patching import device_capped_budget
     from konfai.utils.budget import available_memory_bytes, budget_share, per_rank_budget_bytes
 
@@ -396,10 +310,9 @@ def _default_walk_budget(device: torch.device) -> float:
 def walk_rows(target_grid: Grid, stages: SpatialStages, device: torch.device, budget_bytes: float | None = None) -> int:
     """How many leading-axis rows of ``target_grid`` one walk slab may cover under ``budget_bytes``.
 
-    Priced from the walk itself: per voxel it holds the world point, the continuous index and the
-    output (rank each), a weight and a position per axis per tap, and the gather's flat index and
-    result -- doubled, because torch materializes each binary op's result beside its operands. The
-    default budget is the machine's (:func:`_default_walk_budget`).
+    Priced from the walk itself: per voxel the world point, the continuous index and the output
+    (rank each), a weight and a position per axis per tap, and the gather's flat index and result,
+    doubled for the temporaries torch materializes. The default is :func:`_default_walk_budget`.
     """
     if budget_bytes is None:
         budget_bytes = _default_walk_budget(torch.device(device))
@@ -412,9 +325,8 @@ def walk_rows(target_grid: Grid, stages: SpatialStages, device: torch.device, bu
     per_voxel = 2 * itemsize * (3 * rank + 2 * rank * taps + rank + 1)
     total = int(target_grid.size_zyx[0])
     rows = max(1, min(total, int(budget_bytes) // max(1, plane * per_voxel)))
-    # Balanced slabs: 31 rows under a 15-row ceiling is 16 + 15, never 15 + 15 + 1 -- a one-row
-    # tail pays every fixed cost of a walk (meshgrid, affines, the field's taps) for one row's
-    # worth of work. Same ceiling, same values, one launch fewer.
+    # Balanced slabs: 31 rows under a 15-row ceiling is 16 + 15, never 15 + 15 + 1, a one-row tail
+    # paying every fixed cost of a walk for one row's worth of work.
     return -(-total // -(-total // rows))
 
 
@@ -428,10 +340,8 @@ def source_index_rows(
 ) -> torch.Tensor:
     """:func:`source_index` over rows ``[start, stop)`` of the leading array axis.
 
-    The row indices stay GLOBAL to ``target_grid`` and go through ITS map: re-deriving a chunk as a
-    ``sub_grid`` would fold the start into a new origin, a different association whose world points
-    disagree with the whole region's in the last bit: which is the whole disagreement
-    :func:`source_index`'s docstring forbids.
+    The row indices stay GLOBAL to ``target_grid`` and go through ITS map: a ``sub_grid`` would fold
+    the start into a new origin, whose world points disagree with the whole region's in the last bit.
     """
     rank = target_grid.rank
     axes = [torch.arange(int(extent), dtype=_walk_dtype(), device=device) for extent in reversed(target_grid.size_zyx)]
@@ -456,13 +366,9 @@ def source_index_rows(
 
 
 def _is_diagonal(matrix: np.ndarray) -> bool:
-    """Whether every off-diagonal entry is EXACTLY zero: no tolerance, deliberately.
-
-    A tolerance would admit maps whose separable form is only nearly the general one, and the two
-    would then disagree in the last bit at exactly the coordinates that round to a different voxel.
-    Exact is also not restrictive: an axis-aligned or axis-flipped grid gives exact zeros, and the
-    inverse of such a matrix keeps them.
-    """
+    """Whether every off-diagonal entry is EXACTLY zero: no tolerance. A tolerance would admit maps
+    whose separable form is only nearly the general one, and an axis-aligned or axis-flipped grid
+    gives exact zeros anyway, as does the inverse of such a matrix."""
     return not np.any(matrix - np.diag(np.diag(matrix)))
 
 
@@ -474,21 +380,14 @@ def separable_source_index(
 ) -> list[torch.Tensor] | None:
     """One source index per target ROW of each array axis, or ``None`` when the map does not factorise.
 
-    THE SAME ARITHMETIC, with the terms that are exactly zero left out. Each component of
-    :func:`source_index` is ``translation_k + Σ_j p_j · M[k, j]``; with ``M`` diagonal every ``j ≠ k``
-    contributes ``p_j · 0.0``, and adding an exact zero changes no float. So this is bit-identical
-    where it applies rather than merely close, which is what lets one case take it and another the
-    general path without the two ever having to be reconciled.
+    THE SAME ARITHMETIC, with the terms that are exactly zero left out: each component of
+    :func:`source_index` is ``translation_k + Σ_j p_j · M[k, j]``, and with ``M`` diagonal every
+    ``j ≠ k`` adds an exact zero. Bit-identical where it applies, not merely close.
 
-    A stored map factorises on the same terms. Affine stages fold into the one map the general
-    walk applies between its two world points (:func:`source_index_rows`'s ``pending``: the same
-    ``then`` chain from the identity, so the fold here is that map bit for bit), and a fold that
-    is exactly diagonal (a translation, an axis-aligned scale, their composition) is applied per
-    component as the walk applies it: ``translation_k + w_k · P[k, k]``, the other columns' terms
-    being exact zeros. A displacement stage never factorises.
-
-    What it saves is not arithmetic but MEMORY TRAFFIC: the general path materialises a coordinate
-    per voxel and gathers eight corners through a flat index over the whole volume.
+    A stored map factorises on the same terms. Affine stages fold into the one map the general walk
+    applies between its two world points (:func:`source_index_rows`'s ``pending``), and a fold that
+    is exactly diagonal is applied per component as the walk applies it. A displacement stage never
+    factorises. What it saves is not arithmetic but MEMORY TRAFFIC.
     """
     rank = target_grid.rank
     pending = AffineMap.identity(rank)
@@ -514,9 +413,7 @@ def blend_order(target_grid: Grid, source_grid: Grid) -> list[int]:
     """The array axes in the order to blend them: most source voxels per target voxel first.
 
     Each axis is reduced to its output extent before the next one reads it, so blending the axis
-    that shrinks most FIRST makes every later pass smaller. On an isotropic change of spacing that
-    is worth nothing; on a thick-slice CT brought to isotropic (64x512x512 at 3x0.7x0.7 mm, where
-    z triples while y and x shrink): it is 44 M intermediate elements against 110 M.
+    that shrinks most FIRST makes every later pass smaller.
 
     Keyed on the two grids' SPACINGS, never on the extents in hand: a streamed region and the whole
     volume have to blend in the same order or they stop being bit-identical, and their extents
@@ -541,12 +438,10 @@ def gather_separable(
 ) -> torch.Tensor:
     """:func:`gather`'s rules over a map that factorises, one index per axis, no volume.
 
-    Same interval, same tap clamp, same round-half-up, same fill. It sums the tensor product in a
-    different ORDER than the general gather (axis by axis rather than corner by corner), so the
-    two agree to float rounding rather than bit for bit. That costs nothing: a map either factorises
-    or it does not, so no case is ever served by both. The equality that has to be exact is a
-    streamed region against the whole volume, and it is: the per-axis coordinates are global, so a
-    region takes a sub-range of the very numbers the whole volume takes.
+    Same interval, same tap clamp, same round-half-up, same fill. It sums the tensor product axis by
+    axis rather than corner by corner, so the two agree to float rounding rather than bit for bit,
+    and no case is ever served by both. A streamed region and the whole volume do agree exactly: the
+    per-axis coordinates are global.
     """
     rank = len(axes)
     window_zyx = [int(extent) for extent in source.shape[1:]]
@@ -556,8 +451,7 @@ def gather_separable(
     inside_axes = [(axis >= -0.5) & (axis < source_shape_zyx[array_axis] - 0.5) for array_axis, axis in enumerate(axes)]
     out_shape = [int(source.shape[0]), *extent_zyx]
     if not all(bool(mask.any()) for mask in inside_axes):
-        # Working dtype then cast, as the masked tail fills: a float32 detour quantizes a float64
-        # fill and a fully-outside slab then differs from the unslabbed pass in its fill bits.
+        # Working dtype then cast, as the masked tail fills: a float32 detour quantizes a float64 fill.
         return torch.full(out_shape, fill, device=device, dtype=sampling_dtype(source)).type(source.dtype)
 
     def local(index: torch.Tensor, array_axis: int) -> torch.Tensor:
@@ -577,15 +471,13 @@ def gather_separable(
 
     def taps(tensor: torch.Tensor, array_axis: int, index: torch.Tensor) -> torch.Tensor:
         """``tensor.index_select(array_axis + 1, index)``, spelled as an index: the same copy of the
-        same voxels. index_select on an inner axis walks a scalar loop on the host (measured 0.5 to
-        1.5 s against 9 ms for the index on a [1, 256, 256, 256] float32, 0.3 ms either way on CUDA)."""
+        same voxels. index_select on an inner axis walks a scalar loop on the host."""
         taps_index: tuple[slice | torch.Tensor, ...] = (*[slice(None)] * (array_axis + 1), index)
         return tensor[taps_index]
 
     out = source if mode == "nearest" else source.type(sampling_dtype(source))
     for array_axis in range(rank) if blend is None else blend:
-        # An axis the map leaves alone is read by leaving it alone: two gathers and a blend that
-        # would reproduce the input exactly, over the largest tensor in flight, for nothing.
+        # An axis the map leaves alone is read by leaving it alone.
         if is_identity(array_axis):
             continue
         axis = axes[array_axis]
@@ -594,8 +486,7 @@ def gather_separable(
             continue
         if mode == "cubic":
             # The same axis-by-axis reduction as the blend below, four taps instead of two. The
-            # weights come from the GLOBAL coordinate, so a region sums the very numbers the whole
-            # volume sums.
+            # weights come from the GLOBAL coordinate, so a region sums what the whole volume sums.
             base = torch.floor(axis) - 1.0
             index = base.to(torch.long)
             blended: torch.Tensor | None = None
@@ -605,9 +496,8 @@ def gather_separable(
                 blended = term if blended is None else blended + term
             out = blended if blended is not None else out
             continue
-        # One axis at a time, not eight corners at once. The tensor product is the same sum, but
-        # blending axis by axis reduces each extent before the next axis reads it: six gathers over
-        # shrinking tensors instead of twenty-four over the largest one.
+        # One axis at a time, not eight corners at once. The tensor product is the same sum, and
+        # blending axis by axis reduces each extent before the next axis reads it.
         base = torch.floor(axis)
         share = broadcast((axis - base).to(out.dtype), array_axis)
         index = base.to(torch.long)
@@ -617,14 +507,13 @@ def gather_separable(
         # the only endpoint reachable: w is `x - floor(x)`, so it never reaches 1.
         out = torch.lerp(low, high, share)
     # No float trip for a nearest pick: copies stay in the payload's own dtype the whole way, the
-    # rule `gather` already holds -- a float32 detour rounds every integer label above 2**24, and
-    # the two paths then disagree on the very volumes they are supposed to serve identically.
+    # rule `gather` already holds. A float32 detour rounds every integer label above 2**24.
     if mode == "cubic":
         out = _saturate_overshoot(out, source.dtype)
 
     if all(bool(mask.all()) for mask in inside_axes):
-        # Nothing of this region falls outside the source, which is the ordinary case for a resample
-        # within a volume, so neither the mask nor the pass that applies it is built at all.
+        # Nothing of this region falls outside the source, so neither the mask nor the pass that
+        # applies it is built at all.
         return out.type(source.dtype)
     mask = inside_axes[0]
     for array_axis in range(1, rank):
@@ -645,17 +534,14 @@ def gather(
     The rule is ``sitk.Resample``'s, and it is the same one the separable samplers in
     ``konfai.data.transform`` obey: a sample is inside while its continuous source index lies in
     ``[-0.5, n - 0.5)``; inside, the interpolation taps clamp to the buffer, so the half-voxel rim
-    past the outermost voxel centres reproduces the border value instead of falling off; outside,
-    the sample is ``fill``.
+    past the outermost voxel centres reproduces the border value; outside, the sample is ``fill``.
 
     ``source`` covers ``source_starts_zyx`` onward of a volume of ``source_shape_zyx``; the
     coordinates are GLOBAL indices of that volume.
 
-    THE TWO MODES TAKE DIFFERENT ROUTES, and the difference is what each can afford. Nearest is one
-    gather on the exact index, because the pick is discontinuous and the last bit decides it. Linear
-    is eight gathers over a flat index, which ``grid_sample`` does as one fused kernel, at the cost
-    of normalising by the extent it is handed, so a streamed region and the whole volume agree to
-    ~1e-5 rather than exactly.
+    Nearest is one gather on the exact index, the pick being discontinuous. Linear goes through
+    ``grid_sample``, which normalises by the extent it is handed, so a streamed region and the whole
+    volume agree to ~1e-5 rather than exactly.
     """
     rank = coordinates_xyz.shape[-1]
     window_zyx = [int(extent) for extent in source.shape[1:]]
@@ -670,20 +556,16 @@ def gather(
 
     out_shape = [int(source.shape[0]), *extent_zyx]
     if not bool(inside.any()):
-        # In the WORKING dtype then cast, exactly as the masked path fills: filling in float32
-        # first quantizes a float64 fill, and a walk slab that clears the source then disagrees
-        # with the unslabbed pass in the last bits of its fill value.
+        # In the WORKING dtype then cast, exactly as the masked path fills: filling in float32 first
+        # quantizes a float64 fill.
         return torch.full(out_shape, fill, device=device, dtype=sampling_dtype(source)).type(source.dtype)
 
-    # A nearest pick copies voxels: no blend, no working dtype, and no float trip for a label,
-    # whose values above 2**24 a float32 cannot carry back (gather_separable holds the same rule).
+    # A nearest pick copies voxels: no blend, no working dtype, and no float trip for a label, whose
+    # values above 2**24 a float32 cannot carry back.
     work = source if mode == "nearest" else source.type(sampling_dtype(source))
     if mode == "nearest":
         # One gather, on exact index arithmetic: a nearest pick is discontinuous, so the last bit of
-        # a coordinate decides which voxel it lands on. Measured over 300 random grid pairs, a
-        # single-precision coordinate moves 2.6% of the picks, in a label map, 2.6% of the voxels
-        # wearing a different label. There are no eight corners to fuse here, so nothing is bought
-        # by handing it to a kernel that normalises coordinates.
+        # a coordinate decides which voxel it lands on. There are no eight corners to fuse here.
         flat = torch.zeros(extent_zyx, dtype=torch.long, device=device)
         for array_axis in range(rank):
             index = nearest_index(coordinates_xyz[..., rank - 1 - array_axis])
@@ -691,15 +573,13 @@ def gather(
                 index, source_shape_zyx[array_axis], source_starts_zyx[array_axis], window_zyx[array_axis]
             )
             flat = flat * window_zyx[array_axis] + local
-        # An index, not index_select: the same copy, 3.7x faster on the host over 16.7M voxels
-        # (27 vs 125 ms at one channel, 171 vs 477 at four, measured; 2 ms either way on CUDA).
+        # An index, not index_select: the same copy, several times faster on the host.
         picked = work.reshape(int(work.shape[0]), -1)[:, flat.reshape(-1)].reshape(out_shape)
         return picked.masked_fill(~inside.unsqueeze(0), fill).type(source.dtype)
 
     if mode == "cubic":
         # Keys' four taps per axis, corner by corner over a flat index: grid_sample has no cubic in
-        # 3-D, and the corner walk keeps the coordinates GLOBAL, so a streamed region and the whole
-        # volume agree exactly where the fused blend below pays ~1e-5 to normalisation.
+        # 3-D, and the corner walk keeps the coordinates GLOBAL, so a region agrees exactly.
         base_xyz = torch.floor(coordinates_xyz) - 1.0
         out = torch.zeros(out_shape, dtype=work.dtype, device=device)
         for corner in itertools.product(range(4), repeat=rank):
@@ -721,24 +601,18 @@ def gather(
         out = _saturate_overshoot(out, source.dtype)
         return out.masked_fill(~inside.unsqueeze(0), fill).type(source.dtype)
 
-    # A BLEND goes through grid_sample, which is one fused kernel where the eight corners are eight
-    # gathers over a flat index. `align_corners=False` IS ITK's domain: a sample is inside while
-    # its continuous index lies in [-0.5, n - 0.5): and `padding_mode="border"` IS ITK's tap clamp;
-    # what grid_sample has no notion of is the FILL, so the mask computed above still applies it.
+    # A BLEND goes through grid_sample, one fused kernel where the eight corners are eight gathers
+    # over a flat index. `align_corners=False` IS ITK's domain and `padding_mode="border"` IS ITK's
+    # tap clamp; grid_sample has no notion of the FILL, so the mask computed above still applies it.
+    # It costs the bit-identity between a streamed region and the whole volume: grid_sample takes
+    # NORMALISED coordinates, so it divides by the extent of the tensor handed to it, and a region is
+    # handed a window. The two agree to ~1e-5 instead of exactly.
     #
-    # It costs the bit-identity between a streamed region and the whole volume, and that is the whole
-    # of what it costs: grid_sample takes NORMALISED coordinates, so it divides by the extent of the
-    # tensor handed to it, and a region is handed a window. The two agree to ~1e-5 instead of
-    # exactly. Deliberate, and asked for: 4x on a warp.
-    # grid_sample orders the last dimension (x, y, z): the mirror of the array axes, which is the
-    # order the coordinates already arrive in. The grid counts voxels in float32 WHATEVER the
-    # payload: a half grid quantizes a coordinate at ~2^-11 of the window extent: 0.06 voxel on a
-    # 512 axis, far past the ~1e-5 band above, and the window is upcast with it because
-    # grid_sample takes one dtype. sampling_dtype's keep-half trade was measured for the values.
-    #
-    # Each axis is normalised straight into the grid it belongs in. Keeping them and stacking them
-    # first holds the whole grid twice, once in the coordinates' float64 and once in the cast of
-    # it, where the cast is what the assignment does anyway.
+    # grid_sample orders the last dimension (x, y, z), the order the coordinates already arrive in.
+    # The grid counts voxels in float32 WHATEVER the payload: a half grid quantizes a coordinate at
+    # ~2^-11 of the window extent, and the window is upcast with it because grid_sample takes one
+    # dtype. Each axis is normalised straight into the grid it belongs in: keeping them and stacking
+    # them first would hold the whole grid twice.
     blend_dtype = torch.float32 if work.dtype in (torch.float16, torch.bfloat16) else work.dtype
     sampling = torch.empty((*coordinates_xyz.shape[:-1], rank), dtype=blend_dtype, device=coordinates_xyz.device)
     for array_axis in range(rank):
@@ -764,8 +638,8 @@ def source_window(
 ) -> tuple[slice, ...]:
     """The source window a target region pulls, from the bound alone: no voxel sampled.
 
-    Closed form, which is what lets a cost model price a decomposition without doing the bounding
-    work for it: the target region's world box, mapped through the bound (an exact affine hull
-    grown by the residual), read back as a clamped index window on the source.
+    Closed form, so a cost model can price a decomposition without doing the bounding work for it:
+    the target region's world box, mapped through the bound (an exact affine hull grown by the
+    residual), read back as a clamped index window on the source.
     """
     return source_grid.index_window(bound.map_box(target_grid.world_box()), margin)

--- a/konfai/data/transform/__init__.py
+++ b/konfai/data/transform/__init__.py
@@ -119,9 +119,8 @@ __all__ = [
 
 
 def __getattr__(name: str):
-    # ``KonfAIInference`` lives in konfai-apps (it drives a nested app run), but published configs
-    # spell the bare name, which the TransformLoader resolves against this package: hand the class
-    # over when konfai-apps is installed, refuse with the install otherwise.
+    # ``KonfAIInference`` lives in konfai-apps, but published configs spell the bare name, which the
+    # TransformLoader resolves against this package.
     if name == "KonfAIInference":
         try:
             from konfai_apps.transforms import KonfAIInference

--- a/konfai/data/transform/base.py
+++ b/konfai/data/transform/base.py
@@ -39,33 +39,26 @@ from konfai.utils.utils import get_module
 
 
 class LocalityKind(Enum):
-    """How a transform's output at one voxel depends on its input (its patch-locality contract).
+    """How a transform's output at one voxel depends on its input: its patch-locality contract.
 
-    A transform DECLARES its contract via :meth:`Transform.patch_locality`; the patch-streaming
-    dispatcher (``konfai.data.patching``) reads the declaration and reads only the source region a
-    target patch actually needs, instead of materialising the whole volume.
+    A transform declares it via :meth:`Transform.patch_locality`; the patch-streaming dispatcher
+    (``konfai.data.patching``) then reads only the source region a target patch needs.
 
-    - ``POINTWISE``: output voxel depends only on the same voxel (and its channels): read the
-      exact patch.
-    - ``HALO``: bounded neighbourhood: read the patch enlarged by ``halo`` per axis, crop after.
-    - ``ORIENTATION``: flip/permute: read the index-remapped source region.
-    - ``CROP``: the source region is the target region TRANSLATED: reading it IS the answer,
-      so the stage is not re-applied to it. Unlike a reorientation this drops the voxels outside the
-      box, so it is no bijection and the stored volume's statistics are not its output's.
-    - ``GLOBAL_STAT``: needs whole-volume stats (``stat_keys`` subset of Min/Max/Mean/Std), obtained
-      once from disk and cached: read the exact patch + the cached stat.
-    - ``REGRID``: resample onto another grid: a change of sampling density, of placement, or
-      both, possibly through a map. The target is a grid in its own right, so part of it may read
-      from outside the source altogether and the source region is no mere scaling of the target's.
-      The stage owns both halves: it declares the source region a target region pulls
-      (:meth:`Transform.stream_region_source`) and interpolates it (:meth:`Transform.stream_region`).
-    - ``SLAB``: per-voxel value map, plus a side effect that needs the slabs of the written OUTPUT to
-      arrive in order and tile it once (a per-member stack written beside the result): the
-      streamed-WRITE dispatcher runs it through :meth:`Transform.stream_slab`; the read dispatcher
-      has no such tiling and treats it as ``WHOLE_VOLUME``. A stage that merely needs to know WHERE
-      its region sits (a mask read beside the volume) is ``POINTWISE`` and reads the place from
-      :meth:`Transform.stream_region`, which both dispatchers hand it.
-    - ``WHOLE_VOLUME``-- genuinely needs the whole volume: the dispatcher falls back to a full load.
+    - ``POINTWISE``: the output voxel depends only on the same voxel and its channels: the exact patch.
+    - ``HALO``: a bounded neighbourhood: the patch enlarged by ``halo`` per axis, cropped after.
+    - ``ORIENTATION``: flip/permute: the index-remapped source region.
+    - ``CROP``: the source region is the target region translated, so the stage is not re-applied
+      to it. It drops voxels, so the stored volume's statistics are not its output's.
+    - ``GLOBAL_STAT``: needs whole-volume statistics (``stat_keys``, a subset of Min/Max/Mean/Std),
+      read once from disk and cached: the exact patch plus the cached statistic.
+    - ``REGRID``: resample onto another grid, possibly through a map. The stage owns both halves:
+      the source region a target region pulls (:meth:`Transform.stream_region_source`) and the
+      interpolation (:meth:`Transform.stream_region`).
+    - ``SLAB``: a per-voxel value map plus a side effect needing the written OUTPUT's slabs in
+      order: the streamed-write dispatcher runs :meth:`Transform.stream_slab`; the read dispatcher
+      treats it as ``WHOLE_VOLUME``. A stage that only needs to know where its region sits is
+      ``POINTWISE`` and reads the place from :meth:`Transform.stream_region`.
+    - ``WHOLE_VOLUME``: needs the whole volume: the dispatcher falls back to a full load.
     """
 
     POINTWISE = "pointwise"
@@ -81,9 +74,7 @@ class LocalityKind(Enum):
     def is_region(self) -> bool:
         """Whether this kind is a region stage: its read is a remapped region of its source.
 
-        Region stages compose, so the streamed read and write dispatchers both carry any run of them
-        between their pointwise stages; the set must stay the same on both sides, or a kind added to
-        one would silently fall to the whole-volume path (write) or to a refusal (read) on the other.
+        Region stages compose; the streamed read and write dispatchers must agree on this set.
         """
         return self in (LocalityKind.HALO, LocalityKind.ORIENTATION, LocalityKind.CROP, LocalityKind.REGRID)
 
@@ -91,11 +82,8 @@ class LocalityKind(Enum):
     def preserves_statistics(self) -> bool:
         """Whether this kind leaves every whole-volume statistic of its input untouched.
 
-        Only a reorientation does: a flip or a permute is a bijection on the voxels, so the multiset of
-        values (and therefore Min/Max/Mean/Std over it) is exactly the input's. Every other kind may
-        map values (``POINTWISE``, ``GLOBAL_STAT``), mix neighbours (``HALO``) or interpolate
-        (``REGRID``). This is what decides whether the statistics of the STORED volume are still those
-        of a later transform's own input (see ``DatasetManager._plan_stream_region``).
+        Only a reorientation does: a flip or a permute is a bijection on the voxels. This decides
+        whether the stored volume's statistics are still a later transform's own input's.
         """
         return self is LocalityKind.ORIENTATION
 
@@ -105,9 +93,8 @@ class RegionContext:
     """Where a streamed region sits, for a stage that needs to know.
 
     ``source`` is the part of the stage's INPUT the tensor covers, ``target`` the part of its OUTPUT
-    it must produce; they differ whenever the stage moves or resizes data (a halo read, a resample,
-    a warp onto another grid). ``source_shape`` is the whole extent the source region is cut from: a
-    region alone cannot say how far it is from an edge.
+    it must produce; they differ whenever the stage moves or resizes data. ``source_shape`` is the
+    whole extent the source region is cut from.
     """
 
     source: tuple[slice, ...]
@@ -122,24 +109,20 @@ class PatchLocality:
     ``halo`` is the per-spatial-axis neighbourhood radius in array order (Z, Y, X); a length-1
     tuple broadcasts to every axis. ``stat_keys`` are the ``Attribute`` keys a ``GLOBAL_STAT``
     transform reads before running (a subset of ``Min``/``Max``/``Mean``/``Std``). ``stat_channels``
-    restricts the statistic to those channels (``Normalize.channels``).
-
-    ``reason`` is how a ``WHOLE_VOLUME`` declaration explains itself.
+    restricts the statistic to those channels (``Normalize.channels``). ``reason`` is why a
+    ``WHOLE_VOLUME`` declaration needs the whole volume; the plan prints it.
     """
 
     kind: LocalityKind
     halo: tuple[int, ...] = ()
     stat_keys: frozenset[str] = field(default_factory=frozenset)
     stat_channels: list[int] | None = None
-    # Overrides the kind-level default (see LocalityKind.preserves_statistics): a POINTWISE transform
-    # that maps no value (TensorCast to a float dtype) may declare True so a later GLOBAL_STAT can
-    # still seed from the stored volume.
+    # Overrides the kind-level default: a POINTWISE transform that maps no value (TensorCast to a
+    # float dtype) may declare True so a later GLOBAL_STAT can still seed from the stored volume.
     preserves_statistics: bool | None = None
     #: Why this stage needs the whole volume, in the words the plan prints. A stage that is
-    #: INHERENTLY whole-volume (it changes the tensor's rank) leaves this None and the planner says
-    #: so generically. A stage that is whole-volume only because something was left undeclared owes
-    #: the reader that sentence: "it needs the whole volume" reads as a property of the transform
-    #: when it is in fact a property of the configuration, and the reader then has nothing to change.
+    #: inherently whole-volume (it changes the tensor's rank) leaves this None; one that is
+    #: whole-volume because of its configuration must say so.
     reason: str | None = None
 
     @property
@@ -152,9 +135,8 @@ class PatchLocality:
 def stat_seed_valid(upstream: Iterable[PatchLocality]) -> bool:
     """Whether a ``GLOBAL_STAT`` stage's seed still describes its own input.
 
-    The seed is measured before the chain runs (on the stored volume, or on the fold a ``Reduce``
-    wrote), so it holds only while every stage between the measurement and the statistic leaves the
-    values untouched. Every planner that seeds a statistic must apply this one rule.
+    The seed is measured before the chain runs, so it holds only while every stage between the
+    measurement and the statistic leaves the values untouched.
     """
     return all(locality.statistics_preserving for locality in upstream)
 
@@ -162,26 +144,22 @@ def stat_seed_valid(upstream: Iterable[PatchLocality]) -> bool:
 class Transform(NeedDevice, ABC):
     """Base class for transforms operating on tensors and cached attributes.
 
-    The contract is tiered, and every default is fail-safe, so a stage owes only what its behaviour
-    actually needs:
+    The contract is tiered and every default is fail-safe:
 
-    - **Tier 0 — correct**: implement ``__call__`` alone. The stage runs on the whole volume
-      (the default declaration is ``WHOLE_VOLUME``), keeps its shape and channels, and nothing
-      silently breaks.
-    - **Tier 1 — streaming**: set the :attr:`locality` class attribute (plus :attr:`halo` for a
-      bounded neighbourhood), and override :meth:`transform_shape` / :meth:`output_channels` only
-      if the stage changes the spatial shape or the channel count. A per-voxel value map is one
-      attribute away from streaming.
-    - **Tier 2 — streaming-aware**: the method overrides, needed only where the answer depends on
-      the case (:meth:`patch_locality` read off the header) or where the stage owns a region's
-      geometry or reads beside it (:meth:`stream_region_source`, :meth:`stream_region`,
-      :meth:`plan_region_reads`, :meth:`stream_slab`, :meth:`write_stream_cache_attribute`).
+    - **Tier 0**: implement ``__call__`` alone. The stage runs on the whole volume (the default
+      declaration is ``WHOLE_VOLUME``) and keeps its shape and channels.
+    - **Tier 1**: set the :attr:`locality` class attribute (plus :attr:`halo` for a bounded
+      neighbourhood); override :meth:`transform_shape` / :meth:`output_channels` only if the stage
+      changes the spatial shape or the channel count.
+    - **Tier 2**: the method overrides, where the answer depends on the case (:meth:`patch_locality`)
+      or the stage owns a region's geometry or reads beside it (:meth:`stream_region_source`,
+      :meth:`stream_region`, :meth:`plan_region_reads`, :meth:`stream_slab`,
+      :meth:`write_stream_cache_attribute`).
     """
 
-    #: Tier-1 declaration: the one :class:`LocalityKind` this stage's contract is, when it is
-    #: unconditional. The base :meth:`patch_locality` answers from it; ``None`` (the default) keeps
-    #: the fail-safe ``WHOLE_VOLUME``. A declaration that depends on the configuration or the case
-    #: overrides the method instead, as does one carrying ``stat_keys`` or a ``reason``.
+    #: Tier-1 declaration: the one :class:`LocalityKind` this stage's contract is, when unconditional.
+    #: ``None`` (the default) keeps the fail-safe ``WHOLE_VOLUME``. A declaration that depends on the
+    #: configuration or the case, or carries ``stat_keys`` or a ``reason``, overrides the method.
     locality: LocalityKind | None = None
 
     #: Tier-1 companion to a ``HALO`` :attr:`locality`: the per-spatial-axis radius in array order
@@ -196,45 +174,24 @@ class Transform(NeedDevice, ABC):
     #: Every sizing route reads it: the sweep prices a region with it, a reduction charges the member
     #: chain by it, the whole-volume fallback is sized against it.
     #:
-    #: TWO, not zero, for a stage that says nothing. A default of zero meant silence read as "this
-    #: stage holds nothing", which is the most optimistic reading available and the one that kills a
-    #: run: 33 of the 39 stages KonfAI ships declared nothing, and nine of them held something --
-    #: up to fifteen volumes-worth.
-    #:
-    #: Two because of the dtype a store serves. A CT and an MR are int16, a label map uint8, and a
-    #: stage cannot work in those: it materialises a float copy first and then holds its own working
-    #: copy on top. Measured on stages of four lines each, the shape someone writes on a first try:
-    #: ``(x - x.mean()) / x.std()`` holds 1.00 on float32 and 2.00 on int16, a threshold-and-cast
-    #: 1.25 and 2.25, and ``tensor * 2`` nothing at all either way. One covered the float32 reading
-    #: of a chain whose source is float32, which is the rarer half of this domain.
-    #:
-    #: Declaring is therefore for the CHEAP case, and it is the safe direction to be wrong in: a
-    #: stage that truly holds nothing says 0.0 and gets taller regions, and a mistake there costs a
-    #: shorter region rather than the run. tests/unit/test_transform_working_multiple.py measures
-    #: every built-in against the CUDA allocator, on BOTH dtypes, and fails on any that holds more
-    #: than it declares.
+    #: Two for a stage that declares nothing: a store serves int16 or uint8, so a stage materialises
+    #: a float copy first and holds its own working copy on top. A stage that holds nothing declares
+    #: 0.0; over-declaring costs a shorter region, under-declaring costs the run.
     working_multiple: float = 2.0
 
     def case_working_multiple(self, name: str) -> float:
-        """:attr:`working_multiple` for ONE case, when what the stage holds is a property of the
-        configuration rather than of the class.
-
-        A class attribute cannot answer for a stage whose buffers follow a companion volume: a
-        ``Resample`` through a field at the case's own resolution holds three channels of it beside
-        its sampling grid, and through a field solved four times coarser it holds a sixteenth of
-        that. Both are the same class with the same declaration. Answered from headers, never from
-        values: the plan may not read a voxel.
+        """:attr:`working_multiple` for ONE case, when what the stage holds depends on the
+        configuration rather than the class (a ``Resample`` through a field at the case's own
+        resolution holds more than through one solved coarser). Answered from headers, never values.
         """
         return float(self.working_multiple)
 
-    #: Whether the stage changes the values it is handed. A stage that records a fact on the case
-    #: (Statistics) or writes what passes through (Save) returns its input untouched, so a chain
-    #: that drops it reads the same to a model: the PREDICTION chain check ignores it.
+    #: Whether the stage changes the values it is handed. A stage that returns its input untouched
+    #: (Statistics, Save) declares False: the PREDICTION chain check ignores it.
     alters_values: bool = True
 
     def __init_subclass__(cls, **kwargs: object) -> None:
-        # Every stage records its constructor arguments as given, so konfai.api can write the
-        # config tree back from live objects: the binder's mirror, declared once, on the base.
+        # Constructor arguments are recorded as given, so konfai.api can write the config tree back.
         super().__init_subclass__(**kwargs)
         record_given_arguments(cls)
 
@@ -261,39 +218,27 @@ class Transform(NeedDevice, ABC):
         """How many channels this transform returns for ``channels`` in: the channel-axis twin of
         :meth:`transform_shape`, for the plan's memory arithmetic.
 
-        Identity by default. A stage that WIDENS the axis must say so: the plan sizes a case, and
-        every streamed slab, from the channels a chain holds at its widest, and a one-hot priced at
-        its source's single channel loaded a 50-class volume onto a 2 GB budget and ran out of
-        memory 50 channels later. A stage that narrows may stay silent, that only makes the plan
-        conservative.
+        Identity by default. A stage that widens the axis must say so: the plan sizes a case and
+        every streamed slab from the chain's widest channel count. A stage that narrows may stay
+        silent.
         """
         return channels
 
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
         """Declare how this transform's output depends on its input, for patch streaming.
 
-        Answered from the transform's own ``__init__`` config and, where the honest answer depends on
-        the image, from ``cache_attribute``: the case's SOURCE metadata, as the volume is stored.
-        The dispatcher reads the header before any voxel, so a transform whose contract the image
-        decides (a reorientation that is only a flip when the direction cosines are axis-aligned, a
-        resample whose halo is the case's own scale) can still declare it up front.
-
-        The base answers from the :attr:`locality` attribute where one is set; otherwise the
-        default ``WHOLE_VOLUME`` is the safety net: any transform (including third-party custom
-        ones) that declares nothing falls to the whole-volume path, so nothing silently breaks.
+        Answered from the transform's own ``__init__`` config and, where the answer depends on the
+        image, from ``cache_attribute``: the case's SOURCE metadata, as the volume is stored. The
+        base answers from :attr:`locality` where one is set; otherwise ``WHOLE_VOLUME``.
 
         An override is bound by three rules:
 
-        - **READ-ONLY.** Never write to ``cache_attribute``. A declaration is made once, for the whole
-          case, and what it wrote would be one patch's answer imposed on every other: the
-          first-patch-wins bug the streamed paths are built to avoid. The dispatcher hands over a
-          private copy, so a write cannot reach the case; it is simply lost.
-        - **NO I/O.** Read the attribute already in hand, nothing else. Whether the outside world can
-          honour the declaration (are the disk statistics readable, does a mask group exist) is the
-          dispatcher's call, and it already makes it.
-        - **TOTAL.** Answer for ANY case. The metadata may be absent: the config-time checks probe
-          with an empty ``Attribute``, and a group carries only what its writer stored, so a missing
-          key must return ``WHOLE_VOLUME``, never raise.
+        - **READ-ONLY.** Never write to ``cache_attribute``: the dispatcher hands over a private
+          copy, so a write is lost.
+        - **NO I/O.** Read the attribute in hand, nothing else. Whether the outside world can honour
+          the declaration is the dispatcher's call.
+        - **TOTAL.** Answer for ANY case: the config-time checks probe with an empty ``Attribute``,
+          so a missing key must return ``WHOLE_VOLUME``, never raise.
         """
         if self.locality is not None:
             return PatchLocality(self.locality, halo=self.halo)
@@ -306,16 +251,12 @@ class Transform(NeedDevice, ABC):
         source_spatial_shape: list[int],
         cache_attribute: Attribute,
     ) -> list[slice]:
-        """Map a target-patch's spatial slices to the source spatial region to read (region kinds).
+        """Map a target patch's spatial slices to the source spatial region to read (region kinds).
 
-        Overridden by the kinds whose source region is an index remap of the target's: ``ORIENTATION``
-        maps it and reorients what it reads, ``CROP`` maps it and is done, ``REGRID`` maps it through
-        its own geometry. ``HALO`` is handled generically by the dispatcher, so the base raises for
-        any other transform that declares a region kind without providing the remap.
-
-        ``cache_attribute`` is the case's SOURCE metadata, under the same rules as
-        :meth:`patch_locality`: a remap the image decides (a reorientation whose mirrored axes are the
-        case's own direction cosines) reads it here, and reads nothing else.
+        Overridden by the kinds whose source region is an index remap of the target's
+        (``ORIENTATION``, ``CROP``, ``REGRID``); ``HALO`` is handled by the dispatcher. The base
+        raises for any other transform declaring a region kind. ``cache_attribute`` is the case's
+        SOURCE metadata, under the same rules as :meth:`patch_locality`.
         """
         raise TransformError(
             f"{type(self).__name__} declared a region patch-locality but does not implement stream_region_source().",
@@ -333,9 +274,7 @@ class Transform(NeedDevice, ABC):
         """Run this transform on one finalized slab: rows ``region`` of a ``spatial_shape`` volume.
 
         The streamed-write dispatcher calls this instead of ``__call__`` for a ``SLAB`` declaration:
-        the value map is per-voxel, so the default whole-volume call is exact on the slab, but the
-        stage's side effect needs the slabs in order, tiling the output exactly once per case, which
-        is the one thing this write-side hook promises and :meth:`stream_region` does not.
+        the slabs arrive in order and tile the output exactly once per case.
         """
         del region, spatial_shape
         return self(name, tensor, cache_attribute)
@@ -343,26 +282,16 @@ class Transform(NeedDevice, ABC):
     def prepare(self, konfai_args: str) -> None:
         """Told where this stage's own configuration lives, once, right after it was built.
 
-        The loader knows the subtree a stage read its arguments from; a stage that instantiates
-        something ELSE from configuration (an operator named by classpath) cannot know it, and
-        without this would have to build that object with no arguments at all. The base holds
-        nothing: only a stage with a sub-object of its own overrides it.
+        Only a stage that instantiates something else from configuration (an operator named by
+        classpath) overrides it. The base holds nothing.
         """
 
     def plan_note(self, group_dest: str, name: str, shape: list[int], cache_attribute: Attribute) -> str | None:
         """Something about this case the plan should say, beyond its regime and its cost.
 
-        A stage can be correct, stream, fit the budget, and still surprise the reader: a cost the
-        plan has no column for. The plan is where a run is read before it is trusted, so that is
-        where the sentence belongs, rather than in a viewer afterwards.
-
         Answered from headers on the launcher, per (chain, case), under :meth:`patch_locality`'s
-        rules: read-only, no volume read, and an answer for any case. Identical notes are printed
-        once, so a note about the STAGE may repeat per case without repeating on the page, while a
-        note about the CASE stays one line each.
-
-        The base carries only what the loader recorded: the resolution sentence for a bare name
-        both stage namespaces define, so the plan says which class actually ran.
+        rules. Identical notes are printed once. The base carries the loader's resolution sentence
+        for a bare name both stage namespaces define.
         """
         del group_dest, name, shape, cache_attribute
         return self._ambiguous_name_note
@@ -370,8 +299,7 @@ class Transform(NeedDevice, ABC):
     def stream_abort(self, name: str) -> None:
         """Drop whatever ``stream_slab`` holds open for ``name`` after a mid-case failure.
 
-        Called by the streamed-write dispatcher when a case dies between slabs, so a ``SLAB`` stage's
-        region sink or buffer does not outlive the case. The base holds nothing.
+        Called by the streamed-write dispatcher when a case dies between slabs. The base holds nothing.
         """
 
     def write_stream_cache_attribute(
@@ -379,15 +307,12 @@ class Transform(NeedDevice, ABC):
     ) -> None:
         """Record the geometry a whole-volume ``__call__`` would, given the FULL source shape.
 
-        Called once per case, on the persistent attribute, for the stage that owns a streamed region.
-        A transform whose geometry rewrite depends on the volume's EXTENT (a reorientation's new
-        origin is the corner it mirrors onto) cannot compute it from a patch, which is all its
-        ``__call__`` is handed while streaming: it writes the case-level answer here instead, and the
-        patch-local one it wrote on the way is dropped rather than persisted. The base is a no-op --
-        a transform that leaves geometry alone has nothing to record.
+        Called once per case, on the persistent attribute, for the stage that owns a streamed
+        region: a geometry rewrite that depends on the volume's extent cannot be computed from a
+        patch. The patch-local answer ``__call__`` wrote is dropped. The base is a no-op.
 
-        ``name`` is the case the fold walks: what a per-case answer (a ``Resample`` whose
-        reference follows the case) resolves against; a stage whose answer is case-blind ignores it.
+        ``name`` is the case the fold walks, for a per-case answer (a ``Resample`` whose reference
+        follows the case).
         """
 
     def stream_region(
@@ -399,29 +324,22 @@ class Transform(NeedDevice, ABC):
     ) -> torch.Tensor:
         """Apply this stage to a region, told WHERE that region sits in the volume.
 
-        The dispatcher already computes this position (it has to, to know what to read), and by
-        default throws it away, because almost nothing needs it: a value map gives the same answer
-        wherever its input came from. Override this when the answer does depend on the place, which
-        in practice means a stage reading a SECOND volume aligned with the first (a displacement
-        field, a mask, a bias field): ``region`` says which part of that companion to read.
-
-        ``context`` says which part of the input the tensor covers and which part of the output is
-        expected back. The default delegates to :meth:`__call__`, so every existing transform keeps
-        its behaviour and the whole-volume path stays the reference: an override must give the same
-        answer as ``__call__`` would on the full volume, restricted to ``context.target``.
+        Override it when the answer depends on the place: a stage reading a second volume aligned
+        with the first (a displacement field, a mask). ``context`` says which part of the input the
+        tensor covers and which part of the output is expected back. The default delegates to
+        :meth:`__call__`; an override must give the same answer as ``__call__`` on the full volume,
+        restricted to ``context.target``.
         """
         del context
         return self(name, tensor, cache_attribute)
 
     def plan_region_reads(self, name: str, contexts: Sequence[RegionContext]) -> None:
-        """Declare, before a sweep reads its first region, what :meth:`stream_region` will read
-        beside the tensor it is handed: ``contexts`` are the ones it will be handed, in that order.
+        """Declare, before a sweep reads its first region, the companion windows :meth:`stream_region`
+        will read: ``contexts`` are the ones it will be handed, in that order.
 
-        A stage reading a companion volume per region (a mask) maps each context to the window it
-        will read and declares the sequence to the dataset holding it
-        (:meth:`~konfai.utils.dataset.Dataset.plan_region_reads`): a store that caches decoded
-        blocks then keeps what a later region asks for again and drops what none does. A hint:
-        neither what is read nor its values depend on it. The base declares nothing.
+        A stage reading a companion volume per region maps each context to its window and declares
+        the sequence to the dataset holding it (:meth:`~konfai.utils.dataset.Dataset.plan_region_reads`).
+        A hint: neither what is read nor its values depend on it. The base declares nothing.
         """
         del name, contexts
 
@@ -444,15 +362,10 @@ class TransformInverse(Transform, ABC):
     def inverse_patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
         """Declare how ``inverse``'s output depends on its input, for the streamed-write dispatcher.
 
-        The write mirror of :meth:`patch_locality`: a prediction's finalize chain applies transforms
-        INVERTED, so the streamed-write gate asks each one about its inverse. ``cache_attribute`` is the
-        finalize-time state (the case's attribute as ``inverse`` will receive it, with everything the
-        forward pass pushed still stacked on it) under the same three rules (read-only, no I/O, total).
-
-        The default derives from the forward contract where the derivation is safe for any subclass: a
-        per-voxel value map inverts to a per-voxel value map, and an index remap inverts to an index
-        remap. Every other kind falls to ``WHOLE_VOLUME``: an inverse that is streamable anyway
-        (``Padding``'s crop, ``Resample``'s change of grid) declares itself.
+        The write mirror of :meth:`patch_locality`, under the same three rules. ``cache_attribute``
+        is the finalize-time state: the case's attribute as ``inverse`` will receive it. The default
+        keeps a ``POINTWISE`` or ``ORIENTATION`` forward contract; every other kind falls to
+        ``WHOLE_VOLUME``, and a streamable inverse declares itself.
         """
         forward = self.patch_locality(cache_attribute)
         if forward.kind in (LocalityKind.POINTWISE, LocalityKind.ORIENTATION):
@@ -462,21 +375,17 @@ class TransformInverse(Transform, ABC):
     def inverse_transform_shape(self, shape: list[int], cache_attribute: Attribute) -> list[int]:
         """The spatial shape ``inverse`` produces from ``shape`` (write mirror of ``transform_shape``).
 
-        ``cache_attribute`` is the finalize-time state, as in :meth:`inverse_patch_locality`. The
-        default is the identity, exactly as (in)exact as ``transform_shape``'s: a shape-changing
-        inverse must override it, and the streamed-write dispatcher only trusts it for the kinds
-        :meth:`inverse_patch_locality` declared streamable.
+        Identity by default; a shape-changing inverse must override it. The streamed-write
+        dispatcher trusts it only for the kinds :meth:`inverse_patch_locality` declared streamable.
         """
         return shape
 
     def inverse_stream_cache_attribute(self, cache_attribute: Attribute, source_spatial_shape: list[int]) -> None:
         """State the attribute transition ``inverse`` makes, instead of performing it.
 
-        The write mirror of :meth:`write_stream_cache_attribute`, and it exists because the streamed-
-        write dispatcher plans a pipe by walking a ONE-VOXEL probe through it: a stage whose inverse
-        restores a whole volume cannot be run on that probe just to learn what it pops. The base is a
-        no-op: an inverse that pops nothing has nothing to state, and one whose transition is cheap
-        to perform is simply run.
+        The write mirror of :meth:`write_stream_cache_attribute`: the streamed-write dispatcher plans
+        a pipe on a one-voxel probe, on which an inverse restoring a whole volume cannot run. The
+        base is a no-op.
         """
 
     def stream_region_inverse(
@@ -486,12 +395,10 @@ class TransformInverse(Transform, ABC):
         context: RegionContext,
         cache_attribute: Attribute,
     ) -> torch.Tensor:
-        """Apply ``inverse`` to a region, told WHERE that region sits: the mirror of
-        :meth:`Transform.stream_region`.
+        """Apply ``inverse`` to a region, told WHERE it sits: the mirror of :meth:`Transform.stream_region`.
 
         ``context.target`` is the region of the inverse's OUTPUT being produced and ``context.source``
-        the region of its input on hand. The default delegates to :meth:`inverse`, so an involutive
-        index remap (whose pulled block already IS the answer's input) keeps working untouched.
+        the region of its input on hand. The default delegates to :meth:`inverse`.
         """
         del context
         return self.inverse(name, tensor, cache_attribute)
@@ -505,12 +412,10 @@ class TransformInverse(Transform, ABC):
     ) -> list[slice]:
         """Map a region of ``inverse``'s OUTPUT to the region of its INPUT it is computed from.
 
-        The write mirror of :meth:`stream_region_source`, with the same direction of travel: the slices
-        are in the space being produced (here the written image), the shape is the space being consumed
-        (here the finalized accumulator), and the answer is the consumed region. The streamed-write
-        dispatcher holds a sliding window of finalized slabs and emits each output region once the
-        region this returns has arrived. ``cache_attribute`` is the finalize-time state; a transform
-        whose remap is read from what its own ``inverse`` pops accounts for those pops on a copy.
+        The write mirror of :meth:`stream_region_source`: the slices are in the written image, the
+        shape is the finalized accumulator's, the answer is the consumed region. ``cache_attribute``
+        is the finalize-time state; a transform whose remap depends on what ``inverse`` pops
+        accounts for those pops on a copy.
         """
         raise TransformError(
             f"{type(self).__name__} declared a region inverse patch-locality but does not implement"
@@ -527,9 +432,8 @@ class TransformLoader:
 
     def get_transform(self, classpath: str, konfai_args: str, prefer_augmentation: bool = False) -> Transform:
         """Build the stage ``classpath`` names. A bare name resolves in ``konfai.data.transform``,
-        then in ``konfai.data.augmentation``: those are stages too, declared exactly where they apply
-        (see Expand). ``prefer_augmentation`` reverses the order: past an Expand marker the chain is
-        the copies' draws, so a name both packages have (Flip, Mask, Permute) is the draw there."""
+        then in ``konfai.data.augmentation``; ``prefer_augmentation`` reverses the order (past an
+        Expand marker, a name both packages define is the draw)."""
         first, second = ("konfai.data.augmentation", "konfai.data.transform")
         if not prefer_augmentation:
             first, second = second, first
@@ -570,8 +474,7 @@ class TransformLoader:
             transform.prepare(subtree)
             return transform
         if _is_augmentation(transform):
-            # A draw is handed over as itself: the manager binds it to a copy (AugmentedStage) once
-            # it knows which copy it is planning, which is the one thing the loader cannot know.
+            # A draw is handed over as itself: the manager binds it to a copy once it knows which.
             transform.load(1.0)
             return transform
         return Foreign(transform, classpath)
@@ -579,9 +482,7 @@ class TransformLoader:
     @staticmethod
     def _ambiguity_sentence(name: str, winner: str, loser: str, prefer_augmentation: bool) -> str | None:
         """One sentence naming what a bare name resolved to and the qualified spelling of the loser,
-        when both stage namespaces define it (Flip, Mask, Permute, Foreign): adding or removing an
-        Expand above such a name silently swaps a deterministic transform for a per-copy draw, and
-        with default arguments neither the binder nor strict_config would say so."""
+        when both stage namespaces define it (Flip, Mask, Permute, Foreign)."""
         if not hasattr(importlib.import_module(loser), name):
             return None
         if prefer_augmentation:
@@ -595,8 +496,7 @@ class TransformLoader:
 
     @staticmethod
     def _closest_stage_name(name: str) -> str:
-        """A 'did you mean' over BOTH stage namespaces, so the suggestion is never Python's own
-        guess from whichever module happened to fail last."""
+        """A 'did you mean' over BOTH stage namespaces."""
         import difflib
 
         from konfai.data import augmentation
@@ -609,8 +509,7 @@ class TransformLoader:
             and not candidate.startswith("_")
             and any(base.__name__ in ("Transform", "DataAugmentation") for base in obj.__mro__)
         }
-        # Every resample-ish spelling and Warp are the one Resample stage; difflib alone offers
-        # 'EulerTransform' for 'ResampleTransform' and nothing for 'Warp'.
+        # Every resample-ish spelling and Warp are the one Resample stage.
         if "Resample" in name or name == "Warp":
             return "Closest name: 'Resample' (the 1.8 spelling of every resample and Warp). "
         closest = difflib.get_close_matches(name, sorted(candidates), n=1)
@@ -618,11 +517,8 @@ class TransformLoader:
 
 
 def _is_augmentation(candidate: object) -> bool:
-    """Whether this object is a KonfAI draw, asked without importing the augmentation module here.
-
-    ``konfai.data.augmentation`` imports this module, so the dependency only runs one way; the check
-    walks the class's own ancestry instead of using ``isinstance``.
-    """
+    """Whether this object is a KonfAI draw, without importing the augmentation module here
+    (``konfai.data.augmentation`` imports this module)."""
     return any(base.__name__ == "DataAugmentation" for base in type(candidate).__mro__)
 
 
@@ -636,24 +532,18 @@ class Foreign(Transform):
             minv: 0.0
             maxv: 1.0
 
-    The class must be callable on one tensor and return the transformed tensor, which is what
-    torchvision's transforms, TorchIO's and MONAI's array transforms all are. MONAI's dictionary
-    transforms (``ScaleIntensityd``) take a dictionary of keys instead: a KonfAI group is the key,
-    so name the array class.
+    The class must be callable on one tensor and return the transformed tensor (torchvision's
+    transforms, TorchIO's and MONAI's array transforms). MONAI's dictionary transforms
+    (``ScaleIntensityd``) take a dictionary of keys: name the array class.
 
     The class must be DETERMINISTIC: a transform runs on each group of a case in turn, so a random
-    one would draw again for the label and misalign it from the image. Name it under the
-    augmentations instead, where a draw is made once for the case and every group is handed it.
+    one would misalign the label from the image. Name it under the augmentations instead.
 
-    It reads the whole volume, which is what a class saying nothing about where its output comes
-    from is owed. The shape is checked rather than assumed: the patch grid is planned on the shape a
-    transform announces, and this one announces the shape it was given. Geometry is left as it
-    stands, which a transform of the intensities alone leaves. A class that resamples, crops or
-    reorients owns both, and a ``Transform`` subclass is what states them.
+    It reads the whole volume, must return the shape it was given (checked), and leaves geometry
+    as it stands. A class that resamples, crops or reorients needs a ``Transform`` subclass.
     """
 
-    # Not declared: what a foreign callable allocates between its input and its output is its own,
-    # and nothing here can measure it. The base default is what an unknown stage is priced at.
+    # working_multiple is not declared: a foreign callable's allocations cannot be measured here.
 
     def __init__(self, transform, classpath: str) -> None:
         super().__init__()

--- a/konfai/data/transform/chain.py
+++ b/konfai/data/transform/chain.py
@@ -28,25 +28,17 @@ from konfai.utils.dataset import Attribute
 from konfai.utils.errors import ReductionError, TransformError
 from konfai.utils.utils import get_module
 
-#: Keys the ``Reduce`` stage reads from its own mapping. An operator sharing one of these names
-#: would silently be handed the stage's value, so the collision is refused instead.
+#: Keys the ``Reduce`` stage reads from its own mapping. An operator sharing one of these names is
+#: refused.
 _REDUCE_OWN_KEYS = frozenset({"operator", "output", "grid", "grid_tolerance", "provenance"})
 
 
 def resolve_operator(reduce: "Reduce") -> Reduction:
     """The operator the stage names, as an instance, refusing one that cannot fold a region.
 
-    Configured like every other extension point: its constructor arguments are bound from the same
-    mapping the ``Reduce`` itself was read from, so a custom operator takes parameters exactly as a
-    custom transform or a custom draw does::
-
-        Reduce:
-          operator: mypkg:TrimmedMean
-          output: template
-          trim: 0.2            # the operator's own parameter
-
-    A chain assembled in Python has no configuration to read, and the operator is then built from
-    its own defaults.
+    Its constructor arguments are bound from the same mapping the ``Reduce`` itself was read from
+    (``Reduce: {operator: mypkg:TrimmedMean, output: template, trim: 0.2}`` gives it ``trim``). A
+    chain assembled in Python builds the operator from its own defaults.
     """
     module, name = get_module(reduce.operator_classpath, "konfai.data.reduction")
     factory = getattr(module, name)
@@ -83,22 +75,15 @@ def resolve_operator(reduce: "Reduce") -> Reduction:
 class Reduce(Transform):
     """Fold every case of a group into one volume, at fixed voxel.
 
-    The stage that changes a chain's CARDINALITY: everything before it runs once per case, this
-    folds the cases together, everything after it runs once on the result. A chain carrying one is
-    driven by the reduction engine rather than the per-case loop, so it is never applied as an
-    ordinary transform: ``__call__`` says so rather than quietly reducing one case to itself.
+    Everything before it runs once per case, this folds the cases together, everything after it runs
+    once on the result. A chain carrying one is driven by the reduction engine.
 
     ``operator`` is a classpath resolved against :mod:`konfai.data.reduction` (``Mean``, ``Median``,
-    ``Concat``, or your own :class:`~konfai.data.reduction.Reduction`). ``output`` is the entry name
-    the result is written under, and it is required: a reduction has no case name to inherit, and
-    letting it borrow one member's would tie the deliverable to iteration order.
-
-    ``grid`` decides how much agreement between members is demanded before a byte is read:
-    ``strict`` compares extents AND geometry (Spacing/Origin/Direction) within ``grid_tolerance``;
-    ``shape_only`` compares extents alone, the honest escape hatch for volumes already resampled
-    together but carrying approximate headers; ``reference:<case>`` adopts that member's geometry
-    for the output and still demands equal extents. Nothing can verify that the members truly live
-    in a common space: only that they claim to, which is why the claim is checked and printed.
+    ``Concat``, or your own :class:`~konfai.data.reduction.Reduction`). ``output`` is the required
+    entry name the result is written under. ``grid`` decides how much agreement between members is
+    demanded before a byte is read: ``strict`` compares extents and geometry
+    (Spacing/Origin/Direction) within ``grid_tolerance``; ``shape_only`` compares extents alone;
+    ``reference:<case>`` adopts that member's geometry and still demands equal extents.
     """
 
     def __init__(
@@ -128,7 +113,7 @@ class Reduce(Transform):
             )
         self.operator_classpath = str(operator)
         # Where this stage was configured from, so its operator binds its own parameters from the
-        # same mapping: None when the chain was built in Python, where there is no config to read.
+        # same mapping. None for a chain built in Python.
         self.konfai_args: str | None = None
         self._operator: Reduction | None = None
         self.output = str(output).strip()
@@ -137,8 +122,7 @@ class Reduce(Transform):
         self.provenance = bool(provenance)
 
     def prepare(self, konfai_args: str) -> None:
-        # Bound here, not when the reduction engine first needs it: its parameters sit in the
-        # stage's mapping, and a strict read of the config counts them only if something read them.
+        # Bound here, not lazily: a strict read of the config counts a key only if something read it.
         self.konfai_args = konfai_args
         self._operator = resolve_operator(self)
 
@@ -150,9 +134,8 @@ class Reduce(Transform):
         return self._operator
 
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
-        # A cardinality marker, not a per-case stage: the reduction engine SPLITS it out of the chain
-        # before any manager is built, so this declaration is only the safety net for a chain that
-        # reached the ordinary planner by mistake, where refusing to stream is the right answer.
+        # A cardinality marker, not a per-case stage: the reduction engine splits it out of the
+        # chain before any manager is built.
         return PatchLocality(LocalityKind.WHOLE_VOLUME)
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
@@ -166,33 +149,24 @@ class Reduce(Transform):
 class Expand(Transform):
     """Turn one case into ``nb`` copies, at a declared point of the chain: ``Reduce``'s mirror.
 
-    The stage that changes a chain's cardinality the other way. Everything BEFORE it runs once per
-    case (a ``Save`` there is a cache every copy shares); everything AFTER it runs once per copy,
-    and a ``Save``/``Write`` there writes one entry per copy.
+    Everything before it runs once per case (a ``Save`` there is a cache every copy shares);
+    everything after it runs once per copy, and a ``Save``/``Write`` there writes one entry per copy.
 
-    It multiplies, and nothing else: the draws are ordinary stages of the chain, declared where they
-    apply, so transforms and augmentations interleave freely after the marker::
+    It multiplies, and nothing else: the draws are ordinary stages of the chain, so transforms and
+    augmentations interleave freely after the marker::
 
         transforms:
           Clip:   {min_value: 0.0, max_value: 400.0}   # once per case
           Expand: {nb: 8, pattern: "{name}_r{a:02d}"}
           Rotate: {a_min: -15, a_max: 15}              # a draw, per copy
-          Resample: {spacing: [2, 2, 2]}               # a transform, per copy
-          Brightness: {b_std: 0.2}                     # another draw, per copy
           Write:  {dataset: ./Augmented:omezarr}
 
-    Each draw is parameterised on the grid the stages before it leave, so a shape-changing draw hands
-    the next stage its own extent: a chain, exactly like the transforms it sits among.
-
     ``pattern`` names each copy's entry: ``str.format`` over ``{name}`` (the case) and ``{a}`` (the
-    copy ordinal, 1-based). Both tokens are required, without ``{a}`` every copy of a case writes
-    over the previous one, without ``{name}`` every case does.
+    copy ordinal, 1-based). Both tokens are required.
 
-    Every draw after this marker is parameterised from ``(seed, case, which draw this is)`` rather
-    than from a shared RNG, whose consumption order two chains cannot agree on. Left unset, ``seed``
-    is the run's ``manual_seed``, so an image chain and its mask chain produce matching copies: copy ``k`` of
-    the mask carries copy ``k`` of the image's rotation. Set it to decouple one chain
-    deliberately: that is the only way to ask two chains for DIFFERENT copies of the same cases.
+    Every draw after this marker is parameterised from ``(seed, case, which draw this is)``, not from
+    a shared RNG. Left unset, ``seed`` is the run's ``manual_seed``, so an image chain and its mask
+    chain produce matching copies. Set it to ask two chains for different copies of the same cases.
     """
 
     def __init__(self, nb: int = 2, pattern: str = "{name}_{a:02d}", seed: int | None = None) -> None:
@@ -233,8 +207,7 @@ class Expand(Transform):
 
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
         # A cardinality marker, not a per-case stage: the dispatcher splices the copy's own draw at
-        # this position and never runs the marker itself. This declaration is only the safety net for
-        # a chain that reached a workflow without expansion semantics, where refusing is right.
+        # this position and never runs the marker itself.
         return PatchLocality(LocalityKind.WHOLE_VOLUME)
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:

--- a/konfai/data/transform/ensemble.py
+++ b/konfai/data/transform/ensemble.py
@@ -30,7 +30,6 @@ from konfai.utils.utils import split_path_spec
 class _MemberSpread(Transform):
     """A per-voxel spread across the leading member axis (no spatial neighbour); one member spreads 0."""
 
-    # Measured at 2.00 on the CUDA allocator, in volumes-worth of what it is handed.
     working_multiple = 2.0
     _spread: Callable[[torch.Tensor, int], torch.Tensor]
 
@@ -40,7 +39,6 @@ class _MemberSpread(Transform):
         super().__init__()
 
     def __call__(self, name: str, tensors: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
-        # The member axis stays in both branches: var/std drop it and unsqueeze re-adds it.
         if tensors.shape[0] > 1:
             return self._spread(tensors.float(), 0).unsqueeze(0)
         return torch.zeros_like(tensors[0]).unsqueeze(0)
@@ -55,12 +53,9 @@ class StandardDeviation(_MemberSpread):
 
 
 class SegmentationDisagreement(Transform):
-    # What it holds beyond its input and its output: the pairwise comparison over the model axis: measured 9.33 on the CUDA allocator.
     working_multiple = 24.5
 
-    # Per-voxel majority disagreement across the members. The global torch.unique only widens the
-    # label set with labels absent at a given voxel, which contribute zero counts there and never
-    # change that voxel's majority, so the result is decided voxel by voxel.
+    # Per-voxel majority disagreement across the members.
     locality = LocalityKind.POINTWISE
 
     def __init__(self, ignore_background: bool = False) -> None:
@@ -81,14 +76,14 @@ class SegmentationDisagreement(Transform):
 
         disagreement = torch.zeros_like(tensors[0], dtype=torch.float32)
 
-        # per-voxel disagreement = 1 - (frequency of majority label / number of valid segmentations)
+        # per-voxel disagreement = 1 - (majority label count / number of valid segmentations)
         unique_labels = torch.unique(tensors)
         label_counts: list[torch.Tensor] = []
         for label in unique_labels:
             label_counts.append(((tensors == label) & valid).sum(dim=0))
 
         counts = torch.stack(label_counts, dim=0)  # [L, ...]
-        del label_counts  # the per-label counts live in the stack now: L volumes-worth given back
+        del label_counts  # the per-label counts live in the stack now
         max_count = counts.max(dim=0).values
         valid_count = valid.sum(dim=0)
 
@@ -99,7 +94,6 @@ class SegmentationDisagreement(Transform):
 
 
 class Percentage(Transform):
-    # What it holds beyond its input and its output: the quantile's own copy: measured 1.00 on the CUDA allocator.
     working_multiple = 1.0
 
     locality = LocalityKind.POINTWISE
@@ -113,15 +107,11 @@ class Percentage(Transform):
 
 
 class Magnitude(Transform):
-    """Vector magnitude over the CHANNEL axis: ``[C, ...]`` becomes ``[1, ...]``.
+    """Vector magnitude over the channel axis: ``[C, ...]`` becomes ``[1, ...]``.
 
-    :class:`Norm`'s channel-first sibling. ``Norm`` folds the trailing axis of a stacked ensemble
-    and is whole-volume by construction (a rank change past the streamed write); a stored vector
-    volume (a displacement field read as a case) is channel-first, and its magnitude at a voxel
-    reads that voxel alone: POINTWISE, so it streams.
+    :class:`Norm`'s channel-first sibling, for a stored vector volume such as a displacement field.
     """
 
-    # Measured at 1.00 on the CUDA allocator, in volumes-worth of what it is handed.
     working_multiple = 1.0
 
     locality = LocalityKind.POINTWISE
@@ -136,20 +126,17 @@ class Magnitude(Transform):
 class Norm(Transform):
     """Vector magnitude over the trailing component axis.
 
-    Reduces a stacked vector field (e.g. a displacement-field ensemble ``[N, (D), H, W, C]``) to
-    per-sample magnitudes ``[N, (D), H, W]``, typically before ``Variance``/``StandardDeviation``.
-    The trailing tensor axis is the first geometry axis (numpy order is reversed), so that axis is
-    dropped from ``Origin``/``Spacing``/``Direction``.
+    Reduces a stacked vector field (e.g. ``[N, (D), H, W, C]``) to per-sample magnitudes
+    ``[N, (D), H, W]``. The trailing tensor axis is the first geometry axis, so it is dropped from
+    ``Origin``/``Spacing``/``Direction``.
     """
 
-    # Measured at 2.00 on the CUDA allocator, in volumes-worth of what it is handed.
     working_multiple = 2.0
 
     def __init__(self) -> None:
         super().__init__()
 
-    # WHOLE_VOLUME on purpose: the magnitude drops the trailing spatial axis, and the streamed write
-    # sizes each slab from the pre-finalize accumulator grid: a rank change past it cannot region-stream.
+    # WHOLE_VOLUME on purpose: a rank change past the accumulator grid cannot region-stream.
 
     def __call__(self, name: str, tensors: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         if "Origin" in cache_attribute:
@@ -167,7 +154,6 @@ class Norm(Transform):
 
 
 class InferenceStack(Transform):
-    # Measured at 0.00 on the CUDA allocator: it holds nothing beyond what it is handed.
     working_multiple = 0.0
 
     def __init__(self, dataset: str, name: str, mode: str = "mean"):
@@ -181,9 +167,8 @@ class InferenceStack(Transform):
         self._stack_sinks: dict[str, DataStream] = {}
         self._stack_buffers: dict[str, list[np.ndarray]] = {}
 
-    # The member reduction is per-voxel; the per-member stack write is the side effect that needs
-    # the slab's place in the volume, which is exactly what SLAB declares (whole-volume on the
-    # read side, streamed region by region on the write side via ``stream_slab``).
+    # The member reduction is per-voxel; the per-member stack write needs the slab's place in the
+    # volume, which is what SLAB declares.
     locality = LocalityKind.SLAB
 
     def _stack(self, tensors: torch.Tensor) -> np.ndarray:
@@ -195,11 +180,8 @@ class InferenceStack(Transform):
 
     def _reduce(self, tensors: torch.Tensor) -> torch.Tensor:
         if self.mode != "median":
-            # The mean has to accumulate wider, and torch materialises that copy however it is spelled.
             return tensors.float().mean(0).to(tensors.dtype)
-        # A median SELECTS: the element picked is the same under any monotone cast and comes back in
-        # its own dtype, so the stack is widened only where torch has no median kernel for it
-        # (uint16, uint32, uint64, bool).
+        # A median selects, so the stack is widened only where torch has no median kernel.
         try:
             return torch.median(tensors, dim=0).values
         except NotImplementedError:
@@ -222,8 +204,7 @@ class InferenceStack(Transform):
     ) -> torch.Tensor:
         """The whole-volume call, region by region: reduce the members per voxel and write the slab's
         rows of the per-member stack into a region sink opened at the first slab. A destination that
-        cannot serve region writes falls back to buffering the stack and writing it classically at
-        the last slab: the memory cost of the whole-volume path, never a lost stack."""
+        cannot serve region writes buffers until the last slab."""
         if tensor.shape[0] == 1:
             return tensor.squeeze(0)
         stack = self._stack(tensor)

--- a/konfai/data/transform/intensity.py
+++ b/konfai/data/transform/intensity.py
@@ -28,10 +28,7 @@ from konfai.utils.ITK import _require_simpleitk
 
 
 def _seeded_scalar(cache_attribute: Attribute, key: str) -> float:
-    """A seeded statistic, as whoever seeded it wrote it: a bare scalar or a one-element array.
-
-    ``float()`` reads the first form and ``get_tensor`` the second.
-    """
+    """A seeded statistic, as whoever seeded it wrote it: a bare scalar or a one-element array."""
     try:
         return float(cache_attribute[key])
     except (TypeError, ValueError):
@@ -52,12 +49,9 @@ def _dataset_holding(datasets: list[Dataset], group: str, name: str) -> Dataset:
 class _MaskedStatisticsSeed:
     """The masked whole-volume statistics of a stage's own group, per case, from the stores.
 
-    A masked ``Clip``/``Standardize`` needs the CASE's statistic under the mask before its first
-    region, and a region cannot derive it: the two volumes are scanned once per case, streamed
-    (:func:`read_masked_data_statistics`), and memoised here. The group the chain reads is the one
-    thing ``__call__`` is never told, so ``transform_shape`` records it: every plan folds it before
-    a region flows. The mask is assumed to sit on the volume's own grid, as :class:`~konfai.data.
-    transform.Mask` assumes; the scan refuses a mask whose extent is not the volume's.
+    A masked ``Clip``/``Standardize`` needs the case's statistic under the mask before its first
+    region: the two volumes are scanned once per case, streamed, and memoised here.
+    ``transform_shape`` records the group the chain reads, which ``__call__`` is never told.
     """
 
     def __init__(self, mask: str) -> None:
@@ -92,7 +86,6 @@ class _MaskedStatisticsSeed:
 class Clip(Transform):
     """Clip tensor intensities to a fixed or data-dependent value range."""
 
-    # Measured at 2.50 on the CUDA allocator, in volumes-worth of what it is handed.
     working_multiple = 2.5
 
     def __init__(
@@ -116,18 +109,15 @@ class Clip(Transform):
         self._masked_seed = _MaskedStatisticsSeed(mask) if mask is not None else None
 
     def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
-        # Identity on the shape; a masked bound records the group the chain reads, which the masked
-        # disk scan needs and __call__ is never told.
+        # Identity on the shape; a masked bound records the group the masked disk scan needs.
         if self._masked_seed is not None:
             self._masked_seed.record_group(group_src)
         return shape
 
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
-        # A percentile bound needs the whole histogram (whole-volume). A 'min'/'max' bound needs a
-        # global statistic: a seeded disk one (GLOBAL_STAT with its key), or under a mask a masked
-        # disk scan the stage seeds itself (GLOBAL_STAT with no key: the dispatcher still guards
-        # the seed's validity and seeds nothing). Fixed float bounds never read the mask and clip
-        # each voxel independently (POINTWISE).
+        # A percentile bound needs the whole histogram. A 'min'/'max' bound needs a global statistic:
+        # a seeded disk one, or under a mask a masked disk scan the stage seeds itself (GLOBAL_STAT
+        # with no key). Fixed float bounds are POINTWISE.
         stat_keys: set[str] = set()
         for bound, key in ((self.min_value, "Min"), (self.max_value, "Max")):
             if isinstance(bound, str):
@@ -146,7 +136,7 @@ class Clip(Transform):
         return PatchLocality(LocalityKind.GLOBAL_STAT, stat_keys=frozenset(stat_keys))
 
     def _masked_values(self, name: str, tensor: torch.Tensor) -> torch.Tensor:
-        """The tensor's values under the mask, on the whole-volume path (the reference)."""
+        """The tensor's values under the mask, on the whole-volume path."""
         mask = self.read_companion(self.mask, name)  # type: ignore[arg-type]
         if tuple(mask.shape) != tuple(tensor.shape):
             raise TransformError(
@@ -168,10 +158,8 @@ class Clip(Transform):
 
         if isinstance(self.min_value, str):
             if self.min_value == "min":
-                # Seeded-first, as Normalize reads it: on a streamed path the tensor in hand is one
-                # region of the case -- computed here, the bound (and what save_clip_min records)
-                # would be the region's. A masked bound seeds from the masked disk scan instead: a
-                # bare seed may be an unmasked stage's.
+                # Seeded first: on a streamed path a bound computed here would be one region's. A
+                # masked bound seeds from the masked disk scan, a bare seed being an unmasked stage's.
                 if seeded_masked:
                     min_value = self._masked_seed.statistics(self.datasets, name)["min"]  # type: ignore[union-attr]
                 elif self.mask is None and "StatisticsSeeded" in cache_attribute and "Min" in cache_attribute:
@@ -181,8 +169,7 @@ class Clip(Transform):
             elif self.min_value.startswith("percentile:"):
                 try:
                     percentile = float(self.min_value.split(":")[1])
-                    # ``np.percentile`` cannot coerce a CUDA tensor (finalize slots may hand Clip a
-                    # GPU-resident volume); ``.cpu()`` is a no-op view on a host tensor.
+                    # ``np.percentile`` cannot coerce a CUDA tensor; ``.cpu()`` is a no-op on a host one.
                     min_value = np.percentile(values().detach().cpu(), percentile)
                 except (IndexError, ValueError) as exc:
                     raise ValueError(
@@ -220,23 +207,14 @@ class Clip(Transform):
         else:
             max_value = self.max_value
 
-        # Resolved bounds may be a torch 0-d tensor ("min"/"max") or a numpy scalar
-        # ("percentile:<p>"); coerce to a Python float so the in-place assignments below are valid
-        # for a torch tensor across numpy/torch versions.
+        # A resolved bound may be a torch 0-d tensor or a numpy scalar; the assignments below want a
+        # Python float.
         min_value = float(min_value)
         max_value = float(max_value)
 
-        # Fast path: one fused in-place clamp instead of two float()-copy + where-scatter passes.
-        # Restricted to float32 (integer tensors reject float bounds; float16/float64 would compare
-        # at a different precision than the float()-cast scatter in the else branch below) and to
-        # non-NaN bounds: a NaN bound (from a dynamic min/max/percentile over data containing NaN)
-        # makes clamp_ propagate NaN to the whole tensor, whereas the fallback fill no-ops on it
-        # (NaN comparisons are False). Every other case takes that fallback, unchanged.
-        #
-        # The fallback fills through the MASK it already has. Indexing by torch.where(mask) is
-        # nonzero(as_tuple=True): one int64 array per dimension, one entry per selected voxel,
-        # built to address a scalar store. On a 384^3 block that is 610 MB at half the voxels and
-        # 1.5 GB at all of them, beside a 113 MB block.
+        # Fast path: one fused in-place clamp, for float32 and non-NaN bounds only. An integer tensor
+        # rejects float bounds, float16/float64 compare at another precision than the fallback, and
+        # clamp_ propagates a NaN bound where the fallback fill no-ops on it.
         if tensor.dtype == torch.float32 and min_value == min_value and max_value == max_value:
             tensor.clamp_(min=min_value, max=max_value)
         else:
@@ -252,9 +230,7 @@ class Clip(Transform):
 class Normalize(TransformInverse):
     """Map intensities to a target min/max interval and optionally invert it."""
 
-    # The rescale is a chain of out-of-place ops and torch materialises each one beside its
-    # operands, so a volume-worth stands next to the result at the peak: measured 1.00 on the
-    # CUDA allocator, the same as Standardize, whose arithmetic this is.
+    # The rescale is a chain of out-of-place ops, so a volume-worth stands next to the result.
     working_multiple = 1.0
 
     def __init__(
@@ -276,8 +252,7 @@ class Normalize(TransformInverse):
         self.channels = channels
 
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
-        # Rescaling uses the volume-global Min/Max (restricted to self.channels); the dispatcher reads
-        # those once from disk and seeds them so every patch (and inverse()) sees the same range.
+        # Rescaling uses the volume-global Min/Max, seeded once so every patch sees the same range.
         return PatchLocality(LocalityKind.GLOBAL_STAT, stat_keys=frozenset({"Min", "Max"}), stat_channels=self.channels)
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
@@ -315,8 +290,7 @@ class Normalize(TransformInverse):
         return tensor
 
     def inverse_patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
-        # The forward needs the volume's Min/Max (GLOBAL_STAT); the inverse only pops what the forward
-        # stacked, so on the finalize-time attribute it is a per-voxel affine map.
+        # The inverse only pops what the forward stacked: a per-voxel affine map.
         return PatchLocality(LocalityKind.POINTWISE)
 
     def inverse(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
@@ -329,9 +303,7 @@ class Normalize(TransformInverse):
 
 
 class UnNormalize(Transform):
-    # The rescale is a chain of out-of-place ops and torch materialises each one beside its
-    # operands, so a volume-worth stands next to the result at the peak: measured 1.00 on the
-    # CUDA allocator, the same as Standardize, whose arithmetic this is.
+    # The rescale is a chain of out-of-place ops, so a volume-worth stands next to the result.
     working_multiple = 1.0
 
     locality = LocalityKind.POINTWISE
@@ -366,18 +338,14 @@ class Standardize(TransformInverse):
         self._masked_seed = _MaskedStatisticsSeed(mask) if mask is not None else None
 
     def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
-        # Identity on the shape; a masked statistic records the group the chain reads, which the
-        # masked disk scan needs and __call__ is never told.
+        # Identity on the shape; a masked statistic records the group the masked disk scan needs.
         if self._masked_seed is not None:
             self._masked_seed.record_group(group_src)
         return shape
 
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
-        # Any of mean/std left unset is a global statistic: a seeded disk one (GLOBAL_STAT with its
-        # key), or under a mask a masked disk scan the stage seeds itself, once per case
-        # (GLOBAL_STAT with no key: the dispatcher still guards the seed's validity and seeds
-        # nothing). Once seeded, no region reads the mask: the map is a per-voxel affine. With both
-        # coefficients given, the mask selects nothing that is read (POINTWISE).
+        # Any of mean/std left unset is a global statistic: a seeded disk one, or under a mask a
+        # masked disk scan the stage seeds itself once per case. With both given, POINTWISE.
         stat_keys: set[str] = set()
         if self.mean is None:
             stat_keys.add("Mean")
@@ -390,7 +358,7 @@ class Standardize(TransformInverse):
         return PatchLocality(LocalityKind.GLOBAL_STAT, stat_keys=frozenset(stat_keys))
 
     def _masked_values(self, name: str, tensor: torch.Tensor) -> torch.Tensor:
-        """The tensor's values under the mask, on the whole-volume path (the reference)."""
+        """The tensor's values under the mask, on the whole-volume path."""
         mask = self.read_companion(self.mask, name)  # type: ignore[arg-type]
         if tuple(mask.shape) != tuple(tensor.shape):
             raise TransformError(
@@ -402,9 +370,8 @@ class Standardize(TransformInverse):
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         if self.mask is not None and (self.mean is None or self.std is None) and "StatisticsSeeded" in cache_attribute:
-            # A streamed region: the mask cannot be indexed against it, and a bare 'Mean' seed may
-            # be an unmasked stage's. The case's masked statistic is scanned from the stores once
-            # (memoised) and every region applies the same per-voxel affine map.
+            # A streamed region: the mask cannot be indexed against it, and a bare 'Mean' seed may be
+            # an unmasked stage's, so the masked statistic is scanned from the stores once.
             stats = self._masked_seed.statistics(self.datasets, name)  # type: ignore[union-attr]
             mean_value = torch.tensor(self.mean) if self.mean is not None else torch.tensor([float(stats["mean"])])
             std_value = torch.tensor(self.std) if self.std is not None else torch.tensor([float(stats["std"])])
@@ -459,16 +426,14 @@ class Standardize(TransformInverse):
         if self.lazy:
             return tensor
         else:
-            # The stats parse back as float64 on the CPU; move them to the volume's device (the finalize
-            # chain runs where the volume was blended, possibly CUDA) and compute in float32 so a
-            # whole-volume fp16 output is not promoted to a float64 copy.
+            # The stats parse back as float64 on the CPU; float32 on the volume's device keeps an
+            # fp16 output from being promoted.
             mean = self._broadcast(cache_attribute.pop_tensor("Mean").to(tensor.device, torch.float32), tensor)
             std = self._broadcast(cache_attribute.pop_tensor("Std").to(tensor.device, torch.float32), tensor)
             return tensor * std + mean
 
 
 class TensorCast(TransformInverse):
-    # Measured at 1.00 on the CUDA allocator, in volumes-worth of what it is handed.
     working_multiple = 1.0
 
     # Wide enough to hold every dtype a volume is read as (int8/int16/uint8/float32) with no value moved.
@@ -479,11 +444,8 @@ class TensorCast(TransformInverse):
         self.dtype: torch.dtype = getattr(torch, dtype)
 
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
-        # The promise is that the stored volume's Min/Max/Mean/Std are still a later GLOBAL_STAT's
-        # input statistics, and a cast keeps them only where it keeps every value. The dtype a volume
-        # is stored as is not on its header, so the target is what has to hold whatever that is:
-        # float32 holds an int16 or a float32 exactly, and float16 holds neither, it runs out of
-        # mantissa at 2048, where a CT reaches 3000. An integer cast truncates.
+        # The stored volume's statistics stay a later GLOBAL_STAT's input only where the cast keeps
+        # every value: float32 holds an int16 exactly, float16 runs out of mantissa at 2048.
         return PatchLocality(
             LocalityKind.POINTWISE, preserves_statistics=self.dtype in TensorCast._VALUE_PRESERVING_DTYPES
         )
@@ -507,7 +469,7 @@ class HistogramMatching(Transform):
     """Match a volume's intensity distribution onto a reference group's.
 
     Whole-volume: the LUT is built from the volume's 256-bin histogram, which is not a statistic
-    ``GLOBAL_STAT`` names and cannot be read back out of the sitk filter.
+    ``GLOBAL_STAT`` names.
     """
 
     def __init__(self, reference_group: str) -> None:
@@ -537,12 +499,10 @@ class HistogramMatching(Transform):
 class Statistics(Transform):
     """Record the volume's Min/Max/Mean/Std on the case, under ``Image*`` keys.
 
-    Streams: the four numbers are exactly what the disk-statistics scan already computes, so a
-    streamed chain seeds them (``GLOBAL_STAT``) and each region restates the case's answer instead
-    of a region's own.
+    The four numbers are what the disk-statistics scan computes, so a streamed chain seeds them
+    (``GLOBAL_STAT``) and each region restates the case's answer.
     """
 
-    # Measured at 2.00 on the CUDA allocator, in volumes-worth of what it is handed.
     working_multiple = 2.0
 
     _KEYS = (("Min", "ImageMin"), ("Max", "ImageMax"), ("Mean", "ImageMean"), ("Std", "ImageStd"))

--- a/konfai/data/transform/io.py
+++ b/konfai/data/transform/io.py
@@ -28,18 +28,13 @@ from konfai.utils.utils import split_path_spec
 class Save(Transform):
     """Write the chain's state here, and become a source boundary.
 
-    ``scale_factors`` writes an OME-NGFF PYRAMID instead of a single level: ``[4]`` adds a level 1 at
-    a quarter of the extent per axis, ``[4, 4]`` a level 2 at a sixteenth. Every reader indexes a
-    pyramid BY POSITION (``:omezarr@1`` is the second entry, not one named "1"), so the order is
-    the contract, 0 finest. It applies on both write paths: assembled in memory, or region by region,
-    where the levels are derived once the last region has landed.
-
-    ``downsample_method`` names how the coarse levels are derived, and its default is
-    ``DASK_BIN_SHRINK`` (block averaging), NOT ngff-zarr's own ``ITKWASM_GAUSSIAN``. Measured on a
-    real volume, the Gaussian holds a 0.9998 correlation while crushing peak intensity by 20 %.
+    ``scale_factors`` writes an OME-NGFF pyramid instead of a single level: ``[4]`` adds a level 1 at
+    a quarter of the extent per axis, ``[4, 4]`` a level 2 at a sixteenth. A pyramid is indexed by
+    position (``:omezarr@1`` is the second entry), 0 finest. ``downsample_method`` names how the
+    coarse levels are derived; its default is ``DASK_BIN_SHRINK`` (block averaging), not ngff-zarr's
+    own ``ITKWASM_GAUSSIAN``.
     """
 
-    # Measured at 0.00 on the CUDA allocator: it holds nothing beyond what it is handed.
     working_multiple = 0.0
 
     alters_values = False
@@ -65,14 +60,11 @@ class Save(Transform):
         self._destination: Dataset | None = None
 
     # WHOLE_VOLUME by declaration, yet the case may still stream: a Save whose cache exists is a
-    # source boundary, and an unsatisfied Save with a streamable prefix is materialized slab by slab
-    # first (DatasetManager._materialize_save). Only an unsweepable prefix loads the whole volume.
+    # source boundary, and an unsatisfied one with a streamable prefix is materialized slab by slab.
 
     @property
     def spec(self) -> tuple[str, str] | None:
-        """``(filename, file_format)`` of the dataset this stage names, ``None`` when it names none.
-
-        Parsed only: a parse-time check reads the path without probing the store on disk."""
+        """``(filename, file_format)`` of the dataset this stage names, ``None`` when it names none."""
         if not self.dataset:
             return None
         filename, _flag, file_format = split_path_spec(self.dataset, default_format="mha")
@@ -80,10 +72,7 @@ class Save(Transform):
 
     @property
     def destination(self) -> Dataset | None:
-        """The :class:`Dataset` this stage writes into, ``None`` when it names none.
-
-        Built once: the stage is shared by every case's manager, and constructing a Dataset probes
-        the destination directory on disk."""
+        """The :class:`Dataset` this stage writes into, ``None`` when it names none. Built once."""
         if self._destination is None and (spec := self.spec) is not None:
             self._destination = Dataset(*spec, self.scale_factors, self.downsample_method)
         return self._destination
@@ -95,15 +84,12 @@ class Save(Transform):
 class Write(Save):
     """A :class:`Save` that is a deliverable, not a cache.
 
-    Same object, same boundary semantics, one difference that is the point: ``dataset`` has no
-    default, so a bare ``Write:`` fails at config time instead of silently writing into the source
-    tree (a bare ``Save:`` binds ``dataset`` to nothing and falls back to the manager's own
-    dataset). The TRANSFORM workflow plans, resumes and reports on its ``Write`` stages; a ``Save``
-    between them stays an opportunistic milestone, never written when a satisfied ``Write``
-    downstream lets the boundary skip the whole prefix.
+    Same boundary semantics, with ``dataset`` mandatory: a bare ``Write:`` fails at config time,
+    where a bare ``Save:`` falls back to the manager's own dataset. The TRANSFORM workflow plans,
+    resumes and reports on its ``Write`` stages; a ``Save`` between them stays an opportunistic
+    milestone.
     """
 
-    # Measured at 0.00 on the CUDA allocator: it holds nothing beyond what it is handed.
     working_multiple = 0.0
 
     def __init__(

--- a/konfai/data/transform/labels.py
+++ b/konfai/data/transform/labels.py
@@ -33,10 +33,8 @@ from konfai.utils.ITK import _require_simpleitk
 class Mask(Transform):
     """Set everything outside a mask to a constant.
 
-    Per-voxel: the only thing a region needs beyond its own voxels is WHICH part of the mask lines
-    up with it, which the dispatcher hands over (``stream_region``): a dataset mask is region-read,
-    a ``.mha`` mask sliced from the one cached copy. The mask is assumed aligned to the volume at
-    this point. ``__call__`` (the whole-volume path) stays the reference.
+    Per-voxel: a region needs only the part of the mask that lines up with it, which the dispatcher
+    hands over. The mask is assumed aligned to the volume.
     """
 
     def __init__(self, path: str = "./default.mha", value_outside: int = 0) -> None:
@@ -47,18 +45,17 @@ class Mask(Transform):
         #: Cases whose stored mask was checked against the chain input's extent (once per case).
         self._aligned: set[str] = set()
 
-    # POINTWISE on the promise that the mask sits on the stage's input grid; a declaration may
-    # not do I/O, so the extent is checked at the point of use (stream_region), per case.
+    # POINTWISE on the promise that the mask sits on the stage's input grid, checked in
+    # stream_region once per case.
     locality = LocalityKind.POINTWISE
 
     def _apply(self, tensor: torch.Tensor, mask: torch.Tensor | np.ndarray) -> torch.Tensor:
-        # Index on the tensor's own device so the mask works whether the volume is on CPU or GPU
-        # (``torch.as_tensor`` keeps a torch mask as-is and wraps a numpy one, moving it to the device).
+        # Index on the tensor's own device so the mask works whether the volume is on CPU or GPU.
         tensor[torch.as_tensor(mask, device=tensor.device) == 0] = self.value_outside
         return tensor
 
     def _cached_mha(self) -> torch.Tensor:
-        """The whole ``.mha`` mask, read once: the whole-volume path's, never a region's."""
+        """The whole ``.mha`` mask, read once, for the whole-volume path only."""
         _require_simpleitk()
         if self._cached_mask is None:
             self._cached_mask = torch.tensor(sitk.GetArrayFromImage(sitk.ReadImage(self.path))).unsqueeze(0)
@@ -73,8 +70,7 @@ class Mask(Transform):
         return tuple(int(extent) for extent in reversed(reader.GetSize()))
 
     def _mha_region(self, slices: tuple[slice, ...]) -> torch.Tensor:
-        """One region of the ``.mha`` mask, read as a region: the whole mask is never held on the
-        streamed path (bounded on disk for an uncompressed file, transient for a compressed one)."""
+        """One region of the ``.mha`` mask; the whole mask is never held on the streamed path."""
         _require_simpleitk()
         reader = sitk.ImageFileReader()
         reader.SetFileName(self.path)
@@ -92,8 +88,7 @@ class Mask(Transform):
         raise TransformError(f"'Mask' found no mask '{self.path}' for case '{name}' in any dataset.")
 
     def _mask(self, name: str, slices: tuple[slice, ...] | None) -> torch.Tensor | np.ndarray:
-        """The case's mask, or the ``slices`` region of it: a ``.mha`` mask is read whole for the
-        whole-volume path and by region for a region, a dataset mask likewise."""
+        """The case's mask, or the ``slices`` region of it."""
         if self.path.endswith(".mha"):
             return self._cached_mha() if slices is None else self._mha_region(slices)
         dataset = self._mask_dataset(name)
@@ -105,8 +100,7 @@ class Mask(Transform):
         return self._apply(tensor, self._mask(name, None))
 
     def _check_aligned(self, name: str, context: RegionContext) -> None:
-        """Refuse a mask whose extent is not the stage input's: a region of it would then be read
-        from the wrong place and the masked output would look right. Headers only, once per case."""
+        """Refuse a mask whose extent is not the stage input's. Headers only, once per case."""
         if name in self._aligned:
             return
         expected = tuple(int(extent) for extent in context.source_shape)
@@ -129,8 +123,7 @@ class Mask(Transform):
         return (slice(None), *context.source)
 
     def plan_region_reads(self, name: str, contexts: Sequence[RegionContext]) -> None:
-        # A hint declares nothing it cannot find: a missing mask is the first region's error to
-        # raise, inside the sweep, where the case falls back. SimpleITK plans nothing for a .mha.
+        # A missing mask is the first region's error to raise. SimpleITK plans nothing for a .mha.
         if self.path.endswith(".mha"):
             return
         with contextlib.suppress(TransformError):
@@ -143,16 +136,12 @@ class Mask(Transform):
         context: RegionContext,
         cache_attribute: Attribute,
     ) -> torch.Tensor:
-        # Only the region's part of the mask, 1-channel and far smaller than the output; the mask
-        # is checked to sit on the stage input's grid before its first region is trusted.
+        # Only the region's part of the mask, checked to sit on the stage input's grid first.
         self._check_aligned(name, context)
         return self._apply(tensor, self._mask(name, self._window(context)))
 
 
 class Dilate(Transform):
-    # Measured 15.00 at two sizes on the CUDA allocator, under a budget large enough not
-    # to clamp it: the distance transform's own buffers, not the three a declaration
-    # copied from an interpolation's sampling grid assumed.
     working_multiple = 15.0
 
     def __init__(self, dilate: int = 1) -> None:
@@ -162,9 +151,7 @@ class Dilate(Transform):
         self.dilate = dilate
 
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
-        # A box dilation of radius ``dilate`` spreads foreground by at most ``dilate`` voxels per axis:
-        # a bounded HALO. At the true border the separable max-pool padding matches the whole-volume
-        # result once the halo clamps, so seams are byte-identical. Radius 0 is a spatial identity.
+        # A box dilation spreads foreground by at most ``dilate`` voxels per axis: a bounded halo.
         if self.dilate == 0:
             return PatchLocality(LocalityKind.POINTWISE)
         return PatchLocality(LocalityKind.HALO, halo=(self.dilate,))
@@ -178,10 +165,7 @@ class Dilate(Transform):
         d = self.dilate
         k = 2 * d + 1
 
-        # A cubic (box) structuring element is separable: dilating by a k**n box equals n successive
-        # 1-D max-pools, one per spatial axis. This is bit-identical to a single k**n max-pool (max is
-        # associative and the box is the Minkowski sum of 1-D segments) for ~k**(n-1)x fewer comparisons
-        #: the k**3 dense pool is the dominant cost of the whole-volume mask load.
+        # A box structuring element is separable: a k**n box equals n successive 1-D max-pools.
         if spatial_dims == 2:
             data = F.max_pool2d(data, kernel_size=(k, 1), stride=1, padding=(d, 0))
             data = F.max_pool2d(data, kernel_size=(1, k), stride=1, padding=(0, d))
@@ -201,19 +185,14 @@ class Dilate(Transform):
 def _forget_model_channel_counts(cache_attribute: Attribute) -> None:
     """Take ``number_of_channels_per_model`` off a case's state, as folding the model axis does.
 
-    The key describes the ensemble the fold consumed: once the models' channels are one map it
-    describes an input that no longer exists, and a later ``Sum`` or ``MergeLabels`` reading it off
-    the written store would take the ensemble branch on a one-channel map. The whole-volume pass
-    pops it from the live attribute it writes the header from; a streamed region pops it from a
-    scope that is thrown away, so the case-level state has to say it here.
+    A later ``Sum`` or ``MergeLabels`` reading it off the written store would take the ensemble
+    branch on a one-channel map, and a streamed region pops it from a scope that is thrown away.
     """
     if "number_of_channels_per_model" in cache_attribute:
         cache_attribute.pop_tensor("number_of_channels_per_model")
 
 
 class Sum(Transform):
-    # What it holds beyond its input and its output: the shifted label ranges it adds over: measured 2.42,
-    # on the CUDA allocator, under a budget large enough not to clamp it.
     working_multiple = 3.75
 
     def __init__(self, dim: int = 0) -> None:
@@ -244,26 +223,16 @@ class Sum(Transform):
 class MergeLabels(Transform):
     """Merge the per-model argmax label maps of a ``combine: Concat`` ensemble into one global map.
 
-    Each model's ``Argmax`` produces a LOCAL class index (``0`` = background). A model's
-    non-background labels are shifted past every earlier model's foreground classes (by the
-    CUMULATIVE sum of the earlier models' foreground counts (``nb_class - 1``)), so the models'
-    disjoint label ranges tile a single global label space.
-
-    This is the label-space counterpart of ``InferenceStack`` (which averages *same-class*
-    probability ensembles): use ``MergeLabels`` when the models segment DIFFERENT structures, e.g.
-    the 5-task TotalSegmentator ensemble (organs / vertebrae / cardiac / muscles / ribs). Requires
-    ``number_of_channels_per_model`` in the attribute (written by the ``Concat`` reduction).
-
-    Models are assumed to segment disjoint structures, but boundaries disagree in practice: a voxel
-    claimed by several models takes the label of the LAST model in ensemble order (adding the global
-    ids instead would fabricate a label belonging to neither model).
+    Each model's ``Argmax`` produces a local class index (``0`` = background). A model's
+    non-background labels are shifted past every earlier model's foreground classes, by the
+    cumulative sum of the earlier models' foreground counts (``nb_class - 1``), so the models'
+    disjoint label ranges tile a single global label space. Use it when the models segment different
+    structures. Requires ``number_of_channels_per_model`` in the attribute, written by the ``Concat``
+    reduction. A voxel claimed by several models takes the label of the last model in ensemble order.
     """
 
-    # What it holds beyond its input and its output: the shifted label ranges and the merged result: measured 2.42,
-    # on the CUDA allocator, under a budget large enough not to clamp it.
     working_multiple = 3.75
 
-    # Merges the leading model axis per voxel; spatial support is a single voxel.
     locality = LocalityKind.POINTWISE
 
     def write_stream_cache_attribute(
@@ -289,8 +258,7 @@ class MergeLabels(Transform):
 
 
 def _axis_reduction_locality(dim: int) -> PatchLocality:
-    """POINTWISE for a reduction over the channel axis (dim 0); over a spatial axis it spans the whole
-    extent, so the stage takes the whole volume."""
+    """POINTWISE over the channel axis (dim 0); over a spatial axis the stage takes the whole volume."""
     if dim == 0:
         return PatchLocality(LocalityKind.POINTWISE)
     return PatchLocality(
@@ -300,7 +268,6 @@ def _axis_reduction_locality(dim: int) -> PatchLocality:
 
 
 class Argmax(Transform):
-    # Measured at 0.00 on the CUDA allocator: it holds nothing beyond what it is handed.
     working_multiple = 0.0
 
     def __init__(self, dim: int = 0) -> None:
@@ -315,8 +282,7 @@ class Argmax(Transform):
 
 
 class Softmax(Transform):
-    # Measured at 0.00 on a float input and 1.00 on the int16 a store serves, which widens to float
-    # before the kernel runs: the declaration is the worse of the two.
+    # 0.00 on a float input, 1.00 on the int16 a store serves, which widens before the kernel runs.
     working_multiple = 1.0
 
     def __init__(self, dim: int = 0) -> None:
@@ -327,15 +293,11 @@ class Softmax(Transform):
         return _axis_reduction_locality(self.dim)
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
-        # A store serves int16, and torch.softmax has no integer kernel: a chain that softmaxes a
-        # stored volume failed on the tensor, with torch's message about "host_softmax" and not one
-        # naming the stage. Widened here, where the scores an integer carries are what it means.
+        # torch.softmax has no integer kernel, and a store serves int16.
         return torch.softmax(tensor if tensor.is_floating_point() else tensor.float(), dim=self.dim)
 
 
 class FlatLabel(Transform):
-    # What it holds beyond its input and its output: one relabelled copy beside the input: measured 1.00,
-    # on the CUDA allocator, under a budget large enough not to clamp it.
     working_multiple = 1.0
 
     locality = LocalityKind.POINTWISE
@@ -358,8 +320,6 @@ class FlatLabel(Transform):
 class SelectLabel(Transform):
     """Relabel: each ``"(old,new)"`` pair maps label ``old`` to ``new``; every other voxel is 0."""
 
-    # What it holds beyond its input and its output: the selection mask: measured 1.00,
-    # on the CUDA allocator, under a budget large enough not to clamp it.
     working_multiple = 1.0
 
     locality = LocalityKind.POINTWISE
@@ -382,27 +342,22 @@ class SelectLabel(Transform):
 
 
 class OneHot(TransformInverse):
-    # What it holds beyond its input and its output: half its own wider output: measured 0.50 against the larger of in and out,
-    # on the CUDA allocator, under a budget large enough not to clamp it.
+    # Half its own wider output, against the larger of input and output.
     working_multiple = 0.5
 
     def __init__(self, num_classes: int, inverse: bool = True) -> None:
         super().__init__(inverse)
         self.num_classes = num_classes
 
-    # Expands each voxel's scalar label into a one-hot channel vector (spatially pointwise).
     locality = LocalityKind.POINTWISE
 
     def output_channels(self, channels: int) -> int:
         return self.num_classes * channels
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
-        # Scattered straight into the float32 answer: ``F.one_hot`` builds the classes in int64
-        # first, three times the bytes of the result for the time of a cast (80 GB for 50 classes
-        # of a 512^3 map, where the answer is 27 GB and this holds the answer plus the labels).
+        # Scattered straight into the float32 answer, where ``F.one_hot`` would build int64 first.
         labels = tensor.to(torch.int64)
-        # scatter_ names no label: out of range it is a raw index error on CPU and a device-side
-        # assert on CUDA that poisons the context, where F.one_hot said which value was wrong.
+        # scatter_ names no label, so an out-of-range one is checked here.
         lowest, highest = int(labels.min()), int(labels.max())
         if lowest < 0 or highest >= self.num_classes:
             raise TransformError(
@@ -416,9 +371,7 @@ class OneHot(TransformInverse):
         return result.squeeze(0)
 
     def inverse(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
-        # Argmax the CLASS axis (the one sized num_classes) and re-insert it, restoring a [.., 1, *spatial]
-        # label map. The predictor feeds this per-sample output[i] = [num_classes, *spatial] (class axis 0),
-        # but a batched [B, num_classes, *spatial] (class axis 1) is also handled, so it never argmaxes a
-        # batch or spatial axis.
+        # Argmax the class axis (the one sized num_classes) and re-insert it, restoring a
+        # [.., 1, *spatial] label map. A batched [B, num_classes, *spatial] is handled too.
         class_dim = 0 if tensor.shape[0] == self.num_classes else 1
         return torch.argmax(tensor, dim=class_dim).unsqueeze(class_dim)

--- a/konfai/data/transform/resample.py
+++ b/konfai/data/transform/resample.py
@@ -133,21 +133,12 @@ class _DerivedGrid(_TargetGrid):
 class _ReferenceGrid(_TargetGrid):
     """The grid of a STORED image: extent, spacing, origin and direction, read from its header.
 
-    The target that makes a cohort foldable. A spacing lines up densities and a shape lines up
-    extents, but both leave each case where it was; this adopts one grid whole, which is what gives
-    ``Reduce``'s ``grid: strict`` something true to compare. That is the atlas-template build.
+    The target that makes a cohort foldable: one grid adopted whole, which is what ``Reduce``'s
+    ``grid: strict`` compares against. The reference is an image, not a list of numbers: the header
+    IS the declaration.
 
-    THE REFERENCE IS AN IMAGE, NOT A LIST OF NUMBERS. A grid is fifteen numbers in two axis orders
-    at once, and transcribing them by hand is reliably wrong: silently, because a transposed grid
-    resamples perfectly well onto the wrong place. Naming an
-    image cannot make it: the header IS the declaration. It is also what an atlas loop needs, where
-    round N+1's reference is round N's own output.
-
-    An entry containing ``{case}`` FOLLOWS THE CASE: each case adopts the grid of its own entry --
-    ``reference: '{case}', reference_group: DVF`` puts every moved image on its own field's grid,
-    which is the registration idiom (a displacement field is defined ON the fixed grid). The
-    literal spelling stays one lookup for the whole cohort; a per-case one is one per case,
-    headers only either way.
+    An entry containing ``{case}`` follows the case, so ``reference: '{case}', reference_group: DVF``
+    puts every moved image on its own field's grid. Headers only, either way.
     """
 
     needs = frozenset(_GEOMETRY_KEYS)
@@ -196,11 +187,7 @@ class _ReferenceGrid(_TargetGrid):
         return self.entry.replace("{case}", name)
 
     def grid(self, name: str = "") -> Grid:
-        """The reference's grid, read from its header once per distinct entry.
-
-        Headers only, and memoized by ENTRY: a literal reference is one lookup for the whole
-        cohort, a per-case one is one per case, never the same answer bought again.
-        """
+        """The reference's grid, read from its header once per distinct entry, memoized by entry."""
         entry = self._entry_for(name)
         cached = self._grids.get(entry)
         if cached is not None:
@@ -247,9 +234,7 @@ class _ReferenceGrid(_TargetGrid):
 def _optional_image_filler() -> Any:
     """SimpleITK's own in-place array fill (``_SetImageFromArray``), or ``None``.
 
-    A private symbol, so it is optional on its own: guarded together with the package, a SimpleITK
-    that does not export it would have read as no SimpleITK at all. Its caller
-    (:class:`_SitkInput`) allocates a fresh image instead when it is missing.
+    Guarded on its own: :class:`_SitkInput` allocates a fresh image instead when it is missing.
     """
     try:
         from SimpleITK.SimpleITK import _SetImageFromArray
@@ -264,17 +249,11 @@ _set_image_from_array = _optional_image_filler() if sitk is not None else None
 class _SitkInput:
     """ITK's input image for :func:`_resample_with_sitk`, reused across the regions of a sweep.
 
-    ``GetImageFromArray`` allocates and zero-fills a new image per array, and the fresh mapping
-    pays its page faults: 44-48 ms per 113 MiB against 6-9 ms filled in place (SimpleITK 2.5.5,
-    a resample executed between two fills). The image is filled in place while the regions keep
-    one shape and dtype and replaced when they do not; only one is ever held, the old dropped
-    before the next is allocated. The whole-volume call drops it on its way out: what is held
-    between calls is a region, never a case.
-
-    The fill is the primitive the wrapper itself calls, ``_SetImageFromArray``
-    (SimpleITK/SimpleITK#2683 asks for it as an ``outputImage`` argument). It checks the byte
-    length only, so the shape and dtype key is what keeps a same-length array from being
-    reinterpreted.
+    ``GetImageFromArray`` allocates and zero-fills a new image per array: 44-48 ms per 113 MiB
+    against 6-9 ms filled in place. The image is filled in place while the regions keep one shape
+    and dtype and replaced when they do not; only one is ever held, and the whole-volume call drops
+    it on its way out. The fill checks the byte length only, so the shape and dtype key is what
+    keeps a same-length array from being reinterpreted.
     """
 
     def __init__(self) -> None:
@@ -295,25 +274,16 @@ class _SitkInput:
 
 
 def _warp_field_float32(stages: SpatialStages, region: Grid) -> "Any | None":
-    """The one displacement this whole map is, as a float32 vector image on ``region`` -- or None.
+    """The one displacement this whole map is, as a float32 vector image on ``region``, or None.
 
-    ``sitk.Warp`` is templated on the field's own type, where ``DisplacementFieldTransform`` is
-    not: SimpleITK's transform hierarchy is ``TransformBaseTemplate<double>``, so a field handed to
-    a transform is cast to float64 whatever it was read as, and interleaved into a vector image at
-    that width. On a 122-row native region that is 6.9 GiB built in 5.0 s, 39% of everything the
-    member-region costs -- for a field that came off the store as float32 and whose values fit it
-    exactly.
+    ``sitk.Warp`` is templated on the field's own type where ``DisplacementFieldTransform`` casts to
+    float64: on a 122-row native region that is 6.9 GiB built in 5.0 s, 39% of the member-region.
 
-    Taken only where it changes no value. The field must ALREADY be float32 -- which is what
-    ``precision: fast`` reads, and what a store written in float32 holds either way -- because
-    narrowing a genuine float64 field is a different map, not a cheaper one (pinned: on a field
-    carrying float64 values the two routes disagree). Warp also evaluates the displacement on the
-    OUTPUT grid rather than interpolating it at the target point, so it stands in only where the
-    field IS the output grid, and only where the field is the whole map: one order-1 stage, no
-    affine beside it, nothing to compose. Anything else keeps the composite path.
-
-    Verified bit-identical on two ExaSPIM members at 89% and 98% real coverage (max |diff| 0 over
-    the region), 1.3x faster end to end, and the field's buffer halves.
+    Taken only where it changes no value. The field must ALREADY be float32, which is what
+    ``precision: fast`` reads: narrowing a genuine float64 field is a different map. Warp evaluates
+    the displacement on the OUTPUT grid rather than interpolating it at the target point, so it
+    stands in only where the field IS the output grid and is the whole map: one order-1 stage, no
+    affine beside it. Anything else keeps the composite path.
     """
     from konfai.data.geometry import DisplacementStage
 
@@ -354,13 +324,12 @@ def _resample_with_sitk(
 ) -> torch.Tensor | None:
     """One region of a resample through ITK's own filter, on the host.
 
-    ``payload`` is the SOURCE window read for this region (``region_starts`` says where it sits
-    in the source grid); ``region`` is the target grid of the region. The window becomes an image
-    with the source's geometry shifted to its start; the target region an image with its own
-    grid; the stages one composite transform (:func:`~konfai.utils.ITK.encode_transform_stages`),
-    applied by ``sitk.Resample`` in the direction KonfAI's walk applies it (target point through
-    the stages to the source point). Channels are resampled one by one, which is what ITK does
-    for a vector image anyway. ``None`` for a payload ITK has no pixel type for (bool, f16, bf16).
+    ``payload`` is the SOURCE window read for this region (``region_starts`` says where it sits in
+    the source grid); ``region`` is the target grid of the region. The stages become one composite
+    transform (:func:`~konfai.utils.ITK.encode_transform_stages`), applied by ``sitk.Resample`` in
+    the direction KonfAI's walk applies it (target point through the stages to the source point).
+    Channels are resampled one by one. ``None`` for a payload ITK has no pixel type for (bool, f16,
+    bf16).
     """
     from konfai.utils.ITK import encode_transform_stages
 
@@ -382,8 +351,7 @@ def _resample_with_sitk(
     start_index = np.asarray(list(reversed(region_starts)), dtype=np.float64)  # (x, y, z)
     window_origin = source.index_to_world.apply(start_index)
     # The target grid is given to the filter, not carried by an image standing in for it: a
-    # reference image is read for its geometry and never for its pixels, so allocating and
-    # zero-filling a region's worth of them is a copy nothing reads.
+    # reference image is read for its geometry and never for its pixels.
     resampler = sitk.ResampleImageFilter()
     resampler.SetSize([int(e) for e in reversed(region.size_zyx)])
     resampler.SetOutputOrigin(np.asarray(region.origin_xyz, dtype=np.float64).tolist())
@@ -393,15 +361,10 @@ def _resample_with_sitk(
         resampler.SetTransform(transform)
     resampler.SetInterpolator(interpolator[mode])
     resampler.SetDefaultPixelValue(float(fill))
-    # A blend interpolates in the dtype the walk accumulates in, and torch makes the final cast:
-    # ITK would otherwise accumulate an integer payload in double and cast inside the filter, where
-    # one ulp of difference becomes a whole unit after the truncation both sides do. A nearest pick
-    # copies voxels, so it keeps the payload's own dtype, exactly as the walk does.
-    #
-    # The filter is ASKED for that dtype instead of being handed a region converted into it. ITK
-    # interpolates in double from either, so the values are the same for every dtype float32 carries
-    # exactly (an int32 or int64 past 2^24 blends from its exact values where the cast rounded them),
-    # and the conversion that was a copy of the whole region becomes the filter's own output.
+    # A blend interpolates in the dtype the walk accumulates in, and torch makes the final cast: ITK
+    # would otherwise accumulate an integer payload in double and cast inside the filter, where one
+    # ulp becomes a whole unit after the truncation. A nearest pick keeps the payload's own dtype.
+    # The filter is ASKED for that dtype instead of being handed a region converted into it.
     working_dtype = payload.dtype if mode == "nearest" else sampling_dtype(payload)
     blend_pixel_id = {torch.float32: sitk.sitkFloat32, torch.float64: sitk.sitkFloat64}.get(working_dtype)
     if mode != "nearest" and blend_pixel_id is None:
@@ -420,9 +383,8 @@ def _resample_with_sitk(
         # Held: a view borrows the image's buffer, and a temporary's is freed under it.
         if warp_field is not None:
             # Warp answers in its INPUT's type where the resampler is asked for an output type, so
-            # the blend's dtype is carried in rather than requested. ITK interpolates in double
-            # from either, and float32 carries a uint16 payload exactly, so the values are the
-            # ones the resampler would have written (pinned in test_resample_transform.py).
+            # the blend's dtype is carried in rather than requested (pinned in
+            # test_resample_transform.py).
             resampled = sitk.Warp(
                 image if image.GetPixelID() == pixel_id else sitk.Cast(image, pixel_id),
                 warp_field,
@@ -445,10 +407,8 @@ class _StoredMap:
     """What the plan keeps of a case's decoded stored transform: its bound, and whether the map IS
     the bound's affine part (every stage affine, folded exactly as the walk folds them).
 
-    The decoded stages are not kept. A dense field is a values-sized array per case, and the
-    launcher decodes every case as the plan is built: 50 cases of a 160x256x256 field were 11.7 GiB
-    resident and serialised to every rank. The bound is three vectors, and it is all a pull map
-    needs; the stages are decoded again where a region of their case is sampled, one case at a time
+    The decoded stages are not kept: 50 cases of a 160x256x256 field were 11.7 GiB resident and
+    serialised to every rank. They are decoded again where a region of their case is sampled
     (:meth:`Resample._stored_stages`).
     """
 
@@ -468,34 +428,28 @@ def _stages_bytes(stages: SpatialStages) -> int:
 #: Handing the field to ITK costs three: the values the read cached, the rank component images
 #: encode_transform_stages builds from them, and the vector image sitk.Compose builds beside those
 #: (konfai/utils/ITK.py, all live at the DisplacementFieldTransform call). Measured 21.2 GiB held
-#: against 3.54 charged, on a fold whose plan then announced 4.65 GiB and whose run was killed at
-#: 11.63 -- and killed in its FIRST region, which no run-time measurement can save, since there is
-#: nothing measured yet when it is cut. That is why this is priced rather than left to the probe.
-#:
-#: Charged on every route, though only the host one goes through ITK: a stage is asked what it holds
-#: before a device is chosen, and over-charging costs a shorter region where under-charging costs
-#: the run.
+#: against 3.54 charged. Priced rather than probed: a run cut in its FIRST region has nothing
+#: measured yet. Charged on every route, though only the host one goes through ITK: over-charging
+#: costs a shorter region, under-charging costs the run.
 _FIELD_WINDOW_COPIES = 3.0
 
 #: What one element of a decoded field weighs under the bit-exact walk: read as float64 whatever
-#: the store holds (:meth:`_DisplacementSource.read`), while the plan counts its volumes at
-#: :data:`~konfai.data.patching.budget._SWEEP_ELEMENT_BYTES`: the ratio is what a field window costs in
-#: the currency the plan is written in. Under ``precision: fast`` the field is held in float32 and
-#: weighs half (:meth:`Resample._field_element_bytes`).
+#: the store holds (:meth:`_DisplacementSource.read`), against the plan's count at
+#: :data:`~konfai.data.patching.budget._SWEEP_ELEMENT_BYTES`. Under ``precision: fast`` the field is
+#: held in float32 and weighs half (:meth:`Resample._field_element_bytes`).
 _FIELD_ELEMENT_BYTES = 8
 
 
 class _DisplacementSource:
     """A displacement field on disk: where it is, how far it reaches, and how to read a region of it.
 
-    :class:`Resample` is its one owner (the family's spellings all resolve to it), so every refusal
-    speaks as ``Resample`` and names ``field_group``, the argument the user declared.
+    :class:`Resample` is its one owner, so every refusal speaks as ``Resample`` and names
+    ``field_group``, the argument the user declared.
     """
 
     def __init__(self, field: str | None, group: str | None) -> None:
         # A root of its own, or none: with no ``field`` path the fields are a GROUP of the run's own
-        # dataset_filenames, one entry per case, which is how a cohort registered in place stores
-        # them, beside the volumes they were solved on.
+        # dataset_filenames, one entry per case, beside the volumes they were solved on.
         self.dataset: Dataset | None = None
         if field is not None and str(field).strip():
             filename, _flag, file_format = split_path_spec(str(field), default_format="mha")
@@ -515,9 +469,8 @@ class _DisplacementSource:
     def headers_readable(self) -> bool:
         """Whether every field entry's HEADER opens, memoized: the plan's one probe of the group.
 
-        An unreadable entry fails both routes on whichever case reaches it, and a directory store
-        lists its entries from the filesystem alone, so a corrupt one only surfaces at its header:
-        scanned here, one entry at a time, before any case is chosen.
+        An unreadable entry fails both routes on whichever case reaches it, so the group is scanned
+        here, one entry at a time, before any case is chosen.
         """
         if self._scan_ok is not None:
             return self._scan_ok
@@ -572,9 +525,8 @@ class _DisplacementSource:
     def probe(self, name: str) -> None:
         """The case's own entry, proven present and readable: the per-case half of the scan.
 
-        :meth:`headers_readable` walks what is on disk; it cannot know which cases the plan will
-        ask for, so a missing entry would otherwise surface mid-run, after bytes are written.
-        Memoized: one header read per case, at plan time.
+        :meth:`headers_readable` cannot know which cases the plan will ask for, so a missing entry
+        would otherwise surface mid-run, after bytes are written. Memoized: one header read per case.
         """
         if name in self._probed:
             return
@@ -599,10 +551,8 @@ class _DisplacementSource:
         else:
             data, _attributes = root.read_data_slice(group, name, (slice(None), *region))
         # The walk's dtype, handed down by the owner. float64 is the bit-exact contract: a .float()
-        # here would quantise a float64-stored field before the exact arithmetic ever saw it -- a
-        # silent sitk divergence for any field an external tool wrote in double. float32 is what a
-        # `precision: fast` walk takes the values in regardless, so widening them first is a copy
-        # that costs twice the window and buys nothing.
+        # here would quantise a float64-stored field before the exact arithmetic saw it. float32 is
+        # what a `precision: fast` walk takes the values in regardless.
         field = torch.from_numpy(np.ascontiguousarray(data)).to(torch.float32 if dtype is np.float32 else torch.float64)
         if field.shape[0] != channels:
             raise TransformError(
@@ -616,25 +566,22 @@ class _DisplacementSource:
 class Resample(TransformInverse):
     """Resample a case: onto another grid, through a stored map, or both, in one interpolation.
 
-    Every resample in KonfAI is these two questions, and this is the only stage that answers them.
-
     **Which grid to write on**: at most one of:
 
     - nothing (the default): the case's own grid. The map moves the anatomy; the voxels stay put.
     - ``spacing``: the same field of view at another density, in physical order ``(x, y, z)``. A
       component left at ``0`` keeps its axis.
     - ``shape``: the same field of view at a given count, in array order ``(Z, Y, X)``. A component
-      left at ``0`` keeps its axis. The two orders differ on purpose: a spacing is geometry, a
-      shape is an array extent, and each is written in its own convention.
+      left at ``0`` keeps its axis. A spacing is geometry and a shape is an array extent, so each is
+      written in its own convention.
     - ``reference``: the grid of a stored image, adopted whole: extent, spacing, origin, direction.
-      ``'{case}'`` in the entry follows the case: each case adopts the grid of its OWN entry in
-      ``reference_group``: ``reference: '{case}', reference_group: DVF`` lands every moved image
-      on its own field's grid, which is where a displacement field is defined.
+      ``'{case}'`` in the entry follows the case, so ``reference: '{case}', reference_group: DVF``
+      lands every moved image on its own field's grid.
 
     **What map to write it through**: any of, composed in this order:
 
-    - ``field``: a displacement field, read in world units at each TARGET voxel. Its own grid, its
-      own spacing: a field solved at 120 um moves a volume stored at 30 um without being upsampled.
+    - ``field``: a displacement field, read in world units at each TARGET voxel, on its own grid and
+      spacing: a field solved at 120 um moves a volume stored at 30 um without being upsampled.
     - ``transforms``: transforms stored beside the cases (rigid, affine, BSpline, dense field, or a
       composite of them) mapping GROUP to whether to invert it. The LAST declared is applied first,
       which is SimpleITK's own composite order.
@@ -642,30 +589,23 @@ class Resample(TransformInverse):
     Left out, the map is the identity and this is a change of grid and nothing else.
 
     ONE INTERPOLATION, ALWAYS. A grid change and a warp asked for together are composed into a single
-    coordinate per target voxel and the source is read once, at the displaced point. Doing it as two
-    stages resamples twice, and a volume interpolated twice has lost detail the second pass invented
-    no more of, which is the whole reason an atlas's appearance is rebuilt from native volumes.
+    coordinate per target voxel and the source is read once, at the displaced point.
 
     ``interpolation`` is ``nearest``, ``linear`` (the default; ``uint8`` defaults to ``nearest``) or
     ``cubic``: Keys' cubic convolution (Catmull-Rom, a = -1/2), interpolating and patch-local (four
     taps per axis, one extra voxel of streamed halo). It is NOT a prefiltered B-spline: scipy's
-    ``order=3`` (nnU-Net's resampling) runs a global prefilter this stage does not, so a spline-3
-    recipe is approximated, not reproduced.
+    ``order=3`` runs a global prefilter this stage does not.
 
-    IT STREAMS, and what a region reads is known before a voxel of the SOURCE is touched. A rigid
-    or affine map is an exact affine, so the source box of a target region is that region's box
-    mapped through it. A BSpline and a dense field are values on a grid read through a non-negative
-    kernel that sums to one, so the sup-norm of those values bounds the displacement at EVERY point: a
-    theorem, not a sample of the boundary. A field on disk is read region by region, and the
-    window a region samples is its own box: the sup of the values just read bounds that region's
-    pull, so each slab pays exactly the halo ITS displacements require: measured at run, from a
-    read the sampler needs regardless. Nothing is declared and nothing is recorded: the plan
-    prices the reads as if the field were zero, and says so.
+    IT STREAMS, and what a region reads is known before a voxel of the SOURCE is touched. A rigid or
+    affine map is an exact affine. A BSpline and a dense field are values on a grid read through a
+    non-negative kernel that sums to one, so the sup-norm of those values bounds the displacement at
+    every point. A field on disk is read region by region, and the sup of the values just read bounds
+    that region's pull, so each slab pays exactly the halo ITS displacements require. The plan prices
+    the reads as if the field were zero, and says so.
 
-    ``align`` decides where a ``spacing`` or a ``shape`` grid SITS, and it is the one silent choice
-    in the family: a quarter of a voxel of anatomy, made differently by every library that offers
-    only one of them. ``extent`` keeps the field of view (the outer faces coincide); ``origin`` keeps
-    voxel zero's centre where it is. A ``reference`` states its own placement and ignores this.
+    ``align`` decides where a ``spacing`` or a ``shape`` grid SITS: ``extent`` keeps the field of
+    view (the outer faces coincide), ``origin`` keeps voxel zero's centre where it is. A
+    ``reference`` states its own placement and ignores this.
 
     WHAT IT REFUSES, rather than resample from a window it cannot size or in a space it does not have:
 
@@ -675,18 +615,15 @@ class Resample(TransformInverse):
     - a transform type that decomposes into no bounded map, naming the type;
     - ``invert: true`` on anything but a rigid or affine map: inverting a spline or a field is a
       dense solve over the whole grid, and a field solved per region is not the restriction of the
-      field solved once. Store the inverse, or invert it where it is written;
-    - a case that does not meet the target grid anywhere: judged THROUGH the declared map, so a
-      stored rigid bridging two scanner frames is not mistaken for disjointness. The output would
-      be ``fill`` from edge to edge, and an all-background member is a plausible, wrong
-      contribution to a median.
+      field solved once. Store the inverse instead;
+    - a case that does not meet the target grid anywhere, judged THROUGH the declared map so a
+      stored rigid bridging two scanner frames is not mistaken for disjointness.
 
-    A refusal the whole-volume path can serve (a case with no geometry, an unreadable entry in
-    the field group) declares ``WHOLE_VOLUME`` with its reason and the run proceeds assembled:
-    the chain only stops being bounded, and says so in the plan. One that no route can serve (a
-    map that cannot be decoded, read or inverted, or a disjoint case) refuses as the plan is
-    built, before a byte is written. A case reaching only PART of the target grid is legal and
-    common (the rest takes ``fill``), and the plan prints how much of the grid it covers.
+    A refusal the whole-volume path can serve (a case with no geometry, an unreadable entry in the
+    field group) declares ``WHOLE_VOLUME`` with its reason and the run proceeds assembled. One that
+    no route can serve refuses as the plan is built, before a byte is written. A case reaching only
+    PART of the target grid is legal and common (the rest takes ``fill``), and the plan prints how
+    much of the grid it covers.
     """
 
     working_multiple = 6.5  # the sampling grid, the taps, and the widening a stored integer forces
@@ -740,19 +677,17 @@ class Resample(TransformInverse):
         self.transforms = transforms
         declared = (field is not None and str(field).strip()) or field_group is not None
         self.displacement: _DisplacementSource | None = _DisplacementSource(field, field_group) if declared else None
-        #: Per case: the grid its own header describes. Recorded where that header is in hand --
-        #: transform_shape, called for every case as the manager is built. A region read hands back
-        #: the REGION's Origin, so a grid rebuilt from what a streamed region arrives with would
-        #: place the case by the corner of whichever slab is being written, and slide it further
-        #: with every slab; every voxel would still be an interpolation of real data.
+        #: Per case: the grid its own header describes, recorded where that header is in hand
+        #: (transform_shape, called for every case). A region read hands back the REGION's Origin, so
+        #: a grid rebuilt from a streamed region would place the case by the corner of a slab.
         self._grids: dict[str, Grid] = {}
         #: Per case: the geometry keys its header did not carry (see :meth:`Grid.from_header`).
         self._assumed: dict[str, frozenset[str]] = {}
         #: Per case: what the plan keeps of its stored map (see :class:`_StoredMap`).
         self._maps: dict[str, _StoredMap] = {}
         #: The decoded stages of the last cases sampled, most recent last, within
-        #: ``stored_stage_bytes``. Not pickled: a rank decodes what it samples, not the cohort.
-        # Keyed on (case, box): a field read for one region answers for that region alone.
+        #: ``stored_stage_bytes``. Not pickled. Keyed on (case, box): a field read for one region
+        #: answers for that region alone.
         self._stored: OrderedDict[tuple, SpatialStages] = OrderedDict()
         #: The last field window read, kept for the sampler: sizing a region's source window reads
         #: the very field slab the sampler needs next, so one slot makes the two one read.
@@ -769,9 +704,9 @@ class Resample(TransformInverse):
         state["_sitk_input"] = _SitkInput()
         return state
 
-    #: Bytes of decoded stages kept across cases: the affine maps of a whole cohort (a few hundred
-    #: bytes each) and the dense fields of the last two or three, so a fold reading N members per
-    #: region does not decode a member per region.
+    #: Bytes of decoded stages kept across cases: the affine maps of a whole cohort and the dense
+    #: fields of the last two or three, so a fold reading N members per region does not decode one
+    #: per region.
     stored_stage_bytes = 512 << 20
     #: Region-keyed entries kept at once: an all-affine map prices zero bytes and would never evict.
     stored_stage_slots = 64
@@ -827,9 +762,8 @@ class Resample(TransformInverse):
     def _needs(self) -> frozenset[str]:
         """The geometry keys this configuration cannot be answered without.
 
-        A stored map or a reference grid is applied in physical space and needs all three; a change
-        of density needs the density it starts from; a change of extent needs nothing at all. Being
-        exact about this is what lets one class serve a headerless array and a real volume.
+        A stored map or a reference grid needs all three; a change of density needs the density it
+        starts from; a change of extent needs nothing at all.
         """
         if self.transforms is not None or self.displacement is not None:
             return frozenset(_GEOMETRY_KEYS)
@@ -857,10 +791,8 @@ class Resample(TransformInverse):
     def _target_of(self, name: str) -> tuple[Grid, Grid]:
         """``(source, target)``: needs only what BUILDING the target grid needs.
 
-        Split from :meth:`_grids_of` because the two questions have different answers: the output
-        SHAPE of a warp on the case's own grid is the case's own shape, knowable with no geometry at
-        all, while SAMPLING it is not. Refusing the shape too would take down the plan of a chain
-        whose honest answer is to fall back to the whole volume and say so.
+        Split from :meth:`_grids_of`: the output SHAPE of a warp on the case's own grid is the case's
+        own shape, knowable with no geometry, while SAMPLING it is not.
         """
         source = self._source_grid(name)
         absent = self._assumed.get(name, frozenset())
@@ -878,8 +810,8 @@ class Resample(TransformInverse):
     def slab_height_sensitive(self, name: str) -> bool:
         """Whether this case's streamed values can depend on the slab height: only a map that does
         not factorise (a rotation, a displacement field) interpolates through per-voxel coordinates
-        whose float rounding differs with where the region starts; a separable map is bit-identical
-        whatever the region. Answers True when the question cannot be settled from the headers."""
+        whose float rounding differs with where the region starts. True when the headers cannot
+        settle it."""
         try:
             source, target = self._grids_of(name)
             if self.displacement is not None:
@@ -915,14 +847,11 @@ class Resample(TransformInverse):
     def _stored_stages(self, name: str, box: WorldBox | None = None) -> SpatialStages:
         """This case's stored transforms, decoded and composed, in application order.
 
-        The last cases' stages are held, most recent last, within ``stored_stage_bytes``: a run
-        samples its cases one after the other, a fold reads its members region by region, and
-        a loader interleaving cases through a dense field decodes at each switch past the bound.
+        The last cases' stages are held, most recent last, within ``stored_stage_bytes``.
 
-        KEYED ON THE BOX, because a region's stages are not the case's. A field read for one region
-        answers for that region and no other, so a second region asking with the same case name
-        would otherwise be handed the first one's window and sample outside it -- the border value,
-        silently, where the values it needed were on disk all along.
+        KEYED ON THE BOX: a field read for one region answers for that region and no other, so a
+        second region asking with the same case name would sample outside the first one's window and
+        take the border value silently.
         """
         key = (name, None if box is None else (tuple(box.low_xyz), tuple(box.high_xyz)))
         stages = self._stored.pop(key, None)
@@ -939,10 +868,9 @@ class Resample(TransformInverse):
         stored = self._maps.get(name)
         if stored is None:
             rank = self._source_grid(name).rank
-            # HEADERS ONLY, always: a cached region's stages are that region's, not the case's, and
-            # the plan's own read must not pull a field's values for a bound it cannot form from
-            # them anyway. What comes back is the affine part, exact, with any dense field standing
-            # as the identity -- the same price the declared route puts on its field.
+            # HEADERS ONLY, always: a cached region's stages are that region's, not the case's.
+            # What comes back is the affine part, exact, with any dense field standing as the
+            # identity, which is the price the declared route puts on its field.
             priced = self._decode_stored(name, headers_only=True)
             has_field = self._stored_has_field(name)
             stored = self._maps[name] = _StoredMap(
@@ -955,9 +883,8 @@ class Resample(TransformInverse):
     def _stored_has_field(self, name: str) -> bool:
         """Whether any member of this case's stored map is a dense field, from headers alone.
 
-        Asked rather than counted: one entry can decode to several stages (a composite of two
-        affines is two), so a stage count says nothing about how many members there were, let
-        alone which of them the plan priced away.
+        Asked rather than counted: one entry can decode to several stages, so a stage count says
+        nothing about how many members there were.
         """
         from konfai.utils.dataset import DISPLACEMENT_FIELD_ATTRIBUTE
 
@@ -977,22 +904,18 @@ class Resample(TransformInverse):
         """This case's stored transforms read and decoded, application order, nothing kept.
 
         ``box`` is the world box the map will be evaluated over, folded through the members already
-        decoded so each one is read on the box IT sees rather than the one the region started as: a
-        field applied second is evaluated where the first sent the points, and reading it on the
-        region's own box would be short by everything the first one moves. Without a box the whole
-        entry is read, which is the whole-volume route's answer.
-
-        ``headers_only`` is the plan's read: a dense field member decodes to no stage, which is the
-        identity, and its values are never touched.
+        decoded, so each one is read on the box IT sees: a field applied second is evaluated where
+        the first sent the points. Without a box the whole entry is read, which is the whole-volume
+        route's answer. ``headers_only`` is the plan's read: a dense field member decodes to no
+        stage, the identity, and its values are never touched.
         """
         from konfai.utils.ITK import invert_stages, read_transform_stages
 
         _require_simpleitk()
         rank = self._source_grid(name).rank
         stages: list[AffineStage | DisplacementStage] = []
-        # Reversed: a CompositeTransform applies its members last-first, and this stage has always
-        # built one from `transforms` in declaration order. Decoding normalizes each member to
-        # application order, so the declared list is reversed here to mean the same thing it did.
+        # Reversed: a CompositeTransform applies its members last-first, and decoding normalizes
+        # each member to application order, so the declared list is reversed here to mean the same.
         for group in reversed(list(cast("dict[str, bool]", self.transforms))):
             invert = self.transforms[group] if self.transforms else False
             decoded = None
@@ -1020,9 +943,8 @@ class Resample(TransformInverse):
             if box is not None:
                 # The box the NEXT member is read on, which is where this one sends the points it
                 # was read for: the EFFECTIVE stages, after any inversion. An affine moves it
-                # exactly; a field grows it by the range of the values just read, and a member that
-                # only pushes one way moves the box instead of opening it (TransformBound is an
-                # interval, not a radius).
+                # exactly; a field grows it by the range of the values just read (TransformBound is
+                # an interval, not a radius).
                 box = bound_of(decoded, rank).map_box(box)
             stages.extend(decoded)
         return tuple(stages)
@@ -1031,9 +953,9 @@ class Resample(TransformInverse):
         """The declared field over ``region``, read on its own grid and no wider: once.
 
         The field is evaluated at the TARGET's world points, so the window it needs is that region's
-        own world box: no halo, whatever the displacement is. What the halo sizes is the SOURCE
-        read, which is a different question, answered from these very values
-        (:meth:`measured_region_source`): memoized here so sizing and sampling share one read.
+        own world box, no halo whatever the displacement. What the halo sizes is the SOURCE read,
+        answered from these very values (:meth:`measured_region_source`): memoized here so sizing
+        and sampling share one read.
         """
         key = (tuple(int(extent) for extent in region.size_zyx), tuple(float(v) for v in np.ravel(region.origin_xyz)))
         cached = self._field_window
@@ -1072,11 +994,10 @@ class Resample(TransformInverse):
     def _pricing_bound(self, name: str) -> TransformBound:
         """The map's bound as the PLAN prices it: headers and declarations, never a voxel.
 
-        A field prices as zero displacement, declared or stored: nothing bounds one from headers,
-        and reading its values to find out costs a case's worth of memory for a number the run
-        replaces anyway. The run never trusts this window -- a field's regions are sized from the
-        values it reads for sampling (:meth:`measured_region_source`) -- so the optimism here costs
-        estimate accuracy, not bytes. What is left is the affine part, which is exact.
+        A field prices as zero displacement, declared or stored: nothing bounds one from headers.
+        The run never trusts this window, since a field's regions are sized from the values it reads
+        (:meth:`measured_region_source`), so the optimism costs estimate accuracy, not bytes. What is
+        left is the affine part, which is exact.
         """
         rank = self._source_grid(name).rank
         folded = TransformBound.exact(AffineMap.identity(rank))
@@ -1098,12 +1019,10 @@ class Resample(TransformInverse):
     def _require_runnable(self, name: str) -> None:
         """Refuse AT PLAN TIME a map neither route can apply.
 
-        A refusal the whole-volume path can serve (a case with no geometry) stays a locality
-        answer, and the run proceeds assembled. A stored transform that cannot be decoded, read or
-        inverted fails the streamed path and the whole-volume one at the same line, so declaring
-        WHOLE_VOLUME for it would print a plan the run then contradicts by dying per case, after
-        bytes are written. ``transform_shape`` runs for every case as the plan is built, which is
-        the earliest the failure is knowable and the only place it costs nothing.
+        A refusal the whole-volume path can serve (a case with no geometry) stays a locality answer
+        and the run proceeds assembled. A stored transform that cannot be decoded, read or inverted
+        fails both paths, so declaring WHOLE_VOLUME for it would print a plan the run contradicts by
+        dying per case. ``transform_shape`` runs for every case as the plan is built.
         """
         if self.displacement is not None:
             self.displacement.probe(name)
@@ -1121,10 +1040,9 @@ class Resample(TransformInverse):
             ) from error
 
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
-        # The geometry is judged on the attribute in hand: the case's own header, as the base
-        # contract has it, and not on what the cohort has been seen to carry: one case of a group
-        # may lack an Origin while the rest have one, and a declaration made per case is the honest
-        # one. A config-time probe hands over an empty header, which reads as a case with none.
+        # The geometry is judged on the attribute in hand, the case's own header: one case of a
+        # group may lack an Origin while the rest have one. A config-time probe hands over an empty
+        # header, which reads as a case with none.
         lacking = [key for key in _GEOMETRY_KEYS if key in self._needs and key not in cache_attribute]
         if lacking:
             return PatchLocality(
@@ -1145,12 +1063,10 @@ class Resample(TransformInverse):
     def _probe_cohort(self) -> str | None:
         """Whether every case this stage will see is boundable, or the sentence saying which is not.
 
-        The COHORT's answer, not one case's: a locality is declared once for the stage while the
-        cases are many, so a group whose entries are not uniformly decodable must fall back for all
-        of them rather than for the ones that happen to be planned first. Exceptions are swallowed
-        into a reason: this runs inside the plan, where a raise would take the run down instead of
-        costing it the whole-volume path. The GEOMETRY is not judged here; that is per case, and
-        :meth:`patch_locality` reads it off the header it is handed.
+        The COHORT's answer, not one case's: a locality is declared once for the stage, so a group
+        whose entries are not uniformly decodable falls back for all of them. Exceptions become a
+        reason: a raise here would take the run down instead of costing it the whole-volume path.
+        The GEOMETRY is per case, read by :meth:`patch_locality` off the header it is handed.
         """
         if self.transforms is not None and sitk is None:
             return (
@@ -1158,8 +1074,8 @@ class Resample(TransformInverse):
                 " it. Install it (pip install konfai[itk]) to stream this stage"
             )
         # The field group's HEADERS are the cohort's business here: an unreadable entry anywhere
-        # under it fails both routes on whichever case reaches it. A field that merely records no
-        # bound streams: its windows are sized from the values the run reads (measured_region_source).
+        # under it fails both routes. A field that merely records no bound streams: its windows are
+        # sized from the values the run reads (measured_region_source).
         if self.displacement is not None:
             if not self.displacement.headers_readable():
                 return (
@@ -1195,35 +1111,28 @@ class Resample(TransformInverse):
     def measures_at_run(self) -> bool:
         """Whether the run sizes this stage's windows from the data it reads: any field at all.
 
-        Declared or stored: both are priced as the identity by the plan, so both need the run to
-        say where they actually reach. An affine-only ``transforms`` is not one of them -- its
-        bound is exact from the coefficients, the plan's window is already the right one, and
-        measuring it per region would buy nothing and cost a decode.
-
-        Read off the plan's own records, which ``transform_shape`` fills for every case before
-        anything asks this.
+        Declared or stored: both are priced as the identity by the plan, so both need the run to say
+        where they actually reach. An affine-only ``transforms`` is not one of them: its bound is
+        exact from the coefficients. Read off the plan's own records, which ``transform_shape`` fills
+        for every case.
         """
         return self.displacement is not None or any(stored.field for stored in self._maps.values())
 
     def case_working_multiple(self, name: str) -> float:
         """The sampling grid, plus the field window this case's region holds beside it.
 
-        A region's field window is its own world box on the FIELD's grid -- no halo, whatever the
-        displacement, because the field is evaluated at the target's points -- so its size relative
-        to the region is a ratio of voxel densities, and both are in the headers. At a field solved
-        on the case's own grid that is one component per axis, three volumes-worth beside the three
-        the sampling grid already costs; at a field solved four times coarser per axis it is a
-        sixteenth of that, and the plan should not charge the same for the two.
-
-        Answered from headers alone; a case whose grids are not both known yet answers the class's
-        figure rather than guessing.
+        A region's field window is its own world box on the FIELD's grid, no halo whatever the
+        displacement, so its size relative to the region is a ratio of voxel densities and both are
+        in the headers. A field solved on the case's own grid costs three volumes-worth beside the
+        three the sampling grid costs; one solved four times coarser per axis costs a sixteenth of
+        that. Answered from headers alone; a case whose grids are not both known answers the class's
+        figure.
         """
         base = float(self.working_multiple)
         # NOT the general walk. A map that does not factorise is walked coordinate by coordinate in
-        # float64 and holds 21.4 to 21.6 volumes-worth where a separable one holds 0.19 to 2.85 --
-        # but that walk slabs ITSELF against the declared budget (konfai.data.sampling), so it is
-        # bounded whatever the region is. Charging the region for it as well would shrink every
-        # resampling chain sevenfold for memory the walk does not take.
+        # float64 and holds 21.4 to 21.6 volumes-worth where a separable one holds 0.19 to 2.85, but
+        # that walk slabs ITSELF against the declared budget (konfai.data.sampling), so it is bounded
+        # whatever the region is.
         if self.displacement is None:
             return base
         try:
@@ -1239,10 +1148,8 @@ class Resample(TransformInverse):
         if field_voxel <= 0.0:
             return base
         # In the PLAN'S currency, which counts a volume at _SWEEP_ELEMENT_BYTES: a field window is
-        # read as float64 whatever the store holds (see _DisplacementSource.read, which widens on
-        # purpose so an externally written double field is not quantized before the exact
-        # arithmetic), so each of its components weighs two of the plan's volumes, not one.
-        # Charging it at one was counting eight bytes as four.
+        # read as float64 whatever the store holds (see _DisplacementSource.read), so each of its
+        # components weighs two of the plan's volumes, not one.
         from konfai.data.patching.budget import _SWEEP_ELEMENT_BYTES
 
         widening = self._field_element_bytes / _SWEEP_ELEMENT_BYTES
@@ -1255,8 +1162,8 @@ class Resample(TransformInverse):
 
         float64 is the bit-exact contract with SimpleITK and narrows nothing; a field stored in
         float32 stays float32 under it, losslessly (see
-        :func:`~konfai.utils.ITK._displacement_stage`). ``precision: fast`` lowers the ceiling to
-        the float32 its coordinate walk runs in, which is where a genuinely float64 field narrows.
+        :func:`~konfai.utils.ITK._displacement_stage`). ``precision: fast`` lowers the ceiling to the
+        float32 its coordinate walk runs in.
         """
         return np.float32 if self.precision == "fast" else np.float64
 
@@ -1264,7 +1171,7 @@ class Resample(TransformInverse):
     def _field_element_bytes(self) -> int:
         """What the PLAN charges a field value, at the ceiling rather than at the width the store
         turns out to hold: the plan reads no field header, and over-charging reserves memory a run
-        then does not need, which is the safe direction to be wrong in."""
+        does not need, which is the safe direction."""
         return int(np.dtype(self._field_dtype).itemsize)
 
     def measured_region_source(
@@ -1272,10 +1179,9 @@ class Resample(TransformInverse):
     ) -> list[slice]:
         """The region's source window, sized from the field itself: the read that samples also bounds.
 
-        The field window a region needs is its own box, read for sampling regardless; the sup of
-        the values just read bounds every interpolated displacement in the region (a convex
-        combination cannot exceed the lattice values it blends), so the window is exact per region: a quiet
-        slab pays a quiet halo.
+        The field window a region needs is its own box, read for sampling regardless; the sup of the
+        values just read bounds every interpolated displacement in the region (a convex combination
+        cannot exceed the lattice values it blends), so the window is exact per region.
         """
         del source_spatial_shape, cache_attribute
         source, target = self._grids_of(name)
@@ -1293,8 +1199,8 @@ class Resample(TransformInverse):
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
         shape = [int(extent) for extent in tensor.shape[1:]]
         # Re-recorded on every call: the whole-volume path is handed the case's own evolved header,
-        # never a region's, and a grid recorded by an earlier walk may describe the stored volume
-        # rather than this stage's true input (a Canonical upstream, a Resample before this one).
+        # and a grid recorded by an earlier walk may describe the stored volume rather than this
+        # stage's true input (a Canonical upstream, a Resample before this one).
         self._record(name, shape, cache_attribute)
         source, target = self._grids_of(name)
         # The same call the streamed path makes, over one region that happens to be the whole grid:
@@ -1335,24 +1241,20 @@ class Resample(TransformInverse):
         region = target.sub_grid(target_slices)
         stages = self._stages(name, region)
         shape, mode = list(source.size_zyx), self._mode(sub_tensor)
-        # A map that factorises is read one axis at a time, which is the same arithmetic without the
-        # terms that are zero and without a coordinate per voxel, and it is most maps, because most
-        # volumes are stored axis-aligned. The general form is what a rotation or a displacement
-        # needs, and the two are bit-identical wherever both apply.
+        # A map that factorises is read one axis at a time, the same arithmetic without the terms
+        # that are zero and without a coordinate per voxel, and it is most maps. The general form is
+        # what a rotation or a displacement needs; the two are bit-identical wherever both apply.
         axes = separable_source_index(region, source, stages, sub_tensor.device)
         if axes is not None:
             order = blend_order(target, source)
             return gather_separable(sub_tensor, axes, region_starts, shape, mode, self.fill_value, order)
         # On the HOST, ITK's own resampler is the fastest one there is: sitk.Resample over the same
-        # region, through the same stages, is 12x the torch walk per voxel on this arithmetic
-        # (27 vs 326 ns, measured, 12 threads) -- the walk is written for the GPU, where it is 40x
-        # faster again. Same rule (ITK's), same window, same fill, same working dtype, so the two
-        # agree to the ulp of the blend: as far as a CPU and a CUDA run already agree. On an INTEGER
-        # payload that ulp can straddle a truncation boundary, where it becomes one whole unit
-        # (measured: 2 voxels in 7560 through a rotation, pinned in test_sampling.py). A nearest
-        # pick copies voxels and has no such seam, which is what a label map takes.
-        # 'precision: fast' is a permission the GPU walk uses; on the host the exact answer is also
-        # the cheapest.
+        # region, through the same stages, is 12x the torch walk per voxel (27 vs 326 ns, 12
+        # threads); the walk is written for the GPU, where it is 40x faster again. Same rule, same
+        # window, same fill, same working dtype, so the two agree to the ulp of the blend. On an
+        # INTEGER payload that ulp can straddle a truncation boundary and become one whole unit
+        # (2 voxels in 7560 through a rotation, pinned in test_sampling.py); a nearest pick copies
+        # voxels and has no such seam. On the host the exact answer is also the cheapest.
         if sub_tensor.device.type == "cpu" and sitk is not None:
             resampled = _resample_with_sitk(
                 sub_tensor, region, source, stages, region_starts, mode, self.fill_value, self._sitk_input
@@ -1360,10 +1262,9 @@ class Resample(TransformInverse):
             if resampled is not None:
                 return resampled
         # The walk's coordinate tensor is float64 x rank: on a large region it dwarfs the gathered
-        # payload (9 GB beside a 1 GB slab, measured on an ExaSPIM mask chain). Walking and
-        # gathering slab by slab bounds both under one budget, and changes no value: the row
-        # indices stay global to the region, the gather's window and starts are the region's own,
-        # so every row of every slab is the very tensor the single pass produces.
+        # payload (9 GB beside a 1 GB slab). Walking and gathering slab by slab bounds both under one
+        # budget and changes no value: the row indices stay global to the region and the gather's
+        # window and starts are the region's own.
         rows_total = int(region.size_zyx[0])
         rows = walk_rows(region, stages, sub_tensor.device, budget_bytes)
         if rows >= rows_total:
@@ -1386,10 +1287,9 @@ class Resample(TransformInverse):
     def _mode(self, tensor: torch.Tensor) -> str:
         """``nearest``, ``linear`` or ``cubic``: what a sampler asks before it blends anything.
 
-        A dtype cannot settle this on its own: a CT is int16 and so is nothing else about it. The
-        heuristic therefore claims ``uint8`` and nothing more, and ``interpolation`` answers for
-        everything it cannot know. Getting it wrong is silent: two blended labels give a third
-        that was in no input, in a volume that is still a label map.
+        A dtype cannot settle this on its own, so the heuristic claims ``uint8`` and nothing more and
+        ``interpolation`` answers for the rest. Getting it wrong is silent: two blended labels give a
+        third that was in no input.
         """
         return self.interpolation or ("nearest" if tensor.dtype == torch.uint8 else "linear")
 
@@ -1403,8 +1303,8 @@ class Resample(TransformInverse):
     ) -> None:
         """Push the target grid over the source's, so the case now IS the grid it was written on.
 
-        Pushed and not replaced: the source geometry stays underneath for :meth:`inverse` to pop back
-        to, which is the whole of the stack this and ``_inverse_geometry`` share.
+        Pushed and not replaced: the source geometry stays underneath for :meth:`inverse` to pop
+        back to.
         """
         shape = [int(extent) for extent in source_spatial_shape]
         source, missing = Grid.from_header(shape, cache_attribute, f"case '{name}'" if name else "the case")
@@ -1416,9 +1316,8 @@ class Resample(TransformInverse):
         }
         for key in _GEOMETRY_KEYS:
             # Only over a geometry that was there: a case stored without an Origin is resampled by
-            # ratio, and inventing one for it would be a header nobody measured. Key by key, and not
-            # all-or-nothing, because ``inverse`` pops exactly what is present, so what is pushed
-            # and what is popped are the same condition, read at the two ends.
+            # ratio. Key by key, and not all-or-nothing, because ``inverse`` pops exactly what is
+            # present.
             if key not in missing:
                 cache_attribute[key] = written[key]
         cache_attribute["Size"] = np.asarray(shape)
@@ -1427,13 +1326,12 @@ class Resample(TransformInverse):
     # ------------------------------------------------------------------ the plan
 
     #: Below this, a case is worth a line in the plan: it reaches only part of the target grid and
-    #: the rest of what it writes is fill. Above it, the note would round to "100.0%" and say
-    #: nothing, and a plan that says nothing on every line is one nobody reads.
+    #: the rest of what it writes is fill. Above it the note would round to "100.0%".
     _WORTH_SAYING = 0.999
 
     #: How many probes per axis the coverage estimate uses. Coverage is a volume ratio between two
-    #: boxes that a rotation makes a polytope, so it is counted rather than solved; capped because
-    #: it is a plan line, not a result.
+    #: boxes that a rotation makes a polytope, so it is counted rather than solved; capped because it
+    #: is a plan line, not a result.
     _COVERAGE_PROBES = 24
 
     def coverage(self, name: str) -> float:
@@ -1444,10 +1342,9 @@ class Resample(TransformInverse):
     def _map_bound(self, name: str) -> TransformBound | None:
         """The declared map's bound, for a coverage judged where the samples actually land.
 
-        ``None`` when there is no map: or when nothing bounds it: a coverage that cannot be judged
-        must not refuse, and the unboundable configurations carry a fallback reason of their own.
-        A field prices as zero displacement here (:meth:`_pricing_bound`), so a stored affine
-        beside it still places the samples instead of the grids being judged bare.
+        ``None`` when there is no map, or when nothing bounds it: a coverage that cannot be judged
+        must not refuse. A field prices as zero displacement here (:meth:`_pricing_bound`), so a
+        stored affine beside it still places the samples.
         """
         if self.transforms is None and self.displacement is None:
             return None
@@ -1460,13 +1357,11 @@ class Resample(TransformInverse):
     def _coverage(cls, source: Grid, target: Grid, bound: TransformBound | None = None) -> float:
         """The fraction of ``target`` that reads from inside ``source``, from geometry alone.
 
-        Judged THROUGH the declared map's affine part: a stored transform is what makes a
-        cross-frame pair meet (an MR and a CT in different scanner frames with a rigid bridging
-        them), and a coverage judged before applying it would call every such registration
-        disjoint. The interval MOVES the lattice too, by the offset a stored map carries, and only
-        what varies widens the inside band. Counted on a
-        capped lattice rather than solved, because the sampled set is a box only while the grids
-        are axis-aligned and a rotation makes it a polytope.
+        Judged THROUGH the declared map's affine part: a stored transform is what makes a cross-frame
+        pair meet, and a coverage judged before applying it would call every such registration
+        disjoint. The interval MOVES the lattice too, and only what varies widens the inside band.
+        Counted on a capped lattice rather than solved: the sampled set is a box only while the grids
+        are axis-aligned.
         """
         axes = [
             np.linspace(0.0, float(extent) - 1.0, min(cls._COVERAGE_PROBES, int(extent)))
@@ -1477,10 +1372,9 @@ class Resample(TransformInverse):
         index = to_world.then(source.world_to_index).apply(lattice)
         low = high = np.zeros((1, source.rank))
         if bound is not None:
-            # The interval, folded into index space the way a world box is: its two ends land
-            # where the matrix sends them, and a negative entry swaps which end is which. As a
-            # radius, a map that sent every sample 500 m PAST the case reached back over it just
-            # as far, and covered it.
+            # The interval, folded into index space the way a world box is: its two ends land where
+            # the matrix sends them, and a negative entry swaps which end is which. As a radius, a
+            # map that sent every sample past the case would reach back over it just as far.
             matrix = source.world_to_index.matrix
             rise, fall = np.maximum(matrix, 0.0), np.minimum(matrix, 0.0)
             low = (rise @ bound.low_xyz + fall @ bound.high_xyz)[None, :]
@@ -1495,16 +1389,14 @@ class Resample(TransformInverse):
     def _refuse_if_disjoint(self, name: str) -> None:
         """Refuse a case that does not meet the target grid anywhere.
 
-        Its output would be ``fill`` from edge to edge. That is not an error the arithmetic can
-        find (every voxel of it is exactly what was asked for), so it is one nothing downstream
-        would report: a median over the cohort would simply be pulled toward the background by a
-        member that contributed no anatomy. Counted from the headers, before a byte is read.
+        Its output would be ``fill`` from edge to edge, which no arithmetic finds and nothing
+        downstream reports: a median over the cohort would simply be pulled toward the background.
+        Counted from the headers, before a byte is read.
 
-        Never with a field configured, DECLARED OR STORED: its reach is unknown before its values
-        are read -- the plan prices both at the identity -- and bridging two frames is precisely
-        what a field may be for. A cohort registered onto a template it sits 25 mm from covers
-        exactly nothing until its own field is applied, and refusing it here would drop every
-        member of the build the stage exists to serve.
+        Never with a field configured, DECLARED OR STORED: its reach is unknown before its values are
+        read, the plan prices both at the identity, and bridging two frames is what a field may be
+        for. A cohort registered onto a template it sits 25 mm from covers nothing until its own
+        field is applied.
         """
         if self._target_is_own or self._prices_a_field(name) or self.coverage(name) > 0.0:
             return
@@ -1520,13 +1412,11 @@ class Resample(TransformInverse):
     def _prices_a_field(self, name: str) -> bool:
         """Whether this case's map carries a field the plan prices at the identity.
 
-        A field's reach is known only once its values are read, and the plan reads none: it prices
-        a declared field and a stored one alike as zero displacement. Every geometric judgement
-        built on that price is then a judgement about two grids sitting bare in world space, not
-        about where the samples land -- so neither the refusal nor the plan's coverage note may
-        speak. Measured on a ten-member ExaSPIM build whose fields bridge a 20 mm gap: judged bare,
-        one member covered 0.0% of the target and the note called everything it wrote fill, while
-        the run it was describing read that member in full and the template carried its anatomy.
+        A field's reach is known only once its values are read, and the plan reads none. Every
+        geometric judgement built on that price is about two grids sitting bare in world space, not
+        about where the samples land, so neither the refusal nor the plan's coverage note may speak.
+        On a ten-member build whose fields bridge a 20 mm gap, one member judged bare covered 0.0% of
+        the target while the run read it in full.
         """
         if self.displacement is not None:
             return True
@@ -1536,9 +1426,8 @@ class Resample(TransformInverse):
         """What this case covers of the target grid: measured on the header HANDED OVER.
 
         Not on the grid recorded for the case: the plan asks a stage about its own input, which the
-        stages before it decide, and a note answered from the stored header would describe a volume
-        that no longer exists by the time this stage sees it. Nothing is recorded here either, for
-        the mirror reason: a question must not move the state a region read depends on.
+        stages before it decide. Nothing is recorded here either: a question must not move the state
+        a region read depends on.
         """
         del group_dest
         notes: list[str] = []
@@ -1584,9 +1473,9 @@ class Resample(TransformInverse):
     def _inverse_grids(self, cache_attribute: Attribute, shape: list[int]) -> tuple[Grid, Grid]:
         """``(what the accumulator is on, what to write back onto)``: both off the pushed stack.
 
-        The forward stacked the source geometry under the target's, so the inverse needs no memory
-        of the case: it reads the grid it is holding, pops, and reads the grid it is restoring. A
-        copy is popped when the caller is only asking, because a declaration never mutates.
+        The forward stacked the source geometry under the target's, so the inverse reads the grid it
+        is holding, pops, and reads the grid it is restoring. A copy is popped when the caller is
+        only asking.
         """
         held = self._grid_from(cache_attribute, [int(extent) for extent in shape])
         restored_shape = self._inverse_geometry(cache_attribute)

--- a/konfai/data/transform/shape.py
+++ b/konfai/data/transform/shape.py
@@ -41,13 +41,10 @@ from konfai.utils.errors import TransformError
 class Padding(TransformInverse):
     """Pad the volume's borders (``padding`` pairs in ``F.pad`` order: last axis first).
 
-    A pad is a translation of the volume into a larger grid plus a border it fills, so it streams
-    as a REGRID: a target region pulls the source rows it covers (clamped to the volume, kept wide
-    enough for a reflection to read from) and the stage fills what the clamp cut. The origin moves
-    with the volume, written once from the full extent (``write_stream_cache_attribute``).
+    A pad is a translation of the volume into a larger grid plus a border it fills, so it streams as
+    a REGRID: a target region pulls the source rows it covers and the stage fills what the clamp cut.
     """
 
-    # Measured at 0.00 on the CUDA allocator: it holds nothing beyond what it is handed.
     working_multiple = 0.0
 
     locality = LocalityKind.REGRID
@@ -125,7 +122,7 @@ class Padding(TransformInverse):
         return padded[(slice(None), *crops)]
 
     def inverse_patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
-        # The inverse drops the padded border and keeps a translated copy of what remains: a CROP.
+        # The inverse drops the padded border and keeps what remains: a CROP.
         return PatchLocality(LocalityKind.CROP)
 
     def inverse_transform_shape(self, shape: list[int], cache_attribute: Attribute) -> list[int]:
@@ -138,8 +135,7 @@ class Padding(TransformInverse):
         source_spatial_shape: list[int],
         cache_attribute: Attribute,
     ) -> list[slice]:
-        # Output index o holds input index o + pad_before: a written region pulls its own slices stepped
-        # forward by the leading pad.
+        # Output index o holds input index o + pad_before.
         return [
             slice(target.start + before, target.stop + before)
             for target, (before, _after) in zip(target_slices, self._pairs(len(target_slices)), strict=True)
@@ -157,21 +153,17 @@ class Padding(TransformInverse):
 
 
 class Squeeze(TransformInverse):
-    # Measured at 0.00 on the CUDA allocator: it holds nothing beyond what it is handed.
     working_multiple = 0.0
 
     def __init__(self, dim: int, inverse: bool = True) -> None:
         super().__init__(inverse)
         self.dim = dim
 
-    # WHOLE_VOLUME on purpose: squeeze/unsqueeze changes the tensor rank, and the streamed write sizes
-    # each slab from the pre-finalize accumulator grid: a rank change past it cannot region-stream.
+    # WHOLE_VOLUME on purpose: a rank change past the accumulator grid cannot region-stream.
 
     def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
-        # ``shape`` is the channel-stripped spatial shape (patching strips [C, *spatial] before folding),
-        # so the runtime tensor is [C, *shape] and ``self.dim`` indexes into that. Squeezing the channel
-        # (axis 0) leaves the spatial grid untouched; squeezing a spatial axis drops it from the grid --
-        # but only when it is size 1, exactly as ``torch.squeeze`` does (a non-singleton axis is a no-op).
+        # ``shape`` is the channel-stripped spatial shape, so the runtime tensor is [C, *shape] and
+        # ``self.dim`` indexes into that. A spatial axis is dropped only when it is size 1.
         axis = self.dim if self.dim >= 0 else self.dim + len(shape) + 1
         if 1 <= axis <= len(shape) and shape[axis - 1] == 1:
             return shape[: axis - 1] + shape[axis:]
@@ -188,21 +180,17 @@ class Crop(TransformInverse):
     """Crop a volume to the bounding box of its foreground.
 
     The content-dependent box is computed once (``transform_shape``) and kept on the case as ``box``
-    margins; cropping is then the translation ``out[o] = volume[o + start]``, so a target patch reads
-    its shifted source region. Dropped voxels mean the stored volume's statistics are not the output's
-    (hence ``LocalityKind.CROP``).
+    margins; cropping is then the translation ``out[o] = volume[o + start]``. Dropped voxels make it
+    a ``LocalityKind.CROP``, the stored volume's statistics not being the output's.
     """
 
-    # Measured at 0.00 on the CUDA allocator: it holds nothing beyond what it is handed.
     working_multiple = 0.0
 
     def __init__(self, inverse: bool = True) -> None:
         super().__init__(inverse)
 
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
-        # Total: the box is a fact ``transform_shape`` puts on the case before the dispatcher reads any
-        # declaration, but a group carries only what its writer stored, and without it there is no
-        # translation to make: only the read that would find one.
+        # ``transform_shape`` puts the box on the case, but a group carries only what its writer stored.
         if "box" not in cache_attribute:
             return PatchLocality(
                 LocalityKind.WHOLE_VOLUME,
@@ -218,8 +206,7 @@ class Crop(TransformInverse):
         source_spatial_shape: list[int],
         cache_attribute: Attribute,
     ) -> list[slice]:
-        # Output index o holds source index o + start, so the region behind a target patch is that
-        # patch's own slices stepped forward by the box's near margin.
+        # Output index o holds source index o + start.
         box = Crop._parse_box(cache_attribute["box"])
         return [
             slice(target.start + int(start), target.stop + int(start))
@@ -234,9 +221,7 @@ class Crop(TransformInverse):
             return
         if not {"Origin", "Spacing", "Direction"} <= set(cache_attribute.keys()):
             return
-        # The crop keeps the box's near corner, so the new origin is the physical point that corner
-        # already sat on. A margin is in array order and the geometry is in (x, y, z), hence the
-        # reversed indexing.
+        # The new origin is the physical point the box's near corner sat on.
         box = Crop._parse_box(cache_attribute["box"])
         origin = torch.tensor(cache_attribute.get_np_array("Origin"))
         matrix = torch.tensor(cache_attribute.get_np_array("Direction").reshape((len(origin), len(origin))))
@@ -246,13 +231,9 @@ class Crop(TransformInverse):
         cache_attribute["Origin"] = torch.matmul(origin, torch.inverse(matrix))
 
     def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
-        # The crop box is content-dependent (foreground bounding box), so the output shape
-        # cannot be known without the pixel data. If the box was already computed and persisted
-        # as a sidecar attribute, reuse it and skip the read; otherwise compute it once from the
-        # volume. (A fully-lazy variant would require deferring patch planning past _load().)
-        # ``shape`` is already the channel-stripped spatial shape (patching strips [C, *spatial]
-        # before calling transform_shape), so the crop box (one row per spatial axis) aligns with
-        # ``shape`` directly, exactly like ``__call__`` aligns it with ``tensor.shape[1:]``.
+        # The crop box is the foreground bounding box, so the output shape needs the pixel data: a
+        # box already on the case is reused, otherwise it is computed once. It has one row per
+        # spatial axis, aligned with the channel-stripped ``shape``.
         if "box" in cache_attribute:
             box = self._parse_box(cache_attribute["box"])
             return [int(s - a - b) for (a, b), s in zip(box, shape, strict=False)]
@@ -261,18 +242,15 @@ class Crop(TransformInverse):
             return shape
         box = self._foreground_box(source, group_src, name)
         for i, ((_, b), s) in enumerate(zip(box, shape, strict=False)):
-            # The scan reports the LAST foreground index; the box carries the margin AFTER it, so
-            # the far margin is what lies past that row. Off by one, the crop cut it off.
+            # The scan reports the last foreground index; the box carries the margin after it.
             box[i][1] = max(int(s - b - 1), 0)
         cache_attribute["box"] = box
         return [int(s - a - b) for (a, b), s in zip(box, shape, strict=False)]
 
     @staticmethod
     def _foreground_box(source: Dataset, group_src: str, name: str) -> np.ndarray:
-        """The bounding box (first and last index per spatial axis) of the voxels above the 5th
-        percentile, from bounded passes over the stored volume: the threshold by a quantile scan,
-        the box by one more pass. Memoised on the dataset: every chain of the case asks for the
-        same box, and it is the same volume."""
+        """The bounding box of the voxels above the 5th percentile, first and last index per spatial
+        axis, from bounded passes over the stored volume. Memoised on the dataset."""
         memo = source.case_facts.setdefault((group_src, name), {})
         if "box" not in memo:
             threshold = source.read_data_quantile(group_src, name, 0.05)
@@ -280,7 +258,7 @@ class Crop(TransformInverse):
             last: np.ndarray | None = None
             offset = 0
             for block in source.iter_data_blocks(group_src, name)():
-                foreground = np.any(block > threshold, axis=0)  # every channel votes, as the vector image did
+                foreground = np.any(block > threshold, axis=0)  # every channel votes
                 if foreground.any():
                     axes_first, axes_last = [], []
                     for axis in range(foreground.ndim):
@@ -310,7 +288,7 @@ class Crop(TransformInverse):
             return tensor
         box = self._parse_box(cache_attribute["box"])
         self.write_stream_cache_attribute(cache_attribute, list(tensor.shape[1:]), name)
-        # The box carries the FAR margin, so the stop it crops at is the one the extent in hand decides.
+        # The box carries the far margin, so the extent in hand decides the stop it crops at.
         crops = [
             slice(int(near), extent - int(far)) for (near, far), extent in zip(box, tensor.shape[1:], strict=False)
         ]
@@ -331,7 +309,6 @@ class Crop(TransformInverse):
 class Permute(TransformInverse):
     """Reorder the spatial axes: ``dims`` names the new order, ``|``-separated (``"1|0|2"``)."""
 
-    # Measured at 0.00 on the CUDA allocator: it holds nothing beyond what it is handed.
     working_multiple = 0.0
 
     locality = LocalityKind.ORIENTATION
@@ -347,8 +324,7 @@ class Permute(TransformInverse):
             ) from None
 
     def _remap(self) -> AxisRemap:
-        # Output spatial axis k reads input axis ``self.dims[k + 1] - 1`` (self.dims is
-        # channel-inclusive), never mirrored.
+        # Output spatial axis k reads input axis ``self.dims[k + 1] - 1``, never mirrored.
         return [(d - 1, False) for d in self.dims[1:]]
 
     def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
@@ -373,8 +349,7 @@ class Permute(TransformInverse):
         source_spatial_shape: list[int],
         cache_attribute: Attribute,
     ) -> list[slice]:
-        # The write mirror pulls through the inverse remap: input axis k carries the output axis
-        # that read it.
+        # The write mirror pulls through the inverse remap.
         return remap_region(target_slices, source_spatial_shape, invert_remap(self._remap()))
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
@@ -385,7 +360,6 @@ class Permute(TransformInverse):
 
 
 class Flip(TransformInverse):
-    # Measured at 0.00 on the CUDA allocator: it holds nothing beyond what it is handed.
     working_multiple = 0.0
 
     locality = LocalityKind.ORIENTATION
@@ -402,7 +376,7 @@ class Flip(TransformInverse):
         source_spatial_shape: list[int],
         cache_attribute: Attribute,
     ) -> list[slice]:
-        # A mirror moves no axis: the remap is the identity permutation, mirrored on the flipped axes.
+        # The remap is the identity permutation, mirrored on the flipped axes.
         remap: AxisRemap = [(k, (k + 1) in self.dims) for k in range(len(target_slices))]
         return remap_region(target_slices, source_spatial_shape, remap)
 
@@ -427,14 +401,11 @@ class Canonical(TransformInverse):
     """Reorient a volume onto RAS, the orientation NIfTI is canonical in.
 
     The pipeline writes direction cosines in the SimpleITK convention, where the identity is LPS, so
-    RAS is ``diag(-1, -1, 1)`` there: a volume already in LPS IS reoriented by this stage. That is
-    the same target as nibabel's ``as_closest_canonical``, which is what the NIfTI tooling around a
-    dataset expects.
+    RAS is ``diag(-1, -1, 1)`` there and a volume already in LPS is reoriented by this stage.
 
-    An orthogonal reorientation is a signed permutation of the axes: an exact index remap (values only
-    change place, so whole-volume statistics survive); only an oblique direction is resampled. A remap
-    that permutes axes transposes the extents it swaps, so ``transform_shape`` folds the patch grid
-    onto the reoriented shape.
+    An orthogonal reorientation is a signed permutation of the axes, an exact index remap; only an
+    oblique direction is resampled. A remap that permutes axes transposes the extents it swaps, so
+    ``transform_shape`` folds the patch grid onto the reoriented shape.
     """
 
     working_multiple = 3.0  # an oblique case is resampled: the resample's own figure
@@ -444,34 +415,22 @@ class Canonical(TransformInverse):
         self.canonical_direction = torch.diag(torch.tensor([-1, -1, 1])).to(torch.double)
 
     def _reorientation(self, cache_attribute: Attribute) -> torch.Tensor:
-        """The map taking an output coordinate onto the input it comes from, in (x, y, z).
-
-        A voxel sits at ``D @ (spacing * index) + origin``, so the map is ``D^-1 @ C`` (with the
-        target spacing carried along the permutation, see ``_carried``): NOT the rotation
-        ``C @ D^-1``, which only agrees where the two commute.
-        """
+        """The map taking an output coordinate onto the input it comes from, in (x, y, z): a voxel
+        sits at ``D @ (spacing * index) + origin``, so the map is ``D^-1 @ C``."""
         initial_matrix = cache_attribute.get_tensor("Direction").reshape(3, 3).to(torch.double)
         return initial_matrix.inverse() @ self.canonical_direction
 
     def _orthogonal_remap(self, cache_attribute: Attribute) -> AxisRemap | None:
-        """The exact index remap this case's reorientation is, or ``None`` where it is not one.
-
-        Total: a case whose header carries no usable direction cosines has no remap to make, and an
-        oblique one has none to make either, both answer ``None`` rather than raise, and the resample
-        is what answers for them.
-        """
+        """The exact index remap this case's reorientation is, ``None`` where it is not one: a case
+        with no usable direction cosines and an oblique one both answer ``None``."""
         if "Direction" not in cache_attribute or cache_attribute.get_np_array("Direction").size != 9:
             return None
         return signed_permutation(self._reorientation(cache_attribute), SIGNED_PERMUTATION_ATOL_FLOAT64)
 
     @staticmethod
     def _carried(per_physical_axis: torch.Tensor, remap: list[tuple[int, bool]] | None) -> torch.Tensor:
-        """Carry a per-physical-axis quantity along a remap: output axis c takes the axis it reads.
-
-        A spacing and a half-extent travel with the axis they belong to: what a reorientation
-        preserves is the volume's physical extent, not which axis carries it. An oblique direction is
-        resampled onto the input's own grid, so without a remap nothing moves.
-        """
+        """Carry a per-physical-axis quantity along a remap: output axis c takes the axis it reads. A
+        reorientation preserves the physical extent, not which axis carries it."""
         if remap is None:
             return per_physical_axis
         # The remap is in array order and these are (x, y, z): read in array order, gather, restore.
@@ -501,12 +460,7 @@ class Canonical(TransformInverse):
             mode = "nearest"
         else:
             mode = "bilinear"
-        # Sample in the data's own device and float dtype: the model output is float16 on the GPU, and
-        # affine_grid/grid_sample support float16 on CPU and CUDA. Building the grid on the data's device
-        # (instead of a CPU float32 grid) keeps the whole reorientation on-device: no host round-trip and
-        # no float32 upcast of the (channels x volume) tensor. Integer inputs still need a float grid.
-        # Accepted trade-off: an fp16 grid quantizes the sampling coordinates (up to ~0.1 voxel at 512^3),
-        # chosen over the ~2x transient memory of a float32 grid + volume upcast.
+        # Sample in the data's own device and float dtype; an integer input still needs a float grid.
         work = data if data.is_floating_point() else data.type(torch.float32)
         grid = torch.nn.functional.affine_grid(
             matrix[:, :-1, ...].to(device=work.device, dtype=work.dtype),
@@ -526,17 +480,15 @@ class Canonical(TransformInverse):
         )
 
     def transform_shape(self, group_src: str, name: str, shape: list[int], cache_attribute: Attribute) -> list[int]:
-        # ``shape`` is the channel-stripped SPATIAL shape, and the patch grid is folded from what this
-        # returns: a remap that transposes extents moves the grid onto the reoriented volume.
+        # The patch grid is folded from what this returns.
         remap = self._orthogonal_remap(cache_attribute)
         if remap is None:
             return shape
         return remap_shape(shape, remap)
 
     def patch_locality(self, cache_attribute: Attribute) -> PatchLocality:
-        # Only the case can say which reorientation this is, so only the header can answer. An orthogonal
-        # one (mirroring or permuting) remaps indices, which is what ORIENTATION streams; an oblique
-        # one is resampled from the whole volume.
+        # An orthogonal reorientation remaps indices, which ORIENTATION streams; an oblique one is
+        # resampled from the whole volume.
         if self._orthogonal_remap(cache_attribute) is None:
             return PatchLocality(
                 LocalityKind.WHOLE_VOLUME,
@@ -563,8 +515,7 @@ class Canonical(TransformInverse):
     def write_stream_cache_attribute(
         self, cache_attribute: Attribute, source_spatial_shape: list[int], name: str = ""
     ) -> None:
-        # Nothing to state for a case this cannot reorient: no geometry, or a direction that is not
-        # 3-D. Its __call__ fails loudly before reaching here; a landing fold must not fail for it.
+        # Nothing to state for a case this cannot reorient: no geometry, or a non-3-D direction.
         del name
         if not Grid.readable(cache_attribute) or cache_attribute.get_np_array("Direction").size != 9:
             return
@@ -575,21 +526,14 @@ class Canonical(TransformInverse):
         half_extent = Canonical._half_extent(source_spatial_shape, spacing)
         cache_attribute["Direction"] = self.canonical_direction.flatten()
         cache_attribute["Spacing"] = Canonical._carried(spacing, remap)
-        # The reorientation fixes the volume's centre, so the new origin is that centre stepped back by
-        # the canonical half-extent: the TARGET grid's, which a permutation has carried onto other
-        # axes. The extent is the VOLUME's, never a patch's: it is an argument rather than the handed
-        # tensor's shape.
+        # The reorientation fixes the volume's centre, so the new origin is that centre stepped back
+        # by the target grid's canonical half-extent. The extent is the volume's, never a patch's.
         center = initial_matrix @ half_extent + initial_origin
         cache_attribute["Origin"] = center - self.canonical_direction @ Canonical._carried(half_extent, remap)
 
     def _inverse_remap(self, cache_attribute: Attribute) -> AxisRemap | None:
-        """The forward remap judged on the state ``inverse`` runs from: the popped-to source direction.
-
-        The inverse pops the canonical geometry and reorients back through the SOURCE direction under
-        it, so its streamability is the popped state's: evaluated on a copy, since a declaration
-        never mutates the case. A matrix and its inverse are signed permutations together, so the
-        forward remap answers for both; ``None`` where the case is oblique or carries no direction.
-        """
+        """The forward remap judged on the state ``inverse`` runs from, evaluated on a copy since a
+        declaration never mutates the case. ``None`` where the case is oblique or has no direction."""
         scoped = Attribute(cache_attribute)
         if "Direction" not in scoped:
             return None
@@ -606,8 +550,7 @@ class Canonical(TransformInverse):
         return PatchLocality(LocalityKind.ORIENTATION)
 
     def inverse_transform_shape(self, shape: list[int], cache_attribute: Attribute) -> list[int]:
-        # transform_shape reads target axis k's extent from source axis ``source``; the inverse puts
-        # each extent back on the axis it came from.
+        # The inverse puts each extent back on the axis it came from.
         remap = self._inverse_remap(cache_attribute)
         if remap is None:
             return shape
@@ -620,8 +563,7 @@ class Canonical(TransformInverse):
         source_spatial_shape: list[int],
         cache_attribute: Attribute,
     ) -> list[slice]:
-        # Canonical axis k holds source axis ``source``'s content: a written region pulls through
-        # the inverse remap, per input axis, the slice of the output axis it carries.
+        # A written region pulls through the inverse remap.
         remap = self._inverse_remap(cache_attribute)
         if remap is None:
             raise TransformError(
@@ -632,10 +574,7 @@ class Canonical(TransformInverse):
 
     def _reorient(self, tensor: torch.Tensor, reorientation: torch.Tensor) -> torch.Tensor:
         """Apply a reorientation: an exact index remap where it is one, a resample where it is not.
-
-        An orthogonal reorientation is a bijection on the voxels, so it must reproduce the input's
-        multiset bit for bit, which only a permute and a flip do.
-        """
+        An orthogonal one reproduces the input's values bit for bit."""
         remap = signed_permutation(reorientation, SIGNED_PERMUTATION_ATOL_FLOAT64)
         if remap is None:
             matrix = Canonical._affine_matrix(reorientation, torch.tensor([0, 0, 0]))
@@ -657,14 +596,10 @@ class Canonical(TransformInverse):
 
 
 class Gradient(Transform):
-    #: The one destination the differences are written into, one channel per spatial axis. Measured
-    #: as VmHWM around the call on a 256^3 float32 block, beyond what it is handed and what it
-    #: returns: 3.0 flattened (where the destination is working memory) and 0.0 per_dim (where the
-    #: destination IS the output).
+    #: The one destination the differences are written into, one channel per spatial axis.
     working_multiple = 5.0
 
-    # First-difference gradient: each output voxel reads its immediate neighbour, a HALO of radius
-    # 1. The far-edge ConstantPad reproduces the whole-volume border once the halo clamps there.
+    # Each output voxel reads its immediate neighbour: a halo of radius 1.
     locality = LocalityKind.HALO
     halo = (1,)
 
@@ -674,12 +609,8 @@ class Gradient(Transform):
 
     @staticmethod
     def _differences(image: torch.Tensor) -> torch.Tensor:
-        """The first difference along each spatial axis, written where it belongs.
-
-        One destination, not three differences plus three copies of them padded plus a stack of
-        those: the far edge is the zero the destination is created with, and each difference is
-        subtracted straight into its own slice of it.
-        """
+        """The first difference along each spatial axis, subtracted straight into its own slice of
+        one destination, whose far edge is the zero it is created with."""
         rank = len(image.shape) - 1
         out = torch.zeros((image.shape[0], rank, *image.shape[1:]), dtype=image.dtype, device=image.device)
         for axis in range(rank):
@@ -691,30 +622,22 @@ class Gradient(Transform):
         return out
 
     def output_channels(self, channels: int) -> int:
-        """One channel per spatial axis, per input channel, when the axes are kept separate.
-
-        Three and not the case's own rank, because the rank is not among this method's arguments and
-        over-stating it costs a shorter region where under-stating it costs the run: a 2-D case is
-        charged half a channel more than it takes.
-        """
+        """One channel per spatial axis, per input channel, when the axes are kept separate. Three
+        and not the case's own rank, which is not among the arguments."""
         return channels * 3 if self.per_dim else channels
 
     def __call__(self, name: str, tensor: torch.Tensor, cache_attribute: Attribute) -> torch.Tensor:
-        # (C, rank, *spatial): the axis dimension is its OWN, never folded into the channels by a
-        # squeeze. Squeezing dropped it only when the case had one channel, so a multi-channel case
-        # took its norm across the channels instead of across the axes and handed the writer a
-        # rank-5 array (measured on a 3-channel case: [1, 3, 128, 256, 256], refused by OME-Zarr).
+        # (C, rank, *spatial): the axis dimension is its own, so a multi-channel case takes its norm
+        # across the axes.
         result = Gradient._differences(tensor)
         if self.per_dim:
             return result.flatten(0, 1)
-        # In place where the dtype has the arithmetic: an integer difference has no sigmoid of
-        # its own and takes the widening one, exactly as it did.
+        # In place where the dtype has the arithmetic: an integer difference takes the widening one.
         result = result.mul_(3).sigmoid_() if result.is_floating_point() else torch.sigmoid(result * 3)
         return result.norm(dim=1)
 
 
 class Flatten(Transform):
-    # Measured at 0.00 on the CUDA allocator: it holds nothing beyond what it is handed.
     working_multiple = 0.0
 
     def __init__(self) -> None:

--- a/konfai/evaluator.py
+++ b/konfai/evaluator.py
@@ -52,17 +52,13 @@ from konfai.utils.utils import split_path_spec
 
 
 class CriterionsLoader:
-    """
-    Loader for multiple criterion modules to be applied between a model output and one or more targets.
+    """Loader for the criterion modules applied between a model output and one or more targets.
 
-    Each loss module (e.g., Dice, CrossEntropy, NCC) is dynamically loaded using its fully-qualified
-    classpath. Evaluation criteria carry no per-criterion attributes, so the config value bound to each
-    classpath is an unused placeholder (``None``).
+    Evaluation criteria carry no per-criterion attributes: the value bound to each classpath is an
+    unused placeholder (``None``).
 
     Args:
-        criterions_loader (dict): A mapping from module classpaths (as strings) to placeholder values.
-                                  The module path is parsed and instantiated via `get_module`.
-
+        criterions_loader (dict): Mapping from module classpaths to placeholder values.
     """
 
     def __init__(
@@ -83,16 +79,10 @@ class CriterionsLoader:
 
 
 class TargetCriterionsLoader:
-    """
-    Loader class for handling multiple target groups with associated criterion configurations.
-
-    This class allows defining a set of criterion loaders (e.g., Dice, BCE, MSE) for each
-    target group to be used during evaluation or training. Each target group corresponds
-    to one or more loss functions, all linked to a specific model output.
+    """Loader for the criterion configurations of several target groups, all linked to one model output.
 
     Args:
-        targets_criterions (dict[str, CriterionsLoader]): Dictionary mapping each target group name
-            to a `CriterionsLoader` instance that defines its associated loss functions.
+        targets_criterions (dict[str, CriterionsLoader]): Each target group name to its `CriterionsLoader`.
     """
 
     def __init__(
@@ -102,18 +92,13 @@ class TargetCriterionsLoader:
         self.targets_criterions = targets_criterions
 
     def get_targets_criterions(self, output_group: str) -> dict[str, dict[Criterion, Any]]:
-        """
-        Retrieve the criterion modules and their attributes for a specific output group.
-
-        This function prepares the loss functions to be applied for a given model output,
-        grouped by their target group.
+        """The criterion modules and their placeholders for one output group, keyed by target group.
 
         Args:
             output_group (str): Name of the model output group (e.g., "output_segmentation").
 
         Returns:
-            dict[str, dict[nn.Module, Any]]: A nested dictionary where the first key is the
-            target group name, and the value is a dictionary mapping each loss module to its placeholder.
+            dict[str, dict[nn.Module, Any]]: target group name -> {loss module: placeholder}.
         """
         targets_criterions = {}
         for target_group, criterions_loader in self.targets_criterions.items():
@@ -122,38 +107,29 @@ class TargetCriterionsLoader:
 
 
 class Statistics:
-    """
-    Utility class to accumulate, structure, and write evaluation metric results.
-
-    This class is used to:
-    - Collect metrics for each dataset sample.
-    - Compute aggregate statistics (mean, std, percentiles, etc.).
-    - Export all results in a structured JSON format, including both per-case and aggregate values.
+    """Accumulate per-case metric values, compute aggregates and write both as one JSON report.
 
     Args:
-        filename (str): Path to the output JSON file that will store the final results.
+        filename (str): Path to the output JSON file.
     """
 
     def __init__(self, filename: Path) -> None:
         self.measures: dict[str, dict[str, float]] = {}
         self.filename = filename
-        # Per-metric optimisation direction ("max"/"min"), declared by each criterion's `maximize`
-        # property, so downstream ranking (the MCP leaderboard) reads it instead of guessing from names.
+        # Per-metric optimisation direction ("max"/"min"), from each criterion's `maximize` property.
         self.directions: dict[str, str] = {}
         self._incremental_path: Path | None = None
 
     def open_incremental(self, path: Path) -> None:
-        """Append every case recorded from now on to ``path``, one JSON object per line, as it
-        completes: what a crash keeps, and what a rerun reads back to skip the already-scored."""
+        """Append every case recorded from now on to ``path``, one JSON object per line, as it completes."""
         self._incremental_path = path
 
     def add(self, values: dict[str, float], name_dataset: str) -> None:
-        """
-        Add a set of metric values for a given dataset case.
+        """Add the metric values of one dataset case.
 
         Args:
-            values (dict): Dictionary of metric names and their values.
-            name_dataset (str): Identifier (e.g., case name) for the sample.
+            values (dict): Metric names to values.
+            name_dataset (str): Case identifier.
         """
         for name, value in values.items():
             if name_dataset not in self.measures:
@@ -166,9 +142,8 @@ class Statistics:
 
     @staticmethod
     def load_incremental(paths: list[Path]) -> dict[str, dict[str, float]]:
-        """The cases the given JSONL files hold, last row per name winning; a truncated tail line
-        (a kill mid-append) is dropped, never an error. ``null`` reads back as the NaN it stood for.
-        """
+        """The cases the JSONL files hold, last row per name winning; a truncated tail line is dropped,
+        never an error. ``null`` reads back as NaN."""
         rows: dict[str, dict[str, float]] = {}
         for path in paths:
             try:
@@ -209,11 +184,7 @@ class Statistics:
 
     @staticmethod
     def _to_serializable(obj: Any) -> Any:
-        """
-        Recursively replace non-finite floating-point values with ``None``.
-
-        NaN and ±Infinity have no representation in standard JSON. Converting them
-        to ``null`` keeps the serialized report parseable by strict JSON readers.
+        """Recursively replace non-finite floats with ``None``: NaN and infinities have no JSON representation.
 
         Args:
             obj: Any structure (dict, list, scalar) to normalize.
@@ -230,12 +201,8 @@ class Statistics:
         return obj
 
     def write(self, outputs: list[dict[str, dict[str, Any]]]) -> None:
-        """
-        Write the collected and aggregated statistics to the configured output file.
-
-        The output JSON structure contains:
-        - `case`: All individual metrics per sample.
-        - `aggregates`: Global statistics computed over all cases.
+        """Write the collected and aggregated statistics to the configured output file: ``case`` holds
+        the per-sample metrics, ``aggregates`` the global statistics.
 
         Args:
             outputs (list): List of metric dictionaries to merge and serialize.
@@ -243,8 +210,7 @@ class Statistics:
         measures = {}
         for output in outputs:
             measures.update(output)
-        # JSON payload with heterogeneous blocks: "case"/"aggregates" are nested dicts, "directions"
-        # maps metric-name -> "max"/"min".
+        # "case"/"aggregates" are nested dicts, "directions" maps metric name -> "max"/"min".
         result: dict[str, Any] = {}
         result["case"] = {}
         for name, v in measures.items():
@@ -263,7 +229,6 @@ class Statistics:
         for metric_name, values in tmp.items():
             result["aggregates"][metric_name] = Statistics.get_statistic(values)
 
-        # Declare each metric's optimisation direction so consumers rank without guessing.
         directions = {name: self.directions[name] for name in result["aggregates"] if name in self.directions}
         if directions:
             result["directions"] = directions
@@ -284,10 +249,8 @@ class Statistics:
             if mean_value is None:
                 continue
 
-            # A dict-valued metric emits both an aggregate entry
-            # ("output:target:Metric") and one entry per component
-            # ("output:target:Metric:component"); the latter share the aggregate
-            # key as a prefix, so keep only top-level metrics.
+            # A dict-valued metric emits an aggregate entry ("output:target:Metric") and one per
+            # component ("output:target:Metric:component"): keep only the top-level metrics.
             if key.rsplit(":", 1)[0] in aggregates:
                 continue
 
@@ -298,23 +261,18 @@ class Statistics:
 
 @config()
 class Evaluator(DistributedObject):
-    """
-    Distributed evaluation engine for computing metrics on model predictions.
-
-    This class handles the evaluation of predicted outputs using predefined metric loaders.
-    It supports multi-output and multi-target configurations, computes aggregated statistics
-    across training and validation datasets, and synchronizes results across processes.
-
-    Evaluation results are stored in JSON format and optionally displayed during iteration.
+    """Distributed evaluation engine: metrics on model predictions, multi-output and multi-target,
+    aggregated over the training and validation datasets and synchronized across processes. Results
+    are written as JSON.
 
     Args:
-        train_name (str): Unique name of the evaluation run, used for logging and output folders.
-        metrics (dict[str, TargetCriterionsLoader]): Dictionary mapping output groups to loaders of target metrics.
+        train_name (str): Name of the evaluation run, used for logging and output folders.
+        metrics (dict[str, TargetCriterionsLoader]): Output groups to loaders of target metrics.
         dataset (DataMetric): Dataset provider configured for evaluation mode.
 
     Attributes:
-        statistics_train (Statistics): Object used to store training evaluation metrics.
-        statistics_validation (Statistics): Object used to store validation evaluation metrics.
+        statistics_train (Statistics): Training evaluation metrics.
+        statistics_validation (Statistics): Validation evaluation metrics.
         dataloader (list[DataLoader]): DataLoaders for training and validation sets.
         metric_path (str): Path to the evaluation output directory.
         metrics (dict): Instantiated metrics organized by output and target groups.
@@ -335,37 +293,27 @@ class Evaluator(DistributedObject):
         self.metrics = {k: v.get_targets_criterions(k) for k, v in self.metricsLoader.items()}
         self.statistics_train = Statistics(self.metric_path / "Metric_TRAIN.json")
         self.statistics_validation = Statistics(self.metric_path / "Metric_VALIDATION.json")
-        # A memory budget may patch the evaluation, but only when EVERY metric can rebuild its
-        # whole-case value from partial states; one non-reducible metric keeps the whole-volume path
-        # for everything (correct beats bounded). A metric scoring through a window declares the
-        # halo its patches are read with, and the widest one is read for all.
+        # A memory budget patches the evaluation only when EVERY metric can rebuild its whole-case
+        # value from partial states. A windowed metric declares its halo, and the widest one is read for all.
         criterions = [metric for targets in self.metrics.values() for group in targets.values() for metric in group]
         self.dataset.auto_patch_allowed = all(getattr(metric, "reducible", False) for metric in criterions)
         self.dataset.patch_halo = max((int(getattr(metric, "halo", 0)) for metric in criterions), default=0)
         self.dataset.prepare()
         set_per_rank_budget(self.dataset.resolved_budget().per_rank_bytes(node_local_ranks()))
         bound_chunk_cache()
-        # Set iff the budget actually patched: batches then carry one disjoint patch of a case, and
-        # update() accumulates partial states until the case's last patch before recording it.
+        # Set iff the budget patched: batches carry one disjoint patch, accumulated until the case's last.
         self._streamed = self.dataset.patch is not None
-        # The context each patch is read with past its slot, when the grid reads any: a metric that
-        # declared it is handed the read and told where the slot sits, the others the slot alone.
+        # The halo each patch is read with; a metric that declared it is told where the slot sits.
         self._halo = self.dataset.patch.halo if self.dataset.patch is not None else 0
         self._pending: dict[tuple[str, str, int], tuple] = {}
         self._pending_name: str | None = None
         self._last_result: dict[str, float] = {}
-        #: Cases a previous, interrupted run already scored (read back from the per-rank case
-        #: files): their batches are skipped, and their rows still reach the final aggregate.
+        #: Cases an interrupted run already scored: their batches are skipped, their rows reach the aggregate.
         self._scored_names: set[str] = set()
-        # Per-voxel error maps under the patched path: one region-write sink per (metric, case),
-        # opened at the case's first patch, closed when the case flushes. Disjoint unpadded patches
-        # mean every voxel is written exactly once: the streamed map equals the whole-volume one.
+        # Per-voxel error maps under the patched path: one region-write sink per (metric, case).
         self._map_sinks: dict[tuple[str, str, int], DataStream] = {}
         self._iter_dataset: DatasetIter | None = None
-        # Where the metrics run. An evaluation has no model forward, so its tensors arrive from the
-        # DataLoader on CPU and reading the device off them pinned every metric to CPU: including the
-        # ones that own a network (a perceptual metric moves its model to the tensor's device, and a
-        # segmentation metric runs a whole nested inference). `run_process` sets the run's real device.
+        # The metrics' device; tensors arrive from the DataLoader on CPU, `run_process` sets the real device.
         self._device: torch.device | int = torch.device("cpu")
         # Where a split's wall clock goes, one clock per split (see _evaluate_split).
         self._clock = SweepClock()
@@ -392,27 +340,19 @@ class Evaluator(DistributedObject):
             )
 
     def setup(self, world_size: int):
-        """
-        Prepare the evaluator for distributed metric computation.
-
-        This method performs the following steps:
-        - Checks whether previous evaluation results exist and optionally overwrites them.
-        - Creates the output directory and copies the current configuration file for reproducibility.
-        - Loads the evaluation dataset according to the world size.
+        """Prepare the evaluator: check for previous results and overwrite or resume, create the output
+        directory with a copy of the configuration, load the dataset for ``world_size`` processes.
 
         Args:
             world_size (int): Number of processes in the distributed evaluation setup.
-
         """
-        # An interrupted run (case rows on disk, no aggregate yet) resumes: the scored cases are
-        # read back and skipped, so no prompt and no clearing. A COMPLETED run keeps the usual
-        # overwrite confirmation; --overwrite clears everything, case rows included.
+        # An interrupted run (case rows on disk, no aggregate) resumes without a prompt; a completed
+        # run keeps the overwrite confirmation; --overwrite clears everything, case rows included.
         resumable = os.environ.get("KONFAI_OVERWRITE") != "True" and self._is_resumable()
         if not resumable and self.metric_path.exists() and len(list(self.metric_path.rglob("*.yml"))):
             confirm_overwrite_or_raise(self.metric_path, "metric", EvaluatorError)
             if self.metric_path.exists():
-                # This directory holds the rank-0 evaluation log this process already has open:
-                # clear around it instead of rmtree'ing it out from under the live file.
+                # The directory holds the rank-0 log already open: clear around it, not rmtree.
                 clear_directory_except_logs(self.metric_path)
 
         os.makedirs(self.metric_path, exist_ok=True)
@@ -435,16 +375,14 @@ class Evaluator(DistributedObject):
         )
 
     def update(self, batch_sample: BatchSample, statistics: Statistics) -> dict[str, float]:
-        """
-        Compute metrics for a batch and update running statistics.
+        """Compute the metrics of one batch and update the running statistics.
 
         Args:
-            batch_sample (BatchSample): The batch sample object containing tensors and their metadata.
+            batch_sample (BatchSample): Tensors and their metadata.
             statistics (Statistics): The statistics object to update (train or validation).
 
         Returns:
-            dict[str, float]: Dictionary of computed metric values with keys in the format
-                            'output_group:target_group:MetricName'.
+            dict[str, float]: Metric values keyed 'output_group:target_group:MetricName'.
         """
         if self._streamed:
             return self._update_streamed(batch_sample, statistics)
@@ -502,13 +440,8 @@ class Evaluator(DistributedObject):
         return tensor.to(metric_device, non_blocking=tensor.device.type == "cpu")
 
     def _groups_on(self, batch_sample: BatchSample) -> dict[str, torch.Tensor]:
-        """Every group a metric names, on the metric device, moved once per update.
-
-        A target named by two specs (``CT`` and ``CT;MASK``) or shared by two outputs was uploaded
-        once per spec per case, and per patch on the streamed path. Sharing one copy is safe: a
-        metric never writes into its inputs (a mask multiplies into a new tensor), and the metrics
-        of one spec already read the same tensor.
-        """
+        """Every group a metric names, on the metric device, moved once per update. Sharing one copy is
+        safe: a metric never writes into its inputs."""
         groups = {
             group
             for output_group, targets in self.metrics.items()
@@ -545,12 +478,9 @@ class Evaluator(DistributedObject):
             statistics.directions[base_key] = direction
 
     def _update_streamed(self, batch_sample: BatchSample, statistics: Statistics) -> dict[str, float]:
-        """Accumulate one PATCH's partial states; record the case when its next sibling arrives.
-
-        The evaluation loader walks a case's disjoint patches contiguously (cases shard whole per
-        rank), so a change of case name marks the previous case complete: ``_flush_pending`` at the
-        end of the split closes the last one.
-        """
+        """Accumulate one PATCH's partial states; record the case when its next sibling arrives. Cases
+        shard whole per rank and their patches arrive contiguously, so a change of case name completes
+        the previous one; ``_flush_pending`` closes the split's last case."""
         name = batch_sample[next(iter(self.metrics))].name[0]
         if name in self._scored_names:
             return self._last_result
@@ -610,11 +540,8 @@ class Evaluator(DistributedObject):
         output_group: str,
         patch_map: torch.Tensor,
     ) -> None:
-        """Write one patch's per-voxel map into its case's region-write sink.
-
-        ``partial_map`` is voxel-local, so the patch's map is exactly the region of the whole-case
-        map; the disjoint unpadded evaluation grid writes every voxel once, never twice.
-        """
+        """Write one patch's per-voxel map into its case's region-write sink: ``partial_map`` is
+        voxel-local and the disjoint unpadded grid writes every voxel once."""
         manager = self._manager(output_group, item)
         array = patch_map.numpy()
         sink = self._map_sinks.get(key)
@@ -665,26 +592,14 @@ class Evaluator(DistributedObject):
         self._last_result = result
 
     def run_process(self, world_size: int, global_rank: int, gpu: int, dataloaders: list[DataLoader]):
-        """
-        Execute the distributed evaluation loop over the training and validation datasets.
-
-        This method iterates through the provided DataLoaders (train and optionally validation),
-        updates the metric statistics using the configured `metrics` dictionary, and synchronizes
-        the results across all processes. On the global rank 0, the metrics are saved as JSON files.
-
-        Metrics are displayed in real-time using `tqdm` progress bars, showing a summary of the
-        current batch's computed values.
+        """Run the evaluation loop over the training and validation datasets, synchronize the results
+        across processes and, on rank 0, write the JSON files.
 
         Args:
             world_size (int): Total number of distributed processes.
-            global_rank (int): Global rank of the current process (used for writing results).
+            global_rank (int): Global rank of the current process.
             gpu (int): Local GPU ID used for synchronization.
-            dataloaders (list[DataLoader]): A list containing one or two DataLoaders:
-                - `dataloaders[0]` is used for training evaluation.
-                - `dataloaders[1]` (optional) is used for validation evaluation.
-
-        Notes:
-            - Only the main process (`global_rank == 0`) writes final results to disk.
+            dataloaders (list[DataLoader]): ``[train]`` or ``[train, validation]``.
         """
 
         self._device = get_device(gpu) if len(cuda_visible_devices()) else torch.device("cpu")
@@ -710,10 +625,8 @@ class Evaluator(DistributedObject):
 
         self._iter_dataset = cast(DatasetIter, dataloader.dataset)
         self._clock = SweepClock()
-        # Per-case persistence: what an interrupted run already scored is read back and skipped,
-        # and every case scored from here on is appended to this rank's own case file as it
-        # completes, so a crash at case N-1 of N keeps N-1 cases. The aggregate below is built from
-        # the union.
+        # Cases an interrupted run scored are read back and skipped; each case scored from here on is
+        # appended to this rank's own case file. The aggregate is built from the union.
         scored = Statistics.load_incremental(self._incremental_case_files(statistics))
         self._scored_names = set(scored)
         if scored:
@@ -740,8 +653,7 @@ class Evaluator(DistributedObject):
                 with self._clock.phase("flush"):
                     self._flush_pending(statistics)  # close the split's last case
         except BaseException as error:
-            # A half-written error map must not survive as a valid-looking file: abort the open
-            # region-write sinks so their backends remove the partial entries, then re-raise.
+            # Abort the open region-write sinks so their backends remove the partial entries, then re-raise.
             self._abort_map_sinks(error)
             raise
         if global_rank == 0:
@@ -753,13 +665,9 @@ class Evaluator(DistributedObject):
             statistics.write(outputs)
 
     def _clock_report(self, label: str, min_seconds: float = 1.0) -> str | None:
-        """One line accounting for a split's wall clock, or ``None`` below ``min_seconds``.
-
-        The phases: the wait for the loader's next batch, the move to the metric device, one per
-        metric name, the map writes and the streamed flushes; ``other`` is what none of them names.
-        On a GPU a metric's phase is its enqueue time, not its run: no synchronize is added for the
-        report's sake, so a slow kernel shows up in whatever next waits on the device.
-        """
+        """One line accounting for a split's wall clock, or ``None`` below ``min_seconds``: the wait for
+        the loader, the move to the metric device, one phase per metric name, the map writes and the
+        streamed flushes; ``other`` is what none of them names. On a GPU a metric's phase is its enqueue."""
         wall = self._clock.spent("split")
         if wall < min_seconds:
             return None
@@ -782,8 +690,7 @@ def build_evaluate(
     evaluations_file: Path | str | dict = Path("./Evaluation.yml"),
     evaluations_dir: Path | str = Path("./Evaluations"),
 ) -> DistributedObject:
-    """
-    Build and return the configured evaluation workflow without executing it.
+    """Build and return the configured evaluation workflow without executing it.
 
     Parameters
     ----------
@@ -795,7 +702,7 @@ def build_evaluate(
     Returns
     -------
     DistributedObject
-        Configured evaluator object ready to be executed by the runtime wrapper.
+        Configured evaluator, executed by the runtime wrapper.
     """
     configure_workflow_environment(
         config_path=evaluations_file,
@@ -818,12 +725,10 @@ def evaluate(
     evaluations_file: Path | str | dict = Path("./Evaluation.yml"),
     evaluations_dir: Path | str = Path("./Evaluations"),
 ) -> DistributedObject:
-    """
-    Build and execute the configured evaluation workflow.
+    """Build and execute the configured evaluation workflow.
 
-    ``overwrite``/``gpu``/``cpu``/``quiet``/``tensorboard`` are load-bearing even though the body
-    drops them: :func:`run_distributed_app` reads them from the bound signature to drive the launch.
-    The pure build step is :func:`build_evaluate`.
+    ``overwrite``/``gpu``/``cpu``/``quiet``/``tensorboard`` are read by :func:`run_distributed_app`
+    from the bound signature; the body drops them. The pure build step is :func:`build_evaluate`.
     """
     del overwrite, gpu, cpu, quiet, tensorboard
     return build_evaluate(

--- a/konfai/export.py
+++ b/konfai/export.py
@@ -17,14 +17,9 @@
 """Export a frozen KonfAI ``Network`` to a self-contained ONNX graph + manifest.
 
 A trained model becomes ``model.onnx`` (graph + weights, single file) plus ``manifest.json``
-(patch geometry, input/output spec) for a Python-free runtime. Three constraints shape the code:
-
-* ``Network.named_forward`` is a Python generator, which TorchScript cannot script, so the
-  **dynamo** exporter is used.
-* ``Network.forward`` returns per-output-group results (empty without ``init()``), so the
-  graph is reached via ``named_forward`` and a named head is selected.
-* The dynamo exporter writes weights as external data; they are inlined so the ``.onnx`` is
-  a single self-contained file.
+(patch geometry, input/output spec) for a Python-free runtime. The export uses the **dynamo**
+exporter, reaches the graph through ``named_forward`` and selects a named head, and inlines the
+external weight data so the ``.onnx`` is a single self-contained file.
 """
 
 from __future__ import annotations
@@ -107,8 +102,7 @@ def list_output_modules(model: torch.nn.Module, example_input: torch.Tensor) -> 
 def select_inference_head(model: torch.nn.Module, example_input: torch.Tensor) -> str:
     """Pick the head to export: the last **floating-point** output in execution order.
 
-    Terminal outputs often end in an integer ``Argmax`` label map; a float runtime wants the final
-    probability/regression head, so integer outputs are skipped. Pass ``output_module`` to target a
+    Integer outputs (an ``Argmax`` label map) are skipped. Pass ``output_module`` to target a
     specific head.
     """
     graph = _routed(model)
@@ -201,7 +195,7 @@ def export_to_onnx(
         )
 
     # The dynamo exporter writes weights as external data; inline them so the .onnx is a
-    # single self-contained file. Remove the now-orphan sidecar.
+    # single self-contained file.
     onnx.save(onnx.load(str(onnx_path)), str(onnx_path), save_as_external_data=False)
     sidecar = onnx_path.with_name(onnx_path.name + ".data")
     if sidecar.exists():

--- a/konfai/main.py
+++ b/konfai/main.py
@@ -40,9 +40,7 @@ def _positive_int(value: str) -> int:
 
 
 class _VersionAction(argparse.Action):
-    """``--version``: the installed version, looked up when asked for. ``importlib.metadata.version``
-    scans the installed distributions (17 ms cold), which every other invocation would pay at
-    parser construction."""
+    """``--version``: the installed version, looked up when asked for."""
 
     def __init__(self, option_strings: list[str], dest: str, help: str | None = None) -> None:
         super().__init__(option_strings, dest, default=argparse.SUPPRESS, nargs=0, help=help)
@@ -149,8 +147,7 @@ def _add_transform(subparsers: argparse._SubParsersAction) -> None:
     parser = subparsers.add_parser(
         str(State.TRANSFORM), help="Prepare a dataset: apply a transform chain to every case and write the result."
     )
-    # Deliberately NOT _add_common_args: -tb has no scalar to show, so refusing it here is a parse
-    # error, not a silent no-op.
+    # Deliberately NOT _add_common_args: -tb has no scalar to show, so it is a parse error here.
     parser.add_argument(
         "-c",
         "--config",
@@ -220,7 +217,6 @@ def _run_list(kind: str) -> None:
 
 
 # Command -> (implementation module, entrypoint, the kwarg the config path travels under).
-# Imports stay lazy and by name: the heavy modules load only for the command that runs.
 _COMMANDS: dict[str, tuple[str, str, str]] = {
     str(State.TRAIN): ("konfai.trainer", "train", "config"),
     str(State.RESUME): ("konfai.trainer", "train", "config"),
@@ -242,9 +238,8 @@ _INIT_TARGETS: dict[str, tuple[str, str, str]] = {
 def _run_init(args: dict[str, Any]) -> None:
     """``--init``: bind the workflow once so every default resolves and lands in the file, then exit.
 
-    The file is created seeded with its root key when missing (an empty tree would be refused as
-    holding no root). The build itself never runs anything; a build error after partial binding
-    still leaves what resolved on disk (the strict block flushes on exceptional exit too).
+    The file is created seeded with its root key when missing. The build runs nothing, and a build
+    error after partial binding still leaves what resolved on disk.
     """
     import inspect
     from pathlib import Path
@@ -269,8 +264,7 @@ def _run_init(args: dict[str, Any]) -> None:
 
 
 def _check_gpu_ids(parser: argparse.ArgumentParser, gpu: list[int]) -> None:
-    """The ``--gpu`` choices, checked after parsing: resolving them imports torch, which
-    ``--help`` and a usage error must not pay for."""
+    """The ``--gpu`` choices, checked after parsing, so ``--help`` and a usage error never import torch."""
     if not gpu:
         return
     from konfai import cuda_visible_devices
@@ -288,8 +282,7 @@ def _dispatch(parser: argparse.ArgumentParser, args: dict[str, Any]) -> None:
         _run_list(args["kind"])
         return
     if args["command"] not in _COMMANDS:
-        # Exhaustive on purpose: a fallback would silently launch the trainer for any command it
-        # does not know: a new workflow would train a UNet instead of failing.
+        # Exhaustive on purpose: a fallback would silently launch the trainer for an unknown command.
         parser.error(f"Unknown command '{args['command']}'.")
     _check_gpu_ids(parser, args["gpu"])
     module_name, function_name, config_key = _COMMANDS[args["command"]]
@@ -298,13 +291,11 @@ def _dispatch(parser: argparse.ArgumentParser, args: dict[str, Any]) -> None:
     elif config_key != "config":
         args[config_key] = args.pop("config")
     if args.pop("init", False):
-        # --init must SHORT-CIRCUIT for the same reason --plan does just below.
         _run_init(args)
         return
     if args.pop("plan", False):
         # --plan must SHORT-CIRCUIT here: the distributed wrapper filters kwargs by the entrypoint's
-        # signature, so a 'plan' passed through would be silently dropped and the run would proceed
-        # as if the flag had never been given.
+        # signature, so a 'plan' passed through would be dropped and the run would proceed.
         if "num_nodes" in args:
             parser.error("--plan is a dry run on this machine and submits nothing: use `konfai TRANSFORM --plan`.")
         # plan_transform declares the TRANSFORM flags and nothing else; the command name is not one.

--- a/konfai/metric/measure/segmentation.py
+++ b/konfai/metric/measure/segmentation.py
@@ -128,9 +128,8 @@ class Dice(Criterion):
     @staticmethod
     def _hard_sums(output: torch.Tensor, target: torch.Tensor, labels: list[int] | None) -> LabelSums:
         """The sums of a hard-label pair, exact integers from three ``bincount`` passes over the flat
-        maps (the reference, the prediction, the reference where the two agree): every label at
-        once and one ``.tolist()`` for the lot, where a per-label ``==`` built two float volumes and
-        synchronised twice.
+        maps (the reference, the prediction, the reference where the two agree): every label at once
+        and one ``.tolist()`` for the lot.
 
         With ``labels=None`` every label either map holds gets its sums, so a patch's predicted mass
         for a label its reference lacks still reaches the whole-case ratio in ``combine_metric``;
@@ -164,13 +163,13 @@ class Dice(Criterion):
 
     @staticmethod
     def _soft_sums(output: torch.Tensor, target: torch.Tensor, labels: list[int] | None) -> LabelSums:
-        """The sums of a probability map against a label map, per channel: the intersection is
-        taken only where the reference holds the label (it is zero elsewhere), and one
-        ``.tolist()`` brings every sum back.
+        """The sums of a probability map against a label map, per channel: the intersection is taken
+        only where the reference holds the label (it is zero elsewhere), and one ``.tolist()`` brings
+        every sum back.
 
-        A label at a time, where the loss batches them: this route carries no gradient, so its peak
-        is one channel and never the label count. Batched it read 1050 MiB instead of 346 and took
-        4.44 ms instead of 1.95 on a ``[1, 41, 128, 128, 128]`` patch of 40 labels.
+        A label at a time, where the loss batches them: this route carries no gradient, so its peak is
+        one channel and never the label count (346 MiB and 1.95 ms against 1050 MiB and 4.44 ms
+        batched, on a ``[1, 41, 128, 128, 128]`` patch of 40 labels).
 
         With ``labels=None`` every label either map holds gets its sums, so a patch's predicted mass
         for a label its reference lacks still reaches the whole-case ratio in ``combine_metric``.
@@ -213,24 +212,19 @@ class Dice(Criterion):
     def _soft_loss(
         labels: list[int] | None, output: torch.Tensor, target: torch.Tensor
     ) -> tuple[torch.Tensor, dict[int, float] | LabelledValues]:
-        """The differentiable soft Dice over a probability map's channels, one per label the
-        reference holds, every label in one expression: their channels gathered in one slice, the
-        reference one comparison against the label vector on an axis of its own, and each sum one
-        reduction. That axis sits before the target's channels, so a reference of any channel count
-        broadcasts against a gathered channel exactly as a per-label ``target == label`` did.
+        """The differentiable soft Dice over a probability map's channels, one per label the reference
+        holds, every label in one expression: their channels gathered in one slice, the reference one
+        comparison against the label vector on an axis of its own, and each sum one reduction. That
+        axis sits before the target's channels, so a reference of any channel count broadcasts against
+        a gathered channel exactly as a per-label ``target == label`` did.
 
-        A slice per label cost a gradient write into the whole logits tensor each: 22.7 ``add_`` and
-        28.7 ``fill_`` per step, 10.2 ms of the 28.2 ms of GPU time of a training step of
-        ``examples/Segmentation`` (batch 8, 41 channels, 256x256, autocast + channels_last).
-        Backward held a float copy of both operands per label already, so training peaks lower
-        (242 -> 180 MiB on that batch); with no gradient to build it is the label count that peaks
-        where the loop peaked at one channel (6 -> 180 MiB), and ``_soft_sums`` is the frugal route.
+        A slice per label cost a gradient write into the whole logits tensor each: 10.2 ms of the
+        28.2 ms of GPU time of a training step of ``examples/Segmentation``. With no gradient to build
+        it is the label count that peaks (6 to 180 MiB), and ``_soft_sums`` is the frugal route.
 
-        The reference's own mass is the voxel count ``_reference_counts`` already holds, the exact
-        integer the metric route's ``_score`` divides by. The per-label dices leave as a
-        ``LabelledValues`` read off the device lazily (``Measure._materialize``), never a
-        ``.tolist()`` in the forward: a ``.item()`` per label once drained the CUDA queue mid-loss,
-        twice per label.
+        The reference's own mass is the voxel count ``_reference_counts`` already holds. The per-label
+        dices leave as a ``LabelledValues`` read off the device lazily (``Measure._materialize``),
+        never a ``.tolist()`` in the forward.
         """
         labels, reference = Dice._reference_counts(target, labels)
         held = [label for label, count in zip(labels, reference, strict=True) if count]

--- a/konfai/network/blocks.py
+++ b/konfai/network/blocks.py
@@ -214,23 +214,11 @@ class ResidualBlockD(network.ModuleArgsDict):
     """nnU-Net ResNet-D basic residual block, reproduced as a routed KonfAI graph.
 
     Module-for-module and in forward-execution order equal to
-    ``dynamic_network_architectures.building_blocks.residual.BasicBlockD`` (the block the
-    nnU-Net ``ResidualEncoderUNet`` stacks). It reproduces the ResNet-D structure of He et al.,
-    *Bag of Tricks for Image Classification with CNNs* (CVPR 2019):
-
-    * **Skip path first** (matching ``BasicBlockD.forward``, which evaluates ``self.skip(x)``
-      before the main path): when the block is strided, the residual is downsampled with an
-      ``AvgPool`` of kernel = stride (never a strided conv); when the channel count changes, it is
-      then projected with a ``1x1`` conv whose ``bias`` is **always** ``False`` (independent of
-      ``conv_bias``) followed by a norm. When neither applies the skip is the identity (no extra
-      module, the residual falls back to the block input branch).
-    * **Main path** on branch ``0``: ``Conv(stride) -> Norm -> LeakyReLU -> Conv(stride 1) -> Norm``
-      (the second conv carries no activation, exactly as ``BasicBlockD``).
-    * The two paths are summed and a final ``LeakyReLU`` is applied.
-
-    Executing the skip modules before the main-path convs is what makes the block transparent to
-    the execution-order weight bridge (``konfai.utils.pretrained``): its weighted leaves fire in
-    the same order as ``BasicBlockD`` (skip conv/norm, then conv1, then conv2).
+    ``dynamic_network_architectures.building_blocks.residual.BasicBlockD``. A strided block downsamples
+    the residual with an ``AvgPool`` of kernel = stride, never a strided conv, and a channel change
+    projects it with a ``1x1`` conv whose ``bias`` is always ``False``, independent of ``conv_bias``.
+    The skip modules execute before the main-path convs, so the weighted leaves fire in ``BasicBlockD``
+    order (skip conv/norm, conv1, conv2) for the execution-order weight bridge.
     """
 
     def __init__(
@@ -299,24 +287,12 @@ class ResidualBlockD(network.ModuleArgsDict):
 class ResNetBasicBlock(network.ModuleArgsDict):
     """torchvision ResNet ``BasicBlock`` reproduced as a routed KonfAI graph (the ResNet-18/34 block).
 
-    Module-for-module and in forward-execution order equal to
-    ``torchvision.models.resnet.BasicBlock`` (the block the ``resnet18``/``resnet34`` encoders of
-    ``segmentation_models_pytorch`` stack). It reproduces the post-activation residual block of He et al.,
-    *Deep Residual Learning* (CVPR 2016):
-
-    * **Main path first** (matching ``BasicBlock.forward``, which computes the residual branch before it
-      evaluates ``self.downsample(x)``): on branch ``1`` ``Conv(stride) -> Norm -> ReLU -> Conv(stride 1)
-      -> Norm`` (the second conv carries no activation), keeping the block input untouched on branch ``0``.
-    * **Projection skip** on branch ``2``, evaluated *after* the main path (exactly as ``BasicBlock`` calls
-      ``self.downsample(x)`` only after ``bn2``): a ``1x1`` ``Conv(stride) -> Norm``. It is built when the
-      block is strided or changes channel count; otherwise the residual is the identity (block input).
-    * The two paths are summed onto branch ``0`` and a final ``ReLU`` is applied.
-
-    Evaluating the main-path convs before the downsample projection is what makes the block transparent to
-    the execution-order weight bridge (``konfai.utils.pretrained``): its weighted leaves fire in the same
-    order as ``BasicBlock`` (conv1, bn1, conv2, bn2, downsample.0, downsample.1). ``conv_bias`` defaults to
-    ``False`` (torchvision/timm ResNets never bias their convs) and the norm is ``BatchNorm`` (running stats,
-    so a checkpoint's BN buffers travel through the bridge and the ``eval()`` forward matches).
+    Module-for-module and in forward-execution order equal to ``torchvision.models.resnet.BasicBlock``:
+    the main path on branch ``1``, then the projection skip on branch ``2`` (built when the block is
+    strided or changes channel count, the identity otherwise), the two summed onto branch ``0`` under a
+    final ``ReLU``. The weighted leaves fire in ``BasicBlock`` order (conv1, bn1, conv2, bn2,
+    downsample.0, downsample.1) for the execution-order weight bridge. ``conv_bias`` defaults to
+    ``False`` and the norm is ``BatchNorm``, whose running stats travel with a checkpoint.
     """
 
     def __init__(
@@ -391,12 +367,9 @@ def _same_padding(kernel_size: int | list[int]) -> int | list[int]:
 class ResidualStage(network.ModuleArgsDict):
     """One encoder resolution stage: a stack of ``n_blocks`` :class:`ResidualBlockD` as a single node.
 
-    A generic, reusable building block for residual encoders (e.g. nnU-Net's ``ResidualEncoder``): the
-    **first** block carries ``stride`` and the ``in_channels -> out_channels`` change (nnU-Net strided-conv
-    downsampling), and the remaining ``n_blocks - 1`` blocks are stride 1 at ``out_channels``. The blocks
-    are wired sequentially (each on branch ``0``), so the whole stage is a drop-in single node with one
-    input and one output whose weighted leaves fire in the same order as the equivalent flat stack: it
-    stays transparent to the execution-order weight bridge (``konfai.utils.pretrained``).
+    The **first** block carries ``stride`` and the ``in_channels -> out_channels`` change, the remaining
+    ``n_blocks - 1`` are stride 1 at ``out_channels``, wired sequentially on branch ``0``. The stage's
+    weighted leaves fire in the same order as the equivalent flat stack.
     """
 
     def __init__(
@@ -433,13 +406,11 @@ class ResidualStage(network.ModuleArgsDict):
 class DecoderStage(network.ModuleArgsDict):
     """One U-Net decoder resolution stage as a single two-input node: upsample, concat skip, conv block.
 
-    A generic, reusable building block for U-Net decoders (nnU-Net's ``UNetDecoder`` shares it between the
-    plain and residual encoders). It is a **two-input** node (``in_branch: [coarser, skip]``), that runs
-    ``ConvTranspose(in_channels -> skip_channels, kernel = stride = upsample_stride)`` on the coarser input,
-    concatenates the encoder ``skip`` (transpose output first, then skip), then a :class:`ConvBlock` of
-    ``n_conv`` convs mapping ``2 * skip_channels -> skip_channels``: each Conv -> InstanceNorm(affine) ->
-    LeakyReLU with same-padding. It yields one output. ``upsample_stride`` sets both the transpose kernel and
-    stride so anisotropic plans (per-axis lists) upsample exactly the axes their encoder downsampled.
+    A **two-input** node (``in_branch: [coarser, skip]``): ``ConvTranspose(in_channels -> skip_channels,
+    kernel = stride = upsample_stride)`` on the coarser input, a concat of the encoder ``skip`` (transpose
+    output first), then a :class:`ConvBlock` of ``n_conv`` convs mapping ``2 * skip_channels ->
+    skip_channels``. ``upsample_stride`` sets both the transpose kernel and stride, so a per-axis list
+    upsamples exactly the axes its encoder downsampled.
     """
 
     def __init__(
@@ -473,8 +444,8 @@ class DecoderStage(network.ModuleArgsDict):
         )
         # Concatenate the encoder skip (branch 1); transpose output FIRST, then skip: nnU-Net order.
         self.add_module("Skip", Concat(), in_branch=[0, 1], out_branch=[0])
-        # Conv block: 2 * skip_channels -> skip_channels, then skip_channels -> skip_channels for the rest.
-        # ``kernel_size``/``padding`` pass through as Any so a per-axis (anisotropic) list is accepted.
+        # Conv block: 2 * skip_channels -> skip_channels, then skip_channels -> skip_channels; the
+        # ``kernel_size``/``padding`` pass through as Any so a per-axis list is accepted.
         kernel_value: Any = kernel_size
         padding_value: Any = _same_padding(kernel_size)
         conv_config = BlockConfig(
@@ -501,15 +472,11 @@ class DecoderStage(network.ModuleArgsDict):
 class ResNetStage(network.ModuleArgsDict):
     """One torchvision ResNet encoder stage: a stack of ``n_blocks`` :class:`ResNetBasicBlock` as a single node.
 
-    A generic, reusable building block for the ResNet-18/34 encoders that ``segmentation_models_pytorch``
-    stacks under its U-Net / UNet++ decoders (each is torchvision's ``ResNet`` ``layer1..layer4``). The
-    **first** block carries the stage ``stride`` and the ``in_channels -> out_channels`` change (its ``1x1``
-    projection ``downsample`` skip is built automatically when the stride or the channel count changes) and
-    the remaining ``n_blocks - 1`` blocks are stride 1 at ``out_channels`` with identity skips. The blocks run
-    sequentially on branch ``0``, so the whole stage is a drop-in single node with one input and one output
-    whose weighted leaves fire in the same order as the equivalent flat ``BasicBlock`` stack: it stays
-    transparent to the execution-order weight bridge (``konfai.utils.pretrained``). ``conv_bias`` defaults to
-    ``False`` and the norm to ``BatchNorm``: the torchvision/timm ResNet convention.
+    The **first** block carries the stage ``stride`` and the ``in_channels -> out_channels`` change (its
+    ``1x1`` projection ``downsample`` skip is built when either changes), the remaining ``n_blocks - 1``
+    are stride 1 at ``out_channels`` with identity skips, and they run sequentially on branch ``0``, so
+    the weighted leaves fire in flat ``BasicBlock`` order. ``conv_bias`` defaults to ``False`` and the
+    norm to ``BatchNorm``, the torchvision/timm ResNet convention.
     """
 
     def __init__(
@@ -542,21 +509,15 @@ class ResNetStage(network.ModuleArgsDict):
 class UNetPlusPlusNode(network.ModuleArgsDict):
     """One UNet++ dense-decoder node as a single multi-input node: upsample, dense concat, then Conv-Norm-ReLU.
 
-    A generic, reusable building block for the nested (dense) UNet++ decoder of
-    ``segmentation_models_pytorch`` (``UnetPlusPlusDecoder``). It is a **multi-input** node --
-    ``in_branch: [coarser, skip_0, skip_1, ...]``: that reproduces one grid node ``x_{d}_{l}``:
-
-    * ``Upsample(scale_factor=2, mode='nearest')`` on the shallower-column predecessor (branch ``0``);
-    * a :class:`Concat` of the upsampled feature FIRST, then every same-resolution dense skip and the matching
-      encoder skip (smp order), when any skip is provided;
-    * a :class:`ConvBlock` of ``n_conv`` ``Conv -> BatchNorm -> ReLU`` blocks (smp's ``Conv2dReLU``) mapping the
-      concatenated width ``up_channels + sum(skip_channels)`` to ``out_channels``.
+    A **multi-input** node (``in_branch: [coarser, skip_0, skip_1, ...]``) reproducing one grid node of
+    the nested UNet++ decoder of ``segmentation_models_pytorch``: nearest ``Upsample(scale_factor=2)`` on
+    the shallower-column predecessor, a :class:`Concat` of the upsampled feature FIRST then every dense
+    skip and the encoder skip (smp order), then a :class:`ConvBlock` of ``n_conv`` ``Conv -> BatchNorm ->
+    ReLU`` blocks mapping ``up_channels + sum(skip_channels)`` to ``out_channels``.
 
     ``skip_channels`` is the list of per-skip channel widths in ``in_branch`` order: its length wires the
-    concat (``n_skip + 1`` inputs) and its sum fixes the conv's input width, so the node self-describes the
-    dense fusion. An empty ``skip_channels`` (the final full-resolution ``x_0_depth`` node) drops the concat and
-    convolves the upsampled feature alone. The weighted leaves fire in ``ConvBlock`` order, so the node stays
-    transparent to the execution-order weight bridge (``konfai.utils.pretrained``).
+    concat (``n_skip + 1`` inputs) and its sum fixes the conv's input width. An empty ``skip_channels``
+    drops the concat.
     """
 
     def __init__(
@@ -689,8 +650,7 @@ class Add(torch.nn.Module):
         super().__init__()
 
     def forward(self, *tensor: torch.Tensor) -> torch.Tensor:
-        # Sequential fold: same left-to-right sum as a stacked reduction, without materializing
-        # a contiguous copy of every input, and it exports as ONNX Add nodes.
+        # Sequential fold: the same left-to-right sum without a contiguous copy, exported as ONNX Add nodes.
         output = tensor[0]
         for other in tensor[1:]:
             output = output + other
@@ -708,16 +668,13 @@ class Multiply(torch.nn.Module):
 class ClipNormalize(torch.nn.Module):
     """Clip to a stored intensity range, then standardize: ``(clamp(x, min, max) - mean) / std``.
 
-    The four scalars are buffers restored from the checkpoint, not config values, so a
-    per-checkpoint input normalization (e.g. a CT window baked into a trained model) travels
-    with its weights. It has no learnable parameters. Used as a declarative model's first node
-    so that normalization stays part of the model rather than a separate preprocessing step.
+    The four scalars are buffers restored from the checkpoint, not config values, so a per-checkpoint
+    input normalization travels with its weights. It has no learnable parameters.
     """
 
     def __init__(self) -> None:
         super().__init__()
-        # Default to identity (no clip, zero mean, unit std): a checkpoint fills these, so a model
-        # built before its checkpoint is loaded must pass its input through unchanged.
+        # Default to identity (no clip, zero mean, unit std): a checkpoint fills these in.
         self.clip_min: torch.Tensor
         self.clip_max: torch.Tensor
         self.mean: torch.Tensor
@@ -881,11 +838,8 @@ class Attention(network.ModuleArgsDict):
 class PositionalEmbedding(torch.nn.Module):
     """Add a learnable positional embedding to a token sequence.
 
-    The input is a token sequence shaped ``[B, num_tokens, embedding_dim]`` (batch, sequence, feature),
-    the layout produced by a patch embedding. A single learnable parameter of shape
-    ``[1, num_tokens, embedding_dim]`` is broadcast over the batch and added, giving every token position a
-    trainable offset. This is the ``learnable`` positional encoding of the Vision Transformer; the parameter
-    is registered directly on the module so it is a self-contained, single-purpose building block.
+    The input is a token sequence shaped ``[B, num_tokens, embedding_dim]``. A learnable parameter of
+    shape ``[1, num_tokens, embedding_dim]`` is broadcast over the batch and added.
     """
 
     def __init__(self, num_tokens: int, embedding_dim: int) -> None:
@@ -903,12 +857,11 @@ class PositionalEmbedding(torch.nn.Module):
 class MultiHeadSelfAttention(torch.nn.Module):
     """Multi-head self-attention over a token sequence (the Transformer encoder attention).
 
-    Mirrors the self-attention of MONAI's ``SABlock``/ViT in its default configuration: a single packed
-    ``qkv`` linear projects the ``[B, num_tokens, hidden_size]`` sequence into queries, keys and values,
-    scaled dot-product attention is computed per head with scale ``head_dim ** -0.5``, and an ``out_proj``
-    linear mixes the concatenated heads back to ``hidden_size``. ``qkv_bias`` toggles the bias of the packed
-    projection (the ViT default is ``False``); ``out_proj`` always carries a bias. Both projections are child
-    ``Linear`` leaves, so the module is transparent to execution-order weight transfer.
+    Mirrors MONAI's ``SABlock``/ViT in its default configuration: a packed ``qkv`` linear projects the
+    ``[B, num_tokens, hidden_size]`` sequence into queries, keys and values, scaled dot-product attention
+    runs per head with scale ``head_dim ** -0.5``, and an ``out_proj`` linear mixes the concatenated heads
+    back to ``hidden_size``. ``qkv_bias`` toggles the bias of the packed projection (``False`` by default);
+    ``out_proj`` always carries a bias. Both are child ``Linear`` leaves, transparent to weight transfer.
     """
 
     def __init__(self, hidden_size: int, num_heads: int, qkv_bias: bool = False) -> None:
@@ -926,7 +879,7 @@ class MultiHeadSelfAttention(torch.nn.Module):
         batch, tokens, hidden = tensor.shape
         qkv = self.qkv(tensor).reshape(batch, tokens, 3, self.num_heads, self.head_dim).permute(2, 0, 3, 1, 4)
         query, key, value = qkv[0], qkv[1], qkv[2]
-        # SDPA's default scale is head_dim ** -0.5, the scale this block always used.
+        # SDPA's default scale is head_dim ** -0.5.
         output = torch.nn.functional.scaled_dot_product_attention(query, key, value)
         output = output.permute(0, 2, 1, 3).reshape(batch, tokens, hidden)
         return self.out_proj(output)

--- a/konfai/network/network/network.py
+++ b/konfai/network/network/network.py
@@ -56,13 +56,8 @@ _log = logging.getLogger(__name__)
 
 def _leaf_spatial_stride(module: torch.nn.Module) -> list[int] | None:
     """Per-axis stride of a leaf that shrinks the grid (a ``Conv``, ``MaxPool`` or ``AvgPool``), else
-    ``None``.
-
-    ``ConvTranspose``/``Upsample`` grow the grid, so they read ``None`` and the trace passes their input
-    factor straight through. ``AvgPool`` IS a downsampler (a model may pool on its main path) and is
-    counted: a residual branch's ``AvgPool`` does not inflate the factor because the branch-aware trace
-    merges the parallel main path and shortcut by their per-axis MAX, not their product.
-    """
+    ``None``. ``ConvTranspose``/``Upsample`` grow the grid and read ``None``. ``AvgPool`` IS counted as
+    a downsampler, and the branch-aware trace merges parallel paths by their per-axis MAX."""
     if isinstance(
         module,
         (
@@ -86,14 +81,9 @@ def _leaf_spatial_stride(module: torch.nn.Module) -> list[int] | None:
 
 def _flat_downsampling(module: torch.nn.Module | None, ndim: int) -> list[int]:
     """Product of every strided ``Conv``/``MaxPool`` inside ``module`` (itself included), each
-    trailing-aligned to ``ndim``: a leaf of lower dimensionality acts on the LAST axes, so a 2D conv in
-    a 3D graph leaves the leading axis untouched.
-
-    This is the factor for an OPAQUE child: a plain torch module whose internal graph the branch trace
-    cannot see (a wrapped torchvision/MONAI/smp net added as one ``add_module`` leaf). The flat product
-    over-counts a parallel strided shortcut inside it, but over-padding is safe where under-counting
-    crashes the model's skip reassembly.
-    """
+    trailing-aligned to ``ndim``: a leaf of lower dimensionality acts on the LAST axes. This is the factor
+    for an OPAQUE child, whose internal graph the branch trace cannot see; the flat product over-counts a
+    parallel strided shortcut, and over-padding is safe where under-counting crashes skip reassembly."""
     factor = [1] * ndim
     if module is None:  # an absent child (a NONE norm): named_forward skips it
         return factor
@@ -300,8 +290,7 @@ class ModuleArgsDict(torch.nn.Module, ABC):
 
             elif isinstance(module, torch.nn.modules.batchnorm._BatchNorm):
                 if module.weight is not None:
-                    # Normalisation gamma must centre on 1, not 0 (the pix2pix convention): a gamma
-                    # near 0 scales the normalised activations to ~0 and stalls early training.
+                    # Normalisation gamma must centre on 1, not 0 (the pix2pix convention).
                     torch.nn.init.normal_(module.weight, 1.0, std=init_gain)
                 if module.bias is not None:
                     torch.nn.init.constant_(module.bias, 0.0)
@@ -316,8 +305,7 @@ class ModuleArgsDict(torch.nn.Module, ABC):
     ) -> Iterator[tuple[str, torch.Tensor]]:
         if len(inputs) > 0:
             if self._channels_last:
-                # Once, as the graph is entered: cuDNN hands a channels-last input's output back in
-                # that layout, so converting again at every module only recopies what it kept.
+                # Once, as the graph is entered: cuDNN hands a channels-last input's output back in that layout.
                 inputs = tuple(_channels_last(tensor) for tensor in inputs)
             branchs: dict[str, torch.Tensor] = {}
             attribute_branchs: dict[str, list[Attribute]] = {}
@@ -330,8 +318,7 @@ class ModuleArgsDict(torch.nn.Module, ABC):
             tmp: list[int | str] = []
             for name, module in self.items():
                 # Reset per module: ``tmp`` tracks out_branches a nested sibling already filled via
-                # inner-match. Kept across siblings, a later sibling sharing that out_branch would skip
-                # the fallback below and its output would be silently dropped.
+                # inner-match. Kept across siblings, a later sibling's output would be silently dropped.
                 tmp = []
                 if self._modulesArgs[name].training is None or (
                     not (self._modulesArgs[name].training and self._training == NetState.PREDICTION)
@@ -344,8 +331,7 @@ class ModuleArgsDict(torch.nn.Module, ABC):
                     for ib in self._modulesArgs[name].in_branch:
                         if ib not in branchs:
                             # Numeric branches fall back to the network input (branch '0' = input; extra
-                            # indices are legitimate scratch wiring). A NAMED branch nobody produced is a
-                            # miswired graph: routing the raw input silently would hide it.
+                            # indices are legitimate scratch wiring). A NAMED branch nobody produced is refused.
                             if not ib.lstrip("-").isdigit():
                                 raise ConfigError(
                                     f"Module '{name}' reads branch '{ib}', which no earlier module has produced.",
@@ -413,12 +399,9 @@ class ModuleArgsDict(torch.nn.Module, ABC):
         return cast(torch.Tensor, _v)
 
     def graph_parameters(self, pretrained: bool = False) -> Iterator[tuple[str, torch.nn.parameter.Parameter]]:
-        """The routed graph's trainable parameters, named by dotted module path.
-
-        Unlike ``named_parameters`` (torch semantics, untouched), this walk honours the graph
-        metadata: a module gated off by ``training=False`` is skipped, and ``pretrained=True``
-        keeps only the modules declared ``pretrained=False``.
-        """
+        """The routed graph's trainable parameters, named by dotted module path, honouring the graph
+        metadata where ``named_parameters`` does not: a module gated off by ``training=False`` is
+        skipped, and ``pretrained=True`` keeps only the modules declared ``pretrained=False``."""
         for name, module_args in self._modulesArgs.items():
             module = self[name]
             if isinstance(module, ModuleArgsDict):
@@ -450,15 +433,13 @@ class ModuleArgsDict(torch.nn.Module, ABC):
 
     def _trace_downsampling(self, seeds: list[list[int]], seen: list[list[int]]) -> list[int]:
         """Propagate the per-axis downsampling factor through the branch register, recording each branch
-        value in ``seen``. Parallel branches (a residual shortcut beside the main path) accumulate from
-        the SAME seed and merge at their ``Add`` without multiplying, so a strided projection is not
-        double-counted the way a flat ``modules()`` walk would. A child that is NOT a routed block is
-        opaque and contributes its flat internal product (``_flat_downsampling``).
+        value in ``seen``. Parallel branches accumulate from the SAME seed and merge at their ``Add``
+        without multiplying. A child that is NOT a routed block is opaque and contributes its flat internal
+        product (``_flat_downsampling``).
 
-        ``seeds`` are this block's input factors, one per positional input; the register is seeded from
-        all of them (a decoder block reading ``[upsampled, skip]`` keeps each at its own resolution) and
-        an unwritten branch falls back to the first, exactly as ``named_forward`` seeds it. A module
-        downsamples along its FIRST input branch; the others only route. Returns the last output's factor.
+        ``seeds`` are this block's input factors, one per positional input, and an unwritten branch falls
+        back to the first, as ``named_forward`` seeds it. A module downsamples along its FIRST input
+        branch; the others only route. Returns the last output's factor.
         """
         branches: dict[str, list[int]] = {str(i): seed for i, seed in enumerate(seeds)}
         default = seeds[0]
@@ -477,12 +458,9 @@ class ModuleArgsDict(torch.nn.Module, ABC):
 
 
 class OutputsGroup(list):
-    """Container describing one model output and its source modules.
-
-    Carries the OWNING network, not just its measure: criteria are scheduled on the owner's ``_it``
-    (the counter its backward advances). A composite root never steps its own ``_it``, so scheduling
-    on the root would freeze every start/stop window and loss-weight scheduler at 0.
-    """
+    """Container describing one model output and its source modules. It carries the OWNING network, not
+    just its measure: criteria are scheduled on the owner's ``_it``, the counter its backward advances,
+    which a composite root never steps."""
 
     def __init__(self, network: "Network") -> None:
         self.layers: dict[str, torch.Tensor] = {}
@@ -514,8 +492,7 @@ class Network(ModuleArgsDict, ABC):
         **kwargs,
     ) -> dict[str, object]:
         # The first caller in the recursion is the root graph; thread it (and the dotted key) down so a
-        # nested network can address the whole graph: e.g. a GAN generator whose loss targets a module
-        # of a sibling discriminator branch, which only exists in the root's module namespace.
+        # nested network can address the whole graph (a GAN generator's loss on a discriminator module).
         root = root if root is not None else self
         results: dict[str, object] = {}
         for module in self.values():
@@ -523,8 +500,7 @@ class Network(ModuleArgsDict, ABC):
                 name = name_function(module)
                 known = networks.get(name)
                 if known is module:
-                    # The same object under several module names (a GAN's shared discriminator)
-                    # is visited once.
+                    # The same object under several module names (a GAN's shared discriminator) runs once.
                     continue
                 if known is not None:
                     raise ConfigError(
@@ -599,11 +575,10 @@ class Network(ModuleArgsDict, ABC):
         self.init_type = init_type
         self.init_gain = init_gain
         self.dim = dim
-        #: Opt-in: a checkpoint head whose out-channels mismatch may be re-initialised and
-        #: overlap-copied instead of failing the load (transfer to a different label set).
+        #: Opt-in: a checkpoint head whose out-channels mismatch may be re-initialised and overlap-copied.
         self.allow_head_resize = allow_head_resize
-        #: Set on the root by ModelLoader when ``Model.pretrained_from`` is declared: a fresh
-        #: (checkpoint-less) load seeds the initialised graph from the external reference.
+        #: Set on the root by ModelLoader when ``Model.pretrained_from`` is declared: a checkpoint-less
+        #: load seeds the initialised graph from the external reference.
         self.pretrained_source: PretrainedFrom | None = None
         self._it = 0
         self._nb_lr_update = 0
@@ -644,8 +619,7 @@ class Network(ModuleArgsDict, ABC):
         error_msgs: list[str] = []
 
         metadata = getattr(state_dict, "_metadata", None)
-        # A plain copy: as a KEY the metadata would be collected as an unexpected key by the
-        # strict per-module load; the closure below reads the local variable.
+        # A plain copy: as a KEY the metadata would be collected as an unexpected key by the strict load.
         state_dict = state_dict.copy()
 
         def load(module: torch.nn.Module, prefix=""):
@@ -670,8 +644,7 @@ class Network(ModuleArgsDict, ABC):
                             current_size = child.weight.shape[0]
                             last_size = state_dict[weight_key].shape[0]
 
-                            # Opt-in only: without allow_head_resize the mismatch falls through to the
-                            # strict load below and raises, naming the tensor and both shapes.
+                            # Without allow_head_resize the mismatch falls through to the strict load and raises.
                             if current_size != last_size and self.allow_head_resize:
                                 _log.warning(
                                     "The size of '%s' has changed from %s to %s: re-initialised and "
@@ -683,17 +656,14 @@ class Network(ModuleArgsDict, ABC):
                                 ModuleArgsDict.init_func(child, self.init_type, self.init_gain)
 
                                 bias_key = prefix + name + ".bias"
-                                # Copy the overlap only. Slicing both sides by min(current, last) keeps the
-                                # GROW case (checkpoint smaller -> fill the top rows) working AND fixes the
-                                # SHRINK case (checkpoint larger): `weight[:last_size] = ckpt` would pair the
-                                # smaller current tensor against the larger checkpoint and crash.
+                                # Copy the overlap only: slicing both sides by min(current, last) covers a
+                                # checkpoint that is smaller as well as one that is larger.
                                 overlap = min(current_size, last_size)
                                 with torch.no_grad():
                                     child.weight[:overlap] = state_dict[weight_key][:overlap]
                                     if child.bias is not None and bias_key in state_dict:
                                         child.bias[:overlap] = state_dict[bias_key][:overlap]
-                                # Skip the normal load for this resized leaf, but keep
-                                # loading its siblings.
+                                # Skip the normal load for this resized leaf, but keep loading its siblings.
                                 continue
                         load(child, prefix + name + ".")
 
@@ -722,9 +692,8 @@ class Network(ModuleArgsDict, ABC):
         """
         Apply ``fn`` to each non-``Network`` child module and finally to ``self``.
 
-        Nested ``Network`` instances are skipped: each owns its own state (init, load), so a
-        fan-out over the graph applies ``fn`` per network, never twice through a parent.
-        ``torch.nn.Module.apply`` keeps its native signature and full recursion.
+        Nested ``Network`` instances are skipped: each owns its own state, so a fan-out over the graph
+        applies ``fn`` per network, never twice through a parent.
         """
         for module in self.children():
             if not isinstance(module, Network):
@@ -741,8 +710,7 @@ class Network(ModuleArgsDict, ABC):
         key: str | None = None,
     ):
         # `checkpoint_save` writes the optimizer/iteration/LR-schedule state under the network's DOTTED path
-        # (its get_networks() key, e.g. "Gan.Generator"). `_apply_network` injects that same dotted path as
-        # `key` here, so a nested network resumes its own state instead of silently missing the bare-name key.
+        # (its get_networks() key, e.g. "Gan.Generator"), which `_apply_network` injects as `key` here.
         state_key = key if key is not None else self.get_name()
         if init:
             self.graph_apply(
@@ -765,9 +733,8 @@ class Network(ModuleArgsDict, ABC):
             model_state_dict: OrderedDict[str, torch.Tensor] = OrderedDict()
 
             def remap(path: str) -> str:
-                # Segment-aligned: alias 'layer1' must not claim a module 'layer10', and only the
-                # leading prefix is rewritten, never a later occurrence of the same substring. Of
-                # the matches the longest wins: a nested alias 'p.a1' beats its parent 'p'.
+                # Segment-aligned: alias 'layer1' must not claim a module 'layer10', and only the leading
+                # prefix is rewritten. Of the matches the longest wins: a nested alias 'p.a1' beats 'p'.
                 candidates = [(a, b) for a, b in modules_name.items() if path == a or path.startswith(a + ".")]
                 if not candidates:
                     return path
@@ -779,16 +746,14 @@ class Network(ModuleArgsDict, ABC):
                 model_state_dict[remap(prefix) + alias[len(prefix) :]] = model_state_dict_tmp[alias]
             source_metadata = getattr(model_state_dict_tmp, "_metadata", None)
             if source_metadata is not None:
-                # Keys are module paths: remapped like the tensors so version-aware modules
-                # (_load_from_state_dict) find their entry.
+                # Keys are module paths: remapped like the tensors so version-aware modules find their entry.
                 model_state_dict._metadata = OrderedDict(  # type: ignore[attr-defined]
                     (remap(path), meta) for path, meta in source_metadata.items()
                 )
             self.load_state_dict(model_state_dict)
         elif self.pretrained_source is not None and not ema:
-            # A fresh TRAIN carries no checkpoint entry: the declared reference seeds the graph the
-            # init above just randomised. The EMA copy is deepcopied from the seeded model and must
-            # not pay the transfer again; a checkpoint's own weights take the branch above instead.
+            # A fresh TRAIN carries no checkpoint entry: the declared reference seeds the graph the init
+            # above randomised.
             self.pretrained_source.seed(self)
         if f"{state_key}_optimizer_state_dict" in state_dict and self.optimizer:
             self.optimizer.load_state_dict(state_dict[f"{state_key}_optimizer_state_dict"])
@@ -807,8 +772,7 @@ class Network(ModuleArgsDict, ABC):
         else:
             for scheduler in self.schedulers:
                 if scheduler not in restored:
-                    # A checkpoint from before the schedulers' own state was saved: the counter
-                    # places a step schedule, not a plateau's history or a cooldown.
+                    # No scheduler state: the counter places a step schedule, not a plateau's history.
                     scheduler.last_epoch = self._nb_lr_update
         self.initialized()
 
@@ -822,12 +786,9 @@ class Network(ModuleArgsDict, ABC):
             yield name if occurrence == 1 else f"{name}#{occurrence}", scheduler
 
     def schedule_states(self) -> dict[str, Any]:
-        """This network's scheduler/scaler state, with a distinct identity for each occurrence.
-
-        Version 1 keyed every scheduler by class alone, losing all but the last of a repeated
-        class. Single-class legacy entries remain readable; ambiguous repeated ones cannot be
-        restored exactly and fall back to the update count with a warning.
-        """
+        """This network's scheduler/scaler state, with a distinct identity for each occurrence. Version 1
+        keyed every scheduler by class alone: its single-class entries remain readable, ambiguous repeated
+        ones fall back to the update count with a warning."""
         states: dict[str, Any] = {
             "version": 2,
             "schedulers": {name: scheduler.state_dict() for name, scheduler in self._named_schedulers()},
@@ -944,15 +905,12 @@ class Network(ModuleArgsDict, ABC):
         downsamples.
 
         An encoder/decoder graph (U-Net) only reassembles its skip connections when the input divides
-        evenly at every level, so the input must be a multiple of the coarsest downsampling the graph
-        reaches. That factor is traced through the branch register: a strided ``Conv`` or a ``MaxPool``
-        multiplies the branch it writes, while ``ConvTranspose``/``Upsample`` and a residual branch's
-        ``AvgPool`` pass through. Because the trace follows branches, a residual block's strided shortcut
-        (parallel to its strided main conv, merged by ``Add``) counts ONCE, not twice. Used to size a
-        free (``0``) patch axis to a valid extent (padded up, cropped back after the forward).
+        evenly at every level. The factor is traced through the branch register: a strided ``Conv`` or
+        ``MaxPool`` multiplies the branch it writes, ``ConvTranspose``/``Upsample`` and a residual
+        branch's ``AvgPool`` pass through, and a residual block's strided shortcut counts ONCE. Used to
+        size a free (``0``) patch axis to a valid extent (padded up, cropped back after the forward).
         """
-        # The graph's spatial rank = the WIDEST strided leaf (a 2D side head in a 3D net must not lock
-        # the rank to 2); every leaf stride then aligns to the trailing axes of that rank.
+        # The graph's spatial rank = the WIDEST strided leaf; strides align to that rank's trailing axes.
         ndim = max((len(s) for s in map(_leaf_spatial_stride, self.modules()) if s is not None), default=0)
         if ndim == 0:
             return None
@@ -966,8 +924,7 @@ class Network(ModuleArgsDict, ABC):
         if self.outputs_criterions_loader:
             self.measure = Measure(key, self.outputs_criterions_loader)
             # Validate the criterion targets against the ROOT graph, where runtime matching also happens:
-            # a nested network's loss may address a module in a sibling branch (a GAN generator's
-            # adversarial loss on the discriminator) that exists only in the root's module namespace.
+            # a nested network's loss may address a module that exists only in the root's namespace.
             self.measure.init(root, group_dest)
         if self.patch is not None:
             self.patch.init(f"{konfai_root()}.Model.{key}.Patch")
@@ -1023,8 +980,7 @@ class Network(ModuleArgsDict, ABC):
                         )
                     accumulators[buffer[0][0]].add_layer(i, buffer[0][1])
                 # The leftover entry must not leak into the next patch iteration: the name-transition
-                # branch above would re-add patch i's end-module output at index i+1, and Accumulator
-                # blends incrementally, so a spurious first add cannot be overwritten later.
+                # branch above would re-add patch i's end-module output at index i+1.
                 buffer.clear()
             for name, accumulator in accumulators.items():
                 yield name, accumulator.assemble()
@@ -1119,8 +1075,7 @@ class Network(ModuleArgsDict, ABC):
         checkpoints are placed on."""
         self.init(autocast, state, group_dest)
         if state != State.PREDICTION and all(network.optimizer is None for network in self.get_networks().values()):
-            # A YAML-catalog model with `optimizer: None` once trained an epoch with the backward
-            # skipped, a loss that never moved and a checkpoint written: the refusal names the key.
+            # A graph with no optimizer would run an epoch with the backward skipped: name the key.
             root = os.environ.get("KONFAI_ROOT", "Trainer")
             raise ConfigError(
                 f"No optimizer resolved for '{self.get_name()}': nothing would train.",
@@ -1230,18 +1185,15 @@ class Network(ModuleArgsDict, ABC):
             self.measure.release_targets()
 
     def steps_this_batch(self) -> bool:
-        """Whether this network's optimizer steps on the batch about to be run (its accumulation
-        window closes), read before ``forward`` so the DDP synchronisation can be decided for the
-        whole step."""
+        """Whether this network's optimizer steps on the batch about to be run, read before ``forward``
+        so the DDP synchronisation can be decided for the whole step."""
         return (self._it + 1) % self.nb_batch_per_step == 0
 
     def accumulation_sync(self, model: Any) -> AbstractContextManager[Any]:
-        """The DDP context the coming forward AND backward run under: ``no_sync`` when no network of
-        the graph steps on this batch (its gradients accumulate locally), the ordinary reduction
-        otherwise. DDP marks the gradients to reduce during ``forward``, so a ``no_sync`` entered
-        around the backward alone reduced every micro-batch, which is what accumulation exists
-        to avoid. A graph whose networks step at different cadences reduces whenever one of them
-        does: the others' accumulated gradients travel early, which changes nothing they compute."""
+        """The DDP context the coming forward AND backward run under: ``no_sync`` when no network of the
+        graph steps on this batch, the ordinary reduction otherwise. DDP marks the gradients to reduce
+        during ``forward``, so the context must wrap the forward too. A graph whose networks step at
+        different cadences reduces whenever one of them does."""
         trained = [network for network in self.get_networks().values() if network.optimizer is not None]
         if not trained or any(network.steps_this_batch() for network in trained):
             return nullcontext()
@@ -1249,12 +1201,9 @@ class Network(ModuleArgsDict, ABC):
         return no_sync() if callable(no_sync) else nullcontext()
 
     def backward(self, model: Any) -> dict[str, Any]:
-        """Backpropagate the graph, then step any optimizers waiting for DDP reductions.
-
-        A DDP bucket can span several nested networks. Stepping the first network before the
-        last one's backward completes uses local gradients and can clear the bucket's inputs.
-        Only distributed execution defers the steps; the ordinary per-network order is kept.
-        """
+        """Backpropagate the graph, then step any optimizers waiting for DDP reductions. A DDP bucket can
+        span several nested networks, so stepping the first before the last one's backward completes uses
+        local gradients. Only distributed execution defers the steps."""
         pending: list[Network] | None = [] if isinstance(model, torch.nn.parallel.DistributedDataParallel) else None
         result = self._backward(pending)
         if pending is not None:
@@ -1304,8 +1253,7 @@ class Network(ModuleArgsDict, ABC):
 
     def _rebase_lr_local(self, new_lr: float) -> None:
         """Set this one network's optimizer LR to ``new_lr`` and rebase its schedulers onto it (base_lrs /
-        initial_lr / _last_lr) with last_epoch reset, so the next scheduler step keeps the new value instead
-        of re-decaying from the old anchor. Plain (no fan-out): the callers own the recursion."""
+        initial_lr / _last_lr) with last_epoch reset. Plain (no fan-out): the callers own the recursion."""
         if self.optimizer is not None:
             for param_group in self.optimizer.param_groups:
                 param_group["lr"] = new_lr
@@ -1322,8 +1270,8 @@ class Network(ModuleArgsDict, ABC):
 
     @_function_network()
     def rebase_lr(self, new_lr: float) -> None:
-        """Rebase the learning rate of this network and every nested one onto ``new_lr``: the same restart a
-        RESUME with ``--lr`` applies, reused for a live mid-run change so the value sticks past the scheduler."""
+        """Rebase the learning rate of this network and every nested one onto ``new_lr``, the same restart
+        a RESUME with ``--lr`` applies."""
         self._rebase_lr_local(new_lr)
 
     @_function_network()
@@ -1332,13 +1280,8 @@ class Network(ModuleArgsDict, ABC):
 
     @staticmethod
     def set_channels_last(module: ModuleArgsDict) -> ModuleArgsDict:
-        """Lay the graph's convolution weights out channels-last, and its inputs as they enter.
-
-        cuDNN picks its kernels by layout: under autocast the shipped Segmentation example predicts
-        in 2.2 s against 2.7 s in the default layout (fp32: 4.1 against 4.2 s, where the kernels
-        chosen differ on 3199 of 58.4 million label voxels). Off by default, so the default layout
-        is what a run gets unless it asks.
-        """
+        """Lay the graph's convolution weights out channels-last, and its inputs as they enter. cuDNN
+        picks its kernels by layout, and the kernels it picks differ numerically. Off by default."""
         for tensor in (*module.parameters(), *module.buffers()):
             tensor.data = _channels_last(tensor.data)  # a 4-D and a 5-D weight each take their own layout
         for submodule in module.modules():
@@ -1348,10 +1291,8 @@ class Network(ModuleArgsDict, ABC):
 
     @staticmethod
     def to(module: ModuleArgsDict, device: int, _counter: list[int] | None = None):  # type: ignore[override]  # a placement over the routed graph, not Module.to
-        # `_counter` is a single-element box holding the next GPU index, shared by
-        # reference through the recursion so model-parallel `isGPU_Checkpoint` splits
-        # advance it. Each top-level call starts fresh at `device` so the counter never
-        # leaks across independent placements.
+        # `_counter` is a single-element box holding the next GPU index, shared by reference through the
+        # recursion so model-parallel `isGPU_Checkpoint` splits advance it, fresh at `device` per call.
         if _counter is None:
             _counter = [device]
         for k, v in module.items():
@@ -1387,11 +1328,9 @@ class Network(ModuleArgsDict, ABC):
 class MinimalModel(Network):
     """Small wrapper exposing a single network as a full KonfAI model graph.
 
-    The wrapped model arrives fully constructed: possibly carrying pretrained weights (a
-    torchvision/MONAI/SMP class with ``weights=...``). ``load`` therefore never re-initialises:
-    ``load(init=True)`` at training start applies ``init_func`` over every descendant and would
-    silently destroy those weights with ``init_type`` noise. Models built from scratch keep
-    KonfAI's init behaviour; checkpoint loading is unaffected.
+    The wrapped model arrives fully constructed, possibly carrying pretrained weights, so ``load`` never
+    re-initialises: ``init_func`` over every descendant would destroy them. Checkpoint loading is
+    unaffected.
     """
 
     def load(

--- a/konfai/network/network/network.py
+++ b/konfai/network/network/network.py
@@ -906,8 +906,9 @@ class Network(ModuleArgsDict, ABC):
 
         An encoder/decoder graph (U-Net) only reassembles its skip connections when the input divides
         evenly at every level. The factor is traced through the branch register: a strided ``Conv`` or
-        ``MaxPool`` multiplies the branch it writes, ``ConvTranspose``/``Upsample`` and a residual
-        branch's ``AvgPool`` pass through, and a residual block's strided shortcut counts ONCE. Used to
+        ``MaxPool`` or ``AvgPool`` multiplies the branch it writes, ``ConvTranspose``/``Upsample`` pass
+        through, and a residual block's strided shortcut counts ONCE: parallel paths merge by their
+        per-axis maximum, so a shortcut's ``AvgPool`` beside a strided main path adds nothing. Used to
         size a free (``0``) patch axis to a valid extent (padded up, cropped back after the forward).
         """
         # The graph's spatial rank = the WIDEST strided leaf; strides align to that rank's trailing axes.

--- a/konfai/predictor/ensemble.py
+++ b/konfai/predictor/ensemble.py
@@ -328,7 +328,8 @@ class ModelComposite(Network):
             output_layers (list): List of output layer names to extract from each sub-model.
 
         Returns:
-            list[tuple[str, torch.Tensor]]: Aggregated output per layer, after the reduction.
+            list[tuple[str, list[int], torch.Tensor]]: per layer, its key, the channel counts of
+            the models that produced it, and the aggregated tensor.
         """
         final_outputs: list[tuple[str, list[int], torch.Tensor]] = []
         if not self._loaded:

--- a/konfai/predictor/ensemble.py
+++ b/konfai/predictor/ensemble.py
@@ -37,11 +37,8 @@ from konfai.utils.runtime import (
 def _colocate_loaded_modules(model: torch.nn.Module) -> None:
     """Move any still-CPU leaf module onto the model's device.
 
-    A custom :meth:`Network.load` may append modules after the model was already placed on its
-    device (e.g. a head sized from the checkpoint's class count), and those default to CPU, which
-    then raises a device mismatch on the forward pass. This re-homes any fully-CPU leaf onto the
-    device the rest of the model already lives on. Modules already on a device (including
-    model-parallel splits across several GPUs) are left untouched.
+    A custom :meth:`Network.load` may append modules after the model was placed, and those default to
+    CPU. Modules already on a device, model-parallel splits included, are left untouched.
     """
     target = next((p.device for p in model.parameters() if p.device.type != "cpu"), None)
     if target is None:
@@ -55,10 +52,8 @@ def _colocate_loaded_modules(model: torch.nn.Module) -> None:
 def _require_weights_entry(model: Network, state: dict[str, Any], source: dict[str, Any] | Path | str) -> None:
     """Refuse a checkpoint the stock loader would take no weights from.
 
-    ``Network.load`` reads weights from the ``Model`` entry a KonfAI checkpoint carries and is
-    silent without one: a raw ``nn.Module.state_dict()`` or a ``{"state_dict": ...}`` wrapper
-    then predicts with the constructor's weights and the run reports success. A model whose class
-    overrides ``load`` owns its format, and a weightless model has nothing to load.
+    ``Network.load`` reads weights from a KonfAI checkpoint's ``Model`` entry and is silent without
+    one. A model whose class overrides ``load`` owns its format, and a weightless model loads nothing.
     """
     from konfai.network.network.network import MinimalModel
 
@@ -77,10 +72,9 @@ def _require_weights_entry(model: Network, state: dict[str, Any], source: dict[s
 
 
 def _inference_entries(model: Network, state: dict[str, Any]) -> dict[str, Any]:
-    """What the host cache keeps of a checkpoint: the weights inference reads. A training
-    checkpoint carries the optimizer state beside them, as large again per member for Adam, and
-    an ensemble held every member's whole file. A model whose class owns its ``load`` keeps the
-    file whole: its format is its own."""
+    """What the host cache keeps of a checkpoint: the weights inference reads, dropping the optimizer
+    state a training checkpoint carries beside them. A model whose class owns its ``load`` keeps the
+    file whole."""
     from konfai.network.network.network import MinimalModel
 
     if getattr(type(model), "load", None) not in (Network.load, MinimalModel.load):
@@ -90,13 +84,9 @@ def _inference_entries(model: Network, state: dict[str, Any]) -> dict[str, Any]:
 
 
 def _checkpoint_bytes(value: Any) -> int | None:
-    """Conservative retained size, counting shared tensor storage once within an entry.
-
-    A tiny view can hold a large allocation alive: ``numel * element_size`` is not its cost.
-    Include Python containers/metadata too. Unknown custom objects have no reliable size contract;
-    they remain loadable from files but bypass the cache. Bookkeeping and the active model are
-    outside this payload budget. Separate entries may overcount shared allocations, never undercount.
-    """
+    """Conservative retained size, counting shared tensor storage once within an entry and Python
+    containers too. Unknown custom objects answer ``None`` and bypass the cache. Separate entries may
+    overcount shared allocations, never undercount."""
     seen: set[int] = set()
     storages: set[tuple[str, int, int]] = set()
 
@@ -104,8 +94,7 @@ def _checkpoint_bytes(value: Any) -> int | None:
         if id(item) in seen:
             return 0
         seen.add(id(item))
-        # A container/scalar subclass can hide arbitrary allocations in attributes or C slots.
-        # Only the known representations below have a complete accounting contract.
+        # Only the exact types below have a complete accounting contract; a subclass can hide allocations.
         if type(item) not in (
             dict,
             OrderedDict,
@@ -162,13 +151,9 @@ class ModelComposite(Network):
 
     Args:
         model (Network): The base network to replicate.
-        combine (konfai.data.reduction.Reduction): The reduction method used to combine outputs from
-            all model replicas.
+        combine (konfai.data.reduction.Reduction): The reduction combining the replicas' outputs.
         checkpoint_cache_gib (float): Per-process retained checkpoint budget. Reloadable members
             that do not fit bypass the cache. Dictionary sources must fit in this budget.
-
-    Attributes:
-        combine (konfai.data.reduction.Reduction): The reduction used during forward inference.
     """
 
     def __init__(self, model: Network, combine: Reduction, checkpoint_cache_gib: float = 1.0):
@@ -234,9 +219,8 @@ class ModelComposite(Network):
         size = _checkpoint_bytes(state)
         if size is None or size > self._cache_limit_bytes:
             return
-        # A cyclic ensemble larger than an ordinary LRU cache gets ZERO hits. New members only
-        # take free room, keeping the resident subset hot across batches. If a cached file changes
-        # size, allow its replacement to evict the least recently used reloadable entries instead.
+        # New members only take free room, keeping the resident subset hot across a cyclic ensemble.
+        # A cached file that changed size may evict the least recently used reloadable entries.
         if replace:
             for victim in list(self._state_cache):
                 if self._state_cache_bytes + size <= self._cache_limit_bytes:
@@ -266,8 +250,7 @@ class ModelComposite(Network):
                 state = self._read_state_source(source)
                 if self._source_stamp(source) != stamp:
                     raise PredictorError(f"Checkpoint '{source}' changed while being read; retry prediction.")
-                # Checkpoints are keyed by the base model name, not by the streamed
-                # ensemble suffix added after the previous load.
+                # Checkpoints are keyed by the base model name, not by the streamed ensemble suffix.
                 model.set_name(self._base_model_name)
                 _require_weights_entry(model, state, source)
                 state = _inference_entries(model, state)
@@ -275,17 +258,14 @@ class ModelComposite(Network):
             self._state_stamps[index] = stamp
             model.set_name(self._base_model_name)
             model.load(state, init=False)
-            # A custom load() may append checkpoint-sized modules (e.g. the head) on CPU; co-locate
-            # them with the already device-placed model so the forward pass doesn't hit a mismatch.
+            # A custom load() may append modules on CPU: co-locate them with the placed model.
             _colocate_loaded_modules(model)
             model.set_name(f"{self._base_model_name}_{index}")
             self._loaded_state_index = index
         return model
 
     def _model_for_index(self, index: int) -> Network:
-        # With no checkpoint sources the model is weightless (0 parameters, e.g. a classical/optimisation
-        # engine): run it as constructed, once. The Predictor guards this, it only reaches here with empty
-        # sources when the model has no parameters to load, so there is nothing to stream.
+        # No checkpoint source means a weightless model (0 parameters): run it as constructed, once.
         if not self._state_sources:
             return self._get_model()
         return self._ensure_model_loaded(index)
@@ -295,9 +275,9 @@ class ModelComposite(Network):
         Load weights for each sub-model in the composite from the corresponding state dictionaries.
 
         Args:
-            state_sources (list): One checkpoint source per model replica. Empty ONLY for a weightless model
-                (0 parameters), which is then run once with its constructed weights; empty sources for a model
-                that has trainable parameters is refused here, so a caller cannot silently run random weights.
+            state_sources (list): One checkpoint source per model replica. Empty ONLY for a weightless
+                model (0 parameters), run once with its constructed weights; empty sources for a model
+                with trainable parameters are refused here.
         """
         if not state_sources and any(parameter.numel() for parameter in self._get_model().parameters()):
             raise PredictorError(
@@ -305,8 +285,7 @@ class ModelComposite(Network):
                 "A weightless model (0 parameters) may run with no checkpoint; a parameterised one may not.",
                 "Pass at least one checkpoint source, or wrap a model that has no parameters.",
             )
-        # A dictionary cannot be reloaded after eviction. Charge these resident inputs against the
-        # same ceiling and, for the stock loader, never retain the caller's optimizer via sources.
+        # A dictionary cannot be reloaded after eviction: charge it against the same ceiling.
         sources: list[dict[str, Any] | Path | str] = []
         resident_bytes = 0
         model = self._get_model()
@@ -349,7 +328,7 @@ class ModelComposite(Network):
             output_layers (list): List of output layer names to extract from each sub-model.
 
         Returns:
-            list[tuple[str, torch.Tensor]]: Aggregated output for each layer, after applying the reduction.
+            list[tuple[str, torch.Tensor]]: Aggregated output per layer, after the reduction.
         """
         final_outputs: list[tuple[str, list[int], torch.Tensor]] = []
         if not self._loaded:
@@ -376,8 +355,7 @@ class ModelComposite(Network):
                     count[key] += 1
             for key, acc in sum_acc.items():
                 # The sum was folded in place into the first model's output; a lone model's is the
-                # answer as it stands. Dividing by one copied the batch output (56 MiB per
-                # [1, 14, 128^3] fp16 patch, 512 MiB at 122 channels), on every single-model run.
+                # answer as it stands, and dividing it by one would copy the batch output.
                 final_outputs.append((key, channels[key], acc if count[key] == 1 else acc.div_(count[key])))
         else:
             aggregated = defaultdict(list)

--- a/konfai/predictor/loop.py
+++ b/konfai/predictor/loop.py
@@ -43,27 +43,15 @@ from konfai.utils.runtime import (
     description,
 )
 
-#: Batches between two refreshes of the progress bar's status. The status is an NVML query, two
-#: psutil calls and a forced redraw (95 us per batch, measured) that no batch needs to be current.
+#: Batches between two refreshes of the progress bar's status, an NVML query plus two psutil calls.
 _DESCRIPTION_EVERY = 10
 
 
 def _prediction_report(clock: SweepClock, min_seconds: float = 1.0) -> str | None:
-    """One line accounting for the prediction loop's wall clock, in the sweep report's shape, or
-    ``None`` below ``min_seconds``.
+    """One line accounting for the prediction loop's wall clock, or ``None`` below ``min_seconds``.
 
-    The sum before the bar is the loop's own thread and closes exactly: what its phases do not
-    name (the logging, the progress bar, the bookkeeping between them) is ``other``. ``fetch`` is
-    the wait for the loader's next batch, ``blend`` a patch's inverses and its blend into the
-    accumulator (the copy home included on the host route), the two ``finalize`` the slabs and the
-    cases handed to the writer, ``drain`` the writes still queued when the loop ends. On a GPU the
-    loop only enqueues the forward and the blend; the device's time is waited for where a result
-    crosses to the host.
-
-    After the bar is the writer: its own thread's time, and how long the loop stood waiting on it
-    inside the finalize phases (a full queue, or the write itself when the destination keeps it
-    inline). A slow destination shows there, as the wait that turns the background writer
-    synchronous, which nothing reported before.
+    The phases before the bar sum to the loop's own thread, ``other`` covering what they do not name;
+    after it come the writer's own time and the loop's wait on it inside the finalize phases.
     """
     wall = clock.spent("prediction")
     if wall < min_seconds:
@@ -79,11 +67,7 @@ def _prediction_report(clock: SweepClock, min_seconds: float = 1.0) -> str | Non
 
 class _Predictor:
     """
-    Internal class that runs distributed inference over a dataset using a composite model.
-
-    This class handles patch-wise prediction, output accumulation, logging to TensorBoard, and
-    writing final predictions to disk. It is designed to be used as a context manager and
-    supports model ensembles via `ModelComposite`.
+    Run distributed patch-wise inference over a dataset with a composite model, as a context manager.
 
     Args:
         world_size (int): Total number of processes or GPUs used.
@@ -143,8 +127,7 @@ class _Predictor:
         self.tb: SummaryWriter | NullSummaryWriter | None
         if self._has_runtime_measures or len(self.data_log):
             if SummaryWriter is None:
-                # A missing logger must never refuse the run: the predictions are still written,
-                # only the curves and images are lost. One line says so; the extra keeps them.
+                # A missing logger never refuses the run: the predictions are written, the curves are lost.
                 if self.global_rank == 0:
                     print(
                         "[KonfAI] TensorBoard is not installed: no curves or images will be logged"
@@ -157,27 +140,16 @@ class _Predictor:
             self.tb = None
 
     def __enter__(self):
-        """
-        Enters the prediction context and returns the predictor instance.
-        """
+        """Enter the prediction context."""
         return self
 
     def __exit__(self, exc_type, value, traceback):
-        """
-        Closes the TensorBoard writer upon exit.
-        """
+        """Close the TensorBoard writer."""
         if self.tb:
             self.tb.close()
 
     def run(self):
-        """
-        Run the full prediction loop.
-
-        Iterates over the prediction DataLoader, performs inference using the composite model,
-        applies reduction (e.g., mean), and writes the final results using each `OutputDataset`.
-
-        Also logs intermediate data and metrics to TensorBoard if enabled.
-        """
+        """Run the full prediction loop: forward every batch, reduce, and write each ``OutputDataset``."""
 
         self.model_composite.eval()
         self.model_composite.module.set_state(NetState.PREDICTION)
@@ -187,8 +159,7 @@ class _Predictor:
             with PREDICTION_CLOCK.phase("prediction"):
                 self._run_batches()
         finally:
-            # Every submitted write must be on disk before the run returns: including on the error
-            # path, where the drain also closes the sinks the abort operations enqueued.
+            # Every submitted write must be on disk before the run returns, the error path included.
             with PREDICTION_CLOCK.phase("prediction"), PREDICTION_CLOCK.phase("drain"):
                 for output_dataset in self.outputs_dataset.values():
                     output_dataset.finalize_writes()
@@ -248,7 +219,6 @@ class _Predictor:
                                         )
 
                         if batch_index % _DESCRIPTION_EVERY == 0:
-                            # The bar redraws on its own clock; the status only has to be there by then.
                             batch_iter.set_description(
                                 f"Prediction : {description(self.model_composite)}", refresh=False
                             )
@@ -258,29 +228,13 @@ class _Predictor:
         self,
         batch_sample: BatchSample,
     ):
-        """
-        Log prediction results to TensorBoard, including images and metrics.
+        """Log images from ``data_log`` and the networks' losses and metrics under ``Prediction/``.
 
-        This method handles:
-        - Logging image-like data (e.g., inputs, outputs, masks) using `DataLog` instances,
-        based on the `data_log` configuration.
-        - Logging scalar loss and metric values (if present in the network) under the `Prediction/` namespace.
-        - Dynamically retrieving additional feature maps or intermediate layers if requested via `data_log`.
-
-        Logging is performed only on the global rank 0 process and only if `TensorBoard` is active.
-
-        Args:
-            data_dict (dict): Dictionary mapping group names to 6-tuples containing:
-                - input tensor,
-                - index,
-                - patch_augmentation,
-                - patch_index,
-                - metadata (list of strings),
-                - `requires_grad` flag (as a tensor).
+        Runs on global rank 0 only, and only while TensorBoard is active.
         """
         if self.tb is None or self.global_rank != 0:
-            # Prediction logging is a rank-0 progress indicator; gate before touching the measures so a
-            # non-zero rank never enters a cross-rank collective the unequal shards would deadlock on.
+            # Gate before touching the measures: a non-zero rank must never enter a cross-rank
+            # collective the unequal shards would deadlock on.
             return
 
         measures: dict[str, tuple[dict[str, tuple[float, float, float]], dict[str, tuple[float, float, float]]]] = {}
@@ -307,8 +261,7 @@ class _Predictor:
                     self.it,
                 )
 
-        # Images are a progress peek, not a per-batch record, and a module-layer target re-runs a
-        # full forward (get_layers): both throttle to the status cadence.
+        # Images and a module-layer target (get_layers re-runs a forward) throttle to the status cadence.
         if not len(self.data_log) or self.it % _DESCRIPTION_EVERY != 0:
             return
         images_log = []
@@ -323,9 +276,7 @@ class _Predictor:
             else:
                 images_log.append(name.replace(":", "."))
         if len(images_log):
-            # get_layers is model-scoped, not per-network: run it once per model, or a multi-network
-            # model (a GAN's generator + discriminator) repeats the forward extraction and writes
-            # each image event once per network.
+            # get_layers is model-scoped: run it once per model, not once per network.
             for layer_name, layer, _ in self.model_composite.module.get_layers(
                 [v.tensor for v in batch_sample.values() if v.is_input],
                 images_log,

--- a/konfai/predictor/output.py
+++ b/konfai/predictor/output.py
@@ -64,19 +64,15 @@ from konfai.utils.runtime import (
 )
 from konfai.utils.utils import env_flag, get_module, split_path_spec
 
-#: This rank's prediction loop, phase by phase, summed over the cases it ran: the unit the line
-#: at the end of a run accounts for (see ``_prediction_report``).
+#: This rank's prediction loop, phase by phase, summed over the cases it ran (see ``_prediction_report``).
 PREDICTION_CLOCK = SweepClock()
 
 
 class _AsyncWriter:
     """A background thread owning one output dataset's disk writes, in submission order.
 
-    The prediction loop otherwise waits on every device-to-host copy and destination write between
-    two forwards; submitting them here overlaps that tail with the next batch. The queue is bounded,
-    so a slow destination back-pressures the loop instead of buffering the run; the first failure is
-    kept, later operations drain unexecuted, and the failure re-raises at the next submission and at
-    ``close``: a run never ends with a write silently missing.
+    The queue is bounded, so a slow destination back-pressures the loop. The first failure is kept and
+    re-raised at the next submission and at ``close``; later operations drain unexecuted.
     """
 
     _CAPACITY = 4
@@ -153,23 +149,20 @@ class _FinalizeStage:
 @dataclass(frozen=True)
 class _StreamPlan:
     """How one case streams: the post-reduction stages, split into a per-slab pointwise prefix, a
-    streamed pipe of region and pointwise stages, and (past what streaming can honour) a
-    whole-volume tail.
+    streamed pipe of region and pointwise stages, and a whole-volume tail.
 
-    ``to_sink`` streams straight into a region-write ``DataStream``; ``pipe_start`` is the first
-    region stage (``None`` when the chain is pointwise throughout), and the pipe runs from there to
-    the end: region stages compose, so their number is not limited. Without ``to_sink`` the prefix
-    streams into a post-reduction buffer and ``stages[tail_start:]`` runs once on it (the chain
-    split). The invariants: ``to_sink`` implies no tail, and a pipe implies ``to_sink``: a tail
-    swallows the region stages, so the buffer always sits on the accumulator grid.
+    ``to_sink`` streams straight into a region-write ``DataStream``; ``pipe_start`` is the first region
+    stage (``None`` when the chain is pointwise throughout) and the pipe runs from there to the end.
+    Without ``to_sink`` the prefix streams into a post-reduction buffer and ``stages[tail_start:]``
+    runs once on it. Invariants: ``to_sink`` implies no tail, a pipe implies ``to_sink``, and the
+    buffer sits on the accumulator grid.
     """
 
     stages: list[_FinalizeStage]
     pipe_start: int | None
     tail_start: int
     to_sink: bool
-    # Prefix stages whose declaration is SLAB: per-voxel value maps with a per-region side effect,
-    # run through ``Transform.stream_slab`` so they learn where each slab sits.
+    # Prefix stages declared SLAB: run through ``Transform.stream_slab`` so they learn where each slab sits.
     slab_stages: frozenset[int] = frozenset()
 
     @property
@@ -188,10 +181,8 @@ class _StreamPlan:
 class _RegionState:
     """One case's live streamed pipe: its slab scheduler and the geometry its closures share.
 
-    ``shapes[i]`` is the spatial shape between pipe stage ``i - 1`` and ``i`` (``shapes[0]`` the
-    accumulator's, ``shapes[-1]`` the written image's); a pointwise stage leaves it unchanged, so the
-    per-stage region bookkeeping folds through the same list the pull map composes over. The pipe's
-    stages themselves live in the ``produce``/``pull`` closures the stream was built on.
+    ``shapes[i]`` is the spatial shape between pipe stage ``i - 1`` and ``i``: ``shapes[0]`` the
+    accumulator's, ``shapes[-1]`` the written image's.
     """
 
     shapes: list[list[int]]
@@ -200,11 +191,8 @@ class _RegionState:
     attribute: Attribute | None = None
 
 
-# Streaming pays per-slab work (the pipe traversal, region writes, the TTA aligner); when the
-# assembled accumulators of all copies are below this fraction of allocatable memory (a 2.5D case),
-# holding them whole costs nothing and the case takes the whole-volume path.
-# KONFAI_STREAM_WORTH_THRESHOLD overrides the fraction (tests set 0 to exercise the streamed
-# machinery on toy volumes). See OutputDataset._worth_streaming.
+# Below this fraction of allocatable memory, the case takes the whole-volume path.
+# KONFAI_STREAM_WORTH_THRESHOLD overrides the fraction.
 _STREAM_WORTH_MIN_FRACTION = 0.05
 
 
@@ -228,25 +216,18 @@ class OutputDataset(Dataset, NeedDevice):
     ) -> None:
         filename, _, file_format = split_path_spec(dataset_filename)
         super().__init__(filename, file_format)
-        # ``Dataset.__init__`` does not forward ``super().__init__()``, so the ``NeedDevice`` mixin is
-        # never initialised through the MRO; call it explicitly so ``self.device`` always has its CPU
-        # default. Otherwise an output writer that is never moved (e.g. a CPU-only PREDICTION run, whose
-        # device propagation is CUDA-gated) reads ``self.device`` and raises ``AttributeError``.
+        # ``Dataset.__init__`` does not forward ``super().__init__()``: initialise ``NeedDevice`` here.
         NeedDevice.__init__(self)
         self.group = group
         self._before_reduction_transforms = before_reduction_transforms
         self._after_reduction_transforms = after_reduction_transforms
         self._final_transforms = final_transforms
         self._patch_combine = patch_combine
-        # "key=value" strings rather than a mapping: the config layer accepts list[str] and not
-        # dict[str, str], so a mapping here would be unreachable from the YAML that is supposed to
-        # drive it. Same spelling as the --set overrides.
+        # "key=value" strings: the config layer accepts list[str], not dict[str, str]. Same spelling as --set.
         self._attributes = dict(entry.split("=", 1) for entry in attributes or [])
         self.reduction_classpath = reduction
         self.reduction: Reduction
-        #: The per-rank budget the streamed-vs-assembled route is priced against: the config's
-        #: number, pushed by the predictor, so the route is a function of configuration and data
-        #: rather than of the machine's free memory at the moment a case finalizes.
+        #: The per-rank budget the streamed-vs-assembled route is priced against, pushed by the predictor.
         self._per_rank_budget_bytes: float | None = None
 
         self.before_reduction_transforms: list[Transform] = []
@@ -258,24 +239,16 @@ class OutputDataset(Dataset, NeedDevice):
         self.attributes: dict[int, dict[int, dict[int, Attribute]]] = {}
         self.names: dict[int, str] = {}
         self.nb_data_augmentation = 0
-        # One reusable page-locked buffer for GPU->CPU offload. Accumulators consume it synchronously
-        # into their own storage; callers retaining a CPU patch use ``_offload_to_cpu`` instead.
+        # One reusable page-locked buffer for GPU->CPU offload, consumed synchronously.
         self._pin_buffer: torch.Tensor | None = None
         # Per-CASE blend device, decided once at the case's first patch (see ``_accumulate_device``):
-        # CUDA when the full combined volume of EVERY augmentation fits VRAM (blend on GPU, no per-patch
-        # offload, assembled volume stays on-device for the reduction), else CPU. The decision is per case,
-        # not per (case, augmentation): all of a case's augmentations are reduced together in
-        # ``get_output``, and a mid-case flip would hand the reduction a mixed CPU/CUDA tensor list.
+        # CUDA when every augmentation's volume fits VRAM, else CPU. Never per (case, augmentation).
         self._accum_device: dict[int, torch.device] = {}
         # Same single-decision rule for the CPU-blend reduction device (see ``_reduction_device``).
         self._reduce_device: dict[int, torch.device] = {}
         # Disk writes go to a background writer when the destination serves disjoint files per entry
-        # (see ``Dataset.concurrent_write_safe``) AND the output runs on a GPU: the device-to-host
-        # copy and the write then overlap the next forward, byte-identically: same operations, same
-        # order. A single-store destination stays inline, so nothing ever writes one store from two
-        # threads; a CPU-only loop stays inline too: its blend shares the memory bandwidth the
-        # writer would consume, so there is nothing to overlap and something to lose.
-        # ``KONFAI_ASYNC_WRITES`` is tri-state: unset = automatic, ``0`` kills, ``1`` forces (tests).
+        # (``Dataset.concurrent_write_safe``) AND the output runs on a GPU; anything else stays inline.
+        # ``KONFAI_ASYNC_WRITES`` is tri-state: unset = automatic, ``0`` kills, ``1`` forces.
         raw = os.environ.get("KONFAI_ASYNC_WRITES", "").lower()
         self._async_writes: bool | None
         if raw in ("0", "false") or not self.concurrent_write_safe():
@@ -286,11 +259,8 @@ class OutputDataset(Dataset, NeedDevice):
             self._async_writes = None  # decided at the first write, once the device is placed
         self._writer: _AsyncWriter | None = None
         self.group_src, self.group_dest = same_as_group.split(":")
-        # Slab streaming has no config knob: it is applied automatically, per case, whenever it is
-        # byte-identical to the assembled path (see ``_plan_stream``), finalizing each z-slab as its
-        # patches complete so RAM is bounded at one patch window; otherwise the whole-volume path is
-        # used transparently. ``KONFAI_STREAMED_WRITES=0`` is a global ops/debug kill-switch (also how
-        # a test gets the assembled reference), not a per-output option.
+        # Slab streaming has no config knob: applied per case whenever it is byte-identical to the
+        # assembled path (``_plan_stream``). ``KONFAI_STREAMED_WRITES=0`` is a global kill-switch.
         self._streaming_enabled = env_flag("KONFAI_STREAMED_WRITES", True)
         self._stream_plans: dict[int, _StreamPlan | None] = {}
         self._stream_sinks: dict[int, DataStream] = {}
@@ -298,9 +268,7 @@ class OutputDataset(Dataset, NeedDevice):
         self._stream_buffers: dict[int, torch.Tensor] = {}
         self._post_prefix_attributes: dict[int, Attribute] = {}
         self._reported_paths: set[str] = set()
-        # One aligner per streamed case: the copies' accumulators emit slabs at their own pace, and
-        # the finalize needs every copy's rows together (the cross-copy reduction). A single copy is
-        # simply a one-stream aligner: same path, no special case.
+        # One aligner per streamed case: the finalize needs every copy's rows together for the cross-copy reduction.
         self._aligners: dict[int, SlabAligner] = {}
 
     def set_memory_budget(self, budget_bytes: float | None) -> None:
@@ -314,10 +282,7 @@ class OutputDataset(Dataset, NeedDevice):
     def _submit_write(self, operation: Callable[[], None]) -> None:
         """Run ``operation`` on the background writer, or inline when the destination must stay serial.
 
-        Charged to ``wait(write)`` either way: inline, the write IS the wait, and a submission
-        blocks once the writer's queue is full, which is where a slow destination turns the
-        background writer synchronous with nothing else to show it.
-        """
+        Charged to ``wait(write)`` either way, and a submission blocks once the queue is full."""
         if self._async_writes is None:
             self._async_writes = self._torch_device().type == "cuda"
         with PREDICTION_CLOCK.phase("wait(write)"):
@@ -334,19 +299,12 @@ class OutputDataset(Dataset, NeedDevice):
             writer, self._writer = self._writer, None
             writer.close()
 
-    # A pageable D2H copy on a large multi-class patch is a slow, fully synchronous PCIe transfer;
-    # staging through page-locked memory only pays off once the patch is large enough that the copy,
-    # not the buffer bookkeeping, dominates. Small patches (e.g. single-channel synthesis) take the
-    # plain path unchanged.
+    # Pinned staging pays off only above this size.
     _PINNED_OFFLOAD_MIN_BYTES = 64 * 1024 * 1024
 
     def _offload_to_cpu(self, layer: torch.Tensor) -> torch.Tensor:
-        """Return a CPU patch whose storage is independent of the reusable offload buffer.
-
-        Large CUDA patches stage through pinned memory, then copy into owned pageable storage.
-        Small/non-CUDA patches and a failed pinned allocation retain ``layer.detach().cpu()`` behavior.
-        The synchronous accumulator uses :meth:`_borrow_cpu_patch` to avoid that second copy.
-        """
+        """Return a CPU patch whose storage is independent of the reusable offload buffer. Large CUDA
+        patches stage through pinned memory, then copy into owned pageable storage."""
         with self._borrow_cpu_patch(layer) as patch:
             if patch is not self._pin_buffer:
                 return patch
@@ -358,10 +316,8 @@ class OutputDataset(Dataset, NeedDevice):
     def _borrow_cpu_patch(self, layer: torch.Tensor) -> Iterator[torch.Tensor]:
         """Lend one CPU patch until this context exits, for synchronous accumulation only.
 
-        The blocking CUDA copy completes before yielding. The caller must finish consuming the patch
-        within the context: the next offload may overwrite its storage. Accumulator.add_layer copies
-        or blends into owned storage, and StreamingAccumulator returns slabs cloned from that storage.
-        """
+        The caller must finish consuming the patch within the context: the next offload may overwrite
+        its storage."""
         detached = layer.detach()
         if (
             detached.device.type != "cuda"
@@ -378,7 +334,7 @@ class OutputDataset(Dataset, NeedDevice):
                 yield detached.cpu()
                 return
             self._pin_buffer = buffer
-        # Blocking copy: CPU accumulation must see completed host data before the buffer is lent.
+        # Blocking copy: the host data must be complete before the buffer is lent.
         buffer.copy_(detached)
         yield buffer
 
@@ -395,13 +351,11 @@ class OutputDataset(Dataset, NeedDevice):
         self.after_reduction_transforms = build("after_reduction_transforms", self._after_reduction_transforms)
         self.final_transforms = build("final_transforms", self._final_transforms)
 
-        # A patch grid overlaps whether or not a combine is declared, so the overlap needs a
-        # deterministic owner. Trim keeps each patch's central band: the bands tile the volume
-        # exactly, a seamless selection that never averages (a label map survives it).
+        # The overlap needs an owner whether or not a combine is declared: Trim keeps each patch's
+        # central band and never averages.
         module, name = get_module(self._patch_combine or "Trim", "konfai.data.patching")
         self.patch_combine = apply_config(konfai_args)(getattr(module, name))()
 
-        # Built-in or custom, the operator binds its parameters from its own block, like every stage.
         module, name = get_module(self.reduction_classpath, "konfai.predictor")
         # The classpath is one key, dots and all: escaped so the dotted path is not split through it.
         subtree = f"{konfai_args}.{_escape_key_component(self.reduction_classpath)}"
@@ -421,9 +375,8 @@ class OutputDataset(Dataset, NeedDevice):
         overlap: int | float | str | list[int | float | str] | None,
         nb_data_augmentation: int,
     ) -> None:
-        # Nothing tiled (no axis longer than one voxel) is a single patch covering the volume: no combine
-        # applies. Anything else keeps EVERY axis, the untiled ones as a single broadcast entry, because
-        # the accumulator reads one window per spatial axis (see blend_axes).
+        # A single patch covering the volume takes no combine. Anything else keeps EVERY axis, the
+        # untiled ones as a single broadcast entry.
         if patch_size and any(size > 1 for size in patch_size) and overlap is not None:
             if self.patch_combine is not None:
                 axes = blend_axes(patch_size)
@@ -438,8 +391,7 @@ class OutputDataset(Dataset, NeedDevice):
             transform.to(device)
 
     def is_done(self, index: int) -> bool:
-        # ``.get``: a streamed case cleans itself up inside ``add_layer`` (its slabs are already on
-        # disk), so by the time the run loop asks, the index is gone and the answer is "nothing to do".
+        # ``.get``: a streamed case cleans itself up inside ``add_layer``, so its index may already be gone.
         accumulators = self.output_layer_accumulator.get(index)
         if accumulators is None or len(accumulators) != self.nb_data_augmentation:
             return False
@@ -520,10 +472,7 @@ class OutputDataset(Dataset, NeedDevice):
         source_attribute = (
             Attribute(attribute) if attribute is not None else Attribute(input_dataset.cache_attributes[0])
         )
-        # What the output declares about itself, applied over what it inherited from its input.
-        # Inheritance carries the geometry, which is right, but it also carries whatever the source
-        # entry said it WAS, and that describes the source, not this. Declared last, so the
-        # config always wins; declare a key empty to drop an inherited one.
+        # The declared attributes are applied over the inherited ones; an empty value drops a key.
         for key, value in self._attributes.items():
             if value == "":
                 source_attribute.pop(key, None)
@@ -533,11 +482,8 @@ class OutputDataset(Dataset, NeedDevice):
             self.output_layer_accumulator[index_dataset] = {}
             self.attributes[index_dataset] = {}
             self.names[index_dataset] = input_dataset.name
-            # The streamed consumers (sink target, region pipe, buffer) index their slabs on the
-            # first spatial axis, and the aligner needs every augmentation on the same footing:
-            # a grid swept along another axis takes the whole-volume path until they carry the
-            # axis too.
-            # max(1, ...): the count is set by load(); before it, augmentation 0 always exists.
+            # The streamed consumers index their slabs on the first spatial axis: a grid swept along
+            # another axis takes the whole-volume path. max(1, ...): the count is set by load().
             sweeps_first_axis = all(
                 input_dataset.patch.get_sweep_axis(a) == 0 for a in range(max(1, self.nb_data_augmentation))
             )
@@ -548,14 +494,10 @@ class OutputDataset(Dataset, NeedDevice):
             )
             self._stream_plans[index_dataset] = plan
             if self._streaming_enabled and (plan is None or not plan.to_sink):
-                # The whole-volume fallback is a normal outcome, but a silent one hides that a
-                # large case pays it: say so, once per distinct path.
                 path = "whole-volume" if plan is None else "buffered (the prefix streams, the tail runs whole-volume)"
                 self._report_once(path, f"streaming: case '{input_dataset.name}' takes the {path} path.")
-        # Everything past this point reads the header at index 0; a patch-level inverse reads one
-        # per patch, each undone on a copy of its own taken before any inverse ran. Only then are
-        # the copies made: on a grid of 18,000 thin 2.5D patches with nothing to undo they cost
-        # 473 ms and as many dicts held per (case, augmentation), measured.
+        # Everything past this point reads the header at index 0; a patch-level inverse reads one copy
+        # per patch, taken before any inverse ran.
         attributes = self.attributes[index_dataset][index_augmentation] = {0: source_attribute}
         if self._patch_inverses(dataset):
             for i in range(1, len(input_dataset.patch.get_patch_slices(index_augmentation))):
@@ -571,8 +513,7 @@ class OutputDataset(Dataset, NeedDevice):
         )
 
     def _patch_inverses(self, dataset: DatasetIter) -> list[TransformInverse]:
-        """The patch-level transforms of the mirrored group that each patch is passed back through,
-        last applied first."""
+        """The patch-level transforms of the mirrored group each patch is passed back through, last first."""
         return [
             transform
             for transform in reversed(dataset.groups_src[self.group_src][self.group_dest].patch_transforms)
@@ -591,8 +532,7 @@ class OutputDataset(Dataset, NeedDevice):
                     f"case '{self.names[index_dataset]}' accumulates on the host.",
                 )
         target = self._accum_device[index_dataset]
-        # When the accumulator lives on the GPU, blend the patch straight in (no host round-trip);
-        # otherwise offload each patch to CPU so its device memory is released after post-processing.
+        # A GPU accumulator takes the patch straight in; a CPU one takes an offloaded copy.
         if target.type == "cpu":
             if layer.device.type != "cpu":
                 with self._borrow_cpu_patch(layer) as cpu_patch:
@@ -602,10 +542,7 @@ class OutputDataset(Dataset, NeedDevice):
         try:
             return accumulator.add_layer(index_patch, layer) or []
         except torch.cuda.OutOfMemoryError:
-            # The gate samples free VRAM once per case: another process can reclaim it before this
-            # volume-sized first allocation lands. Nothing is blended yet, so fall back to the
-            # memory-safe CPU blend for the rest of the case; ``get_output`` reconciles augmentations
-            # already blended on the GPU. A mid-blend OOM (buffer already resident) stays fatal.
+            # Nothing is blended yet, so the rest of the case blends on the CPU; a mid-blend OOM is fatal.
             if layer.device.type == "cpu" or not accumulator.is_empty():
                 raise
             self._accum_device[index_dataset] = torch.device("cpu")
@@ -654,9 +591,7 @@ class OutputDataset(Dataset, NeedDevice):
 
     @staticmethod
     def _voxel_local(locality: PatchLocality, attribute: Attribute) -> bool:
-        """Whether a finalize stage is a per-voxel map here: POINTWISE, or GLOBAL_STAT whose statistic
-        the case already carries: the finalize attribute holds what the forward pass pushed, and there
-        is no stored volume left to derive a missing one from."""
+        """POINTWISE, or GLOBAL_STAT whose statistic the case attribute already carries."""
         if locality.kind is LocalityKind.POINTWISE:
             return True
         return locality.kind is LocalityKind.GLOBAL_STAT and all(key in attribute for key in locality.stat_keys)
@@ -668,15 +603,9 @@ class OutputDataset(Dataset, NeedDevice):
             print(f"[KonfAI] {message}")
 
     def _worth_streaming(self, dataset: DatasetIter, index: int, layer: torch.Tensor) -> bool:
-        """Whether this case's accumulators are heavy enough for the per-slab machinery to pay:
-        every copy holds a volume-sized accumulator, and when all of them together are a sliver of
-        allocatable memory (a 2.5D case) the assembled path costs nothing to hold: streaming it
-        would spend pipe traversals and region writes to save nothing.
-
-        ``layer`` carries the accumulator's channel count and dtype whatever the ensemble combine is
-        (a Concat layer arrives already concatenated); the estimate is taken before the patch-level
-        inverses, so a dtype-widening inverse under-counts by at most 2x: inside the threshold's
-        margin."""
+        """Whether this case's accumulators are heavy enough for the per-slab machinery to pay. The
+        estimate is taken before the patch-level inverses, so a dtype-widening inverse under-counts by
+        at most 2x."""
         spatial = dataset.get_dataset_from_index(self.group_dest, index).shapes[0]
         assembled = int(layer.shape[0]) * int(np.prod(spatial)) * layer.element_size() * self.nb_data_augmentation
         raw = os.environ.get("KONFAI_STREAM_WORTH_THRESHOLD")
@@ -688,9 +617,7 @@ class OutputDataset(Dataset, NeedDevice):
                 stacklevel=2,
             )
             fraction = _STREAM_WORTH_MIN_FRACTION
-        # The config's budget, never the machine's mood: the same case takes the same route on a
-        # loaded machine and an idle one. A writer no predictor configured (a bare test) prices
-        # against the auto-budget's own rule.
+        # The config's budget, never the machine's free memory.
         budget = self._per_rank_budget_bytes
         if budget is None:
             budget = resolve_memory_budget(None).per_rank_bytes(node_local_ranks())
@@ -706,16 +633,11 @@ class OutputDataset(Dataset, NeedDevice):
     ) -> _StreamPlan | None:
         """The streaming plan for this case, or ``None`` for the whole-volume path.
 
-        The streamed part of the finalize chain is ``[pointwise*][region and pointwise stages]``:
-        region stages compose (each pulls through the one before it), so any number of geometry
-        inverses streams to the write. What streaming cannot honour (a WHOLE_VOLUME stage, a
-        statistic nothing seeded) becomes a whole-volume TAIL: the prefix still streams slab by slab
-        into a light post-reduction buffer and the tail runs once on that buffer. A destination that
-        cannot serve region writes buffers too, and writes classically. Only a non-streamable start
-        refuses outright: a reduction that is not voxel-local, a non-voxel-local before-reduction
-        transform (it runs per model chunk inside the slab prefix), a TTA copy whose un-augment does
-        not act slab by slab (see ``_tta_streamable``), or a case too light for the per-slab
-        machinery to pay (``_worth_streaming``: gauged from ``layer`` when the caller has one).
+        The streamed part of the finalize chain is ``[pointwise*][region and pointwise stages]``. What
+        streaming cannot honour becomes a whole-volume TAIL run once on a post-reduction buffer, as does
+        a destination that cannot serve region writes. Refused outright: a reduction that is not
+        voxel-local, a non-voxel-local before-reduction transform, a TTA copy whose un-augment does not
+        act slab by slab (``_tta_streamable``), or a case too light to pay (``_worth_streaming``).
         """
         if self.nb_data_augmentation < 1:
             return None
@@ -727,9 +649,8 @@ class OutputDataset(Dataset, NeedDevice):
             return None
         for transform in self.before_reduction_transforms:
             locality = transform.patch_locality(Attribute(attribute))
-            # A SLAB before-reduction transform (InferenceStack) streams per slab through ``stream_slab``
-            # in ``_prepare_copy_slab``, so it does not force the whole-volume path; anything else that
-            # is not voxel-local (a spatial mix, an unseeded statistic) still refuses outright.
+            # A SLAB before-reduction transform streams through ``stream_slab``; any other
+            # non-voxel-local one refuses outright.
             if not self._voxel_local(locality, attribute) and locality.kind is not LocalityKind.SLAB:
                 return None
         stages = [
@@ -749,10 +670,7 @@ class OutputDataset(Dataset, NeedDevice):
             if self._voxel_local(locality, attribute):
                 continue
             if locality.kind is LocalityKind.SLAB and not stage.inverted and pipe_start is None:
-                # A per-voxel stage with a per-region side effect streams through ``stream_slab``: # but only
-                # on the accumulator grid: past a region stage the emissions are regions of
-                # ANOTHER space, so there it falls to the tail (whose whole-volume call is its
-                # classic behaviour).
+                # A SLAB stage streams through ``stream_slab`` only on the accumulator grid.
                 slab_stages.add(position)
                 continue
             if locality.kind.is_region:
@@ -762,8 +680,7 @@ class OutputDataset(Dataset, NeedDevice):
             tail_start = position
             break
         if tail_start < len(stages) or not self.can_stream_data(attribute):
-            # A whole-volume tail swallows the region stages too: the buffer sits on the accumulator
-            # grid, and the tail runs the true whole-volume operators on it: byte-identical for free.
+            # A whole-volume tail swallows the region stages too: the buffer sits on the accumulator grid.
             if pipe_start is not None:
                 tail_start = min(tail_start, pipe_start)
             return _StreamPlan(stages, None, tail_start, to_sink=False, slab_stages=frozenset(slab_stages))
@@ -771,8 +688,7 @@ class OutputDataset(Dataset, NeedDevice):
 
     @staticmethod
     def _copy_draw(dataset: DatasetIter, index_augmentation: int) -> tuple[list[DataAugmentation], int] | None:
-        """The augmentations copy ``index_augmentation`` carries and its index within their list, or
-        ``None`` for the un-augmented copy."""
+        """The augmentations of copy ``index_augmentation`` and its index in their list, ``None`` for copy 0."""
         if index_augmentation == 0:
             return None
         i = index_augmentation - 1
@@ -785,8 +701,8 @@ class OutputDataset(Dataset, NeedDevice):
     def _unaugment(
         self, dataset: DatasetIter, index: int, index_augmentation: int, tensor: torch.Tensor
     ) -> torch.Tensor:
-        """Undo copy ``index_augmentation``'s draw on ``tensor``: the augmentations applied in
-        reverse, bound by the case index the draw was made under (the manager's own)."""
+        """Undo copy ``index_augmentation``'s draw on ``tensor``: the augmentations applied in reverse,
+        bound by the case index the draw was made under."""
         draw = self._copy_draw(dataset, index_augmentation)
         if draw is None:
             return tensor
@@ -799,14 +715,8 @@ class OutputDataset(Dataset, NeedDevice):
     def _tta_streamable(self, dataset: DatasetIter, index: int, attribute: Attribute) -> bool:
         """Whether every copy's un-augment acts slab by slab, read from the declarations alone.
 
-        The slab-synchronized reduce applies each augmentation's ``inverse`` to a finalized z-slab,
-        which equals the whole-volume inverse restricted to that slab exactly when the draw maps every
-        slab onto itself: a POINTWISE draw does (a per-voxel map inverts per voxel), and an
-        ORIENTATION draw does when its declared region remap fixes the slab axis row for row and its
-        shape fold keeps the slab extent: probed here against ``stream_region_source``, never by
-        running patches. A z-flip mirrors the rows (row 0 pulls the last), a z-moving permute
-        relocates them: both fail the probe and the case falls back to the whole-volume path. Any
-        other kind (a halo'd translate, a whole-volume draw) refuses outright.
+        A POINTWISE draw does; an ORIENTATION draw does when its declared region remap fixes the slab
+        axis row for row and its shape fold keeps the slab extent. Any other kind refuses outright.
         """
         try:
             input_dataset = dataset.get_dataset_from_index(self.group_dest, index)
@@ -832,7 +742,7 @@ class OutputDataset(Dataset, NeedDevice):
                         if (source[0].start, source[0].stop) != (row, row + 1):
                             return False
                     shape = out_shape
-        except Exception:  # nosec B110 - an unprobeable draw just keeps the case on the whole-volume path
+        except Exception:  # nosec B110 - an unprobeable draw keeps the case on the whole-volume path
             return False
         return True
 
@@ -844,8 +754,7 @@ class OutputDataset(Dataset, NeedDevice):
         dataset: DatasetIter,
     ) -> None:
         """Run each jointly finalized slab through the plan: prefix per slab, then sink, region
-        stream, or buffer. The first slab fixes the case's state (post-prefix attribute, region
-        scheduler or buffer; see ``_init_stream_state``)."""
+        stream, or buffer. The first slab fixes the case's state (see ``_init_stream_state``)."""
         plan = cast(_StreamPlan, self._stream_plans[index])
         for region, copies in slabs:
             block, attribute = self._finalize_slab(index, copies, number_of_channels_per_model, plan, dataset, region)
@@ -867,12 +776,7 @@ class OutputDataset(Dataset, NeedDevice):
     def _init_stream_state(
         self, index: int, plan: _StreamPlan, block: torch.Tensor, attribute: Attribute
     ) -> _StreamPlan:
-        """Fix the case's streaming state at its first slab, when the prefix output is known.
-
-        A ``REGRID`` stage streams through the very code its whole-volume call runs, over a region
-        that happens to be smaller, so the streamed and whole-volume answers are equal by
-        construction rather than by agreement and a large resample never has to be held whole.
-        """
+        """Fix the case's streaming state at its first slab, when the prefix output is known."""
         self._post_prefix_attributes[index] = Attribute(attribute)
         spatial = [int(extent) for extent in self.output_layer_accumulator[index][0].shape]
         if plan.pipe_start is not None:
@@ -894,20 +798,13 @@ class OutputDataset(Dataset, NeedDevice):
     def _make_pipe_state(
         self, index: int, plan: _StreamPlan, in_shape: list[int], block: torch.Tensor
     ) -> _RegionState | None:
-        """Wire the case's streamed pipe into one :class:`SlabRegionStream`: or answer ``None`` for
+        """Wire the case's streamed pipe into one :class:`SlabRegionStream`, or answer ``None`` for
         the buffered tail where streaming would not be exact.
 
-        Region stages compose: the pull map folds each stage's own declaration backward: a written
-        region pulls through the last stage, whose region pulls through the one before it, down to
-        the accumulator, and ``produce`` walks the pipe forward over the pulled window, handing each
-        stage the region pair the same fold computed for it. Pointwise stages ride along unchanged.
-
-        The fold is planned by walking a one-voxel corner of the real first slab through the pipe
-        with one evolving attribute: each stage declares against, and remaps from, the state the
-        stages before it left (a second resample pops the Size stack the first one already popped,
-        a reorientation after a permute reads the moved axes), and the walk carries the dtype.
-        ``produce`` then replays the same transitions on a fresh copy per emission (the same
-        slab-local scoping as the prefix).
+        The pull map folds each stage's declaration backward from the written region down to the
+        accumulator; ``produce`` walks the pipe forward over the pulled window. The fold is planned
+        by walking a one-voxel corner of the first slab through the pipe with one evolving attribute,
+        and ``produce`` replays the same transitions on a fresh copy per emission.
         """
         attr0 = self._post_prefix_attributes[index]
         pipe = plan.stages[cast(int, plan.pipe_start) :]
@@ -930,9 +827,8 @@ class OutputDataset(Dataset, NeedDevice):
                     shapes.append(list(shape))
                     probe = stage(name, probe, walking)
                 elif locality.kind is LocalityKind.REGRID:
-                    # A regrid states its transition instead of performing it: its inverse restores a
-                    # whole volume from a region, which is not something the one-voxel probe can be
-                    # run through, and its forward answer here would be one voxel's target grid.
+                    # A regrid states its transition instead of performing it: the one-voxel probe
+                    # cannot run through its inverse.
                     transform = stage.transform
                     if stage.inverted:
                         remapper = cast(TransformInverse, transform)
@@ -953,8 +849,7 @@ class OutputDataset(Dataset, NeedDevice):
                         pull_fns.append(_RemapPull(stage.transform.stream_region_source, shape, snapshot, name))
                         out = stage.transform.transform_shape(self.group_src, name, list(shape), Attribute(walking))
                     shapes.append([int(extent) for extent in out])
-                    # The stage's attribute transition, on a one-voxel corner: a crop's tensor answer
-                    # is meaningless there (the map is the action) but its pops are the case's.
+                    # The stage's attribute transition on the probe: a crop's tensor answer is dropped, its pops kept.
                     result = stage(name, probe, walking)
                     if locality.kind is not LocalityKind.CROP:
                         probe = result
@@ -1006,14 +901,12 @@ class OutputDataset(Dataset, NeedDevice):
     ) -> torch.Tensor:
         """Run one pipe stage on its pulled block, by declared kind, never by stage name."""
         if kind is LocalityKind.CROP:
-            # The pull already translated the region, so the block IS the answer. The stage still runs
-            # for its attribute transition (a crop restores the origin it recorded); its tensor answer
-            # is one window's, dropped.
+            # The pull already translated the region, so the block IS the answer; the stage still
+            # runs for its attribute transition.
             stage(name, block, attribute)
             return block
         if kind is LocalityKind.REGRID:
-            # Region-aware on both sides, and the geometry written from the FULL shape: what the
-            # stage records on the way is one region's, and the case's answer is the whole grid's.
+            # Region-aware on both sides; the geometry is written from the FULL shape.
             context = RegionContext(tuple(source), tuple(target), tuple(in_shape))
             if stage.inverted:
                 remapper = cast(TransformInverse, stage.transform)
@@ -1024,9 +917,8 @@ class OutputDataset(Dataset, NeedDevice):
                 stage.transform.write_stream_cache_attribute(attribute, in_shape, name)
             return result
         if kind is LocalityKind.ORIENTATION and not stage.inverted:
-            # A forward orientation writes the case origin/direction from the extent it is handed; run
-            # the tensor action on a throwaway scope so it does not record the SLAB's extent, then write
-            # the case geometry from the full ``in_shape`` (its documented contract): as REGRID does.
+            # Run the tensor action on a throwaway scope so it does not record the SLAB's extent, then
+            # write the case geometry from the full ``in_shape``.
             result = stage(name, block, Attribute(attribute))
             cast(TransformInverse, stage.transform).write_stream_cache_attribute(attribute, in_shape, name)
             return result
@@ -1040,12 +932,10 @@ class OutputDataset(Dataset, NeedDevice):
     def _write_stream_block(
         self, index: int, target: tuple[slice, ...], block: torch.Tensor, attribute: Attribute
     ) -> None:
-        """Write one finalized output block into the case's sink (opened at the first block, once the
-        chain has fixed the output's shape, channel count and dtype).
+        """Write one finalized output block into the case's sink (opened at the first block).
 
-        The whole write (device-to-host copy, lazy sink open, region write) is one submitted
-        operation, so ``_stream_sinks`` is only ever touched in submission order; the attribute is
-        snapshotted because the region state's evolves with later emissions."""
+        The whole write is one submitted operation, so ``_stream_sinks`` is only touched in
+        submission order; the attribute is snapshotted: the region state's evolves."""
         state = self._region_states.get(index)
         spatial = (
             state.shapes[-1]
@@ -1099,12 +989,10 @@ class OutputDataset(Dataset, NeedDevice):
         region: slice,
         spatial: list[int],
     ) -> torch.Tensor:
-        """One copy's slab through the per-copy head of ``_get_output``: un-augment it (exact on a
-        slab: the gate admitted only slab-parallel draws), split the model chunks, run
-        before_reduction on each, and stack to the copy's ``[1, M, C, ...]`` block. A per-voxel
-        before-reduction transform is told where the slab sits (``stream_region``, the accumulator
-        grid, where before_reduction runs), so one reading a companion volume (a mask) reads its
-        slab region instead of the whole; a SLAB one goes through ``stream_slab``."""
+        """One copy's slab through the per-copy head of ``_get_output``: un-augment it, split the model
+        chunks, run before_reduction on each, and stack to the copy's ``[1, M, C, ...]`` block. A
+        per-voxel before-reduction transform is told where the slab sits (``stream_region``); a SLAB
+        one goes through ``stream_slab``."""
         layer = self._unaugment(dataset, index, index_augmentation, layer)
         attribute = Attribute(self.attributes[index][index_augmentation][0])
         chunks = self._split_model_chunks(layer, number_of_channels_per_model, attribute)
@@ -1134,12 +1022,8 @@ class OutputDataset(Dataset, NeedDevice):
         """The finalize chain of ``_get_output``/``get_output``, on one z-slab of every copy, up to
         the plan's prefix boundary.
 
-        Every prefix stage passed the gate as voxel-local (a SLAB stage additionally learns where the
-        slab sits, through ``stream_slab``) and every copy as slab-parallel, so each step is the
-        whole-volume computation restricted to the slab (same ops, same order, same reduction call)
-        which is what makes the streamed output byte-identical. Each slab gets its own copy of the
-        case attribute (transform writes stay slab-local, and case-level pops repeat identically per
-        slab).
+        Each step is the whole-volume computation restricted to the slab (same ops, same order, same
+        reduction call). Each slab gets its own copy of the case attribute.
         """
         spatial = [int(extent) for extent in self.output_layer_accumulator[index][0].shape]
         blocks = [
@@ -1156,15 +1040,13 @@ class OutputDataset(Dataset, NeedDevice):
             if position in plan.slab_stages:
                 result = stage.transform.stream_slab(self.names[index], result, region, spatial, attribute)
             else:
-                # Told where the slab sits: exact on a slab for every voxel-local stage the gate
-                # admitted, and a stage reading a companion volume (Mask) reads its slab region.
+                # Told where the slab sits, so a stage reading a companion volume (Mask) reads its slab region.
                 result = stage.stream_region(self.names[index], result, context, attribute)
         return result, attribute
 
     def reset(self) -> None:
         """Drop every in-flight accumulation (the OOM-restart path re-runs the rank's cases from scratch)."""
-        # Aborting an attempt mid-stream: abort each open sink so the backend removes the partial
-        # entry (a reader must never see a half-written volume); the restart rewrites it.
+        # Abort each open sink so the backend removes the partial entry; the restart rewrites it.
         error = PredictorError("prediction restart: the partial streamed output is discarded")
         for sink in self._stream_sinks.values():
             try:
@@ -1218,20 +1100,17 @@ class OutputDataset(Dataset, NeedDevice):
         layer: torch.Tensor, number_of_channels_per_model: list[int] | None, attribute: Attribute
     ) -> list[torch.Tensor]:
         """Split an ensemble layer into per-model chunk views and tag the attribute with the layout; a
-        layer whose channels do not match the ensemble layout stays whole. One splitter serves the
-        whole-volume and slab paths, so the two cannot drift."""
+        layer whose channels do not match the ensemble layout stays whole."""
         if number_of_channels_per_model and layer.shape[0] == sum(number_of_channels_per_model):
             attribute["number_of_channels_per_model_0"] = torch.tensor(number_of_channels_per_model)
             return list(torch.split(layer, number_of_channels_per_model, dim=0))
         return [layer]
 
     def _reduce_copies(self, copies: list[torch.Tensor]) -> torch.Tensor:
-        """The cross-copy reduction, identical for a slab and a whole volume: the streamed path's
-        byte-identity rests on the two staying in lockstep.
+        """The cross-copy reduction, identical for a slab and a whole volume.
 
-        Mixed devices can only come from a mid-case OOM fallback: reconcile on the host. Reduce, then
-        drop the singleton stack axis; Mean/Median also drop the singleton model axis, while Concat
-        keeps the ``[M, C, ...]`` model axis for after_reduction (Sum) to merge into labels."""
+        Mixed devices (a mid-case OOM fallback) reconcile on the host. Reduce, then drop the singleton
+        stack axis; Mean/Median also drop the singleton model axis, Concat keeps ``[M, C, ...]``."""
         if len({copy.device for copy in copies}) > 1:
             copies = [copy.cpu() if copy.device.type != "cpu" else copy for copy in copies]
         result = self.reduction(copies).squeeze(0)
@@ -1247,13 +1126,9 @@ class OutputDataset(Dataset, NeedDevice):
         base_attr = self.attributes[index][index_augmentation][0]
         chunks = self._split_model_chunks(layer, number_of_channels_per_model, base_attr)
 
-        # The per-model channel reduction (softmax/argmax over the class dimension of a whole-volume
-        # multi-class output) materialises a working volume on top of the resident accumulator. Decide
-        # once per case whether it fits free VRAM, with the accumulator already resident whatever device
-        # it sits on: if it fits, reduce on the GPU (a no-op move when the volume is already there); else
-        # move the finalize to the host. One decision per case: deciding per augmentation would let free
-        # VRAM shrinking between augmentations flip the device mid-case and hand the reduction a
-        # mixed-device list.
+        # The per-model channel reduction materialises a working volume on top of the resident
+        # accumulator. Decided once per case whether it fits free VRAM; per augmentation would let the
+        # device flip mid-case and hand the reduction a mixed-device list.
         if index not in self._reduce_device:
             self._reduce_device[index] = (
                 self._reduction_device(chunks[0], len(chunks)) if chunks else torch.device("cpu")
@@ -1265,13 +1140,11 @@ class OutputDataset(Dataset, NeedDevice):
             layer = layer.to(reduce_device)
             for transform in self.before_reduction_transforms:
                 layer = transform(self.names[index], layer, Attribute(attr))
-            # Keep the chunk on its current device; ``get_output`` decides once (via the GPU-finalize
-            # gate) whether the whole finalize chain stays on the GPU or moves back to the host.
+            # The chunk stays on its current device; ``get_output`` runs the finalize where the volume is.
             results.append(layer)
 
-        # Mean, Median -> [1, C, ...] | Concat -> [M, C, ...]. A lone chunk stacks as a view: the copy
-        # torch.stack made was the assembled volume, 448 MiB and 54 ms for a [14, 256^3] fp16 case
-        # (measured), once per augmentation. No reduction writes into what it is handed.
+        # Mean, Median -> [1, C, ...] | Concat -> [M, C, ...]. A lone chunk stacks as a view; no
+        # reduction writes into what it is handed.
         if len(results) == 1:
             return results[0].unsqueeze(0)
         return torch.stack(results, dim=0)
@@ -1284,28 +1157,23 @@ class OutputDataset(Dataset, NeedDevice):
         if device.type != "cuda":
             return torch.device("cpu")
         try:
-            # The forward pass leaves the allocator holding a large reserved cache; release the unused part
-            # back to the driver so a genuinely-free GPU is not mistaken for a full one.
+            # Release the allocator's unused reserved cache so ``mem_get_info`` reports what is free.
             torch.cuda.empty_cache()
             free, _ = torch.cuda.mem_get_info(device)
         except Exception:  # nosec B110 - any CUDA query failure just keeps the reduction on CPU
             return torch.device("cpu")
-        # Every transformed chunk is parked on the reduce device until the final stack (a combine:Concat
-        # ensemble keeps M of them), so budget all of them plus a same-size working temp per chunk and
-        # one stack copy.
+        # Every transformed chunk is parked on the reduce device until the final stack: budget all of
+        # them plus a same-size working temp per chunk and one stack copy.
         needed = chunk.numel() * chunk.element_size() * (2 * max(1, nb_chunks) + 1)
         return device if needed < free else torch.device("cpu")
 
-    # A forward runs alongside the resident accumulator on every patch; the memory queries below happen
-    # before those allocations land, so keep ~10 % of free VRAM in reserve for fragmentation and a
-    # concurrent process.
+    # The memory queries run before a forward's allocations land: keep ~10 % of free VRAM in reserve
+    # for fragmentation and a concurrent process.
     _ACCUMULATE_MARGIN = 0.9
 
     def _accumulate_device(self, layer: torch.Tensor, accumulator: Accumulator) -> torch.device:
-        """Device on which to blend a case's patches. On the GPU the accumulator stays resident through
-        the case (no per-patch offload, no CPU blend, and the reduction runs where the volume already is).
-        Decided once per case, at the first patch, when the accumulator fits alongside the memory a
-        forward needs; else the accumulation runs on the CPU."""
+        """Device on which to blend a case's patches: the GPU when the accumulator fits alongside the
+        memory a forward needs, decided once per case at the first patch; else the CPU."""
         device = torch.device("cuda", self.device) if isinstance(self.device, int) else self.device
         if device.type != "cuda" or layer.device.type != "cuda":
             return torch.device("cpu")
@@ -1313,30 +1181,25 @@ class OutputDataset(Dataset, NeedDevice):
             # Return the reserved-but-unused cache so ``mem_get_info`` reports the memory actually free.
             torch.cuda.empty_cache()
             free, _ = torch.cuda.mem_get_info(device)
-            # A forward's transient footprint above the resident set, measured on the batch that just ran
-            # (its activations are already freed). ``max_memory_allocated`` is a high-water mark, so this
-            # bounds the next forward from above: the gate errs toward the CPU, never toward an OOM.
+            # A forward's transient footprint above the resident set, from the batch that just ran;
+            # ``max_memory_allocated`` is a high-water mark, so the gate errs toward the CPU.
             transient = torch.cuda.max_memory_allocated(device) - torch.cuda.memory_allocated(device)
         except Exception:  # nosec B110 - any CUDA query failure keeps the blend on CPU
             return torch.device("cpu")
         voxels = int(np.prod(accumulator.footprint_shape))
-        # result [C, volume] + weight_sum [volume] at the patch dtype, for EVERY augmentation of the
-        # case: ``is_done`` requires all augmentations complete before ``get_output``, so their
-        # accumulators are resident simultaneously and the per-case device decision must budget them all.
+        # result [C, volume] + weight_sum [volume] at the patch dtype, for EVERY augmentation: all of
+        # a case's accumulators are resident simultaneously.
         accumulator_bytes = (layer.shape[0] + 1) * voxels * layer.element_size() * max(1, self.nb_data_augmentation)
-        # During accumulation the resident accumulator and one forward coexist. The channel reduction's
-        # working volume is budgeted separately, at ``get_output`` time, by ``_reduction_device``.
+        # The channel reduction's working volume is budgeted separately by ``_reduction_device``.
         needed = accumulator_bytes + transient
         if isinstance(accumulator, StreamingAccumulator):
-            # Transients on top of the resident window (``voxels`` is the window footprint): the advance
-            # clone of the retained rows, the emission slab and its weight clamp, and, when the
-            # background writer engages: up to ``_AsyncWriter._CAPACITY`` emitted blocks alive on the
-            # device until their device-to-host copy runs. Two window footprints bound the sum.
+            # Transients on top of the resident window: the advance clone, the emission slab and its
+            # weight clamp, and up to ``_AsyncWriter._CAPACITY`` emitted blocks awaiting their copy.
+            # Two window footprints bound the sum.
             needed += 2 * layer.shape[0] * voxels * layer.element_size()
             if self.nb_data_augmentation > 1:
-                # Slab-aligned TTA holds pending slabs per copy (the arrival skew, ~one window) and
-                # reduces the joint interval through a float32 accumulate: budget one window per copy
-                # plus one more for the reduction's transients.
+                # Slab-aligned TTA holds pending slabs per copy and reduces through a float32
+                # accumulate: one window per copy plus one more for the reduction's transients.
                 needed += (self.nb_data_augmentation + 2) * layer.shape[0] * voxels * layer.element_size()
         return device if needed < free * self._ACCUMULATE_MARGIN else torch.device("cpu")
 
@@ -1348,48 +1211,15 @@ class OutputDataset(Dataset, NeedDevice):
         self.output_layer_accumulator.pop(index)
         self._accum_device.pop(index, None)
         self._reduce_device.pop(index, None)
-        # The volume stays on whatever device it was blended on (GPU when it fit VRAM, else CPU): the
-        # reduction and every finalize transform are device- and dtype-transparent, so the whole finalize
-        # simply runs where the volume already is. Only the final result is returned to the host.
+        # The finalize runs where the volume was blended; only the final result returns to the host.
         result = self._reduce_copies(results)
-        # Reduction strategy overview:
-        #
-        # Terminology:
-        #   - combine : aggregation across models (model ensembling)
-        #   - reduce  : aggregation across TTA (test-time augmentation)
-        #
-        # Let:
-        #   M = number of models
-        #   T = number of TTA samples
-        #   C = number of output channels
-        #
-        # Case 1 - combine = Mean / Median, reduce = Mean / Median:
-        #   Models are aggregated first:
-        #     [M, C, ...] -> combine -> [C, ...]
-        #   TTA samples are then reduced:
-        #     [T, C, ...] -> reduce -> [C, ...]
-        #
-        # Case 2 - combine = Mean / Median, reduce = Concat:
-        #   Models are aggregated first:
-        #     [M, C, ...] -> combine -> [C, ...]
-        #   TTA samples are concatenated:
-        #     [T, C, ...] -> concat -> [T, C, ...]
-        #
-        # Case 3 - combine = Concat, reduce = Mean / Median:
-        #   Model outputs are concatenated:
-        #     [M, C, ...] -> concat -> [M, C, ...]
-        #   TTA samples are then reduced:
-        #     [T, M, C, ...] -> reduce -> [M, C, ...]
-        #
-        # Case 4 - combine = Concat, reduce = Concat:
-        #   No reduction is applied at either level:
-        #     [M, C, ...] x T -> concat -> [M * T, C, ...]
-        #
-        # Important:
-        #   If combine = Concat or reduce = Concat,
-        #   the first transform in `after_reduction_transforms`
-        #   must be either `InferenceStack` or `Sum`,
-        #   to ensure a [C, ....] after
+        # combine = aggregation across models (M), reduce = aggregation across TTA copies (T):
+        #   Mean/Median at both levels : [M, C, ...] -> [C, ...], then [T, C, ...] -> [C, ...]
+        #   combine Concat, reduce Mean : [T, M, C, ...] -> [M, C, ...]
+        #   reduce Concat               : [T, C, ...] stays [T, C, ...]
+        #   Concat at both levels       : [M * T, C, ...]
+        # With a Concat at either level, the first ``after_reduction_transforms`` entry must be
+        # ``InferenceStack`` or ``Sum`` so a ``[C, ...]`` follows.
         for transform in self.after_reduction_transforms:
             result = transform(self.names[index], result, self.attributes[index][0][0])
 

--- a/konfai/predictor/workflow.py
+++ b/konfai/predictor/workflow.py
@@ -58,12 +58,9 @@ class Predictor(vram.VramAutoPatchMixin, DistributedObject):
     """
     KonfAI's main prediction controller.
 
-    This class orchestrates the prediction phase by:
-    - Loading model weights from checkpoint(s) or URL(s)
-    - Preparing datasets and output configurations
-    - Managing distributed inference with optional multi-GPU support
-    - Applying transformations and saving predictions
-    - Optionally logging results to TensorBoard
+    It loads the model weights from checkpoint(s) or URL(s), prepares the datasets and the output
+    configurations, runs the inference distributed over the available GPUs, applies the transforms and
+    writes the predictions, and optionally logs to TensorBoard.
 
     Attributes:
         model (Network): The neural network model to use for prediction.
@@ -125,8 +122,7 @@ class Predictor(vram.VramAutoPatchMixin, DistributedObject):
         for output_dataset in self.outputs_dataset.values():
             output_dataset.set_memory_budget(per_rank_budget)
             self.datasets_filename.append(output_dataset.filename)
-            # Rebase under the run directory, re-deriving is_directory: a bare string + "/" would flag an
-            # h5 output as a directory and write the hidden dotfile Predictions/<run>/Dataset/.h5.
+            # Rebase under the run directory, re-deriving is_directory from the path, not from a trailing "/".
             output_dataset.rebase(self.predict_path)
         self.data_log = data_log
         modules = [name for name, _ in self.model.named_modules()]
@@ -141,8 +137,8 @@ class Predictor(vram.VramAutoPatchMixin, DistributedObject):
                 )
 
         self.gpu_checkpoints = gpu_checkpoints
-        # Cut the grids with the model's downsampling multiple already known, so each case's free axis
-        # rounds up to a valid input size (the graph (hence the factor) is final before init()).
+        # Cut the grids with the model's downsampling multiple known, so each case's free axis rounds up
+        # to a valid input size.
         self.dataset.set_free_axis_multiple(self.model.downsampling_factor())
         self.dataset.prepare()
         self.model.bind(
@@ -181,19 +177,10 @@ class Predictor(vram.VramAutoPatchMixin, DistributedObject):
             )
 
     def setup(self, world_size: int):
-        """
-        Set up the predictor for inference.
-
-        This method performs all necessary initialization steps before running predictions:
-        - Ensures output directories exist, and optionally prompts the user before overwriting existing predictions.
-        - Copies the current configuration file (Prediction.yml) into the output directory for reproducibility.
-        - Dynamically loads pretrained weights from local files or remote URLs.
-        - Wraps the base model into a `ModelComposite` to support ensemble inference.
-        - Initializes the prediction dataloader, with proper distribution across available GPUs.
-
-        Args:
-            world_size (int): Total number of processes or GPUs used for distributed prediction.
-
+        """Set up the predictor for inference: create the output directories, copy the configuration
+        file (Prediction.yml) into the output directory, load the pretrained weights from local files or
+        remote URLs, wrap the base model into a ``ModelComposite`` for ensemble inference and build the
+        prediction dataloader, distributed over the ``world_size`` processes or GPUs.
         """
         for dataset_filename in self.datasets_filename:
             path = self.predict_path / dataset_filename
@@ -202,10 +189,9 @@ class Predictor(vram.VramAutoPatchMixin, DistributedObject):
 
         shutil.copyfile(config_file(), self.predict_path / "Prediction.yml")
 
-        # Per-case resume, the semantics TRANSFORM documents: a case whose every configured output
-        # is already on disk is skipped, so a rerun after a mid-cohort failure pays only the missing
-        # cases; --overwrite recomputes everything. The set is frozen here, on the launcher, so
-        # every rank (and every OOM-restart re-plan) shards the same reduced work list.
+        # Per-case resume, the semantics TRANSFORM documents: a case whose every configured output is
+        # already on disk is skipped, and --overwrite recomputes everything. The set is frozen here, on
+        # the launcher, so every rank (and every OOM-restart re-plan) shards the same work list.
         if os.environ.get("KONFAI_OVERWRITE") != "True" and self.outputs_dataset:
             self._done_case_indices = {
                 index
@@ -220,9 +206,8 @@ class Predictor(vram.VramAutoPatchMixin, DistributedObject):
 
         self.model_composite = ModelComposite(self.model, self.combine, checkpoint_cache_gib=self.checkpoint_cache_gib)
         if not self.path_to_models and any(parameter.numel() for parameter in self.model.parameters()):
-            # A model WITH weights but no checkpoint would run with random weights and silently produce
-            # garbage: refuse it. A WEIGHTLESS model (0 parameters, e.g. a classical/optimisation engine
-            # such as registration) is legitimate with no checkpoint: it is run once as constructed.
+            # A model WITH weights but no checkpoint would run with random weights: refuse it. A WEIGHTLESS
+            # model (0 parameters, a classical engine such as registration) runs once as constructed.
             raise PredictorError(
                 "No model checkpoint available for prediction.",
                 "This model has trainable weights, so at least one '.pt' checkpoint must be provided (for "
@@ -234,8 +219,7 @@ class Predictor(vram.VramAutoPatchMixin, DistributedObject):
         try:
             self._report_chain_drift()
         except (OSError, KonfAIError, ValueError, TypeError) as error:
-            # A diagnostic reading someone else's config file never fails the prediction it reports
-            # on; what stopped it is said instead of swallowed.
+            # A diagnostic reading someone else's config file never fails the prediction it reports on.
             print(f"[KonfAI] the training-chain check did not run: {type(error).__name__}: {error}")
 
         self.size = len(self.gpu_checkpoints) + 1 if self.gpu_checkpoints else 1
@@ -246,9 +230,8 @@ class Predictor(vram.VramAutoPatchMixin, DistributedObject):
     def _drop_done_cases(self) -> None:
         """Drop the already-written cases' entries from the prepared patch mapping.
 
-        Applied to the mapping rather than the case list so the surviving cases keep their indices
-        (the managers and the loader's remapping stay untouched), and re-applied after every
-        ``replan_patch``, which rebuilds the mapping from scratch.
+        Applied to the mapping rather than the case list so the surviving cases keep their indices, and
+        re-applied after every ``replan_patch``, which rebuilds the mapping from scratch.
         """
         if not self._done_case_indices:
             return
@@ -260,11 +243,9 @@ class Predictor(vram.VramAutoPatchMixin, DistributedObject):
         """Warn when the chain applied to a model input is not the one its checkpoint trained on.
 
         Same checkpoint, different preprocessing is silent: the run succeeds and only the values are
-        wrong (the Synthesis example shipped ``Standardize(mask: None)`` in training against
-        ``Standardize(mask: MASK)`` here, and paid 409 HU of MAE instead of 98). A legitimate
-        difference exists, so this warns and never refuses, and ``check_training_transforms: false``
-        silences it. Compared against the resolved config the training run left in its ``Statistics``
-        directory, read without writing it back.
+        wrong. A legitimate difference exists, so this warns and never refuses, and
+        ``check_training_transforms: false`` silences it. Compared against the resolved config the
+        training run left in its ``Statistics`` directory, read without writing it back.
         """
         if not self.check_training_transforms:
             return
@@ -307,21 +288,12 @@ class Predictor(vram.VramAutoPatchMixin, DistributedObject):
         self.path_to_models = path_to_models
 
     def _load(self) -> list[dict[str, Any] | Path | str]:
-        """
-        Resolve checkpoint sources for ensemble prediction.
+        """Resolve the checkpoint sources for ensemble prediction, one per model.
 
-        This method handles both remote and local model sources:
-        - A URL remains a reloadable source: torch.hub keeps its download on disk, while the
-          composite's bounded host cache decides which deserialized weights stay resident.
-        - If the model path is local:
-            - it keeps only the checkpoint path and lets `ModelComposite` stream weights into a single model
-              instance during prediction to reduce memory pressure.
-
-        Returns:
-            list[dict[str, dict[str, torch.Tensor]] | Path | str]: A list of checkpoint sources, one per model.
-
-        Raises:
-            Exception: If a model path does not exist or cannot be loaded.
+        A URL remains a reloadable source: torch.hub keeps its download on disk, while the composite's
+        bounded host cache decides which deserialized weights stay resident. A local path is kept as a
+        path and ``ModelComposite`` streams its weights into a single model instance during prediction.
+        Raises when a path neither exists nor is a URL.
         """
         state_dicts: list[dict[str, Any] | Path | str] = []
         for path_to_model in self.path_to_models:
@@ -340,15 +312,10 @@ class Predictor(vram.VramAutoPatchMixin, DistributedObject):
         local_rank: int,
         dataloaders: list[DataLoader],
     ):
-        """
-        Launch prediction on the given process rank.
+        """Launch prediction on the given process rank.
 
-        Args:
-            world_size (int): Number of model replicas sharding the data: the spawned process count
-                already divided by the model-parallel size (``gpu_checkpoints``), NOT the GPU count.
-            global_rank (int): Rank of the current process.
-            local_rank (int): Local device rank.
-            dataloaders (list[DataLoader]): List of data loaders for prediction.
+        ``world_size`` is the number of model replicas sharding the data: the spawned process count
+        already divided by the model-parallel size (``gpu_checkpoints``), NOT the GPU count.
         """
 
         model_composite = (
@@ -365,8 +332,8 @@ class Predictor(vram.VramAutoPatchMixin, DistributedObject):
         model_composite = Model(model_composite)
         device = local_rank * self.size if len(cuda_visible_devices()) else None
         dataloader = dataloaders[0]
-        # A whole-axis extent still too large for VRAM OOMs into the shrink loop below, which keeps
-        # the size valid too (the border padding fills the round-up, cropped back after the forward).
+        # A whole-axis extent still too large for VRAM OOMs into the shrink loop below, which keeps the
+        # size valid too.
         if self._vram_patch_candidate is None and self._presize_free_axes():
             dataloader = self._rank_dataloader(world_size, global_rank)
         while True:
@@ -385,12 +352,9 @@ class Predictor(vram.VramAutoPatchMixin, DistributedObject):
                     p.run()
                 return
             except torch.cuda.OutOfMemoryError:
-                # The restart loop IS the sizing iteration (no probe phase): the run that just OOMed
-                # already measured the step's transient for free. Read it BEFORE the reset (the peak
-                # still includes the resident accumulators on both sides of the difference), free the
-                # in-flight state: open streamed sinks abort and remove their partial entries, so a
-                # reader never sees a half-written volume even when the OOM is fatal, then read the
-                # honest free VRAM.
+                # The restart loop IS the sizing iteration: the run that just OOMed already measured the
+                # step's transient. Read it BEFORE the reset, free the in-flight state (open streamed sinks
+                # abort and remove their partial entries), then read the honest free VRAM.
                 measured = vram.transient_at_oom(device)
                 for output_dataset in self.outputs_dataset.values():
                     output_dataset.reset()
@@ -416,8 +380,7 @@ class Predictor(vram.VramAutoPatchMixin, DistributedObject):
     def _shrunken_patch(self, measured: int | None, usable: float) -> list[int] | None:
         """The shared shrink step, with the blend kept on the GPU when it fits: the accumulation
         footprint is RESERVED beside the forward, so the sized patch passes the accumulation gate.
-        Only when that reserve fits at no size (or cannot be priced) is the forward sized alone:
-        the gate's memory-safe CPU blend absorbs that case.
+        Only when that reserve fits at no size, or cannot be priced, is the forward sized alone.
         """
         if self._vram_patch_template is None:
             return None
@@ -435,10 +398,10 @@ class Predictor(vram.VramAutoPatchMixin, DistributedObject):
         return super()._shrunken_patch(measured, usable)
 
     def _accumulation_reserve(self, candidate: list[int], worst: list[int]) -> float | None:
-        """Bytes each case keeps resident while its patches accumulate, per output writer: the
-        streamed window (one patch extent x the cross-section) when the writer will stream --
-        single augmentation, voxel-local reduction: the assembled volume otherwise. ``None``
-        when a writer's channels cannot be read off the model trace (no reserve, gate decides).
+        """Bytes each case keeps resident while its patches accumulate, per output writer: the streamed
+        window (one patch extent x the cross-section) when the writer will stream (single augmentation,
+        voxel-local reduction), the assembled volume otherwise. ``None`` when a writer's channels cannot
+        be read off the model trace.
         """
         trace = {name: args.out_channels for name, _, args in self.model.named_module_args_dict()}
         elem = 2  # ModelComposite casts float32 outputs to float16 before accumulation
@@ -478,22 +441,11 @@ def build_predict(
     prediction_file: Path | str | dict = Path("./Prediction.yml"),
     predictions_dir: Path | str = Path("./Predictions"),
 ) -> DistributedObject:
-    """
-    Build and return the configured prediction workflow without executing it.
+    """Build and return the configured prediction workflow without executing it.
 
-    Parameters
-    ----------
-    models : list[Path]
-        One or more checkpoint files to load for prediction.
-    prediction_file : Path | str, optional
-        Prediction configuration file.
-    predictions_dir : Path | str, optional
-        Directory where prediction outputs are written.
-
-    Returns
-    -------
-    DistributedObject
-        Configured predictor object ready to be executed by the runtime wrapper.
+    ``models`` are the checkpoint files to load, ``prediction_file`` the prediction configuration and
+    ``predictions_dir`` the directory the outputs are written to. The predictor comes back ready to be
+    executed by the runtime wrapper.
     """
     configure_workflow_environment(
         config_path=prediction_file,
@@ -519,12 +471,11 @@ def predict(
     prediction_file: Path | str | dict = Path("./Prediction.yml"),
     predictions_dir: Path | str = Path("./Predictions"),
 ) -> DistributedObject:
-    """
-    Build and execute the configured prediction workflow.
+    """Build and execute the configured prediction workflow.
 
-    ``overwrite``/``gpu``/``cpu``/``quiet``/``tensorboard`` are load-bearing even though the body
-    drops them: :func:`run_distributed_app` reads them from the bound signature to drive the launch.
-    The pure build step is :func:`build_predict`.
+    ``overwrite``/``gpu``/``cpu``/``quiet``/``tensorboard`` are load-bearing even though the body drops
+    them: :func:`run_distributed_app` reads them from the bound signature to drive the launch. The pure
+    build step is :func:`build_predict`.
     """
     del overwrite, gpu, cpu, quiet, tensorboard
     return build_predict(

--- a/konfai/trainer.py
+++ b/konfai/trainer.py
@@ -81,11 +81,8 @@ def _checkpoint_score(path: Path, default: float) -> float:
 
 
 def _ddp_kwargs(model: Network, local_rank: int, size: int) -> dict[str, Any]:
-    """DDP options compatible with the graph's gradient accumulation cadence.
-
-    Static-graph DDP cannot start its first backward inside ``no_sync``. An accumulating
-    network needs the ordinary reducer; graphs stepping every batch keep the static fast path.
-    """
+    """DDP options for the graph's gradient accumulation cadence: an accumulating network needs the
+    ordinary reducer, a graph stepping every batch keeps the static-graph fast path."""
     accumulates = any(
         network.optimizer is not None and network.nb_batch_per_step > 1 for network in model.get_networks().values()
     )
@@ -120,9 +117,8 @@ def _restore_checkpoint_rng(states: dict[str, Any]) -> None:
 class EarlyStoppingBase:
     """Minimal protocol for early stopping strategies used by :class:`Trainer`."""
 
-    # Single source of truth for the optimisation direction of the monitored score. The default
-    # (no configured EarlyStopping) monitors the summed loss, so lower is better; EarlyStopping
-    # overrides this from its `mode` config. Both early stopping and BEST-checkpoint retention read it.
+    # Direction of the monitored score, read by early stopping and BEST-checkpoint retention. The
+    # default (no EarlyStopping) monitors the summed loss, lower is better.
     mode: str = "min"
 
     def __init__(self):
@@ -219,10 +215,8 @@ class EarlyStopping(EarlyStoppingBase):
 
 
 def _on_host(value: Any) -> Any:
-    """``value`` with every tensor copied into host memory: a snapshot the writer serialises while the
-    training thread moves on. Containers keep their type and attributes (a state dict is an
-    OrderedDict, possibly carrying ``_metadata``), so the file's layout is the one torch.save of the
-    live objects would write."""
+    """``value`` with every tensor copied into host memory. Containers keep their type and attributes
+    (a state dict is an OrderedDict, possibly carrying ``_metadata``)."""
     if isinstance(value, torch.Tensor):
         return value.detach().to("cpu", copy=True)
     if isinstance(value, dict):
@@ -241,9 +235,8 @@ def _dataset(loader: DataLoader) -> DatasetIter:
 
 
 class _CheckpointWriter:
-    """Serialises one checkpoint at a time on a thread of its own. ``submit`` first joins the previous
-    write, so at most one is in flight; a failure on the thread is raised by the next ``join``, on the
-    training thread, never lost."""
+    """Serialises one checkpoint at a time on a thread of its own: ``submit`` joins the previous write,
+    and a failure on the thread is raised by the next ``join`` on the training thread."""
 
     def __init__(self) -> None:
         self._thread: threading.Thread | None = None
@@ -275,24 +268,14 @@ def _ema_network(model_ema: AveragedModel) -> Network:
 
 
 class _Trainer:
-    """
-    Internal class for managing the training loop in a distributed or standalone setting.
+    """Training loop for one process, distributed or standalone: epochs with optional validation,
+    autocast, EMA, early stopping, TensorBoard logging, checkpoint saving (ALL or BEST).
 
-    Handles:
-    - Epoch iteration with training and optional validation
-    - Mixed precision support (autocast)
-    - Exponential Moving Average (EMA) model tracking
-    - Early stopping
-    - Logging to TensorBoard
-    - Model checkpoint saving and selection (ALL or BEST)
-
-    This class is intended to be used via a context manager
-    (`with _Trainer(...) as trainer:`)  inside the public `Trainer` class.
+    Used as a context manager (``with _Trainer(...) as trainer:``) inside :class:`Trainer`.
     """
 
-    # Rank-aligned poll cadence (iterations) shared by the validation-request and live-tunable pollers,
-    # and the cadence of the progress bar's description (an NVML query, two psutil queries and the
-    # last values of every criterion; refreshed on the bar's own schedule, not once per batch).
+    # Poll cadence (iterations), rank-aligned, shared by the validation-request and live-tunable
+    # pollers and by the progress bar's description refresh.
     _LIVE_POLL_INTERVAL = 20
 
     def __init__(
@@ -355,14 +338,13 @@ class _Trainer:
         self.it_lr_update = len(dataloader_training) if it_lr_update is None else it_lr_update
         self.it = it
         self._declare_measure_window()
-        # Live steering: an external steerer (MCP/Studio) drops control.json in the run dir; the loop applies
-        # each new revision at a DDP poll boundary and records the change into the run's config snapshot.
+        # Live steering: control.json in the run dir; each new revision is applied at a DDP poll
+        # boundary and recorded in the run's config snapshot.
         self._config_snapshot = config_snapshot
         self._live_control = LiveControl(statistics_directory() / self.train_name / "control.json")
         self._interventions: list[dict[str, Any]] = []
         if SummaryWriter is None:
-            # A missing logger must never refuse the run: training still produces a model, and only
-            # the curves are lost. One line says so; the extra keeps them.
+            # A missing logger never refuses the run: only the curves are lost.
             if self.global_rank == 0:
                 print(
                     "[KonfAI] TensorBoard is not installed: no curves or images will be logged"
@@ -389,10 +371,8 @@ class _Trainer:
     def __exit__(self, exc_type, value, traceback):
         """Close the writer and save an exit checkpoint only when it records anything.
 
-        An exit at the last save's iteration adds nothing, and the auto-patch OOM restart is about
-        to rebuild and continue: both used to leave a multi-GB worst-score snapshot behind (the
-        restart's, of untrained weights, unprunable). A genuine failure that DID advance keeps its
-        crash-save, under a name that says what it is.
+        An exit at the last save's iteration and the auto-patch OOM restart add nothing; a failure
+        that advanced keeps its crash-save.
         """
         if self.tb is not None:
             self.tb.close()
@@ -412,12 +392,10 @@ class _Trainer:
                     network.measure.set_window(max(self.it_validation, validation))
 
     def _initialize_best_checkpoint_state(self) -> None:
-        """Bootstrap BEST-checkpoint tracking once, including resume scenarios.
+        """Bootstrap BEST-checkpoint tracking once, including on resume.
 
-        Crash saves (``crash_*.pt``) are the user's to manage: never a contender for best, never
-        pruned. When only unscored checkpoints remain (their stored loss is the worst-score
-        sentinel), they all hold the same claim, so the newest: the most-trained snapshot: is kept
-        and the rest are pruned; ``is_better`` is strict, so no scan can elect one best.
+        Crash saves (``crash_*.pt``) are never a contender for best and never pruned. When only
+        unscored checkpoints remain, the newest is kept and the rest are pruned.
         """
         path = checkpoints_directory() / self.train_name
         if not path.exists():
@@ -462,12 +440,8 @@ class _Trainer:
         checkpoint_path.unlink()
 
     def run(self) -> None:
-        """
-        Launches the training loop, performing one epoch at a time.
-        Triggers early stopping and resets data augmentations between epochs.
-        """
-        # SIGUSR1 requests an on-demand validation pass (KonfAI Studio's "Validate now"); the handler only
-        # flips a flag: the loop consumes it at a poll boundary, DDP-safe (see _poll_live_requests).
+        """Run the training loop one epoch at a time, with early stopping and augmentation resets."""
+        # SIGUSR1 requests an on-demand validation; the flag is consumed at a poll boundary (_poll_live_requests).
         sigusr1 = getattr(signal, "SIGUSR1", None)  # absent on Windows
         if sigusr1 is not None:
             with suppress(ValueError, OSError):  # signals only install on the main thread
@@ -539,8 +513,7 @@ class _Trainer:
     def _save_epoch_boundary(self) -> None:
         """Publish a continuation cursor only after every optimizer finishes its accumulation window.
 
-        Every rank contributes its generator state. No extra optimizer step/zeroing is introduced to
-        make a boundary eligible: an incomplete window stays live for the next ordinary batch.
+        Every rank contributes its generator state; an incomplete window stays live for the next batch.
         """
         pending = [
             name
@@ -610,14 +583,7 @@ class _Trainer:
         self.checkpoint_save(self._deferred_score)
 
     def train(self) -> None:
-        """
-        Performs a full training epoch with support for:
-        - mixed precision
-        - DDP / CPU training
-        - EMA updates
-        - loss logging and checkpoint saving
-        - validation at configurable iteration interval
-        """
+        """One training epoch: autocast, DDP or CPU, EMA, logging, checkpoints, validation at ``it_validation``."""
         self._epoch_complete = False
         self._deferred_score = None
         self._resume_cursor = {
@@ -677,9 +643,8 @@ class _Trainer:
 
                         stop = False
                         if self.global_rank == 0:
-                            # Default selection scores on the losses only (always lower-is-better).
-                            # An explicit monitor may reference a metric; then use the full dict, and
-                            # its direction comes from EarlyStopping.mode (is_better).
+                            # Default selection scores the losses only (lower is better); an explicit
+                            # monitor reads the full dict with the direction of EarlyStopping.mode.
                             if isinstance(self.early_stopping, EarlyStopping) and self.early_stopping.monitor:
                                 score = self.early_stopping.get_score(loss)
                             else:
@@ -692,8 +657,7 @@ class _Trainer:
                                 with clock.phase("checkpoint"):
                                     self.checkpoint_save(score)
 
-                            # Stop once the schedulers have decayed the learning rate to zero:
-                            # no further optimisation is possible, so end the run cleanly.
+                            # Stop once the schedulers have decayed the learning rate to zero.
                             optimizer = self.model.module.optimizer
                             if not stop and optimizer is not None and optimizer.param_groups[0]["lr"] <= 0:
                                 self.early_stopping.stop()
@@ -718,12 +682,9 @@ class _Trainer:
     @staticmethod
     def _epoch_report(clock: SweepClock, min_seconds: float = 1.0) -> str | None:
         """One line accounting for the epoch's wall clock, in the sweep report's format, or ``None``
-        below ``min_seconds``. ``forward`` is the graph walk alone, the criteria being timed inside it;
-        what no phase names is ``other``, so the sum closes on the wall clock. On a device a phase
-        is the time its kernels took to enqueue: the device's own time lands where the host next
-        waits for it, so ``criteria`` carries the forward's kernels: its first target upload waits on
-        them, 13.8 s of a 20.2 s epoch on the shipped 2D example. The rest lands at the loss read, a
-        checkpoint's host copy and the validation."""
+        below ``min_seconds``. ``forward`` is the graph walk alone; what no phase names is ``other``. On
+        a device a phase is the time its kernels took to enqueue, so ``criteria`` carries the forward's
+        kernels."""
         wall = clock.spent("epoch")
         if wall < min_seconds:
             return None
@@ -735,9 +696,7 @@ class _Trainer:
 
     @torch.no_grad()
     def _validate(self) -> dict[str, float]:
-        """
-        Executes the validation phase, evaluates loss and metrics.
-        Updates model states and resets augmentation for validation set.
+        """Validation pass: losses and metrics, model states updated, augmentation reset for validation.
 
         Returns:
             dict[str, float]: Validation losses and metrics; empty off rank 0 or without a validation set.
@@ -774,9 +733,7 @@ class _Trainer:
         return self._validation_log(batch_sample)
 
     def _broadcast_from_master(self, value: Any) -> Any:
-        """Rank 0's value on every rank, so the loop stays synchronized under DDP: one broadcast of a
-        pickled object, where an all_gather would ship every rank's copy for a rank-0 payload. Any
-        picklable object rides through; callers cast as they need."""
+        """Rank 0's value on every rank, one broadcast of a pickled object; callers cast as they need."""
         if not dist.is_initialized():
             return value
         payload = [value if self.global_rank == 0 else None]
@@ -786,28 +743,19 @@ class _Trainer:
         return payload[0]
 
     def _broadcast_stop(self, stop: bool) -> bool:
-        """
-        Share rank 0's stop decision with every rank so the training loop is left together.
-
-        Only rank 0 owns the aggregated metrics and therefore the early-stopping decision.
-        Broadcasting it prevents ranks from diverging (some breaking, some continuing).
-        """
+        """Rank 0's stop decision on every rank, so the loop is left together."""
         return bool(self._broadcast_from_master(stop))
 
     def _poll_from_rank0(self, producer: Callable[[], Any]) -> Any:
-        """Rank 0 produces the value; every rank receives the same one via broadcast, so all ranks act on
-        the same value at the same iteration. Non-master ranks contribute a neutral placeholder that the
-        broadcast overwrites; single-process runs skip the collective entirely (like _broadcast_stop)."""
+        """Rank 0 produces the value and every rank receives it; single-process runs skip the collective."""
         value = producer() if self.global_rank == 0 else None
         if self.world_size > 1:
             value = self._broadcast_from_master(value)
         return value
 
     def _poll_live_requests(self) -> tuple[bool, dict[str, Any] | None]:
-        """What rank 0 has pending, at the poll cadence: an on-demand validation (SIGUSR1) and the
-        control file's new tunables, in one broadcast. Rank 0's state is authoritative, so every rank
-        acts on the same pair at the same iteration; the cadence bounds the latency while keeping the
-        collective rare, and single-process runs skip it entirely."""
+        """Rank 0's pending requests at the poll cadence, in one broadcast: an on-demand validation
+        (SIGUSR1) and the control file's new tunables."""
         if self.it % self._LIVE_POLL_INTERVAL != 0:
             return False, None
         requested, pending = self._poll_from_rank0(lambda: (self._validate_now, self._live_control.take()))
@@ -844,8 +792,8 @@ class _Trainer:
         return None
 
     def _record_interventions(self) -> None:
-        """Append the intervention audit trail to the run's config snapshot and reflect the current
-        it_validation, so the on-disk config stays a truthful record of the run. Rank 0, atomic."""
+        """Append the intervention audit trail and the current it_validation to the config snapshot.
+        Rank 0, atomic."""
         target = self._config_snapshot
         if not target.is_file():
             return
@@ -866,18 +814,15 @@ class _Trainer:
         os.replace(tmp, target)
 
     def checkpoint_save(self, loss: float | None, crash: bool = False) -> None:
-        """
-        Saves model and optimizer states. Keeps either all checkpoints or only the best one.
+        """Save model and optimizer states, keeping all checkpoints or only the best one.
 
-        The training thread copies the states into host memory and returns; the serialisation, the
-        publish and the BEST-mode pruning run on the writer's thread, joined before the next save and
-        at exit.
+        The training thread copies the states into host memory; serialisation, publish and BEST
+        pruning run on the writer's thread, joined before the next save and at exit.
 
         Args:
             loss (float): Current loss used for best checkpoint selection.
-            crash (bool): A save on an exceptional exit: named ``crash_<date>.pt`` and left outside
-                BEST retention, so the last state survives beside the best one instead of being
-                retired by it.
+            crash (bool): A save on an exceptional exit, named ``crash_<date>.pt`` and left outside
+                BEST retention.
         """
         if self.global_rank != 0:
             return
@@ -894,8 +839,7 @@ class _Trainer:
             collision += 1
         self._saved_at_it = self.it
 
-        # An unscored checkpoint (the final save at close) carries the worst possible score so
-        # `_update_best_checkpoint` retires it in BEST mode instead of leaving it beside the real best.
+        # An unscored checkpoint carries the worst possible score so BEST mode retires it.
         checkpoint_loss = loss if loss is not None else self.early_stopping.worst_score
         save_dict: dict[str, Any] = {
             "epoch": self.epoch,
@@ -941,18 +885,14 @@ class _Trainer:
         snapshot = _on_host(save_dict)
 
         def publish() -> None:
-            # Staged and renamed, the invariant the dataset writers hold: a multi-GB torch.save takes
-            # seconds, and a kill mid-write left a truncated .pt under a plausible name that RESUME
-            # then died on with an opaque unpickling error.
+            # Staged and renamed: a kill mid-write must not leave a truncated .pt under a plausible name.
             staging = save_path.with_name(f"{save_path.name}.{os.getpid()}.tmp")
             torch.save(snapshot, staging)
             os.replace(staging, save_path)
             if not crash and snapshot["resume"]["kind"] == "epoch_boundary":
-                # The newest dated save may be intermediate or a crash even in ALL mode.
-                # Keep an explicit latest continuation, sharing storage with its dated file.
+                # An explicit latest continuation, sharing storage with its dated file.
                 latest = path / "resume_latest.pt"
-                # A reused name could be a stale hard link left by a crashed process:
-                # truncating it in the copy fallback would also truncate its old BEST inode.
+                # A reused name may be a stale hard link; truncating it would also truncate its old BEST inode.
                 with tempfile.TemporaryDirectory(prefix=".resume-", dir=path) as temporary:
                     resume_staging = Path(temporary) / "checkpoint.pt"
                     try:
@@ -971,15 +911,14 @@ class _Trainer:
         type_log: str,
         batch_sample: BatchSample,
     ) -> dict[str, float]:
-        """
-        Logs losses, metrics and optionally images to TensorBoard.
+        """Log losses, metrics and optionally images to TensorBoard.
 
         Args:
             type_log (str): "Training" or "Validation".
             batch_item (dict): Dictionary of BatchItem from current batch.
 
         Returns:
-            dict[str, float]: Dictionary of aggregated losses and metrics on rank 0; empty on the other ranks.
+            dict[str, float]: Aggregated losses and metrics on rank 0; empty on the other ranks.
         """
         models: dict[str, Network] = {"": self.model.module}
         if self.model_ema is not None:
@@ -1015,12 +954,10 @@ class _Trainer:
 
         for label, model in models.items():
             for name, network in model.get_networks().items():
-                # EMA has no training forward, so its first validation has not produced a
-                # measurement yet. The collector omits such empty windows.
+                # EMA has no training forward: its first window may be empty, and the collector omits it.
                 if network.measure is None or f"{name}{label}" not in measures:
                     continue
-                # Losses and metrics take the same pair of boards: the measured value, and the
-                # weight that scaled it into the total.
+                # Losses and metrics take the same pair of boards: the value, and the weight that scaled it.
                 for board, table in (("Loss", 0), ("Metric", 1)):
                     entries = measures[f"{name}{label}"][table]
                     self.tb.add_scalars(
@@ -1035,9 +972,7 @@ class _Trainer:
                     )
 
             if len(images_log):
-                # get_layers is model-scoped, not per-network: run it once per model, or a
-                # multi-network model (a GAN's generator + discriminator) repeats the forward
-                # extraction and writes each image event once per network.
+                # get_layers is model-scoped: run it once per model, not once per network.
                 for name, layer, _ in model.get_layers(
                     [v.tensor for v in batch_sample.values() if v.is_input],
                     images_log,
@@ -1065,9 +1000,7 @@ class _Trainer:
                 minimized.update({k: v[2] for k, v in measures[name][0].items()})
                 loss.update({k: v[1] for k, v in measures[name][0].items()})
                 loss.update({k: v[1] for k, v in measures[name][1].items()})
-        # The default selection scores the losses by what they minimized, not by what they report:
-        # a Dice loss reports the coefficient, so summing that with a cross entropy kept the epoch
-        # with the worst overlap. A metric's direction varies and only an explicit monitor reads it.
+        # The default selection scores the losses by what they minimized, not by what they report.
         self._loss_score = minimized
         return loss
 
@@ -1084,12 +1017,8 @@ class _Trainer:
 
 def _agreed_patch(gathered: list, template: list[int]) -> list[int] | None:
     """The per-axis MIN of the candidates gathered at the OOM shrink rendezvous, ``None`` when no rank
-    proposed one (every rank is at its floor: the OOM is not recoverable).
-
-    A gathered entry that is not a patch candidate means another rank was still training and its own
-    collective crossed this rendezvous: an asymmetric OOM. That is not recoverable either, but it
-    must fail as a diagnosis, not as an opaque ``TypeError`` from ``min``.
-    """
+    proposed one. A gathered entry that is not a patch candidate is an asymmetric OOM (another rank's
+    collective crossed this rendezvous): unrecoverable, failed as a diagnosis."""
     proposals = [proposal for proposal in gathered if proposal is not None]
     if not proposals:
         return None
@@ -1110,15 +1039,8 @@ def _agreed_patch(gathered: list, template: list[int]) -> list[int] | None:
 
 @config()
 class Trainer(vram.VramAutoPatchMixin, DistributedObject):
-    """
-    Public API for training a model using the KonfAI framework.
-    Wraps setup, checkpointing, resuming, logging, and launching distributed _Trainer.
-
-    Main responsibilities:
-    - Initialization from config (via @config)
-    - Model and EMA setup
-    - Checkpoint loading and saving
-    - Distributed setup and launch
+    """Public API for training a model: setup, checkpointing, resuming, logging, and the distributed
+    ``_Trainer`` launch.
 
     Args:
         model (ModelLoader): Loader for model architecture.
@@ -1185,14 +1107,10 @@ class Trainer(vram.VramAutoPatchMixin, DistributedObject):
         self.size = len(self.gpu_checkpoints) + 1 if self.gpu_checkpoints else 1
 
         state = State[konfai_state()]
-        # Cut the grids with the model's downsampling multiple already known, so each case's free axis
-        # rounds up to a valid input size (the graph (hence the factor) is final before init()).
+        # The model's downsampling multiple is final before init(); each case's free axis rounds up to it.
         self.dataset.set_free_axis_multiple(self.model.downsampling_factor())
-        # The train/validation split is drawn inside prepare() here on the launcher, before spawn.
-        # It always comes from a CONCRETE seed: the configured one, or the seed the previous run
-        # recorded, or a fresh draw: an unseeded split would be redrawn on RESUME and leak
-        # validation cases into training. Per-rank seeding for the actual training happens later in
-        # the distributed runtime, and stays opt-in (`manual_seed`), as do the cudnn flags.
+        # The split is drawn on the launcher before spawn, from a concrete seed (configured, recorded,
+        # or fresh): an unseeded split would be redrawn on RESUME and leak validation cases into training.
         self._split_seed = self._resolve_split_seed(state)
         seed_all(self._split_seed)
         self.dataset.prepare()
@@ -1203,12 +1121,9 @@ class Trainer(vram.VramAutoPatchMixin, DistributedObject):
         self._downsampling_factor = self.model.downsampling_factor()
 
     def _resolve_split_seed(self, state: State) -> int:
-        """The seed every draw in ``prepare()`` (the split first) comes from, always concrete.
-
-        The configured ``manual_seed`` when there is one; on RESUME of an unseeded run, the seed the
-        TRAIN run recorded in its workspace, so the rebuilt split is the one the checkpoint trained
-        on; otherwise a fresh draw, recorded by ``setup`` for the next RESUME.
-        """
+        """The seed every draw in ``prepare()`` comes from: the configured ``manual_seed``, else the seed
+        the TRAIN run recorded (RESUME rebuilds the split the checkpoint trained on), else a fresh draw
+        recorded by ``setup`` for the next RESUME."""
         if self.manual_seed is not None:
             return self.manual_seed
         if state == State.RESUME:
@@ -1224,12 +1139,8 @@ class Trainer(vram.VramAutoPatchMixin, DistributedObject):
             return None
 
     def setup(self, world_size: int):
-        """
-        Initializes the training environment:
-        - Clears previous outputs (unless resuming)
-        - Initializes model and EMA
-        - Loads checkpoint (if resuming)
-        - Prepares dataloaders
+        """Initialize the training environment: clear previous outputs unless resuming, build the model
+        and EMA, load the checkpoint when resuming, prepare the dataloaders.
 
         Args:
             world_size (int): Total number of distributed processes.
@@ -1242,8 +1153,7 @@ class Trainer(vram.VramAutoPatchMixin, DistributedObject):
                 shutil.rmtree(checkpoints_path)
             elif checkpoints_path.exists():
                 checkpoints_path.unlink()
-            # The statistics directory holds the rank-0 log this process already has open: clear
-            # around it instead of rmtree'ing the directory out from under the live file.
+            # The statistics directory holds the rank-0 log already open: clear around it, not rmtree.
             statistics_path = statistics_directory() / self.name
             if statistics_path.is_dir():
                 clear_directory_except_logs(statistics_path)
@@ -1255,8 +1165,6 @@ class Trainer(vram.VramAutoPatchMixin, DistributedObject):
             if state != State.TRAIN:
                 state_dict = self._load()
             self.model.load(state_dict, init=True, ema=False, override_lr=self.override_lr)
-            # The EMA weights are restored from the same checkpoint: the startup line accounts for
-            # them where the reader looks for the weights, not in what setup does around them.
             if self.ema_decay > 0:
                 self.model_ema = AveragedModel(self.model, **self._ema_update())
                 if state_dict is not None:
@@ -1274,8 +1182,7 @@ class Trainer(vram.VramAutoPatchMixin, DistributedObject):
         with open(statistics_directory() / self.name / f"Validation_{self.it}.txt", "w") as f:
             for name in validation_names:
                 f.write(name + "\n")
-        # The seed the split was drawn from, kept where RESUME looks for it (_resolve_split_seed):
-        # written here, after the fresh-TRAIN clearing above, so it survives its own run.
+        # The split seed, where _resolve_split_seed reads it on RESUME; written after the clearing above.
         (statistics_directory() / self.name / "Seed.txt").write_text(f"{self._split_seed}\n")
 
     def set_model(self, path_to_model: str | Path) -> None:
@@ -1285,8 +1192,7 @@ class Trainer(vram.VramAutoPatchMixin, DistributedObject):
         self.override_lr = lr
 
     def _load(self) -> dict[str, Any]:
-        """
-        Loads a previously saved checkpoint from local disk or URL.
+        """Load a previously saved checkpoint from local disk or URL.
 
         Returns:
             dict: State dictionary loaded from checkpoint.
@@ -1317,15 +1223,14 @@ class Trainer(vram.VramAutoPatchMixin, DistributedObject):
             self.epoch = next_epoch
             self._resume_state = cursor
         elif "epoch" in state_dict:
-            # Old integers meant the epoch being executed. Never reinterpret them as next_epoch.
+            # An integer "epoch" is the epoch being executed, never next_epoch.
             self.epoch = state_dict["epoch"]
         if "it" in state_dict:
             self.it = state_dict["it"]
         return state_dict
 
     def _ema_update(self) -> dict[str, Any]:
-        """The EMA rule for AveragedModel: torch's fused ``multi_avg_fn``, one ``_foreach_lerp_``
-        per device and dtype."""
+        """The EMA rule for AveragedModel: torch's fused ``multi_avg_fn``."""
         return {"multi_avg_fn": get_ema_multi_avg_fn(self.ema_decay)}
 
     def run_process(
@@ -1335,9 +1240,7 @@ class Trainer(vram.VramAutoPatchMixin, DistributedObject):
         local_rank: int,
         dataloaders: list[DataLoader],
     ):
-        """
-        Launches the actual training process via internal `_Trainer` class.
-        Wraps model with DDP or CPU fallback, attaches EMA, and starts training.
+        """Launch the training via ``_Trainer``: wrap the model with DDP or the CPU fallback, attach EMA.
 
         Args:
             world_size (int): Number of model replicas sharding the data: the spawned process count
@@ -1390,21 +1293,15 @@ class Trainer(vram.VramAutoPatchMixin, DistributedObject):
             except torch.cuda.OutOfMemoryError:
                 if self._vram_patch_template is None:
                     raise  # no free axis declared: not auto-patched
-                # The restart loop IS the sizing iteration: the step that just OOMed already measured
-                # its transient for free. Drop the failed step's gradients before reading free VRAM.
-                # The auto-patch OOM fires on the first batch's FORWARD (the memory peak), before any
-                # optimizer.step(), so no weights are updated. The rare case where it fires mid-step
-                # instead leaves that first batch's partial update in place (the restart continues from
-                # it); this is a bounded one-batch perturbation, not worth a whole-run state snapshot.
+                # The step that just OOMed measured its transient. Drop its gradients before reading free
+                # VRAM. The OOM fires on the first batch's forward, before any optimizer.step(); a mid-step
+                # OOM leaves a one-batch partial update in place, which the restart continues from.
                 measured = vram.transient_at_oom(device)
                 self.model.zero_grad(set_to_none=True)
                 candidate = self._shrunken_patch(measured, vram.usable_after_oom(device))
-                # Every rank must train the same grid, so the shrink is agreed at a rendezvous: each
-                # failing rank proposes its own candidate and all adopt the per-axis MIN. A rank that
-                # did NOT run out never reaches this all-gather; the job then dies at the collective
-                # timeout, exactly as an unhandled OOM kills it. Ranks failing together recover
-                # together when they fail at the same collective offset (the common case: they
-                # share the patch size); an offset mismatch pairs foreign payloads, caught below.
+                # Every rank must train the same grid: each failing rank proposes a candidate and all
+                # adopt the per-axis MIN. A rank that did not run out never reaches this all-gather and
+                # the job dies at the collective timeout; an offset mismatch pairs foreign payloads.
                 if world_size > 1:
                     print(
                         f"[KonfAI] VRAM: rank {global_rank} ran out of memory -> waiting at the shrink"
@@ -1438,7 +1335,7 @@ def build_train(
     Parameters
     ----------
     command : State, optional
-        Training command variant, typically ``State.TRAIN`` or ``State.RESUME``.
+        ``State.TRAIN`` or ``State.RESUME``.
     model : Path | str | None, optional
         Checkpoint path used when resuming training.
     config : Path | str, optional
@@ -1448,14 +1345,13 @@ def build_train(
     statistics_dir : Path | str, optional
         Output directory for statistics and logs.
     lr : float | None, optional
-        Runtime learning-rate override applied when resuming/fine-tuning. When
-        ``None`` the checkpoint learning rate is resumed and the scheduler
-        continues; when set, the learning rate restarts from this value.
+        Learning-rate override when resuming: ``None`` resumes the checkpoint's rate and scheduler,
+        a value restarts from it.
 
     Returns
     -------
     DistributedObject
-        Configured trainer object ready to be executed by the runtime wrapper.
+        Configured trainer, executed by the runtime wrapper.
     """
     configure_workflow_environment(
         config_path=config,
@@ -1471,8 +1367,7 @@ def build_train(
     with strict_config("Trainer", refuse=False):
         trainer = apply_config()(Trainer)()
     if model is not None:
-        # Keep https:// checkpoint URLs as raw strings: Path() collapses the '//' into
-        # 'https:/…', which then fails both the startswith('https://') check and Path.exists().
+        # Keep https:// checkpoint URLs as raw strings: Path() collapses the '//'.
         trainer.set_model(model if isinstance(model, str) and model.startswith("https://") else Path(model))
     trainer.set_lr(lr)
     return trainer
@@ -1492,12 +1387,10 @@ def train(
     statistics_dir: Path | str = Path("./Statistics/"),
     lr: float | None = None,
 ) -> DistributedObject:
-    """
-    Build and execute the configured training workflow.
+    """Build and execute the configured training workflow.
 
-    ``overwrite``/``gpu``/``cpu``/``quiet``/``tensorboard`` are load-bearing even though the body
-    drops them: :func:`run_distributed_app` reads them from the bound signature to drive the launch.
-    The pure build step is :func:`build_train`.
+    ``overwrite``/``gpu``/``cpu``/``quiet``/``tensorboard`` are read by :func:`run_distributed_app`
+    from the bound signature; the body drops them. The pure build step is :func:`build_train`.
     """
     del overwrite, gpu, cpu, quiet, tensorboard
     return build_train(

--- a/konfai/transformer.py
+++ b/konfai/transformer.py
@@ -16,12 +16,10 @@
 
 """The TRANSFORM workflow: dataset preparation, a declared transform chain applied to every case.
 
-The engine is :class:`~konfai.data.materialize.CaseMaterializer` (the streamed Save sweep with its
-whole-volume fallback, over each case's manager), and the product is the plan: before a byte is
-written, every (case, chain) is planned on the launcher, each output destination is probed with a
-real region-write open (created then removed, so the verdict is the run's own), and the whole thing
-opens the run's log, the console getting the one-line summary of it.
-Nothing here falls back silently: a chain that cannot stream says which stage refused and why, and
+The engine is :class:`~konfai.data.materialize.CaseMaterializer`, and the product is the plan: before
+a byte is written, every (case, chain) is planned on the launcher, each output destination is probed
+with a real region-write open, and the plan opens the run's log, the console getting its one-line
+summary. Nothing falls back silently: a chain that cannot stream says which stage refused, and
 ``on_fallback`` decides whether that is information, a warning, or an error.
 """
 
@@ -93,12 +91,10 @@ class TransformPlanEntry:
     #: The largest single tensor the case's chain holds (a reduction: its resident regions).
     case_bytes: int
     #: What this entry holds at its peak, the figure the budget bounds: the engine's whole-volume
-    #: working set (the case, one in-flight copy, the widest stage's own buffers), or a
-    #: reduction's regions.
+    #: working set, or a reduction's regions.
     working_set_bytes: int
-    #: The cases folded into one, for a reduction. Empty for an ordinary per-case entry. Printed in
-    #: full: a reduction whose case list silently changed writes a different volume under the same
-    #: name, and nothing about the output would look wrong.
+    #: The cases folded into one, for a reduction. Empty for an ordinary per-case entry, printed in
+    #: full otherwise.
     reduced: tuple[str, ...] = ()
     #: The case this entry is an Expand copy of ("" for anything that is not a copy).
     expanded_from: str = ""
@@ -117,17 +113,14 @@ class TransformPlan:
     dropped_cases: dict[str, int]
     dtype_hypothesis: str
     #: What the stages themselves asked the plan to say (``Transform.plan_note``): a cost the
-    #: columns above have no room for. Part of the plan, not of the run, so ``--plan`` carries it:
-    #: a note only worth reading after the bytes are written is not worth printing.
+    #: columns above have no room for.
     notes: tuple[str, ...] = ()
-    #: The chain spelled out with its destination, one label per ``(group_src, group_dest)``
-    #: pair: the one fact a reader wants from a plan line ("what runs, and where does it land").
+    #: The chain spelled out with its destination, one label per ``(group_src, group_dest)`` pair.
     chain_labels: dict[tuple[str, str], str] = field(default_factory=dict)
     #: What the store's decoded-chunk cache may hold out of the budget: part of what the process
     #: holds, so the header says it, and says when a budget puts it under the floor it is worth.
     chunk_cache_bytes: int = 0
-    #: Where the chain will run, so the header can name the ceiling the REGIONS are cut
-    #: under, which on a GPU is not the declared budget (see device_capped_budget).
+    #: Where the chain will run: on a GPU the regions' ceiling is not the declared budget.
     chain_device: "torch.device | None" = None
 
     @property
@@ -136,22 +129,14 @@ class TransformPlan:
 
     @property
     def refused_entries(self) -> list[TransformPlanEntry]:
-        """Entries no route can write: a reduction that cannot stream (unlike a per-case chain it has
-        no whole-volume path to fall back to), an entry whose destination is a remote root (no
-        route writes there). These refuse the run whatever ``on_fallback`` says."""
+        """Entries no route can write: a reduction that cannot stream, an entry whose destination is
+        a remote root. These refuse the run whatever ``on_fallback`` says."""
         return [entry for entry in self.entries if entry.verdict is Verdict.REFUSED]
 
     def budget_violations(self) -> list[TransformPlanEntry]:
         """Entries whose working set exceeds what they were sized against: a whole-volume fallback
-        (the case, its in-flight copy, the widest stage's buffers) against the whole budget, a
-        reduction against the share its regions were solved for. A headers-only estimate; the
-        report prints the margin.
-
-        The share and not the whole figure for a REDUCE, because that is the number ``fit_budget``
-        solves the height against: judged on the whole budget it could only ever speak when a
-        single row did not fit, so a fold needing twice its share announced a plan it could not
-        keep and was killed by the kernel instead of refused here.
-        """
+        against the whole budget, a reduction against the share its regions were solved for
+        (``fit_budget``). A headers-only estimate; the report prints the margin."""
         return [
             entry
             for entry in self.entries
@@ -160,23 +145,15 @@ class TransformPlan:
         ]
 
     def ceiling_for(self, verdict: Verdict) -> float:
-        """What an entry of this verdict is judged against, and what the report names.
-
-        A whole-volume fallback holds the case and nothing else is running: the whole budget. A
-        reduction holds its regions while the member chains and the store's cache hold theirs, so
-        it is judged against the share ``fit_budget`` solved its height for -- the same figure, in
-        the gate and on the line that explains it.
-        """
+        """What an entry of this verdict is judged against, and what the report names: the whole
+        budget for a whole-volume fallback, the regions' share for a reduction."""
         if verdict is Verdict.REDUCE:
             return budget_share("regions", self.budget_bytes) or self.budget_bytes
         return self.budget_bytes
 
     def summary(self) -> str:
-        """The plan in one line: what the run will do, and where to read the rest.
-
-        The console form, bounded: the full plan's notes and case lists grow with the cohort, so it
-        stays in the run's log (and ``--plan`` prints it on demand). What is folded away is counted here,
-        so nothing goes missing in silence."""
+        """The plan in one line: what the run will do, and where to read the rest. The full plan
+        stays in the run's log; what is folded away is counted here."""
         counts = Counter(entry.verdict for entry in self.entries)
         verdicts = ", ".join(f"{count} {verdict}" for verdict, count in sorted(counts.items())) or "nothing to do"
         dropped = sum(self.dropped_cases.values())
@@ -199,12 +176,8 @@ class TransformPlan:
         return "\n".join(lines)
 
     def _region_ceiling(self) -> str:
-        """What the REGIONS are cut under, said only when that is not the declared budget.
-
-        The budget is declared in host bytes and the regions of a GPU chain live in VRAM, so the two
-        ceilings differ and only one of them was printed. A second group whose card was already full
-        was cut at 7.63 GiB where the first had 11.58, and nothing in the plan said so: the run just
-        halved its region height and read twice as much."""
+        """What the REGIONS are cut under, said only when that is not the declared budget: the budget
+        is declared in host bytes and the regions of a GPU chain live in VRAM."""
         capped = device_capped_budget(self.budget_bytes, self.chain_device)
         if capped is None or self.chain_device is None or capped >= self.budget_bytes:
             return ""
@@ -214,8 +187,7 @@ class TransformPlan:
         )
 
     def _header(self) -> str:
-        # What a rank holds that the region sizing does not take out of the budget: said here rather
-        # than left to be discovered in a resident set.
+        # What a rank holds that the region sizing does not take out of the budget.
         beside = [f"engine ~{format_bytes(SWEEP_ENGINE_FLOOR_BYTES)}"]
         if self.chunk_cache_bytes:
             under = (
@@ -293,8 +265,7 @@ class TransformPlan:
 
     @staticmethod
     def _refused_count(counts: Counter[Verdict]) -> str:
-        """The REFUSED count of a chain's line, only where there is one: no chain writes anywhere
-        it refuses, so the usual line has nothing to count."""
+        """The REFUSED count of a chain's line, only where there is one."""
         return f", {counts[Verdict.REFUSED]} REFUSED" if counts[Verdict.REFUSED] else ""
 
     @staticmethod
@@ -324,11 +295,9 @@ class TransformPlan:
 
 @dataclass
 class WorkItem:
-    """One unit of the run, the same object the plan lines, the shards weigh and a rank executes.
-
-    A plain case, an Expand case with all its copies (the engine shares one read pass across them,
-    which a per-copy item could not), or a reduction (every member folded into one output).
-    """
+    """One unit of the run, the same object the plan lines, the shards weigh and a rank executes: a
+    plain case, an Expand case with all its copies, or a reduction (every member folded into one
+    output)."""
 
     kind: Literal["case", "expansion", "reduction"]
     group_src: str
@@ -393,13 +362,10 @@ class Transformer(DistributedObject):
         self.on_fallback = on_fallback
         self.manual_seed = int(manual_seed)
         self.dataset = dataset
-        # The seed reaches the Expand draws by DERIVATION, not by seeding a global RNG: each chain
-        # builds its own stage objects, so what a shared RNG hands them depends on the order the
-        # chains happen to be built, and an image and its mask would drift apart. Handed over before
-        # prepare(), which is where the chains are bound and the draws happen.
+        # The seed reaches the Expand draws by DERIVATION, not by seeding a global RNG. Handed over
+        # before prepare(), where the chains are bound and the draws happen.
         self.dataset.manual_seed = self.manual_seed
-        # prepare() binds the chains and runs every parse-time refusal (terminal Write, output
-        # collisions, writes into the source, inference transforms) before any byte is read.
+        # prepare() binds the chains and runs every parse-time refusal before any byte is read.
         self.dataset.prepare()
         self._overwrite = False
         self._budget_bytes: float | None = None
@@ -419,8 +385,7 @@ class Transformer(DistributedObject):
 
     @staticmethod
     def _terminal_destination(manager: DatasetManager) -> tuple[Dataset, str]:
-        # Guarded rather than indexed blindly: an empty chain is refused at parse time, but this
-        # runs on every case of every plan and a bare IndexError would say nothing about why.
+        # Guarded rather than indexed blindly: a bare IndexError would say nothing about why.
         terminal = manager.transforms[-1] if manager.transforms else None
         if not isinstance(terminal, Save):
             raise TransformerError(
@@ -430,9 +395,8 @@ class Transformer(DistributedObject):
         return save_destination(terminal, manager.dataset, manager.group_dest)
 
     def _reduction(self, group_dest: str, managers: list[DatasetManager]) -> CaseReduction | None:
-        """The reduction this chain declares, or ``None``. Built once per chain and kept: the plan, the
-        shards and the run must execute the same object. Its members are re-managed with the
-        pre-reduction stages only (a manager holding the ``Reduce`` itself cannot stream)."""
+        """The reduction this chain declares, or ``None``. Built once per chain and kept, so the plan,
+        the shards and the run execute the same object; its members hold the pre-reduction stages only."""
         if group_dest in self._reductions:
             return self._reductions[group_dest]
         reduction = self._build_reduction(group_dest, managers)
@@ -478,8 +442,7 @@ class Transformer(DistributedObject):
 
     def _work_items(self) -> list[WorkItem]:
         """The run's work items, in run order: a chain's cases one by one, or its reduction as one
-        item for all of them. Built once and kept: the plan, the shards and the run walk this one
-        list, so the run executes exactly what the plan measured."""
+        item for all of them. Built once and kept, so the run executes what the plan measured."""
         if self._items is not None:
             return self._items
         items: list[WorkItem] = []
@@ -517,10 +480,7 @@ class Transformer(DistributedObject):
     @staticmethod
     def _dtype_hypothesis(manager: DatasetManager) -> np.dtype:
         """The planned output dtype: the last cast's target if the chain declares one, else float32.
-
-        The engine takes the real dtype from the first computed slab; the plan says so instead of
-        pretending to know.
-        """
+        The engine takes the real dtype from the first computed slab."""
         dtype = np.dtype("float32")
         for transform in manager.transforms:
             declared = getattr(transform, "dtype", None)
@@ -536,10 +496,9 @@ class Transformer(DistributedObject):
     ) -> str | None:
         """Open a real region-write stream on each Save/Write destination, then remove it.
 
-        This is what makes the plan the run's own verdict: ``can_stream_data`` is a capability
-        check, but the refusals that matter (rank, dtype, geometry) live in ``open_data_stream``,
-        which the engine only reaches at the first computed slab. The probe pays one entry creation
-        per destination and takes it back (with the store, when the probe created it).
+        The refusals that matter (rank, dtype, geometry) live in ``open_data_stream``, which the
+        engine only reaches at the first computed slab, so the plan opens it here: one entry creation
+        per destination, taken back with the store when the probe created it.
         """
         manager = engine.manager
 
@@ -547,8 +506,7 @@ class Transformer(DistributedObject):
             destination, group = save_destination(save, manager.dataset, manager.group_dest)
             return str(destination.filename), group
 
-        # Every case of a chain shares its destinations: past the first case there is nothing to
-        # probe, and the fold that sizes the probe (the whole chain, per case) is skipped.
+        # Every case of a chain shares its destinations: past the first there is nothing to probe.
         if all(key_of(stage) in probed for stage in manager.chain_stages(a) if isinstance(stage, Save)):
             return None
         channels = int(manager.base_shape[0])
@@ -593,8 +551,7 @@ class Transformer(DistributedObject):
     @staticmethod
     def _remove_probe_entry(destination: Dataset, existed_before: bool) -> None:
         """Take back what the probe created beyond its entry: the case directory of a directory store
-        (``get_names`` would list it as a case) and, when the store did not exist before, the store
-        itself. ``rmdir``, never ``rmtree``: anything in there is not the probe's."""
+        and, when the store did not exist before, the store itself. ``rmdir``, never ``rmtree``."""
         with contextlib.suppress(OSError):
             if destination.is_directory:
                 (destination.path_on_disk / _PROBE_ENTRY).rmdir()
@@ -604,11 +561,7 @@ class Transformer(DistributedObject):
 
     def output_destinations(self) -> list[dict[str, str]]:
         """Every chain's terminal ``Write``, as ``{group_src, group_dest, dataset, path, group, format}``.
-
-        What the run produced, said in the run's own terms. The deliverable never lives under the
-        run directory, so this is how a reader: a person, Studio's run panel, the next workflow --
-        finds it without parsing the plan or re-reading the config.
-        """
+        The deliverable never lives under the run directory, so this is how a reader finds it."""
         destinations: list[dict[str, str]] = []
         for group_dest, managers in self.dataset.managers.items():
             if not managers:
@@ -629,10 +582,8 @@ class Transformer(DistributedObject):
         return destinations
 
     def _route(self, engine: CaseMaterializer, budget_bytes: float) -> tuple[Verdict, str | None]:
-        """``STREAM`` or ``LOAD``. A case streams unless its source serves no bounded region read,
-        so that every region of a sweep would decode the store whole, and it fits the budget: that
-        one is read once, whole. A fact of the store, not a prediction of the chain's reads. Expand
-        copies are not routed here: they share one read pass."""
+        """``STREAM`` or ``LOAD``. A case streams unless its source serves no bounded region read and
+        it fits the budget: that one is read once, whole. Expand copies are not routed here."""
         working_set = engine.fallback_working_set_bytes()
         if working_set <= budget_bytes and engine.reads_its_source_whole(0, apply_augmentations=False):
             return Verdict.LOAD, (
@@ -645,9 +596,7 @@ class Transformer(DistributedObject):
     def _remote_destination(manager: DatasetManager, *destinations: Dataset) -> str | None:
         """Why no route writes this chain, or ``None``: the first destination that is a remote root,
         as :func:`uri.refuse_write` refuses it. The chain's own Saves are always among them, and
-        ``destinations`` names what the route adds (a reduction's own output). Asked of the plan, not
-        of the first slab: every route ends in that refusal, and the whole-volume one reads and
-        transforms a case before reaching it."""
+        ``destinations`` names what the route adds (a reduction's own output)."""
         chain = tuple(
             save_destination(stage, manager.dataset, manager.group_dest)[0]
             for stage in manager.transforms
@@ -706,11 +655,8 @@ class Transformer(DistributedObject):
         if item.kind == "reduction":
             return [self._plan_reduction(item, overwrite)]
         # The plan prices the very slabs the run will sweep: same budget, same rows. And the SHARE,
-        # not the whole declaration: a sweep's block price already covers the chain that runs on it
-        # (DatasetManager.sweep_block_bytes folds in working_multiple), so it takes the landing's
-        # share and the chain's together -- what is left is the store's cache, which is holding its
-        # own beside every block. Handed the whole figure, a per-case sweep and the cache summed to
-        # more than the declaration and a 12 GiB machine was killed on a chain a reduction survived.
+        # not the whole declaration: a sweep's block price already covers the chain that runs on it,
+        # so what is left is the store's cache, holding its own beside every block.
         item.manager.set_memory_budget(sweep_share(budget_bytes))
         if item.kind == "expansion":
             return self._plan_copies(item, overwrite, probed)
@@ -721,9 +667,8 @@ class Transformer(DistributedObject):
         or the regions it will hold, and its destination is probed like a chain's."""
         reduction = item.reduction
         assert reduction is not None  # nosec B101 - the item was built from the same predicate
-        # Read off the chain, not assumed: a pointwise cast is allowed after the Reduce, and
-        # the probe below opens the destination with this dtype. A constant here would test
-        # a write the run never makes, and mha refuses on dtype.
+        # Read off the chain, not assumed: a pointwise cast is allowed after the Reduce, and the
+        # probe below opens the destination with this dtype.
         reduction_dtype = self._dtype_hypothesis(item.manager)
         reduction_plan = reduction.plan()
         remote = self._remote_destination(item.manager, reduction.destination)
@@ -733,8 +678,7 @@ class Transformer(DistributedObject):
         if remote is not None:
             verdict, reason = Verdict.REFUSED, remote
         elif verdict is Verdict.REDUCE:
-            # A reduction has no whole-volume fallback, so a destination that would refuse
-            # its stream at the first region refuses the plan: probed here, like a chain's.
+            # A reduction has no whole-volume fallback, so a refusing destination refuses the plan.
             probe_failure = self._probe_destination(
                 reduction.destination,
                 reduction.group,
@@ -786,9 +730,8 @@ class Transformer(DistributedObject):
         if not budget.shared_across_ranks and node_ranks > 1:
             # An explicit budget is per rank and never divided: the node holds N of them.
             budget_desc += f", per rank: x{node_ranks} = {format_bytes(per_rank_budget * node_ranks)} on the node"
-        # Resolved before anything is planned, because a reduction sizes its regions against it --
-        # the plan must measure the same run setup() will enforce. The store's decoded-chunk cache
-        # is bounded here too: it is part of what the process holds.
+        # Resolved before anything is planned: a reduction sizes its regions against it. The store's
+        # decoded-chunk cache is bounded here too, as part of what the process holds.
         self._budget_bytes = per_rank_budget
         self._rank_budget_bytes = budget.per_rank_bytes(node_ranks)
         set_per_rank_budget(per_rank_budget)
@@ -806,9 +749,8 @@ class Transformer(DistributedObject):
             entries.extend(planned)
             if item.kind == "case" and planned[0].verdict is Verdict.STREAM and item.engine.sub_cap_sweep():
                 sub_cap_sweeps = True
-        # From the walk that already happened, never a walk of its own: under a subset naming its
-        # cases the roots were asked about those alone, and asking for the rest is the listing it
-        # avoided. What that walk found and the run does not keep is a requested case one group lacks.
+        # From the walk that already happened, never a walk of its own. What that walk found and the
+        # run does not keep is a requested case one group lacks.
         kept = set(self.dataset.case_names)
         dropped = {group: len(held - kept) for group, held in (self.dataset.cohort_names or {}).items()}
         dtype_hypothesis = f"{'/'.join(sorted(planned_dtypes)) or 'float32'} / source channels"
@@ -850,9 +792,8 @@ class Transformer(DistributedObject):
 
     def setup(self, world_size: int):
         """Plan, print, enforce, shard: before any spawn, before any byte."""
-        # No overwrite prompt on the run folder: it holds the logs and a config copy, both
-        # rewritten in place, and prompting here would break the default per-case resume (a second
-        # run would refuse because the first one left its config copy behind).
+        # No overwrite prompt on the run folder: it holds the logs and a config copy, both rewritten
+        # in place, and prompting would break the default per-case resume.
         os.makedirs(self.transform_path, exist_ok=True)
         config_copy = self.transform_path / config_file().name
         if not (config_copy.exists() and config_copy.samefile(config_file())):  # -c may name the copy itself
@@ -860,25 +801,20 @@ class Transformer(DistributedObject):
 
         self._overwrite = os.environ.get("KONFAI_OVERWRITE", "False") == "True"
         plan = self.compute_plan(world_size, self._overwrite)
-        # The full plan opens the run's log, where a run is read after the fact; the console gets the
-        # one-line summary of it. One artifact, not two: the log is already the record of the run,
-        # and a second file holding the same text is one more thing to know about.
+        # The full plan opens the run's log; the console gets the one-line summary of it.
         kept = record(plan.report())
         print(f"{plan.summary()}" + (f" -> full plan in {kept}" if kept else ""))
         self._guard_sharded_destinations(world_size)
         self._enforce_plan(plan)
-        # Where the data went, machine-readable beside the human-readable plan. This run directory
-        # holds a log, a plan and a config copy, never the deliverable, which lands wherever each
-        # Write pointed. Without this, the one thing a reader wants after the run is the one thing
-        # nothing in the run directory names. Past the refusals: a run that writes nothing names
-        # no outputs.
+        # Where the data went, machine-readable beside the human-readable plan: the run directory
+        # holds a log, a plan and a config copy, never the deliverable. Past the refusals: a run
+        # that writes nothing names no outputs.
         (self.transform_path / "outputs.json").write_text(
             json.dumps(self.output_destinations(), indent=2) + "\n", encoding="utf-8"
         )
 
         self._budget_bytes = plan.budget_bytes
-        # The run executes the route the plan priced (LOAD assembles by choice, not fallback), and
-        # the console only speaks when the run DEVIATES from what the plan already printed.
+        # The run executes the route the plan priced; the console speaks only when it deviates.
         self._planned = {(entry.group_dest, entry.case): entry.verdict for entry in plan.entries}
         self._shard_work(world_size)
 
@@ -891,12 +827,10 @@ class Transformer(DistributedObject):
                 if not isinstance(transform, Save):
                     continue
                 destination, _group = save_destination(transform, managers[0].dataset, managers[0].group_dest)
-                # The question here is NOT concurrent_write_safe(): that one asks whether two
-                # entries of one shared store may be written at once, and answers no for
-                # omezarr, which would refuse the very destination this workflow recommends. Ranks
-                # shard by CASE, and a directory dataset gives each case its own file or store
-                # (<root>/<case>/<group>.<ext>), so their writes are disjoint by construction.
-                # Only a single-file store (h5) puts every case in one handle.
+                # NOT concurrent_write_safe(): that asks whether two entries of one shared store may
+                # be written at once, and answers no for omezarr. Ranks shard by CASE, and a
+                # directory dataset gives each case its own file or store, so their writes are
+                # disjoint; only a single-file store (h5) puts every case in one handle.
                 if not destination.is_directory:
                     raise TransformerError(
                         f"--cpu {world_size}: destination '{destination.filename}' is a"
@@ -950,8 +884,7 @@ class Transformer(DistributedObject):
                     " Write at a local path and upload the result separately.",
                 )
             reduction = self._reduction(first.group_dest, self.dataset.managers.get(first.group_dest, []))
-            # A grid disagreement gets its own remedy: a Save changes nothing about the grids, so
-            # the generic advice would send the reader in a circle.
+            # A grid disagreement gets its own remedy: a Save changes nothing about the grids.
             remedy = (
                 "The members do not land on one grid: resample them onto a common grid before the"
                 " Reduce, or declare grid: reference:<case> / shape_only if the cohort is already"
@@ -974,16 +907,13 @@ class Transformer(DistributedObject):
             )
 
     def _shard_work(self, world_size: int) -> None:
-        """Split the run into per-rank shards of work items.
-
-        Work items, not cases: an ordinary chain has one per case, a reduction exactly one for all
-        of them. Each item still writes its own entry, so the disjoint-writes guard of
-        :meth:`_guard_sharded_destinations` holds."""
+        """Split the run into per-rank shards of work items: an ordinary chain has one per case, a
+        reduction exactly one for all of them. Each item still writes its own entry, so the
+        disjoint-writes guard of :meth:`_guard_sharded_destinations` holds."""
         items = self._work_items()
         weights = [item.weight_bytes for item in items]
-        # Balanced by bytes, not by count: one large case among many small ones would otherwise
-        # hold a rank alone while the others finish, and a chain's cases would all land on the
-        # first ranks. Heaviest first onto the least-loaded rank (LPT); shards keep the run order.
+        # Balanced by bytes, not by count. Heaviest first onto the least-loaded rank (LPT); shards
+        # keep the run order.
         ranks = max(1, world_size)
         loads = [0] * ranks
         shards: list[list[int]] = [[] for _ in range(ranks)]
@@ -1001,21 +931,14 @@ class Transformer(DistributedObject):
         return []  # a rank walks its shard of work items; there is no loader
 
     def _held_line(self) -> str | None:
-        """What this rank actually held, against what it was allowed to hold.
-
-        A budget is a promise about resident memory, and until the run says what it held the promise
-        could only be checked from outside, with a cgroup and a stopwatch. The plan announces what it
-        SIZED for, which is not the same number: the sizing solves for a share of the budget, so a
-        chain holding more than it was priced at shows up here and nowhere else.
-        """
+        """What this rank actually held, against what it was allowed to hold. The plan announces what
+        it SIZED for, which is a share of the budget, so a chain holding more than it was priced at
+        shows up here."""
         peak = run_peak_resident_bytes()
         if peak is None:
             return None
-        # The RANK's whole figure, not the share left for the work. The peak is this process's
-        # high-water mark and it includes the interpreter and the libraries; the work budget has
-        # those taken off it, so judging one against the other counts the same bytes twice and
-        # reads as an overshoot that is not there (2.26x on a 2 GiB machine where the truth is
-        # 1.24x, the difference being the 661 MiB the process held before it read anything).
+        # The RANK's whole figure, not the share left for the work: the peak includes the interpreter
+        # and the libraries, which the work budget has taken off it.
         budget = self._rank_budget_bytes or self._budget_bytes
         held = f"held {format_bytes(peak)} at its peak"
         if not budget or budget <= 0:
@@ -1028,23 +951,20 @@ class Transformer(DistributedObject):
         """Materialize this rank's cases. The plan already said what will happen: the console gets
         the deviations from it, the live counter, and one final line that says how it went."""
         del dataloaders
-        # The one caller that knows its device: cuda:<rank> when the launch requested GPUs (the
-        # runtime narrowed CUDA_VISIBLE_DEVICES to them), CPU otherwise. The chain then runs where
-        # the rank runs; regions still land on the host for every write.
+        # The one caller that knows its device: cuda:<rank> when the launch requested GPUs, CPU
+        # otherwise. Regions still land on the host for every write.
         device = get_device(local_rank)
         chain_device = torch.device(f"cuda:{device}") if isinstance(device, int) else device
         started = time.monotonic()
         SWEEP_CLOCK.reset()
-        # What a region is measured above: the process as it stands before its first case, so the
-        # pages one region frees and the next reuses count as the resident bytes they are. The
-        # run's own, released with it (the closing line below reads the peak first).
+        # What a region is measured above: the process as it stands before its first case. Released
+        # with the run; the closing line below reads the peak first.
         record_resident_floor()
         try:
             items = self._work_items()
             shard = self._shards[global_rank]
             counts: Counter[Verdict] = Counter()
-            # 'error' holds at run time too: a fallback the plan could not see (a sweep that fails, a
-            # field bound exceeded) raises at that case instead of quietly costing a volume.
+            # 'error' holds at run time too: a fallback the plan could not see raises at that case.
             allow_fallback = self.on_fallback != "error"
 
             def description() -> str:
@@ -1111,8 +1031,7 @@ class Transformer(DistributedObject):
             return counts
         manager = item.manager
         if item.kind == "expansion":
-            # One item per case, all its copies inside: the engine shares one read pass
-            # across the copies whose draws allow it, which a per-copy loop could not.
+            # One item per case, all its copies inside: the engine shares one read pass across them.
             copies = list(range(1, item.copies + 1))
             todo = [a for a in copies if item.pending(manager.copy_entry(a), self._overwrite)]
             counts[Verdict.SKIP] += len(copies) - len(todo)
@@ -1158,12 +1077,10 @@ def build_transform(
 ) -> DistributedObject:
     """Build the configured transform workflow without executing it: ``compute_plan()`` is the
     dry run, ``setup()`` prints and enforces the plan. ``transform_file`` may be the config tree as
-    a dict; it is materialized to a file here, so the strict read sees what every other reader will.
+    a dict; it is materialized to a file here.
 
-    The read is strict: a key nothing binds (a typo'd ``memory_budge:``, a ``Clip: {min_val: 0}``)
-    is refused with its path instead of being carried along with its default used in its place.
-    Everything the workflow reads from the file is bound inside ``__init__`` (the chains, their
-    draws, a ``Reduce``'s operator), which is what lets the check close when it returns.
+    The read is strict: a key nothing binds is refused with its path. Everything the workflow reads
+    from the file is bound inside ``__init__``, which lets the check close when it returns.
     """
     if isinstance(transform_file, dict):
         transform_file = _materialized_config(transform_file, "Transformer")
@@ -1187,10 +1104,8 @@ def plan_transform(
     transforms_dir: Path | str = Path("./Transforms").resolve(),
 ) -> TransformPlan:
     """CLI ``--plan``: build, plan, print, and stop. Same flags and world size as :func:`transform`,
-    so the plan shards the way the run will; the plan is the requested output, printed whatever
-    ``quiet`` says; nothing is written under ``transforms_dir``. The write probe opens then removes
-    one entry per destination and takes back a store it created, so plan mode leaves no output
-    behind.
+    so the plan shards the way the run will; the plan is printed whatever ``quiet`` says, and
+    nothing is written under ``transforms_dir``.
     """
     del quiet
     workflow = build_transform(transform_file=transform_file, transforms_dir=transforms_dir)
@@ -1209,10 +1124,7 @@ def transform(
     transform_file: Path | str | dict = Path("./Transform.yml").resolve(),
     transforms_dir: Path | str = Path("./Transforms").resolve(),
 ) -> DistributedObject:
-    """Build and execute the configured transform workflow.
-
-    ``transform_file`` accepts the config tree as a dict: the pure-Python spelling of the same
-    run; the resolved YAML still lands in the workspace as the run's record.
-    """
+    """Build and execute the configured transform workflow. ``transform_file`` accepts the config
+    tree as a dict; the resolved YAML still lands in the workspace as the run's record."""
     del overwrite, gpu, cpu, quiet
     return build_transform(transform_file=transform_file, transforms_dir=transforms_dir)

--- a/konfai/utils/ITK.py
+++ b/konfai/utils/ITK.py
@@ -44,9 +44,7 @@ def read_displacement_field(path: str | Path) -> sitk.Image:
     """A displacement field, from an ITK image file OR an NGFF RFC-5 OME-Zarr store.
 
     A field written as a store cannot go through ``sitk.ReadImage``, and reading it as an ordinary
-    image is worse than failing: the component axis looks like any other, so indexing it yields one
-    third of the field and a registration that is wrong without being obviously wrong. This is the one
-    place that knows how to open either form, so no caller has to decide.
+    image yields one third of the field. This is the one place that knows how to open either form.
 
     The result is ``sitkVectorFloat64``: what ``DisplacementFieldTransform`` requires.
     """
@@ -69,8 +67,8 @@ def read_displacement_field(path: str | Path) -> sitk.Image:
     axes = get_ome_zarr_info(path)["axes"]
     n_axes = 1 + sum(axis in axes for axis in ("z", "y", "x"))  # channel-first C[Z]YX
     data, metadata = read_ome_zarr_data_slice(path, tuple(slice(None) for _ in range(n_axes)))
-    # Origin, Spacing and Direction together: NGFF scale/translation alone cannot express the
-    # direction matrix, so the geometry comes from the konfai sidecar through data_to_image.
+    # NGFF scale/translation cannot express the direction matrix, so the geometry comes from the
+    # konfai sidecar through data_to_image.
     field = data_to_image(data, ome_zarr_attributes(metadata))
     return sitk.Cast(field, sitk.sitkVectorFloat64)
 
@@ -162,16 +160,11 @@ def box_with_mask(mask: sitk.Image, label: list[int], dilatations: list[int]) ->
 def _linear_map(transform: sitk.Transform) -> AffineMap:
     """The exact world map of a linear transform: ``T(p) = M p + T(0)``.
 
-    ``M`` comes from ``GetMatrix`` where the type has one: the number ITK itself resamples with,
-    read past the centre/translation parameterisation that differs between Euler, Similarity,
-    Scale and Affine, and from ``T(e_k) - T(0)`` otherwise. The offset is ``T(0)`` directly
-    rather than assembled from centre and translation: one call, no cancellation, and true for
-    every parameterisation at once.
-
-    Probing is sound HERE and nowhere else in this file: for an affine map the columns are the map,
-    exactly, by linearity. For a non-linear one the same arithmetic measures a local gradient and
-    extrapolates it, which under-bounds, which is why a BSpline's affine part is the identity and
-    all of its reach lives in the residual.
+    ``M`` comes from ``GetMatrix`` where the type has one, past the centre/translation
+    parameterisation that differs between Euler, Similarity, Scale and Affine, and from
+    ``T(e_k) - T(0)`` otherwise. Probing is sound HERE and nowhere else in this file: for an affine
+    map the columns are the map exactly, while for a non-linear one the same arithmetic measures a
+    local gradient and under-bounds.
     """
     from konfai.data.geometry import AffineMap
 
@@ -207,20 +200,11 @@ def _displacement_stage(
     where they are not that already, none where they are.
 
     ``dtype`` is a CEILING, not a target: the values are held at the width the STORE holds them at,
-    never widened past it. A field written in float32 -- which is how ITK writes one, and how a DVF
-    normally sits on disk -- carries no more information as float64, so widening it buys a copy of
-    twice the bytes to say exactly the same thing, three times over once the sampler holds its own
-    (``_FIELD_WINDOW_COPIES``), and quantised straight back by any walk that runs in float32.
-
-    So float64 (the default ceiling, the bit-exact contract with SimpleITK) narrows nothing that
-    was stored wide, and lets a float32 store stay float32 -- losslessly, with no flag to set and
-    no precision traded, which is also what lets :func:`~konfai.data.transform._warp_field_float32`
-    apply such a field without a float64 transform to hold it. A caller whose coordinate walk runs
-    in float32 lowers the ceiling to float32, and there a genuinely float64 field does narrow: that
-    is the trade ``precision: fast`` names.
-
-    Anything not already float32 or float64 -- an integer field, a float16 one -- is converted to
-    the ceiling: those are widths SimpleITK has no pixel type for, and the walk no kernel for.
+    never widened past it. So float64, the default ceiling and the bit-exact contract with
+    SimpleITK, narrows nothing that was stored wide and lets a float32 store stay float32. A caller
+    whose coordinate walk runs in float32 lowers the ceiling to float32, the trade
+    ``precision: fast`` names, and there a genuinely float64 field does narrow. Anything not already
+    float32 or float64 is converted to the ceiling: SimpleITK has no pixel type for those widths.
     """
     from konfai.data.geometry import DisplacementStage
 
@@ -240,16 +224,15 @@ def _displacement_stage(
 def decode_transform_stages(transform: sitk.Transform) -> SpatialStages:
     """A stored transform as geometry stages in APPLICATION order, or a refusal naming the type.
 
-    ``CompositeTransform`` applies its member list in REVERSE (the last added runs first: verified
-    against SimpleITK, where ``GetNthTransform(0)`` is nonetheless the first added); the reversal is
-    normalized here, once, so every consumer reads stages first-applied-first.
+    ``CompositeTransform`` applies its member list in REVERSE (the last added runs first, though
+    ``GetNthTransform(0)`` is the first added); the reversal is normalized here, once, so every
+    consumer reads stages first-applied-first.
     """
     _require_simpleitk()
     if isinstance(transform, sitk.CompositeTransform):
         stages: list[AffineStage | DisplacementStage] = []
         for index in reversed(range(transform.GetNumberOfTransforms())):
-            # Downcast restores the member's concrete type where GetNthTransform hands back the
-            # generic wrapper, which the isinstance dispatch below cannot read.
+            # Downcast restores the concrete type behind GetNthTransform's generic wrapper.
             stages.extend(decode_transform_stages(transform.GetNthTransform(index).Downcast()))
         return tuple(stages)
     from konfai.data.geometry import AffineStage
@@ -265,9 +248,7 @@ def decode_transform_stages(transform: sitk.Transform) -> SpatialStages:
         )
     if isinstance(transform, sitk.DisplacementFieldTransform):
         # One copy of the field: the view is (Z, Y, X, rank) with the components (x, y, z) fastest,
-        # and the stage's component-first float64 layout is written straight from it (measured
-        # 159 MiB of peak against 50 MiB of content on a 128^3 field through GetArrayFromImage,
-        # a per-component ascontiguousarray and a stack).
+        # and the stage's component-first float64 layout is written straight from it.
         field = transform.GetDisplacementField()
         values = np.array(np.moveaxis(sitk.GetArrayViewFromImage(field), -1, 0), dtype=np.float64, order="C")
         return (_displacement_stage(_grid_of_image(field), values, 1, "this displacement field"),)
@@ -291,31 +272,19 @@ def read_transform_stages(
 ) -> SpatialStages:
     """The stored transform ``(group, name)`` of ``dataset`` as geometry stages in APPLICATION order.
 
-    A displacement entry becomes its stage straight from the array the store hands over, on the
-    grid its attributes describe: the field never passes through a SimpleITK image (a float32 store
-    widens to float64 exactly, where the image route copied it three times over on the way in and
-    once more on the way out). Every other entry decodes through :func:`decode_transform_stages`,
-    as does everything a store that serves transforms alone (``read_transform`` and nothing else)
-    hands over.
+    A displacement entry becomes its stage straight from the array the store hands over, on the grid
+    its attributes describe, without passing through a SimpleITK image. Every other entry decodes
+    through :func:`decode_transform_stages`, as does everything a store that serves transforms alone
+    (``read_transform`` and nothing else) hands over.
 
-    ``box`` is the world box the caller will evaluate the map over, and it is read from the headers
-    before a voxel is fetched: a field entry then comes back as its own sub-grid over the window
-    that box falls in, plus the lattice point linear interpolation reaches for. Without it the whole
-    entry is read, which is what a whole-volume call and the plan's own decode still want. A field
-    solved at full resolution is gigabytes -- 14.5 GiB per ExaSPIM case, and float64 on the way in
-    doubles it -- so a region that read the whole one would hold, per case, more than the budget
-    sizing it was ever told about.
-
-    Only a displacement entry is windowed. An affine is a matrix and a BSpline a coarse control
-    grid: both are small, and a BSpline's coefficients are not indexed by the box anyway.
-
+    ``box`` is the world box the caller will evaluate the map over, read from the headers before a
+    voxel is fetched: a field entry then comes back as its own sub-grid over the window that box
+    falls in, plus the lattice point linear interpolation reaches for. Without it the whole entry is
+    read, which is what a whole-volume call and the plan's own decode want. Only a displacement
+    entry is windowed: an affine is a matrix and a BSpline a coarse control grid, both small.
     ``headers_only`` is the plan's read: a dense field comes back as NO stage at all, which is the
-    identity, and its values are never touched. Nothing bounds a field from headers -- so a plan
-    that read them would pay a case's worth of memory for a number it cannot use, which is exactly
-    what the declared route already declines to do (:meth:`Resample._pricing_bound`).
-
-    ``field_dtype`` is what a dense field's values are held in: float64 for the bit-exact walk,
-    float32 for a caller whose walk runs in float32 and would quantise them back anyway.
+    identity, and its values are never touched. ``field_dtype`` is what a dense field's values are
+    held in: float64 for the bit-exact walk, float32 for a caller whose walk runs in float32.
     """
     from konfai.data.geometry import Grid
     from konfai.utils.dataset import DISPLACEMENT_FIELD_ATTRIBUTE, data_to_transform
@@ -326,17 +295,14 @@ def read_transform_stages(
     what = f"the displacement field '{group}' of case '{name}'"
     if headers_only:
         # The PLAN's read: a dense field answers as the identity and its values are never touched.
-        # Nothing bounds a field from headers, so there is nothing to read them for -- and reading
-        # them anyway is what put 29 GiB of one native case beside a budget that never saw it.
-        # Everything else is coefficients, small, and bounded exactly, so it decodes as usual.
+        # Everything else is coefficients, small and bounded exactly, so it decodes as usual.
         shape, header = dataset.get_infos(group, name)
         if DISPLACEMENT_FIELD_ATTRIBUTE in header:
             return ()
         data, attribute = read_data(group, name)
         return decode_transform_stages(data_to_transform(data, attribute, name))
     window = None
-    # A backend that cannot serve a slice reads whole, which is what it would do for any window it
-    # was given: the transform-only stores (read_transform and nothing else) are already out above.
+    # A backend that cannot serve a slice reads whole, as it would for any window it was given.
     if box is not None and getattr(dataset, "read_data_slice", None) is not None:
         shape, header = dataset.get_infos(group, name)
         if DISPLACEMENT_FIELD_ATTRIBUTE in header:
@@ -361,8 +327,7 @@ def encode_transform_stages(stages: SpatialStages) -> sitk.Transform:
     An affine stage becomes an ``AffineTransform`` (matrix and translation, world units); a
     displacement stage of order 1 a ``DisplacementFieldTransform`` on its own grid, of order 3 a
     ``BSplineTransform`` from its coefficient images. ``CompositeTransform`` applies its members
-    LAST-ADDED-FIRST, so the stages are added in reverse to run in order (the mirror of what
-    :func:`decode_transform_stages` undoes). One stage is returned as itself.
+    LAST-ADDED-FIRST, so the stages are added in reverse to run in order.
     """
     _require_simpleitk()
     from konfai.data.geometry import AffineStage
@@ -406,9 +371,8 @@ def encode_transform_stages(stages: SpatialStages) -> sitk.Transform:
 def invert_stages(stages: SpatialStages, rank: int) -> SpatialStages | None:
     """The exact inverse of an all-affine decoded map, or ``None`` when one is not algebraic.
 
-    A BSpline or a field inverts by an iterative dense solve, not an algebraic step, and a field
-    solved per region is not the restriction of the field solved once, so a non-affine inverse is
-    ``None`` here and the caller refuses with the remedy, rather than resampling through a guess.
+    A BSpline or a field inverts by an iterative dense solve, and a field solved per region is not
+    the restriction of the field solved once, so a non-affine inverse is ``None``.
     """
     from konfai.data.geometry import AffineMap, AffineStage
 

--- a/konfai/utils/budget.py
+++ b/konfai/utils/budget.py
@@ -16,9 +16,8 @@
 
 """The memory budget: what a run may hold, resolved once and shared by every consumer.
 
-An ``auto`` budget measures the node (a cgroup ceiling, a SLURM grant, the host's free RAM), a
-declared one is the caller's per-rank figure; both land in a :class:`MemoryBudget` that answers the
-one question every consumer had been re-deriving: what is MY rank's share.
+An ``auto`` budget measures the node (a cgroup ceiling, a SLURM grant, the host's free RAM) and the
+ranks sharing that node split it; a declared budget is the caller's per-rank figure.
 """
 
 from __future__ import annotations
@@ -36,8 +35,7 @@ import psutil
 from konfai.utils.errors import ConfigError
 
 # Fraction of the detected node memory an ``"auto"`` budget offers the cache; the rest is reserved for
-# the model's optimizer/gradient state, DataLoader worker copies, CUDA pinned staging buffers, and
-# allocator slack. Caching runs with zero DataLoader workers, so a fifth of the node held back is ample.
+# the model's optimizer/gradient state, DataLoader worker copies, pinned staging buffers and allocator slack.
 AUTO_MEMORY_SAFETY_FRACTION = 0.8
 
 #: The smallest declared budget the stack can honor (see the warning in resolve_memory_budget).
@@ -54,7 +52,7 @@ _MEMORY_UNIT_BYTES: dict[str, int] = {
 
 
 def format_bytes(num_bytes: float) -> str:
-    """Human bytes at the unit that carries digits: a 0.3 MB refusal must not read '0.00 GiB'."""
+    """Human-readable bytes at the largest unit that carries digits."""
     for shift, unit in ((40, "TiB"), (30, "GiB"), (20, "MiB"), (10, "KiB")):
         if abs(num_bytes) >= 2**shift:
             return f"{num_bytes / 2**shift:.2f} {unit}"
@@ -63,13 +61,9 @@ def format_bytes(num_bytes: float) -> str:
 
 @dataclass(frozen=True)
 class MemoryBudget:
-    """A resolved memory budget that knows its own scope.
-
-    The one decision no consumer may make for itself: an ``auto`` budget measures the NODE, so
-    ranks sharing it split it; an explicit budget is the user's per-rank figure, taken as is.
-    Handing consumers a bare number with an ``is_auto`` flag makes each of them re-derive that
-    rule: this object answers it once, through :meth:`per_rank_bytes`.
-    """
+    """A resolved memory budget that knows its own scope: an ``auto`` budget measures the NODE, so
+    ranks sharing it split it, where an explicit budget is the user's per-rank figure taken as is.
+    :meth:`per_rank_bytes` applies that rule."""
 
     total_bytes: float
     description: str
@@ -79,19 +73,9 @@ class MemoryBudget:
         return self.total_bytes / max(1, world_size) if self.shared_across_ranks else self.total_bytes
 
     def work_bytes(self, world_size: int) -> float:
-        """What is left of this rank's budget for the work itself.
-
-        An ``auto`` budget is the MACHINE's figure, and the interpreter, torch and the imaging
-        libraries are resident out of it before the first voxel is read: measured at 647 MiB, which
-        is 0.8% of an 80 GiB budget and 22% of the 2.91 GiB a 4 GiB machine offers -- the whole of
-        its margin, and why chains that ran inside an 8 GiB machine were killed on a 4 GiB one.
-
-        A DECLARED budget is not the machine's: a caller who writes ``memory_budget: 2G`` is saying
-        what the work may take, not what the process may weigh, so nothing is taken off it.
-
-        Read, not assumed: what the process holds depends on which optional libraries the chain
-        pulled in. Never below zero, where the refusals speak for a budget already spent.
-        """
+        """What is left of this rank's budget for the work itself. An ``auto`` budget is the MACHINE's
+        figure, so what the process already holds resident is taken off it; a DECLARED budget states what
+        the work may take, so nothing is. Never below zero."""
         per_rank = self.per_rank_bytes(world_size)
         if not self.shared_across_ranks:
             return per_rank
@@ -100,12 +84,7 @@ class MemoryBudget:
 
 #: How a declared per-rank budget divides between the consumers that can be holding AT ONCE:
 #: shares of ONE declaration, so they add to one. Which consumers are simultaneous is a property of
-#: the call path, not of this table: a whole-volume fallback and a swept tile are alternatives and
-#: each may take the route's whole share, while a fold's regions and its members' chains are not,
-#: because a member's sweep fires from inside the fold loop.
-#:
-#: The cache is the one to give up first: it is an optimisation, its own miss costs a re-decode, and
-#: the other two are the working set itself.
+#: the call path, not of this table.
 BUDGET_SHARES: dict[str, float] = {
     "regions": 0.50,  # what a route holds in the regions it is landing (a fold's kept folds included)
     "chains": 0.35,  # what a chain may hold while producing one of them: its sweeps, its walk slab
@@ -117,11 +96,8 @@ if abs(sum(BUDGET_SHARES.values()) - 1.0) > 1e-9:  # pragma: no cover - a typo, 
 
 
 def budget_share(name: str, budget_bytes: float | None = None) -> float | None:
-    """One consumer's share of the declared per-rank budget, or ``None`` when none was declared.
-
-    Asked by name so the division is read in one place (:data:`BUDGET_SHARES`) rather than
-    rediscovered as a fraction in each consumer's own file.
-    """
+    """One consumer's share of the declared per-rank budget (:data:`BUDGET_SHARES`), or ``None``
+    when none was declared."""
     declared = per_rank_budget_bytes() if budget_bytes is None else budget_bytes
     if not declared or declared <= 0:
         return None
@@ -131,11 +107,8 @@ def budget_share(name: str, budget_bytes: float | None = None) -> float | None:
 def sweep_share(budget_bytes: float | None = None) -> float | None:
     """What a per-case sweep's block may hold: the landing's share and the chain's together.
 
-    A sweep is not a fold. Its block price already folds in what the chain running on it holds
-    (:meth:`~konfai.data.patching.DatasetManager.sweep_block_bytes` multiplies the chain's working
-    multiple into the block), so the two shares are one figure here where a reduction spends them
-    separately -- its regions are landed by one loop and its members' chains run inside another.
-    What is left over is the store's cache, which holds its own beside every block either way.
+    A sweep's block price already includes what the chain running on it holds, so the two shares
+    are one figure here. What is left over is the store's cache.
     """
     declared = per_rank_budget_bytes() if budget_bytes is None else budget_bytes
     if not declared or declared <= 0:
@@ -143,16 +116,14 @@ def sweep_share(budget_bytes: float | None = None) -> float | None:
     return declared * (BUDGET_SHARES["regions"] + BUDGET_SHARES["chains"])
 
 
-#: This rank's share of the budget, as the workflow that resolved it published it. Some consumers of
-#: a budget sit inside a ``Dataset``, which a workflow reaches through doors that carry no budget (a
-#: transform reading a companion volume, a statistics scan, a store's decoded-chunk cache): they read
-#: it from here instead of every door growing a parameter for them.
+#: This rank's share of the budget, as the workflow that resolved it published it. Consumers sitting
+#: inside a ``Dataset``, which a workflow reaches through doors that carry no budget, read it here.
 _per_rank_bytes: float | None = None
 
 
 def set_per_rank_budget(budget_bytes: float | None) -> None:
-    """Publish this rank's budget. ``None`` (or a non-positive figure) means none was declared, which
-    is what every consumer falls back to its own default on."""
+    """Publish this rank's budget. ``None`` or a non-positive figure means none was declared, and
+    every consumer falls back to its own default."""
     global _per_rank_bytes
     _per_rank_bytes = float(budget_bytes) if budget_bytes and budget_bytes > 0 else None
 
@@ -165,45 +136,30 @@ def per_rank_budget_bytes() -> float | None:
 def peak_resident_bytes() -> int | None:
     """The most this process has ever held resident, or ``None`` where the kernel does not say.
 
-    A budget is a promise about resident memory, and until a run reports what it actually held the
-    promise could only be checked from outside. ``VmHWM`` is a lifetime high-water mark, so it
-    answers "did this run stay inside its budget" and not "which region was the worst".
-
-    NOT the cgroup's ``memory.peak``, which is the figure to reach for from outside but the wrong one
-    to report from inside: it counts the page cache the run's reads pulled in, which is reclaimable
-    and kills nothing. Measured on one TRANSFORM over native-resolution fields: cgroup 36.9 GiB
-    against 31.25 here, the difference being cache behind 88 GiB of decoded chunks. What the OOM
-    killer counts is the anonymous set (``anon-rss`` in its message), and this tracks it: at the end
-    of that same run ``RssFile`` was 0.30 GiB against 11.05 of ``RssAnon``, so a process whose file
-    mappings are small -- which a streamed run's are, since it reads rather than maps -- has a
-    ``VmHWM`` that is its anonymous peak.
+    ``VmHWM`` is a lifetime high-water mark, so it answers "did this run stay inside its budget" and not
+    "which region was the worst". NOT the cgroup's ``memory.peak``, which also counts the reclaimable
+    page cache; ``VmHWM`` tracks the anonymous set the OOM killer counts.
     """
     return _status_bytes("VmHWM")
 
 
-#: The highest ``VmHWM`` read before a reset: what a run's closing line adds back, so a scope's
-#: reset (a region measured for the growth) never makes the run report less than it held.
+#: The highest ``VmHWM`` read before a reset, added back by :func:`run_peak_resident_bytes` so a
+#: scope's reset never makes the run report less than it held.
 _peak_before_resets = 0
 
 
 def run_peak_resident_bytes() -> int | None:
     """The most this process has held resident over the whole run, across every
-    :func:`reset_resident_peak`: the figure a run's closing line reports, where
-    :func:`peak_resident_bytes` reads the scope since the last reset."""
+    :func:`reset_resident_peak`, where :func:`peak_resident_bytes` reads the scope since the last reset."""
     peak = peak_resident_bytes()
     return None if peak is None else max(peak, _peak_before_resets)
 
 
 def reset_resident_peak() -> bool:
     """Set this process's resident high-water mark back to what it holds now, so the next reading of
-    :func:`peak_resident_bytes` is a peak over one scope rather than over the whole run.
-
-    ``VmHWM`` only rises, which is what makes it the right figure for a whole run and the wrong one
-    for a step. Writing ``5`` to ``/proc/self/clear_refs`` is the kernel's own reset for exactly this
-    (``CLEAR_REFS_MM_HIWATER_RSS``): it assigns the current RSS and walks nothing, so it costs a
-    write and no page-table scan. ``False`` where the kernel does not offer it, and a caller that
-    gets ``False`` has no per-step peak and should not pretend otherwise.
-    """
+    :func:`peak_resident_bytes` is a peak over one scope rather than over the whole run. Writes ``5`` to
+    ``/proc/self/clear_refs``. Returns ``False`` where the kernel does not offer it, and such a caller
+    has no per-step peak."""
     global _peak_before_resets
     peak = peak_resident_bytes()
     try:
@@ -227,11 +183,8 @@ _resident_floor: int | None = None
 def record_resident_floor() -> int | None:
     """Record what this process holds resident now as the run's floor (:func:`resident_floor`).
 
-    Called by a workflow after its setup and before its first case, so a region is measured above
-    the interpreter, the libraries and the workflow's own objects, and never above the pages an
-    earlier region freed and this one reuses: those are resident, and the budget is about what is
-    resident. Measured above where a scope started instead, a region reusing a predecessor's pages
-    read as holding nothing.
+    Called by a workflow after its setup and before its first case, so a region is measured above the
+    interpreter, the libraries and the workflow's own objects.
     """
     global _resident_floor
     _resident_floor = resident_bytes()
@@ -244,8 +197,7 @@ def resident_floor() -> int | None:
 
 
 def clear_resident_floor() -> None:
-    """Forget the recorded floor: a workflow's own, released when it ends, so the next workflow in
-    the same process (a notebook) measures above its own floor or above where its scopes start."""
+    """Forget the recorded floor, so the next workflow in the same process measures above its own."""
     global _resident_floor
     _resident_floor = None
 
@@ -271,28 +223,20 @@ def _positive_int_env(name: str) -> int | None:
 
 
 def node_local_ranks(world_size: int | None = None) -> int:
-    """How many ranks of this run share ONE node's RAM: the divisor a node-scoped budget needs.
-
-    The launcher publishes the count in ``KONFAI_LOCAL_RANKS``, because a budget is often sized before
-    the spawn where a world size exists at all. Without it (direct API use, a garbled value) the
-    world size stands in: exact on a single node, conservative everywhere else.
-    """
+    """How many ranks of this run share ONE node's RAM: the divisor a node-scoped budget needs. The
+    launcher publishes the count in ``KONFAI_LOCAL_RANKS``; without it the world size stands in, exact
+    on a single node and conservative everywhere else."""
     local = _positive_int_env("KONFAI_LOCAL_RANKS")
     if local is None:
         return max(1, world_size or 1)
     return min(local, world_size) if world_size else local
 
 
-# psutil.virtual_memory() always reports the HOST, so inside a container or a SLURM cgroup that grants
-# far less than the node has, a memory budget derived from it would overshoot the real limit and get
-# OOM-killed. The cgroup ceiling is read directly instead: the process's own cgroup (from
-# /proc/self/cgroup, since only ``docker run`` puts it at the mount root) and every ancestor up to the
-# mount, the tightest one winning. cgroup v2 exposes ``memory.max`` (the literal ``"max"`` means
-# unbounded); cgroup v1 exposes ``memory.limit_in_bytes`` with a page-aligned near INT64_MAX sentinel.
-# What the cgroup already holds is read from ``memory.stat`` and counts only the unreclaimable part
-# (``anon`` + ``kernel`` in v2, ``rss`` in v1): ``memory.current``/``usage_in_bytes`` include the page
-# cache, which the kernel drops under pressure, so a step that has streamed a cohort would otherwise
-# look full. Only Linux has these files.
+# psutil.virtual_memory() always reports the HOST, so the cgroup ceiling is read directly: the process's
+# own cgroup (from /proc/self/cgroup) and every ancestor up to the mount, the tightest one winning.
+# cgroup v2 exposes ``memory.max`` (the literal ``"max"`` means unbounded); v1 exposes
+# ``memory.limit_in_bytes`` with a page-aligned near INT64_MAX sentinel. What the cgroup already holds is
+# read from ``memory.stat``, the unreclaimable part only (``anon`` + ``kernel`` in v2, ``rss`` in v1).
 _CGROUP_ROOT = "/sys/fs/cgroup"
 _PROC_SELF_CGROUP = "/proc/self/cgroup"
 _CGROUP_UNLIMITED = 1 << 62  # any v1 limit at or above this is the "no limit" sentinel
@@ -317,8 +261,8 @@ def _own_cgroup(controller: str) -> tuple[Path, str, bool] | None:
         if hierarchy == "0" and controllers == "":
             return root, path, True
         if controller in controllers.split(","):
-            # A v1 controller mounts under the name it is mounted with: on most distributions the
-            # joint "cpu,cpuacct" with a "cpu" symlink beside it, on some only the joint one.
+            # A v1 controller mounts under the name it is mounted with: the joint "cpu,cpuacct" or
+            # the plain "cpu".
             mount = next((root / d for d in (controllers, controller) if (root / d).is_dir()), None)
             if mount is not None:
                 return mount, path, False
@@ -382,8 +326,7 @@ def forget_cgroup_cpu_ceiling() -> None:
 
 def _cgroup_cpu_ceiling() -> int | None:
     """The tightest CPU quota over this process's cpu cgroup and its ancestors, in cores; ``None``
-    when unbounded. Read once per process: the cgroup a process sits in does not move, and the
-    walk opens a file per ancestor, which a caller on every patch paid 300,000 times an epoch."""
+    when unbounded. Read once per process: the walk opens a file per ancestor."""
     key = (_PROC_SELF_CGROUP, _CGROUP_ROOT)
     if key not in _cpu_quota_cores:
         ceiling: int | None = None
@@ -398,9 +341,7 @@ def _cgroup_cpu_ceiling() -> int | None:
 
 def available_cpus() -> int:
     """The cores this process may actually run on: the tighter of its affinity mask and its cgroup
-    CPU quota (v2 ``cpu.max``, v1 ``cpu.cfs_quota_us``/``cpu.cfs_period_us``, over its ancestors).
-    ``os.cpu_count()`` is the host's core count, which a container sees in full while being allowed
-    a fraction of it, and every thread past that fraction is contention."""
+    CPU quota (v2 ``cpu.max``, v1 ``cpu.cfs_quota_us``/``cpu.cfs_period_us``, over its ancestors)."""
     try:
         cores = len(os.sched_getaffinity(0))
     except (AttributeError, OSError):
@@ -430,11 +371,9 @@ def _held_memory_bytes(directory: Path, keys: tuple[str, ...]) -> int | None:
 def _read_cgroup_memory_limit() -> tuple[int, int] | None:
     """``(ceiling, held bytes)`` for this process's cgroup, or ``None`` when unbounded or absent.
 
-    The ceiling is the tightest ``memory.max``/``limit_in_bytes`` on the path from the process's own
-    cgroup to the mount root; the held bytes are the innermost cgroup's unreclaimable memory, so a
-    SLURM step already holding memory does not count it as free. A missing hierarchy (non-Linux,
-    cgroups disabled), the ``"max"`` keyword, the v1 sentinel and unparseable values all mean "no
-    bound at this level".
+    The ceiling is the tightest ``memory.max``/``limit_in_bytes`` from the process's own cgroup to the
+    mount root; the held bytes are the innermost cgroup's unreclaimable memory. A missing hierarchy, the
+    ``"max"`` keyword, the v1 sentinel and unparseable values all mean "no bound at this level".
     """
     limits: list[int] = []
     held: int | None = None
@@ -457,8 +396,8 @@ def _read_cgroup_memory_limit() -> tuple[int, int] | None:
 
 def _slurm_memory_grant() -> int | None:
     """The bytes SLURM granted this step (``--mem`` / ``--mem-per-cpu``, in MB), or ``None`` outside a job.
-    Read as well as the cgroup: on a cluster whose slurmd does not enforce cgroups, the env is the bound.
-    ``--mem=0`` means the whole node, not zero: a zero grant is no bound."""
+    Read as well as the cgroup, which a slurmd may not enforce. ``--mem=0`` means the whole node,
+    so a zero grant is no bound."""
     per_node = _positive_int_env("SLURM_MEM_PER_NODE")
     if per_node is not None:
         return per_node * 2**20
@@ -470,13 +409,9 @@ def _slurm_memory_grant() -> int | None:
 
 
 def available_memory_bytes() -> tuple[int, str]:
-    """Return ``(bytes a process may safely allocate, source label)``, honouring a cgroup limit.
-
-    ``psutil`` sees the host's free RAM, which overshoots a container/cgroup ceiling; the tightest of
-    the cgroup's remaining room (its ceiling minus what it already holds), a SLURM memory grant and
-    the host figure wins, so the number is safe on a bare host, in a memory-capped container and in a
-    SLURM step alike. The label names which bound won, for the startup decision log.
-    """
+    """Return ``(bytes a process may safely allocate, source label)``: the tightest of the cgroup's
+    remaining room (its ceiling minus what it already holds), a SLURM memory grant and the host's free
+    RAM. The label names which bound won."""
     candidates = [(int(psutil.virtual_memory().available), "host available RAM")]
     cgroup = _read_cgroup_memory_limit()
     if cgroup is not None:
@@ -491,11 +426,10 @@ def available_memory_bytes() -> tuple[int, str]:
 def parse_memory_budget_bytes(value: str | float) -> int:
     """Parse an explicit memory budget to bytes: a bare number is GiB, a string carries its own unit.
 
-    KonfAI reports RAM in GiB throughout, so an unadorned ``24`` reads as ``24 GiB``: whether it
-    arrives as a number or, through the YAML binding, as the string ``"24"``. A string may name its
-    unit: decimal ``GB``/``MB`` (10^n) or binary ``GiB``/``MiB`` (2^n), case-insensitive, optional
-    space (``"24GB"``, ``"32 GiB"``, ``"512mb"``); ``"b"`` means bytes. ``"auto"`` is resolved by the
-    caller, not here.
+    An unadorned ``24`` reads as ``24 GiB``, as a number or as the YAML string ``"24"``. A string may
+    name its unit: decimal ``GB``/``MB`` (10^n) or binary ``GiB``/``MiB`` (2^n), case-insensitive, with
+    an optional space (``"24GB"``, ``"32 GiB"``, ``"512mb"``); ``"b"`` means bytes. ``"auto"`` is
+    resolved by the caller.
     """
     if isinstance(value, str):
         match = re.fullmatch(r"\s*(?P<number>[0-9]*\.?[0-9]+)\s*(?P<unit>[a-z]*)\s*", value.lower())
@@ -519,12 +453,9 @@ def parse_memory_budget_bytes(value: str | float) -> int:
 
 
 def resolve_memory_budget(memory_budget: str | float | None) -> MemoryBudget:
-    """The configured ``memory_budget`` as an object that knows its own scope.
-
-    ``None``/``"auto"`` offers ``AUTO_MEMORY_SAFETY_FRACTION`` of the node's allocatable memory: a
-    NODE budget, which ranks sharing the node split; an explicit budget is the caller's own figure,
-    per rank as declared.
-    """
+    """The configured ``memory_budget`` as an object that knows its own scope: ``None``/``"auto"`` offers
+    ``AUTO_MEMORY_SAFETY_FRACTION`` of the node's allocatable memory, a NODE budget which the ranks
+    sharing the node split, where an explicit budget is per rank as declared."""
     if memory_budget is None or (isinstance(memory_budget, str) and memory_budget.strip().lower() == "auto"):
         node_bytes, source = available_memory_bytes()
         return MemoryBudget(
@@ -534,12 +465,9 @@ def resolve_memory_budget(memory_budget: str | float | None) -> MemoryBudget:
         )
     declared = parse_memory_budget_bytes(memory_budget)
     if declared < MINIMUM_DECLARED_BUDGET_BYTES:
-        # Below this the declaration describes no process that can run: the interpreter with torch
-        # and one imaging backend was measured at 647 MiB resident before the first voxel, and the
-        # per-case engine floor, the statistics scan's blocks and one collate copy sit outside the
-        # sizing model (a smaller declaration held at 512 MiB and broke below 128 as an
-        # unattributable kill deep in a run). Warned rather than refused: tests and probes size
-        # tiny fixtures under tiny declarations on purpose.
+        # Below this the declaration describes no process that can run: the interpreter with torch and
+        # one imaging backend is already several hundred MiB resident before the first voxel. Warned
+        # rather than refused: tests and probes size tiny fixtures under tiny declarations on purpose.
         warnings.warn(
             f"memory_budget {memory_budget!r} is below the smallest supported declaration"
             f" ({MINIMUM_DECLARED_BUDGET_BYTES >> 20} MiB): the process floor alone is several times"

--- a/konfai/utils/config.py
+++ b/konfai/utils/config.py
@@ -47,8 +47,8 @@ _log = logging.getLogger(__name__)
 class Range:
     """UI hint attached to a parameter's type: its inclusive numeric bounds.
 
-    Use ``Annotated[int, Range(0, 100)]`` (or ``float``) in a config-bound signature: the binder ignores the
-    metadata and validates the base type, while a UI reads the bounds to size a spinbox. Introspection-only.
+    Use ``Annotated[int, Range(0, 100)]`` (or ``float``). The binder ignores the metadata and validates the
+    base type; a UI reads the bounds. Introspection-only.
     """
 
     min: float
@@ -59,10 +59,9 @@ class Choices:
     """UI hint attached to a parameter's type: its allowed values.
 
     Use ``Annotated[str, Choices([...])]`` for a fixed list, or ``Annotated[str, Choices(resolver)]`` where
-    ``resolver`` is a zero-arg callable the app owns (e.g. one that lists a model registry it already
-    fetches). ``resolve()`` returns the list: a reader calls it lazily, so the app resolves its own values
-    and no tool re-fetches. Introspection-only; the binder ignores it (a value outside the list is still
-    accepted, e.g. a local path). For a small FIXED, binder-validated set, prefer ``Literal[...]``.
+    ``resolver`` is a zero-arg callable; ``resolve()`` returns the list. Introspection-only: the binder
+    ignores it, so a value outside the list is accepted. For a small fixed, binder-validated set, use
+    ``Literal[...]``.
     """
 
     def __init__(self, values) -> None:
@@ -95,15 +94,13 @@ def _load_tree(filename: Path | str) -> dict:
 
 
 def _write_tree(target: Path, tree: dict) -> None:
-    """Write TREE to TARGET atomically: a sibling temp file, then ``os.replace``, so a concurrent
-    independent launch reading the file never observes it truncated and binds all-defaults."""
+    """Write TREE to TARGET atomically (a sibling temp file, then ``os.replace``); a concurrent reader
+    never observes it truncated."""
     tmp = target.with_name(f"{target.name}.{os.getpid()}.tmp")
     try:
         with open(tmp, "w", encoding="utf-8") as yml:
             yaml.dump(tree, yml)
-        # Windows can deny the replace while the target is briefly held (a virus scanner or an
-        # indexer touching the fresh file): retried a few times, then refused. Never an in-place
-        # rewrite, which a concurrent reader would see truncated and bind all-defaults from.
+        # Windows can deny the replace while the target is briefly held: retried, then refused.
         for attempt in range(5):
             try:
                 os.replace(tmp, target)
@@ -121,9 +118,8 @@ def _write_tree(target: Path, tree: dict) -> None:
 
 
 def _merge_into(target: MutableMapping, source: Mapping) -> None:
-    """Fold SOURCE into TARGET in place: a mapping recurses, a value replaces, a ``None`` is not
-    written (a nested object's placeholder, materialized by its own context). A key TARGET lacks is
-    appended, so what a context sets lands after what the contexts opened inside it appended."""
+    """Fold SOURCE into TARGET in place: a mapping recurses, a value replaces, a ``None`` (a nested
+    object's placeholder) is not written. A key TARGET lacks is appended."""
     for key, value in source.items():
         existing = target.get(key)
         if existing is value or value is None:
@@ -159,11 +155,9 @@ _shared_trees: list[_SharedTree] = []
 
 
 def _occurrence_mapping(entries: list, where: str) -> dict:
-    """A chain written as a YAML list (``- Clip: {...}``, ``- Clip: {...}``) as the mapping the
-    binder reads: each stage under its class name, a repeated class under ``Name#2``, ``Name#3``
-    (the suffix is the stage's identity here; :func:`get_module` drops it when resolving the
-    class). Application order is the list's. The mapping form keeps its two spellings (bare and
-    module-qualified) as before."""
+    """A chain written as a YAML list as the mapping the binder reads: each stage under its class name,
+    a repeated class under ``Name#2``, ``Name#3`` (:func:`get_module` drops the suffix). Application
+    order is the list's."""
     mapping: dict = {}
     seen: dict[str, int] = {}
     for index, entry in enumerate(entries):
@@ -185,8 +179,7 @@ def _occurrence_mapping(entries: list, where: str) -> dict:
 
 def _normalize_chain_lists(tree: object, keys: Sequence[str]) -> None:
     """Along ``keys``, a list where a block is walked (a chain spelled as a YAML list) becomes its
-    occurrence mapping, in place, so the contexts opened under it and the write-back read one
-    tree. A context is only ever opened at an object's level, never at a list-valued parameter's."""
+    occurrence mapping, in place."""
     node = tree
     for index, key in enumerate(keys):
         if not isinstance(node, collections.abc.MutableMapping) or key not in node:
@@ -243,26 +236,19 @@ _ledgers: list[_KeyLedger] = []
 def strict_config(root: str, refuse: bool = True) -> Iterator[None]:
     """Report, when the block ends, every key of the config file that nothing bound inside it read.
 
-    The binder reads a key when a parameter names it and materializes the default when none does,
-    so a typo'd key is carried along and its default used in its place. Inside this block every
-    ``Config`` context records the keys its level held and the keys read there; on a clean exit
-    the difference is reported by path, with the keys read at that level and the closest of them:
-    a :class:`ConfigError` when ``refuse``, a warning otherwise. The block must contain everything
-    the workflow binds from the file: a key a later, lazily bound callable would read is unknown to
-    it. On entry the file must hold ROOT: a missing root binds an all-defaults workflow and writes
-    the whole block back over the user's file.
+    Inside this block every ``Config`` context records the keys its level held and the keys read there;
+    on a clean exit the difference is reported by path, with the keys read at that level and the closest
+    of them: a :class:`ConfigError` when ``refuse``, a warning otherwise. The block must contain
+    everything the workflow binds from the file: a key a later, lazily bound callable would read is
+    unknown to it. On entry the file must hold ROOT.
 
-    The file is read once here and written once when the block ends, whatever the number of
-    contexts opened inside it, and whatever the number of blocks opened over the same file: they
-    all resolve against the one tree held in memory, read and written by the outermost. A build of N
-    nested objects otherwise parses the file 2N+1 times and writes it N times (Config_GAN.yml, 7 KB,
-    76 objects: 153 parses and 76 dumps, 2.96 s of a 4.7 s build; 0.05 s held in memory).
+    The file is read once here and written once when the block ends, whatever the number of contexts
+    and nested blocks opened over it: they all resolve against the one tree held in memory, read and
+    written by the outermost.
     """
     filename = os.environ.get("KONFAI_config_file")
     tree: dict = {}
-    # A block opened inside another one on the same file binds to the tree already held: reloading
-    # it would hide what the outer contexts bound, and flushing it would be undone by the outer
-    # flush of a tree that predates this block.
+    # A block opened inside another one on the same file binds to the tree already held.
     outer = _shared_tree(Path(filename)) if filename else None
     if filename and Path(filename).exists():
         tree = outer.tree if outer is not None else _load_tree(filename)
@@ -286,8 +272,7 @@ def strict_config(root: str, refuse: bool = True) -> Iterator[None]:
         unknown = ledger.unknown(root)
         if shared is not None:
             _shared_trees.remove(shared)
-            # Written whatever ended the block, EXCEPT when the block is about to refuse the config:
-            # a refused run must leave the user's file exactly as it was.
+            # Not written when the block is about to refuse the config: a refused run leaves the file as it was.
             if not (refuse and unknown):
                 shared.flush()
     if unknown:
@@ -306,18 +291,15 @@ def _report(refuse: bool, *messages: str) -> None:
 
 
 class Config:
-    """
-    Context manager for reading and updating a subtree of the active YAML
-    config.
+    """Context manager for reading and updating a subtree of the active YAML config.
 
-    Inside a :func:`strict_config` block the context reads the block's in-memory tree and folds
-    what it set back into it on exit; outside one it loads and writes the file itself.
+    Inside a :func:`strict_config` block the context reads the block's in-memory tree and folds what it
+    set back into it on exit; outside one it loads and writes the file itself.
 
     Parameters
     ----------
     key : str
-        Dot-separated path pointing to the configuration subtree to inspect or
-        materialize.
+        Dot-separated path to the configuration subtree to inspect or materialize.
     """
 
     def __init__(self, key: str) -> None:
@@ -353,16 +335,14 @@ class Config:
 
             self.config = self.config[key]
         if self._shared is not None and isinstance(self.config, collections.abc.MutableMapping):
-            # The context works on a copy of its level and folds it back on exit: what it sets is
-            # not seen by the contexts opened inside it, and lands after what they appended, as
-            # when every context read and wrote the file itself.
+            # The context works on a copy of its level and folds it back on exit.
             self.config = dict(self.config)
         for ledger in _ledgers:
             ledger.opened(tuple(self.keys), self.config if isinstance(self.config, collections.abc.Mapping) else ())
         return self
 
     def __exit__(self, exc_type, value, traceback) -> None:
-        # Only the visited subtree is folded back; the merge preserves the rest of the tree untouched.
+        # Only the visited subtree is folded back; the rest of the tree is untouched.
         subtree = self.config
         for key in reversed(self.keys):
             subtree = {key: subtree}
@@ -370,8 +350,7 @@ class Config:
             _merge_into(self._shared.tree, subtree)
             return
         data = _load_tree(self.filename)
-        # The file still spells a chain as a list until this write: merged as a list it would be
-        # replaced by the one entry a nested context folds back, and the others lost.
+        # A chain the file still spells as a list must be normalized before the merge, or one entry replaces it.
         _normalize_chain_lists(data, self.keys)
         _merge_into(data, subtree)
         _write_tree(self.filename, data)
@@ -391,9 +370,8 @@ class Config:
             ledger.read(tuple(self.keys), name)
 
         if name in self.config:
-            # An explicit null (`name:` empty or `name: null`) is the disabled spelling, exactly like
-            # the string "None": substituting the default here would silently reactivate the very
-            # thing the line was written to suppress.
+            # An explicit null (`name:` empty or `name: null`) is the disabled spelling, like the string
+            # "None"; the default is never substituted for it.
             value = self.config[name] if self.config[name] is not None else "None"
             value_config = value
         else:
@@ -416,10 +394,8 @@ class Config:
                     else:
                         value_tmp = next(v for k, v in value.items() if "default" in k)
 
-                    # dict[str, Object] entries are materialised by a later nested Config context,
-                    # so a None placeholder is correct; primitive entries have no such pass, so they
-                    # must be persisted here or the write-back collapses the whole dict to ``{}``
-                    # (empty on the next run, silently dropping the defaults).
+                    # dict[str, Object] entries are materialized by a later nested Config context (None
+                    # placeholder); primitive entries must be persisted here or the write-back drops them.
                     value_config[resolved] = value_tmp if isinstance(value_tmp, int | float | str | bool) else None
                     dict_value[resolved] = value_tmp
                 value = dict_value
@@ -460,13 +436,8 @@ _CONFIG_PRIMITIVE_TYPES = {
 
 
 def _tensor_type() -> type | None:
-    """``torch.Tensor`` when torch is already imported, else None.
-
-    torch is never imported here: an annotation can only mention Tensor if its declaring module
-    already paid the import, and keeping config.py torch-free keeps the light-import contract of
-    ``konfai/__init__`` honest for consumers like the Slicer-facing konfai-apps helpers (measured:
-    634 of this module's 676 ms import was torch).
-    """
+    """``torch.Tensor`` when torch is already imported, else None. torch is never imported here: this
+    module stays torch-free."""
     return getattr(sys.modules.get("torch"), "Tensor", None)
 
 
@@ -478,11 +449,8 @@ _CONFIG_SUPPORTED_TYPES_MESSAGE = (
 
 
 def _recordable(value):
-    """Normalize a default to the form the config file stores and the callable accepts back.
-
-    An ``Enum`` is recorded as its ``.value``, any other ``type`` as its ``.__name__``: the forms
-    the declaring parameter accepts (``LossReduction | str``, ``numpy.dtype | type | str``).
-    """
+    """Normalize a default to the form the config file stores and the callable accepts back: an ``Enum``
+    as its ``.value``, any other ``type`` as its ``.__name__``."""
     if isinstance(value, Enum):
         return value.value
     if isinstance(value, type):
@@ -491,11 +459,8 @@ def _recordable(value):
 
 
 def _annotation_namespace(function) -> dict[str, Any]:
-    """The globals an annotation's names resolve against.
-
-    Under ``from __future__ import annotations`` an annotation is source text resolved against its
-    defining module's ``__globals__``. A class has none of its own, so fall back to its ``__init__``'s.
-    """
+    """The globals an annotation's names resolve against: the function's ``__globals__``, or its
+    ``__init__``'s for a class."""
     namespace = getattr(function, "__globals__", None)
     if namespace is None:
         namespace = getattr(getattr(function, "__init__", None), "__globals__", None)
@@ -534,11 +499,8 @@ def _resolve_annotation(function, annotation):
 
 
 def _unwrap_optional(annotation) -> tuple[Any, bool]:
-    """Return ``(bound type, was Optional[X])``.
-
-    The flag is what tells an ``X | None`` parameter from a plain ``X``: both bind on ``X``, but only
-    the first may legitimately stay ``None`` (see the nested-object binding in ``apply_config``).
-    """
+    """Return ``(bound type, was Optional[X])``. Only ``X | None`` collapses to ``X``; a genuine union
+    (``float | str``) is kept intact."""
     origin = get_origin(annotation)
     if origin not in {Union, types.UnionType}:
         return annotation, False
@@ -546,8 +508,6 @@ def _unwrap_optional(annotation) -> tuple[Any, bool]:
     args = [arg for arg in get_args(annotation) if arg not in {type(None), types.NoneType}]
     if len(args) == 1:
         return args[0], True
-    # Genuine unions (e.g. ``float | str``) are kept intact so the binding can try each
-    # member type; only ``Optional[X]`` (``X | None``) collapses to ``X``.
     return annotation, False
 
 
@@ -579,19 +539,15 @@ def _convert_union_sequence_value(
     valid_types: tuple[type | object, ...],
     param_name: str,
 ) -> object:
-    # Keep a value whose runtime type already satisfies a union member. Coercing in declaration order is
-    # lossy: int(0.25) == 0 silently beats a float member, str([1, 2]) swallows a list member, and a
-    # list[...] member is never a `type`, so a list value could otherwise never bind through it.
+    # A value whose runtime type already satisfies a union member is kept as is; coercion in declaration
+    # order is lossy (int(0.25) == 0, str([1, 2])) and applies only when no member matches.
     if value not in (None, "None"):
         for candidate_type in valid_types:
             if _value_matches_annotation(value, candidate_type):
                 return value
 
     if isinstance(value, Mapping) and not any(get_origin(member) is dict for member in valid_types):
-        # No member of these unions can hold a mapping, and the coercion loop must not see one:
-        # `str` is a member of most of them, `str(mapping)` never fails, and a block bound as its
-        # own repr fails far from here, on whatever that text then selects. This key is the last
-        # place the shape of the YAML is still visible.
+        # No member holds a mapping and `str(mapping)` never fails: refused here, not bound as a repr.
         raise ConfigError(
             f"Parameter '{param_name}' was given a nested block, but it takes a value.",
             f"Expected one of: {valid_types}.",
@@ -641,10 +597,8 @@ def _bind_literal(config: Config, param: inspect.Parameter, annotation, is_optio
     allowed_values = get_args(annotation)
     default_value = param.default if param.default != inspect._empty else allowed_values[0]
     value = config.get_value(param.name, f"default|{default_value}")
-    # get_value can hand back the raw "default|X" marker or the stringified "X"; recover the
-    # correctly-typed Literal member so NON-string Literals (Literal[1, 2], Literal[True, False])
-    # bind and round-trip through the resolved-config write-back instead of failing the
-    # membership check.
+    # get_value hands back the raw "default|X" marker or the stringified "X": the typed Literal member
+    # is recovered so non-string Literals (Literal[1, 2], Literal[True, False]) bind and round-trip.
     if isinstance(value, str) and value.startswith("default|"):
         value = value.split("|", 1)[1]
     if is_optional and value in (None, "None"):
@@ -675,10 +629,9 @@ def _parse_bool(value: object) -> bool:
 
 
 def _coerce_scalar(value: object, target: type) -> object:
-    """``value`` as the scalar type ``target``: the one coercion every binding path uses (a plain
-    parameter, a list element, a union member), so a quoted ``"false"`` reads False wherever a
-    bool is expected and never ``bool("false") == True``. Raises ValueError/TypeError when the
-    value is not that type's."""
+    """``value`` as the scalar type ``target``, the one coercion every binding path uses: a quoted
+    ``"false"`` reads False wherever a bool is expected. Raises ValueError/TypeError when the value is
+    not that type's."""
     if target is bool:
         return _parse_bool(value)
     if isinstance(value, bool) and target in (int, float):
@@ -725,8 +678,7 @@ def _bind_primitive(config: Config, param: inspect.Parameter, annotation, sectio
     value = config.get_value(param.name, param.default)
     if annotation in {int, float, bool, str} and value is not None:
         if isinstance(value, Mapping | list | tuple):
-            # `str` never fails to coerce, so without this a nested block or list binds as its
-            # Python repr and fails far downstream, on whatever that text then selects.
+            # `str` never fails to coerce: a nested block or list is refused here, not bound as a repr.
             shape = "a nested block" if isinstance(value, Mapping) else "a list"
             raise ConfigError(
                 f"Parameter '{section_key}.{param.name}' was given {shape}, but it takes a {annotation.__name__}.",
@@ -787,8 +739,7 @@ def _bind_dict(config: Config, param: inspect.Parameter, annotation, section_key
     }:
         return _coerce_config_value(values, annotation, f"{section_key}.{param.name}")
     if isinstance(values, list):
-        # The list spelling of a chain: bound under occurrence keys, and the level's copy holds the
-        # mapping, so the write-back and the nested contexts read one tree.
+        # The list spelling of a chain: bound under occurrence keys, the level's copy holds the mapping.
         values = _occurrence_mapping(values, f"{section_key}.{param.name}")
         config.config[param.name] = values
     try:
@@ -801,9 +752,8 @@ def _bind_dict(config: Config, param: inspect.Parameter, annotation, section_key
 
 
 def _bind_config_object(config: Config, param: inspect.Parameter, annotation, is_optional: bool, section_key: str):
-    # ``X | None = None`` declares an object the config must ASK for: binding it anyway would build
-    # X's defaults and write them back, turning "no patch" into a patch nobody configured. A non-None
-    # default (``X | None = X()``) is the opposite declaration and still binds.
+    # ``X | None = None`` declares an object the config must ask for: unbound unless the file names it.
+    # A non-None default (``X | None = X()``) still binds.
     if is_optional and param.default is None:
         annotation_key = getattr(annotation, "_key", None)
         if annotation_key is None or config.get_value(annotation_key, None) is None:
@@ -820,8 +770,7 @@ def _bind_parameter(function, config: Config, param: inspect.Parameter, section_
     if hasattr(annotation, "__metadata__"):  # Annotated[T, meta]: bind on T, meta is a UI hint
         annotation = get_args(annotation)[0]
     annotation, is_optional = _unwrap_optional(annotation)
-    # After unwrapping, so ``Literal[X] | None`` binds as a literal (or None) instead of falling through
-    # to _bind_config_object, which would try to instantiate the Literal as a class.
+    # After unwrapping, so ``Literal[X] | None`` binds as a literal (or None).
     if get_origin(annotation) is Literal:
         return _bind_literal(config, param, annotation, is_optional)
 
@@ -834,8 +783,7 @@ def _bind_parameter(function, config: Config, param: inspect.Parameter, section_
 
     tensor = _tensor_type()
     if tensor is not None and annotation is tensor:
-        # A bare (or Optional) Tensor parameter is a value, not a nested config object: bind the
-        # YAML scalar/list through torch.tensor, as the union path does.
+        # A bare (or Optional) Tensor parameter is a value: the YAML scalar/list binds through torch.tensor.
         value = config.get_value(param.name, param.default)
         return None if value is None else _convert_union_sequence_value(value, (tensor,), param.name)
 
@@ -887,8 +835,7 @@ def apply_config(konfai_args: str | None = None):
                         if not isinstance(config.config, collections.abc.Mapping):
                             if config.config in (None, "None"):
                                 return None
-                            # `optimizer: AdamW` where a block is expected would otherwise bind the
-                            # whole object to None and the run would proceed without it, silently.
+                            # `optimizer: AdamW` where a block is expected is refused, never bound to None.
                             raise ConfigError(
                                 f"'{key_tmp}' holds the value '{config.config}' where a block is expected.",
                                 f"Nest its settings under '{key_tmp.rsplit('.', 1)[-1]}:' as a mapping"
@@ -903,9 +850,7 @@ def apply_config(konfai_args: str | None = None):
                             if param.name in without:
                                 continue
 
-                            # ``*args`` and ``**kwargs`` name no parameter: they stand for the ones a
-                            # caller passes. There is nothing to bind them to, and binding them hands
-                            # the callable a parameter called "kwargs".
+                            # ``*args`` and ``**kwargs`` name no parameter: nothing to bind.
                             if param.kind in {inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD}:
                                 continue
 
@@ -926,21 +871,15 @@ def apply_config(konfai_args: str | None = None):
 
 
 def record_given_arguments(cls: type) -> None:
-    """Make ``cls`` record, on each instance, the constructor arguments AS GIVEN: the binder's mirror.
+    """Make ``cls`` record, on each instance, the constructor arguments as given (``_konfai_given``).
 
-    The binder builds an object from a config subtree; this makes the reverse spelling possible: an
-    object built in Python remembers what the caller said (``_konfai_given``), so :mod:`konfai.api`
-    can write a workflow tree from live objects with no second grammar: the recorded kwargs go
-    back through the binder, which stays the one place that validates and resolves defaults.
-
-    Only the OUTERMOST constructor records: a subclass delegating to ``super().__init__`` keeps its
-    own spelling, which is what the caller wrote. Applied by the extension bases'
-    ``__init_subclass__``, so a subclass that defines no ``__init__`` inherits a recording one. An
-    ``__init__`` taking ``*args`` cannot be spelled as a config subtree; such an instance records
-    nothing and :mod:`konfai.api` refuses it by name.
+    :mod:`konfai.api` writes a workflow tree from live objects by sending the recorded kwargs back
+    through the binder. Only the outermost constructor records: a subclass delegating to
+    ``super().__init__`` keeps its own spelling. Applied by the extension bases' ``__init_subclass__``,
+    so a subclass that defines no ``__init__`` inherits a recording one. An ``__init__`` taking
+    ``*args`` records nothing and :mod:`konfai.api` refuses it by name.
     """
-    # A subclass with no __init__ of its own wraps the inherited one here: the extension bases are
-    # never passed through this function, so their raw constructors record nothing by themselves.
+    # A subclass with no __init__ of its own wraps the inherited one here.
     original = cls.__dict__.get("__init__") or cls.__init__  # type: ignore[misc]
     if getattr(original, "_konfai_records", False):
         return
@@ -964,9 +903,8 @@ def record_given_arguments(cls: type) -> None:
                         arguments.update(dict(value))  # type: ignore[call-overload]
                     else:
                         arguments[name] = value
-            # None is recorded too: it marks the instance as spoken for, so a delegating
-            # super().__init__ cannot record the INNER spelling under the outer class's name --
-            # kwargs the outer constructor does not accept.
+            # None is recorded too: it marks the instance as spoken for, so a delegating super().__init__
+            # cannot record the inner spelling under the outer class's name.
             self._konfai_given = arguments  # type: ignore[attr-defined]
         original(self, *args, **kwargs)
 

--- a/konfai/utils/dataset/abstract.py
+++ b/konfai/utils/dataset/abstract.py
@@ -38,9 +38,8 @@ if TYPE_CHECKING:
 class AbstractFile(ABC):
     """One storage backend: how a ``(group, name)`` entry is read, written and enumerated.
 
-    The per-backend FACTS live here as class-level declarations, so a new backend is one module
-    plus one :data:`~konfai.utils.dataset.backend.BACKENDS` entry: the dataset consults the class,
-    never a format-name branch of its own.
+    The per-backend facts are class-level declarations; a new backend is one module plus one
+    :data:`~konfai.utils.dataset.backend.BACKENDS` entry.
     """
 
     #: One store holds every case (a single ``.h5`` file); a directory backend keeps one file (or
@@ -48,9 +47,8 @@ class AbstractFile(ABC):
     single_store: bool = False
 
     #: Whether writes to different entries land in disjoint files, so a background writer may
-    #: flush one entry while another thread writes elsewhere in the dataset. A backend whose
-    #: entries share handles or metadata (one HDF5 file, a zarr hierarchy, a DICOM series)
-    #: declares False and stays serial.
+    #: flush one entry while another thread writes elsewhere. A backend whose entries share
+    #: handles or metadata (one HDF5 file, a zarr hierarchy, a DICOM series) declares False.
     concurrent_write_safe: bool = True
 
     #: The suffix a case file carries implicitly on disk (``.h5``), or ``None`` when the case path
@@ -82,8 +80,7 @@ class AbstractFile(ABC):
         scale_factors: list[int] | None = None,
         downsample_method: str | None = None,
     ) -> AbstractFile:
-        """This backend on ``filename``, built from the dispatch's full hand: each backend takes
-        the arguments its constructor actually needs and ignores the rest."""
+        """This backend on ``filename``; each backend takes the arguments its constructor needs."""
         del file_format, level, scale_factors, downsample_method
         return cls(filename, read)
 
@@ -91,8 +88,7 @@ class AbstractFile(ABC):
     def can_stream(cls, file_format: str, attributes: Attribute) -> bool:
         """Whether this backend can serve incremental region writes for ``file_format``.
 
-        The base answers ``False``: a backend that cannot stream is written whole through
-        ``data_to_file``.
+        The base answers ``False``: such a backend is written whole through ``data_to_file``.
         """
         del file_format, attributes
         return False
@@ -116,30 +112,10 @@ class AbstractFile(ABC):
     def bounded_region_reads(self, name: str) -> bool:
         """Whether a region read decodes only the region, or the whole volume behind the scenes.
 
-        The base answers ``False``: getting this wrong only ever costs speed, never correctness,
-        and an unknown backend is priced pessimistically. What it prices is the ROUTE: a store
-        that decodes the whole volume once per slab makes streaming read the source many times
-        over, where loading reads it once.
-
-        A compressed stream answers ``False`` but is not all-or-nothing: ITK decodes forward from
-        the start and stops on the region, so a read costs its END offset, not its size. Measured
-        on a 256^3 int16 volume, one 32^3 region at z = 0 / 64 / 128 / 224:
-
-        =============  ======  ======  ======  ======
-        store            z=0    z=64   z=128   z=224
-        =============  ======  ======  ======  ======
-        .mha            0.8ms   0.9ms   0.8ms   0.8ms
-        .mha (zlib)    14.6ms  41.8ms  70.5ms  112.6ms
-        .nii.gz        16.1ms  35.8ms  55.5ms  85.2ms
-        =============  ======  ======  ======  ======
-
-        The uncompressed row is flat because it seeks; the other two are linear in depth, and the
-        deepest read costs the whole file (102 ms). Sweeping in K regions therefore costs about
-        K/2 whole decodes, which is why ``False`` here buys the LOAD verdict -- one ordered read
-        -- rather than a streamed route, and why the patch route can only warn and advise a
-        chunked store. Blocked compression (Zarr, HDF5) and indexed access into one stream
-        (``zran``/``indexed_gzip``, which nibabel uses) both solve it; ITK does neither, and the
-        header it writes carries ``CompressedDataSize`` and no compression table.
+        The base answers ``False``, which only costs speed: a store that decodes the whole volume
+        once per slab is planned as one ordered LOAD rather than a streamed route. A compressed ITK
+        stream (``.mha`` zlib, ``.nii.gz``) decodes forward from the start, so a region costs its
+        end offset; blocked compression (Zarr, HDF5) serves the region alone.
         """
         del name
         return False
@@ -147,9 +123,8 @@ class AbstractFile(ABC):
     def read_granularity(self, name: str) -> tuple[int, ...] | None:
         """The stored block a region read is served in, as a ``C[Z]YX`` shape, or ``None``.
 
-        A chunked backend decodes whole blocks, so a window costs the block-aligned hull that
-        covers it: a decomposition that straddles the grid pays every block it touches in full.
-        ``None`` says a read costs what it asks for, which is what the base answers.
+        A window costs the block-aligned hull that covers it. ``None`` (the base) says a read
+        costs what it asks for.
         """
         del name
         return None
@@ -157,10 +132,8 @@ class AbstractFile(ABC):
     def plan_region_reads(self, name: str, windows: Sequence[tuple[slice, ...]]) -> None:
         """Declare the windows a caller will read from ``name``, in the order it will read them.
 
-        A hint and never a promise: a backend that caches decoded blocks keeps what a later
-        window asks for again and drops what none does, which is the fewest decodes any policy
-        can reach and none can reach without the future. The base ignores it, as does any caller
-        that declares nothing.
+        A hint, never a promise: a backend that caches decoded blocks evicts by next use. The base
+        ignores it.
         """
         del name, windows
 
@@ -186,8 +159,7 @@ class AbstractFile(ABC):
 
     def get_names(self, group: str) -> list[str]:
         """The cases of ``group`` this store holds. Only a backend that enumerates its own entries
-        answers (a single store, a store-per-case directory); a plain-file backend's cases are the
-        root's listing, which the dataset walks itself."""
+        answers; a plain-file backend's cases are the root's listing, which the dataset walks."""
         raise NotImplementedError(f"{type(self).__name__} keeps one file per entry; the dataset lists its root.")
 
     def get_group(self) -> list[str]:

--- a/konfai/utils/dataset/attribute.py
+++ b/konfai/utils/dataset/attribute.py
@@ -36,27 +36,17 @@ from konfai.utils.errors import DatasetManagerError
 
 
 def _attribute_text(value: Any) -> str:
-    """One value as an attribute holds it: its printed form, on one line and complete.
+    """One value as an attribute holds it: its printed form, on one line, complete and exact.
 
-    The single place a value stops being a live object, because every consumer takes text --
-    ``SetMetaData`` on a SimpleITK image, an h5 attribute, a zarr sidecar. The printed form is left
-    as each type prints it: a sequence has two, :meth:`Attribute.get_np_array` reads both, and
-    ``ast.literal_eval`` (:meth:`Dataset.read_transform`, on the parameter keys) needs the Python
-    one, so normalising to either here breaks the other reader.
-
-    Complete, because an attribute is a record and not a display: NumPy's own printing elides values
-    past a threshold, and an elided record is one no reader can parse back. Exact, for the same
-    reason: a float is printed as the shortest text that reads back to the very same float64 --
-    NumPy's default (8 decimals for an array, the float32-shortest form for a float32 scalar) is a
-    display, and a statistic that came back a few ulps off made the whole-volume and the streamed
-    path of one chain disagree by that much (measured: a Min/Max rescale, 28% of voxels one ulp
-    apart on CUDA).
+    The printed form is left as each type prints it: :meth:`Attribute.get_np_array` reads both
+    forms of a sequence and ``ast.literal_eval`` (:meth:`Dataset.read_transform`) needs the Python
+    one. No value is elided, and a float is printed as the shortest text that reads back to the
+    same float64.
     """
     if type(value) is str:
-        return value.replace("\n", "")  # what the printing below does to a str, without entering it
+        return value.replace("\n", "")
     if isinstance(value, torch.Tensor):
-        # Accept a tensor from any device: attributes are host-side strings, and finalize transforms
-        # (Normalize, Statistics, ...) may hand over stats computed on a CUDA-resident volume.
+        # A tensor from any device: attributes are host-side strings.
         value = value.detach().cpu().numpy()
     if isinstance(value, np.generic | np.ndarray) and np.issubdtype(value.dtype, np.floating):
         value = np.asarray(value, dtype=np.float64)[()] if isinstance(value, np.generic) else value.astype(np.float64)
@@ -73,8 +63,7 @@ def region_geometry(
     """The geometry record of the samples a normalized spatial slice keeps: the first sample's
     world position as the origin, the spacing scaled by the step.
 
-    THE region-geometry update, shared by every backend so a stepped read carries the same record
-    whatever format the volume is stored in. ``spatial_slices`` arrive array-ordered (``(Z)YX``,
+    Shared by every backend. ``spatial_slices`` arrive array-ordered (``(Z)YX``,
     ``slice.indices``-normalized); geometry is ``(x, y, z)``.
     """
     origin = np.asarray(origin, dtype=np.float64)
@@ -88,13 +77,8 @@ def region_geometry(
 class Attribute(dict[str, Any]):
     """Metadata container storing repeated values with a stack-like naming scheme.
 
-    Values are text, always. Both doors normalize (assignment and construction), so an attribute
-    built from a store's own sidecar, which JSON hands back as live lists, is the same thing as one
-    assigned in Python. Anything less and a value can be stored and not written back out.
-
-    Copying one is a dict copy: its values are text already, and the streamed route of every
-    workflow copies the case's attributes three to five times per patch (measured 69 us for a
-    23-key copy through the normalising door, 2 us at dict level).
+    Values are text, always; assignment and construction both normalize. Copying one is a dict
+    copy.
     """
 
     def __init__(self, attributes: dict[str, Any] | None = None) -> None:
@@ -109,8 +93,7 @@ class Attribute(dict[str, Any]):
 
     @staticmethod
     def _is_stack_member(stored_key: str, key: str) -> bool:
-        # Values are stacked as ``{key}_{n}``; match that exact pattern (or the bare key) so a sibling that
-        # merely shares a prefix (``SpacingOriginal`` vs ``Spacing``) is not miscounted as another entry.
+        # Values are stacked as ``{key}_{n}``; a sibling sharing a prefix (``SpacingOriginal``) is not one.
         if stored_key == key:
             return True
         prefix = f"{key}_"
@@ -150,24 +133,12 @@ class Attribute(dict[str, Any]):
 
     @staticmethod
     def _parse_array(text: str) -> np.ndarray:
-        """Both printed forms of a sequence: NumPy's ``[1.5 1.5 2.]`` and Python's ``[1.5, 1.5, 2.0]``.
-
-        Which one an attribute holds follows from what the writer handed over (an ``ndarray``, or
-        the plain list a JSON sidecar gives back), and no reader should have to make that
-        distinction. ``np.fromstring`` reads whitespace only, so the commas go first.
-        """
+        """Both printed forms of a sequence: NumPy's ``[1.5 1.5 2.]`` and Python's ``[1.5, 1.5, 2.0]``."""
         return np.fromstring(text[1:-1].replace(",", " "), sep=" ", dtype=np.double)
 
     @staticmethod
     def _parsed_array(key: str, text: str) -> np.ndarray:
-        """:meth:`_parse_array`, refusing by name what does not parse back as a flat array.
-
-        The sidecar stores any value as its print, so a >= 2-D array is accepted at write and its
-        nested print fails only here, far from the writer: ``np.fromstring`` used to surface it as
-        an anonymous ``ValueError`` deep in numpy. (``Crop`` deliberately records its 2-D ``box``
-        and reads it back through its own parser, never this door, which is why the write door
-        cannot refuse the rank outright.)
-        """
+        """:meth:`_parse_array`, refusing by name what does not parse back as a flat array."""
         try:
             return Attribute._parse_array(text)
         except ValueError:
@@ -203,13 +174,8 @@ def is_an_image(attributes: Attribute) -> bool:
 def as_channel_first(data: np.ndarray, attributes: Attribute) -> np.ndarray:
     """Give back its channel axis to a block that folded it away, where the header says it did.
 
-    A stage may hand back a volume without its channel axis (``Sum(dim=0)`` and ``MergeLabels`` fold
-    the leading axis, which in a TRANSFORM chain is the channel one). An array with as many axes as
-    the geometry has spatial axes IS a single-channel image: read as channel-first it would be a 2-D
-    image with a plane's worth of channels, refused by ITK or, worse, stored that way in silence.
-
-    The header is what declares the spatial rank, so a block that comes with none is handed back
-    untouched: only the caller knows whether it can be written as it is or must be refused.
+    An array with as many axes as the geometry has spatial axes is a single-channel image. A block
+    with no header is handed back untouched.
     """
     if "Spacing" in attributes and data.ndim == len(attributes.get_np_array("Spacing")):
         return data[None]
@@ -219,9 +185,7 @@ def as_channel_first(data: np.ndarray, attributes: Attribute) -> np.ndarray:
 def data_to_image(data: np.ndarray | torch.Tensor, attributes: Attribute) -> sitk.Image:
     """Convert a NumPy array and KonfAI attributes into a SimpleITK image."""
     if isinstance(data, torch.Tensor):
-        # Accept a torch tensor on any device: SimpleITK works on host arrays, so a SITK-backed transform
-        # fed a CUDA-resident volume converts here and naturally returns on the CPU (the pipeline then
-        # continues on the CPU). This keeps every transform usable regardless of the volume's device.
+        # A tensor on any device: SimpleITK works on host arrays.
         data = data.detach().cpu().numpy()
     if not is_an_image(attributes):
         raise DatasetManagerError(
@@ -229,8 +193,7 @@ def data_to_image(data: np.ndarray | torch.Tensor, attributes: Attribute) -> sit
             "This reader serves volumes; a transform or a point set is read by its own backend.",
         )
     if data.dtype == np.float16:
-        # ITK has no half-float pixel type (GetImageFromArray rejects float16), so widen to float32 --
-        # exact and lossless. The streamed .mha writer widens the same way, so both write identical bytes.
+        # ITK has no half-float pixel type; the streamed .mha writer widens the same way.
         data = data.astype(np.float32)
     if data.shape[0] == 1:
         image = sitk.GetImageFromArray(data[0])
@@ -247,18 +210,16 @@ def data_to_image(data: np.ndarray | torch.Tensor, attributes: Attribute) -> sit
 
 
 # Set on an entry read back from a store that types its component axis as an RFC-5 displacement
-# field, so ``Dataset.read_transform`` can rebuild the transform. The underscore matters: a key
-# without one is stack-renamed by ``Attribute.__setitem__`` (``Transform`` becomes ``Transform_0``).
+# field, so ``Dataset.read_transform`` can rebuild the transform. The underscore keeps the key out
+# of ``Attribute.__setitem__``'s stack renaming.
 DISPLACEMENT_FIELD_ATTRIBUTE = "konfai_displacement_field"
 
 
 def displacement_field_to_data(transform: sitk.Transform, name: str) -> tuple[np.ndarray, Attribute]:
     """A displacement-field transform as a channel-first array plus its geometry.
 
-    The counterpart of ``_encode_transform_leaves`` for the one transform kind that cannot go through
-    it: a displacement field's parameters ARE the field, so serialising it as a parameter vector
-    would drop the geometry that makes it meaningful. It travels as an image instead, and the store
-    records what it is (see ``write_ome_zarr(displacement_field=True)``).
+    The counterpart of ``_encode_transform_leaves`` for a field, which travels as an image; the
+    store records what it is (``write_ome_zarr(displacement_field=True)``).
     """
     if not isinstance(transform, sitk.DisplacementFieldTransform):
         raise DatasetManagerError(
@@ -271,45 +232,28 @@ def image_to_data(image: sitk.Image) -> tuple[np.ndarray, Attribute]:
     """Convert a SimpleITK image into a channel-first NumPy array and attributes."""
     attributes = Attribute()
     for k in image.GetMetaDataKeys():
-        # ``ITK_*`` keys are the reader's own bookkeeping (the input filter's name, the file's original
-        # direction and spacing), not the volume's metadata: carried into an output they describe the
-        # source of a resampled volume, which nothing should read as the output's.
+        # ``ITK_*`` keys are the reader's own bookkeeping, not the volume's metadata.
         if not k.startswith("ITK_"):
             attributes[k] = image.GetMetaData(k)
-    # AFTER the metadata import, deliberately. data_to_image stamps every attribute -- the
-    # geometry stack included -- back onto the image as metadata text, and the loop above imports
-    # it verbatim (versioned keys carry a '_', so they land as-is). Recorded first, the header
-    # landed as Origin_0 and the stale text then OVERWROTE that very key: an image read, moved
-    # (SetOrigin) and written back kept its old origin, silently. Recorded last, the header
-    # appends the next version of the stack, which is the one every reader takes.
+    # After the metadata import: the metadata may carry a stale geometry stack, and the header must
+    # land as its latest version.
     attributes["Origin"] = np.asarray(image.GetOrigin())
     attributes["Spacing"] = np.asarray(image.GetSpacing())
     attributes["Direction"] = np.asarray(image.GetDirection())
     if image.GetNumberOfComponentsPerPixel() == 1:
         return np.expand_dims(sitk.GetArrayFromImage(image), 0), attributes
-    # One copy, written channel-first straight off ITK's interleaved buffer: the array is contiguous
-    # for whatever holds it next, where the copy of the buffer transposed was a strided view every
-    # consumer needing a contiguous field copied again (a 3x128^3 float64 field: 50 MiB each time).
-    # np.array and not ascontiguousarray: a one-voxel image is contiguous however its axes are moved,
-    # and a view of ITK's buffer would outlive the image.
+    # One contiguous channel-first copy off ITK's interleaved buffer. np.array and not
+    # ascontiguousarray: a view of ITK's buffer would outlive the image.
     return np.array(np.moveaxis(sitk.GetArrayViewFromImage(image), -1, 0), order="C"), attributes
 
 
 def ome_zarr_attributes(metadata: dict[str, Any]) -> Attribute:
     """A KonfAI ``Attribute`` (Origin / Spacing / Direction) from an OME-Zarr entry's metadata.
 
-    The store's konfai sidecar wins when present (it carries the full Direction matrix, which NGFF
-    scale/translation cannot express) otherwise geometry falls back to the NGFF transforms, Direction
-    defaulting to identity. Shared by the Dataset OME-Zarr reader and ``ITK.read_displacement_field``
-    so both recover geometry the one same way.
-
-    THE SIDECAR DESCRIBES ONE LEVEL: the one the writer was handed, and it writes the finest. Every
-    level of a pyramid carries its own scale and translation, so a sidecar taken at its word on a
-    coarser level put level 0's spacing and origin on level 1's voxels: half the extent along every
-    axis, a brain that reads at half its size for anything that asks for ``@1``. The sidecar is
-    therefore trusted for Spacing and Origin only where its Spacing IS this level's scale; on any other level those two come from the level's
-    own transforms, and the sidecar still supplies what NGFF cannot: the Direction, and every other
-    key it recorded.
+    The store's konfai sidecar carries the Direction matrix, which NGFF cannot express, and every
+    other key it recorded; Direction defaults to identity without it. The sidecar describes one
+    level, the finest: its Spacing and Origin are trusted only where its Spacing is this level's
+    scale, and any other level takes both from its own transforms.
     """
     attributes = Attribute(metadata.get("attributes", {}))
     axes = metadata["axes"]
@@ -321,9 +265,7 @@ def ome_zarr_attributes(metadata: dict[str, Any]) -> Attribute:
     if "Spacing" in attributes:
         recorded = attributes.get_np_array("Spacing")
         if recorded.shape != level_spacing.shape or not np.allclose(recorded, level_spacing, rtol=1e-6, atol=0.0):
-            # Another level than the one the sidecar was written for: its own geometry, not the
-            # sidecar's. Popped then set, so the key keeps its place in the stack rather than
-            # gaining a rung that a later write would record twice.
+            # Another level than the sidecar's. Popped then set, so the key keeps its place in the stack.
             attributes.pop("Spacing")
             attributes["Spacing"] = level_spacing
             if "Origin" in attributes:
@@ -340,11 +282,7 @@ def ome_zarr_attributes(metadata: dict[str, Any]) -> Attribute:
 
 
 def _flatten_transforms(transform: sitk.Transform) -> list[sitk.Transform]:
-    """The leaf transforms of a (possibly nested) composite, in application order.
-
-    ``CompositeTransform.GetNthTransform`` can itself return a composite, so a single-level walk
-    leaves a nested composite in the list and the serializer rejects it. Recurse to the leaves.
-    """
+    """The leaf transforms of a (possibly nested) composite, in application order."""
     if isinstance(transform, sitk.CompositeTransform):
         leaves: list[sitk.Transform] = []
         for i in range(transform.GetNumberOfTransforms()):
@@ -354,10 +292,7 @@ def _flatten_transforms(transform: sitk.Transform) -> list[sitk.Transform]:
 
 
 def _transform_codec() -> list[tuple[type, str, Any]]:
-    """(sitk class, serialized type tag, decode factory) for every supported transform kind.
-
-    Built lazily because ``sitk`` is an optional import.
-    """
+    """(sitk class, serialized type tag, decode factory) for every supported transform kind."""
     return [
         (sitk.Euler3DTransform, "Euler3DTransform_double_3_3", sitk.Euler3DTransform),
         (sitk.AffineTransform, "AffineTransform_double_3_3", lambda: sitk.AffineTransform(3)),
@@ -390,9 +325,9 @@ def _decode_transform(transform_type: str, name: str) -> sitk.Transform:
 
 
 def data_to_transform(data: np.ndarray, attributes: Attribute, name: str) -> sitk.Transform:
-    """The transform a stored entry holds: a displacement field is its image in float64, what
-    ``DisplacementFieldTransform`` requires, widened here exactly so the image is built once in that
-    type; any other entry is the parameter rows and type keys of ``_encode_transform_leaves``."""
+    """The transform a stored entry holds: a displacement field is its image in float64, which
+    ``DisplacementFieldTransform`` requires; any other entry is the parameter rows and type keys of
+    ``_encode_transform_leaves``."""
     if DISPLACEMENT_FIELD_ATTRIBUTE in attributes:
         return sitk.DisplacementFieldTransform(data_to_image(np.asarray(data, dtype=np.float64), attributes))
     transforms = []
@@ -415,8 +350,7 @@ def get_infos(filename: str | Path) -> tuple[list[int], Attribute]:
     attributes["Direction"] = np.asarray(file_reader.GetDirection())
     for k in file_reader.GetMetaDataKeys():
         attributes[k] = file_reader.GetMetaData(k)
-    # SimpleITK GetSize() is (x, y, [z], ...); KonfAI arrays are numpy-order [C, (Z), Y, X], so the
-    # spatial size must be reversed for EVERY rank: a 3-D-only reversal transposes 2-D/4-D data.
+    # SimpleITK GetSize() is (x, y, [z], ...); KonfAI arrays are [C, (Z), Y, X]: reversed for every rank.
     size = list(reversed(file_reader.GetSize()))
     size = [file_reader.GetNumberOfComponents(), *size]
     return size, attributes

--- a/konfai/utils/dataset/backend.py
+++ b/konfai/utils/dataset/backend.py
@@ -33,8 +33,7 @@ if TYPE_CHECKING:
     from konfai.utils.dataset.abstract import AbstractFile
 
 #: The backend each format token dispatches to; every token not named here is a plain-file
-#: extension SitkFile serves. THE token-to-class table: a new backend registers here and declares
-#: its facts on the class (see ``AbstractFile``), and nothing else needs a format-name branch.
+#: extension SitkFile serves. A new backend registers here and declares its facts on the class.
 BACKENDS: dict[str, type[AbstractFile]] = {
     "h5": H5File,
     "omezarr": OmeZarrFile,
@@ -44,8 +43,7 @@ BACKENDS: dict[str, type[AbstractFile]] = {
 
 
 def backend_for(file_format: str) -> type[AbstractFile]:
-    """The backend class serving ``file_format``: where ``File.__enter__`` and ``Dataset`` read
-    the per-backend facts from."""
+    """The backend class serving ``file_format``."""
     return BACKENDS.get(file_format, SitkFile)
 
 

--- a/konfai/utils/dataset/core.py
+++ b/konfai/utils/dataset/core.py
@@ -105,30 +105,22 @@ class Dataset:
     ) -> None:
         base_format, self.level = split_format_level(file_format)
         normalized_format = base_format.lower().removeprefix(".")
-        # One vocabulary for a store: every spelling the walk accepts on disk is a token here, the
-        # dotted one included, since that is the suffix a store actually carries.
+        # Every spelling the walk accepts on disk for a store is a token here, the dotted one included.
         file_format = "omezarr" if f".{normalized_format}" in STORE_FORMS else normalized_format
         if file_format not in SUPPORTED_FORMATS:
-            # Unchecked, the token reaches the SimpleITK writer, which either raises on an extension
-            # it cannot name or writes a file no backend of ours probes: 'hd5' for 'h5' wrote and read
-            # back correctly while ``is_dataset_exist`` said no, so a resumed run redid the work.
+            # Unchecked, the token reaches the SimpleITK writer, which may write a file no backend probes.
             raise DatasetManagerError(
                 f"'{base_format}' is not a format KonfAI writes.",
                 "Use one of: " + ", ".join(sorted(SUPPORTED_FORMATS)) + ".",
             )
         self.filename, self.is_directory = Dataset._normalize_path(filename, file_format)
         self.file_format = file_format
-        # The store backend is auto-detected from what is actually on disk (like SitkFile already probes
-        # every supported extension): an OME-Zarr / Zarr / DICOM store is a directory whose type is
-        # knowable from its structure, so a ``:mha`` token never forces it to be mis-read. The token then
-        # only carries the WRITE format and the OME-Zarr pyramid level (``@N``).
+        # A store backend (OME-Zarr / Zarr / DICOM) is detected from disk; the token then only carries
+        # the write format and the OME-Zarr pyramid level (``@N``).
         detected = Dataset._detect_directory_store_format(self.filename) if self.is_directory else None
         if detected is not None:
             self.file_format = detected
-        # Write-side pyramid, declared by the Save/Write that owns this destination. Refused here
-        # rather than ignored: only OME-NGFF has multiple levels, so a pyramid asked of an mha or an
-        # h5 is a request the format cannot serve, and silently writing one level would leave the
-        # consumer's ``@1`` resolving to a level that does not exist.
+        # A pyramid asked of a format without levels is refused, never silently written as one level.
         if scale_factors and not backend_for(self.file_format).writes_pyramid:
             raise DatasetManagerError(
                 f"A pyramid was asked of a '{self.file_format}' destination, which has no levels.",
@@ -138,13 +130,12 @@ class Dataset:
         self.downsample_method = downsample_method
         self._names_cache: dict[str, list[str]] = {}
         self._infos_cache: dict[tuple[str, str], tuple[list[int], Attribute]] = {}
-        #: Root-existence and case-path probes are one round-trip each on a remote root, per entry
-        #: read without these: a root seen once is not re-probed (a vanished one fails loudly at
-        #: the read), and a case resolved once keeps its path until a write drops the caches.
+        #: A root seen once is not re-probed, and a case resolved once keeps its path until a write
+        #: drops the caches (one round-trip each on a remote root).
         self._root_seen = False
         self._case_paths: dict[tuple[str, str], str] = {}
         #: Facts a stage derived from an entry's pixels (a Crop's foreground box), keyed by
-        #: ``(group, name)``: computed once per volume, whatever the number of chains reading it.
+        #: ``(group, name)``: computed once per volume.
         self.case_facts: dict[tuple[str, str], dict[str, Any]] = {}
 
     def _file(self, filename: str, read: bool) -> _File:
@@ -153,16 +144,13 @@ class Dataset:
 
     @property
     def _backend(self) -> type[_AbstractFile]:
-        """The class serving this dataset's format: where the per-backend facts are declared."""
+        """The class serving this dataset's format."""
         return backend_for(self.file_format)
 
     @staticmethod
     def _normalize_path(filename: str | Path, file_format: str) -> tuple[str, bool]:
         # A single store is one file, every other backend a directory of cases: only the latter gets the
-        # trailing slash that marks ``is_directory``. Keep the two in lock-step so a path never ends up a
-        # directory-flagged h5 (which would write the hidden dotfile ``<dir>/.h5``). ``as_posix`` keeps the
-        # separator forward on every OS, so the stored filename (and the trailing-slash marker) is the same
-        # on Windows, where ``prefix / name`` would otherwise render backslashes.
+        # trailing slash that marks ``is_directory``. The separator stays forward on every OS.
         path = uri.normalize(filename)
         if not backend_for(file_format).single_store and not path.endswith("/"):
             path += "/"
@@ -171,22 +159,19 @@ class Dataset:
     def rebase(self, prefix: Path) -> None:
         """Prepend ``prefix`` to this dataset's path, re-deriving ``is_directory`` from the format.
 
-        A rebased root is an output root, and ``prefix / uri`` folds the scheme's second slash away:
-        refused as a remote root before it can stop looking like one.
+        A rebased root is an output root: a remote root is refused.
         """
         uri.refuse_write(self.filename)
         self.filename, self.is_directory = Dataset._normalize_path(prefix / self.filename, self.file_format)
 
     @staticmethod
     def _detect_directory_store_format(root: str) -> str | None:
-        """Detect a directory dataset's store backend from disk (``omezarr`` / ``dicom``), independent of the
-        format token; ``None`` when it is plain per-file volumes (the SitkFile path, which auto-detects the
-        extension itself). Probes the first case's entries only: cheap, and cases share one layout."""
+        """The store backend of a directory dataset, from disk (``omezarr`` / ``dicom``), or ``None`` for
+        plain per-file volumes. Probes the first case's entries only."""
         if not uri.is_dir(root):
             return None
         if uri.is_uri(root):
-            # Only the store backend reads a remote root, and a store is told by its name: a
-            # remote entry is never probed as a path, which on a bare name asks the working directory.
+            # A remote store is told by its name, never probed as a path.
             names = Dataset._first_case_entries(root)
             return "omezarr" if any(is_store_name(name.name) for name in names) else None
         for entry in Dataset._first_case_entries(root):
@@ -197,12 +182,7 @@ class Dataset:
 
     @staticmethod
     def _first_case_entries(root: str) -> list[Path]:
-        """What ``root``'s first case directory holds, empty when it has none.
-
-        Unsorted on a local root: any case is representative of the layout, and ``iterdir`` stops at
-        the first directory where a listing materialises the whole of a resume's output tree. A
-        remote listing is one request either way, and arrives sorted.
-        """
+        """What ``root``'s first case directory holds, empty when it has none."""
         if uri.is_uri(root):
             cases = (name for name in uri.list_names(root))
             case = next((name for name in cases if uri.is_dir(uri.join(root, name))), None)
@@ -212,12 +192,8 @@ class Dataset:
 
     @property
     def store_root(self) -> str:
-        """Where the store lives, as text: its root directory, or the ``.h5`` file for a single-file
-        store (named with or without the suffix, as the backend opens it).
-
-        Text, because ``Path`` eats the second slash of a URI; :attr:`path_on_disk` is the local-only
-        view, for the callers that manipulate the path.
-        """
+        """Where the store lives, as text (a URI has no ``Path``): its root directory, or the ``.h5``
+        file for a single-file store. :attr:`path_on_disk` is the local-only view."""
         root = self.filename
         suffix = self._backend.case_file_suffix
         if self._backend.single_store and suffix and not root.endswith(suffix):
@@ -230,17 +206,12 @@ class Dataset:
         return Path(self.store_root)
 
     def exists_on_disk(self) -> bool:
-        """Whether the store is there, asked of whichever filesystem owns it. A remote root that
-        cannot be reached raises; only one that answers gets to say no."""
+        """Whether the store is there. A remote root that cannot be reached raises."""
         return uri.exists(self.store_root)
 
     def concurrent_write_safe(self) -> bool:
         """Whether writes to different entries land in disjoint files, so a background writer may
-        flush one entry while another thread writes elsewhere in the dataset.
-
-        The backend's own declaration: a store that shares handles or metadata across entries (one
-        HDF5 file, a zarr hierarchy, a DICOM series) says so and stays serial.
-        """
+        flush one entry while another thread writes elsewhere (the backend's own declaration)."""
         return self._backend.concurrent_write_safe
 
     def _write_target(self, group: str, name: str) -> tuple[_File, str]:
@@ -249,7 +220,6 @@ class Dataset:
         A directory dataset routes any sub-directory prefix of ``group`` into the file path (one file
         per case); a single store keeps one file and a ``group/name`` entry.
         """
-        # Ahead of the makedirs below, which would take a URI for a directory name.
         uri.refuse_write(self.filename)
         self._names_cache.clear()
         self._infos_cache.clear()
@@ -292,12 +262,8 @@ class Dataset:
             file.data_to_file(entry, data, attributes)
 
     def can_stream_data(self, attributes: Attribute) -> bool:
-        """Whether ``open_data_stream`` can serve this dataset's write format.
-
-        The backend's own declaration: H5 and OME-Zarr always can; MetaImage/NIfTI need image
-        geometry to write their headers up front; every other format only writes whole volumes
-        (use ``write``).
-        """
+        """Whether ``open_data_stream`` can serve this dataset's write format: H5 and OME-Zarr always;
+        MetaImage/NIfTI with image geometry; every other format only writes whole volumes."""
         return self._backend.can_stream(self.file_format, attributes)
 
     def open_data_stream(
@@ -315,10 +281,8 @@ class Dataset:
         the volume and uses ``write``. The returned stream is a context manager: a clean exit
         finalizes the entry, an exception removes the partial one.
 
-        ``region_shape`` is the extent the caller will write at a time, channels included. A store
-        that chunks on it never pays a read-modify-write; a store left to guess pays one on every
-        region that straddles a chunk. Declaring it is the writer's job, it is the only party that
-        knows its own access pattern.
+        ``region_shape`` is the extent the caller will write at a time, channels included; a store
+        that chunks on it never pays a read-modify-write.
         """
         if attributes is None:
             attributes = Attribute()
@@ -338,10 +302,8 @@ class Dataset:
     def _case_path(self, sub_directory: str, name: str) -> str | None:
         """The file a directory dataset stores case ``name`` under, or ``None`` if absent on disk.
 
-        The returned path omits the implicit ``.h5`` suffix h5 case files carry: ``H5File``
-        re-appends it on open. A case found once is not probed again (the probe is a round-trip on
-        a remote root, per entry read); an ABSENT case stays a fresh question, because a run may
-        produce it mid-read.
+        The returned path omits the implicit ``.h5`` suffix h5 case files carry. A case found once
+        is not probed again; an absent case stays a fresh question.
         """
         memo_key = (sub_directory, name)
         memoised = self._case_paths.get(memo_key)
@@ -353,10 +315,8 @@ class Dataset:
             self._case_paths[memo_key] = path
             return path
         if uri.is_uri(on_disk):
-            return None  # no writer of a remote root, so no backup of one to recover
-        # Absent is not always absent: a writer killed mid-replacement leaves the previous version
-        # under its backup name, which the listings hide. Asked of disk again after the attempt: the
-        # recovery declines to a publish that landed meanwhile, and that publish is the entry.
+            return None  # no writer of a remote root, so no backup to recover
+        # A writer killed mid-replacement leaves the previous version under its backup name.
         _recover_orphaned_backup(Path(on_disk))
         return path if os.path.exists(on_disk) else None
 
@@ -369,12 +329,12 @@ class Dataset:
             return file.is_exist(group)
 
     def _resolve_entry(self, groups: str, name: str, action: Callable[[_AbstractFile, str, str], _T]) -> _T:
-        """Run ``action`` on the open file holding ``(groups, name)``: THE place entry resolution lives.
+        """Run ``action`` on the open file holding ``(groups, name)``.
 
-        ``action`` receives the backend and the entry's coordinates INSIDE that file: a directory
-        dataset stores one case per file, addressed by ``name``, with the entry keyed by the group
-        path's last component, so the coordinates are ``("", group)`` there and ``(groups, name)``
-        on a single-file dataset. Raises ``DatasetManagerError`` when the dataset or the entry is missing.
+        ``action`` receives the backend and the entry's coordinates inside that file: ``("", group)``
+        on a directory dataset (one case per file, the entry keyed by the group path's last
+        component), ``(groups, name)`` on a single-file dataset. Raises ``DatasetManagerError`` when
+        the dataset or the entry is missing.
         """
         if not self._root_seen and not self.exists_on_disk():
             raise DatasetManagerError(
@@ -393,8 +353,7 @@ class Dataset:
                 "Check the groups_src spelling and that the case carries every group it names.",
             )
         with self._file(self.filename, True) as file:
-            # A wildcard group is expanded by get_names, as is_dataset_exist resolves it; is_exist
-            # would take the '*' literally.
+            # is_exist would take a wildcard group's '*' literally.
             exists = name in file.get_names(groups) if "*" in groups else file.is_exist(groups, name)
             if not exists:
                 raise DatasetManagerError(
@@ -413,30 +372,26 @@ class Dataset:
 
     def read_granularity(self, groups: str, name: str) -> tuple[int, ...] | None:
         """The stored block reads of ``(groups, name)`` are served in, or ``None`` when a read costs
-        exactly what it asks for. What a decomposition is sized and aligned against."""
+        exactly what it asks for."""
         with contextlib.suppress(Exception):
-            # The entry's path INSIDE the file: a single-file store (h5) keys it by its group as well.
+            # The entry's path inside the file: a single-file store (h5) keys it by its group as well.
             return self._resolve_entry(
                 groups, name, lambda file, group, entry: file.read_granularity(f"{group}/{entry}" if group else entry)
             )
         return None
 
     def plan_region_reads(self, groups: str, name: str, windows: Sequence[tuple[slice, ...]]) -> None:
-        """Declare the region reads about to happen on ``(groups, name)``, in order. A backend that
-        can use it does; the rest ignore it, and so does a caller that declares nothing."""
+        """Declare the region reads about to happen on ``(groups, name)``, in order. A hint the
+        backend may ignore."""
         with contextlib.suppress(DatasetManagerError):
             self._resolve_entry(groups, name, lambda file, _group, entry: file.plan_region_reads(entry, windows))
 
     def iter_data_blocks(self, groups: str, name: str) -> Callable[[], Iterator[np.ndarray]]:
         """A factory of passes over one entry, block by block along the first spatial axis, each
-        block about ``_STATISTICS_CHUNK_ELEMENTS`` elements: what a scan that must never hold the
-        volume iterates (the statistics fold, the quantile scan). A store that cannot serve bounded
-        region reads (gzipped NIfTI, compressed MetaImage) is read whole ONCE and kept for every
-        pass the factory serves: those formats have no bounded reader to use instead, a block read
-        decodes the whole volume anyway, so reading per block would hold the same peak N times over.
-        This is the declared whole-volume route, not a way around the streaming invariant: a case
-        that needs it plans as LOAD, and the plan refuses it when the volume does not fit the
-        budget, before a byte is written."""
+        block about ``_STATISTICS_CHUNK_ELEMENTS`` elements: what the statistics fold and the
+        quantile scan iterate. A store that cannot serve bounded region reads (gzipped NIfTI,
+        compressed MetaImage) is read whole once and kept for every pass: the declared whole-volume
+        route, which the plan names LOAD and refuses when the volume does not fit the budget."""
         shape, _ = self.get_infos(groups, name)
         if len(shape) < 2 or not self.bounded_region_reads(groups, name):
             resident: list[np.ndarray] = []
@@ -447,11 +402,10 @@ class Dataset:
                 yield resident[0]
 
             return whole
-        # A whole number of update pieces, so the fold sees the same sequence of pieces in the same
-        # order whatever the read grain: the running mean and std are then the budget's business
-        # only in how much is held, never in what they answer.
+        # A whole number of update pieces: the fold sees the same pieces in the same order whatever
+        # the read grain, so the budget never changes what the running mean and std answer.
         budget = per_rank_budget_bytes()
-        # Only a declared budget sizes anything from it, so only a declared budget pays the probe.
+        # Only a declared budget pays the probe.
         element_bytes = (
             statistics._STATISTICS_ELEMENT_BYTES if budget is None else self._scanned_element_bytes(groups, name, shape)
         )
@@ -484,12 +438,7 @@ class Dataset:
 
     def _scanned_element_bytes(self, groups: str, name: str, shape: list[int]) -> int:
         """What one element of a scanned block costs: the store's own element size, read off a
-        one-voxel region.
-
-        A block of a scan is the bytes the store hands over, never a cast copy of them, so a
-        float64 source held twice what the budget was told at every block in flight. The probe is a
-        bounded read, which is the route this entry is on, and one voxel of it.
-        """
+        one-voxel region."""
         probe = (slice(0, 1),) * len(shape)
         return max(1, int(self.read_data_slice(groups, name, probe)[0].dtype.itemsize))
 
@@ -498,20 +447,13 @@ class Dataset:
         holding the volume: bounded passes over :meth:`iter_data_blocks`."""
         low, high, weight = _order_statistics(self.iter_data_blocks(groups, name), float(q))
         if not np.issubdtype(np.asarray(low).dtype, np.inexact):
-            # numpy.quantile promotes an integer input to float64 before it interpolates: the
-            # difference of two order statistics would wrap on a narrow signed type, and an exact
-            # index would answer in the stored dtype where numpy answers in float64.
+            # numpy.quantile promotes an integer input to float64 before it interpolates.
             low, high = np.float64(low), np.float64(high)
         return _lerp_like_numpy(low, high, weight) if weight else low
 
     def bounded_region_reads(self, groups: str, name: str) -> bool:
-        """Whether a region read of this entry decodes only the region, or the whole volume.
-
-        What it prices is the ROUTE, never the answer: a store that decodes the whole volume once
-        per slab (compressed MetaImage, NRRD, gzipped NIfTI) makes streaming read the source many
-        times over, where loading reads it once. ``False`` for a missing entry: pessimistic, and
-        only ever costing speed.
-        """
+        """Whether a region read of this entry decodes only the region, or the whole volume
+        (compressed MetaImage, NRRD, gzipped NIfTI). ``False`` for a missing entry."""
         try:
             return self._resolve_entry(groups, name, lambda file, _, entry: file.bounded_region_reads(entry))
         except DatasetManagerError:
@@ -526,9 +468,8 @@ class Dataset:
     ) -> dict[str, Any]:
         """Min/max/mean/std of one entry, over the volume and per channel (``channels`` restricts
         both to those), folded over :meth:`iter_data_blocks`: the volume is never held. ``keys``
-        names the statistics the caller reads (``min``, ``max_per_channel``, ...): a request
-        without a mean or std is folded in the stored dtype with one min and one max per block,
-        and its other figures are not computed. ``None`` computes the four."""
+        names the statistics the caller reads (``min``, ``max_per_channel``, ...): without a mean or
+        std the fold stays in the stored dtype and computes the extrema only. ``None`` computes the four."""
         update = _update_running_statistics if needs_moments(keys) else _update_running_extrema
         state = None
         for block in self.iter_data_blocks(groups, name)():
@@ -553,12 +494,10 @@ class Dataset:
         return len(self.get_names(group))
 
     def is_group_exist(self, group: str, requested: set[str] | None = None) -> bool:
-        """Whether this root holds ``group``, asked as narrowly as the caller will read it.
+        """Whether this root holds ``group``.
 
         ``requested`` is what the caller is about to select (:meth:`select_names`): with it, the
-        first case holding the group answers, where counting would walk a cohort the run then
-        discards. Without it the caller reads the whole listing next, so this takes that listing
-        and leaves it cached.
+        first case holding the group answers. Without it the whole listing is taken and cached.
         """
         if requested is None or not self.is_directory:
             return bool(self.get_names(group))
@@ -571,26 +510,19 @@ class Dataset:
     def is_dataset_exist(self, group: str, name: str) -> bool:
         """Whether ``(group, name)`` is on disk, asked of disk at the moment it is asked.
 
-        Deliberately NOT a slice of :meth:`get_names`: that listing is a planning-time snapshot, and a
-        group the run itself produces (a ``Save`` writing into the dataset being read) gains cases
-        while it is read, through a different ``Dataset`` object and, when the loader has workers, a
-        different PROCESS. No memo can be invalidated across that boundary, so membership asks the disk.
-        One entry, one probe: O(1) in the number of cases, where the listing is O(N) headers, and cheaper
-        than the listing it replaces.
+        Never a slice of :meth:`get_names`: a group the run itself produces gains cases while it is
+        read, from another ``Dataset`` object and possibly another process.
         """
         if not self.exists_on_disk():
-            # A store that is not there yet holds nothing: the first probe of every fresh
-            # destination, which a single-file backend would otherwise turn into an open error.
             return False
         if self.is_directory:
-            # Not _resolve_entry: membership keeps scanning past a case file whose group is absent,
-            # and answers False instead of raising.
+            # Not _resolve_entry: answers False instead of raising.
             entry_group = group.split("/")[-1]
             return any(
                 self._holds(sub_directory, entry_group, name) for sub_directory in self._get_sub_directories(group)
             )
         with self._file(self.filename, True) as file:
-            # A wildcard group is a path pattern; only the store's own listing expands it.
+            # Only the store's own listing expands a wildcard group.
             return name in file.get_names(group) if "*" in group else file.is_exist(group, name)
 
     def _get_sub_directories(self, groups: str, sub_directory: str = ""):
@@ -615,10 +547,7 @@ class Dataset:
         return sub_directories
 
     def _iter_names(self, groups: str) -> Generator[str, None, None]:
-        """Every case of ``groups`` this root holds, one entry open at a time and in no order.
-
-        Lazy so a caller that only needs to know whether there IS one stops at the first.
-        """
+        """Every case of ``groups`` this root holds, one entry open at a time and in no order."""
         if not self.is_directory:
             with self._file(self.filename, True) as file:
                 yield from file.get_names(groups)
@@ -645,14 +574,11 @@ class Dataset:
         return [name for i, name in enumerate(sorted_names) if i in index]
 
     def select_names(self, groups: str, requested: set[str] | None) -> list[str]:
-        """The names of ``groups`` this root holds, asked of it as narrowly as the caller can ask.
+        """The names of ``groups`` this root holds, narrowed to ``requested``.
 
-        ``requested`` is the set the caller will keep, or ``None`` when only the whole cohort
-        answers its selection. A root holding one entry per case is opened once per case it HOLDS
-        to enumerate, and once per case the caller ASKED for to answer this, which is the whole
-        difference between a wide root and a narrow subset. A root that is one entry answers
-        either from the single listing it already takes. A name is probed only as the listing
-        would have spelled it: one path component, so ``case/`` or ``./case`` selects nothing.
+        ``requested`` is the set the caller will keep, or ``None`` for the whole cohort. A directory
+        root probes each requested name instead of enumerating; a name is probed only as the listing
+        would spell it, one path component, so ``case/`` or ``./case`` selects nothing.
         """
         if requested is None or not self.is_directory:
             names = self.get_names(groups)
@@ -681,7 +607,7 @@ class Dataset:
             groups_set = set()
             for root_dir, _, files in os.walk(self.filename):
                 for file in files:
-                    if file.startswith(".") or is_staging_entry(file):  # a staging write, or its crashed leftover
+                    if file.startswith(".") or is_staging_entry(file):
                         continue
                     path = Path(root_dir, file.split(".")[0]).relative_to(self.filename).as_posix()
                     parts = path.split("/")
@@ -695,10 +621,7 @@ class Dataset:
         return list(groups)
 
     def get_infos(self, groups: str, name: str) -> tuple[list[int], Attribute]:
-        # Memoize the header read (SITK reader + ReadImageInformation, or the HDF5/Zarr
-        # metadata parse): get_infos is called once per name per group per build-pass at
-        # setup, so caching it (like get_names) avoids re-parsing the same header N times.
-        # Cache and hand back copies so a caller mutating the geometry cannot poison it.
+        # The header read is memoised; copies go in and out so a caller cannot mutate the cache.
         cache_key = (groups, name)
         cached = self._infos_cache.get(cache_key)
         if cached is not None:

--- a/konfai/utils/dataset/dicom_file.py
+++ b/konfai/utils/dataset/dicom_file.py
@@ -78,8 +78,7 @@ class DicomFile(AbstractFile):
     def read_granularity(self, name: str) -> tuple[int, ...] | None:
         from konfai.utils.dicom import get_dicom_info
 
-        # One file per z step, decoded as a whole plane: a window narrower than a plane costs the
-        # plane, exactly the band a memmapped volume declares.
+        # One file per z step, decoded as a whole plane.
         shape = get_dicom_info(self._path(name))["shape"]
         return (1, 1, int(shape[2]), int(shape[3]))
 
@@ -87,7 +86,7 @@ class DicomFile(AbstractFile):
         from konfai.utils.dicom import get_dicom_info, read_dicom_series_slice
 
         path = self._path(name)
-        info = dict(get_dicom_info(path))  # copy: get_dicom_info is memoised, and we update it below
+        info = dict(get_dicom_info(path))  # copy: get_dicom_info is memoised
         data, origin, spacing, direction = read_dicom_series_slice(
             path, slices, series_uid=info["series_uid"], info=info
         )

--- a/konfai/utils/dataset/h5.py
+++ b/konfai/utils/dataset/h5.py
@@ -47,13 +47,9 @@ from konfai.utils.errors import DatasetManagerError
 
 
 def _open_h5(path: str, mode: str, **kwargs: Any) -> Any:
-    """Every h5py open in this module. Unlocked, because the flag must agree across a file's handles:
-    HDF5 refuses to open a file this process already holds under the other file-locking flag, and the
-    read pool keeps a handle open on a store while a stream writes it (the "invisible until finalize"
-    read contract reads the store mid-write). A held HDF5 lock would also block every other process's
-    open of the file for as long as the handle lives, the pool's whole lifetime. Same-process races
-    are held off by the per-file thread lock.
-    """
+    """Every h5py open in this module. Unlocked: the flag must agree across a file's handles, and the
+    read pool holds a handle on a store while a stream writes it. Same-process races are held off by
+    the per-file thread lock."""
     return h5py.File(path, mode, locking=False, **kwargs)
 
 
@@ -72,13 +68,8 @@ _h5_file_locks_guard = threading.Lock()
 
 
 class _PooledRead(NamedTuple):
-    """An open read handle and the store it was opened on, as one thing: the two travel together through
-    eviction and re-insertion, so no site can pair a handle with a view it never had.
-
-    The sidecars travel with them: an entry's attributes, read off the handle once and kept for its
-    life, so a patch read costs one hyperslab and not one HDF5 attribute open per key on top (measured
-    15 opens, 327 us, on a 15-key sidecar beside a 222 us slice). A handle replaced or dropped takes
-    its sidecars with it, which is every way the store can have changed underneath them."""
+    """An open read handle, the store as it was when opened, and the entries' attributes read off the
+    handle once and kept for its life."""
 
     file: Any
     opened_on: tuple[int, int] | None
@@ -88,16 +79,10 @@ class _PooledRead(NamedTuple):
 class _H5ReadPool:
     """Pooled read handles, one per file per process, LRU-bounded.
 
-    The HDF5 chunk cache lives on the open handle, so reusing the handle across patch reads is what
-    makes the cache effective: a per-read open rebuilds it empty every time. ``get``/``drop`` must be
-    called under the file's lock; a write drops the file's reader so it never serves stale metadata;
-    handles inherited across ``fork`` are dropped unused (closing them would flush another process's
-    state).
-
-    A handle also stops answering for a store another PROCESS has written (a loader worker producing
-    the group its parent reads), so one is kept only while the file it was opened on is unchanged.
-    Reopening alone would not do: HDF5 shares a file's metadata state across the handles one process
-    holds, so a second handle inherits the first's view. The stale one is closed before the new open."""
+    The HDF5 chunk cache lives on the open handle. ``get``/``drop`` must be called under the file's
+    lock; a write drops the file's reader; handles inherited across ``fork`` are dropped unused. A
+    handle is kept only while the file it was opened on is unchanged, and the stale one is closed
+    before the new open (HDF5 shares a file's metadata state across one process's handles)."""
 
     _MAX = 8
     _OPEN_ATTEMPTS = 4
@@ -118,12 +103,8 @@ class _H5ReadPool:
         return info.st_mtime_ns, info.st_size
 
     def _open(self, filename: str, **open_kwargs: Any) -> _PooledRead:
-        """A handle, with the store as it was when it was opened.
-
-        The reopen happens exactly when another process has just written, which is when that process is
-        most likely to still be mid-transaction: HDF5 without SWMR then refuses the open. It is transient,
-        so it is retried, and each attempt takes its own stamp: a handle is never paired with a view of
-        the store taken before the write that made the previous attempt fail."""
+        """A handle, with the store as it was when it was opened. An open refused mid-transaction by
+        another process's write is retried, each attempt with its own stamp."""
         for remaining in reversed(range(self._OPEN_ATTEMPTS)):
             stamp = self._stamp(filename)
             try:
@@ -135,16 +116,14 @@ class _H5ReadPool:
         raise AssertionError("unreachable: the last attempt either returns or raises")
 
     def get(self, filename: str, **open_kwargs: Any) -> _PooledRead:
-        # Read before the open, never after: a write landing in between then leaves a stamp older than
-        # the handle, and the next call reopens. The reverse would record a view it never had.
+        # Stamped before the open, never after: a write landing in between makes the next call reopen.
         stamp = self._stamp(filename)
         with self._guard:
             if os.getpid() != self._pid:
                 self._handles.clear()
                 self._pid = os.getpid()
             pooled = self._handles.pop(filename, None)
-        # Outside the pool guard: opening touches the filesystem and may sleep between attempts. The
-        # caller holds this file's lock, so no other thread of ours is reading or reopening it here.
+        # Outside the pool guard: opening may sleep between attempts. The caller holds this file's lock.
         if pooled is not None and (not pooled.file.id.valid or pooled.opened_on != stamp):
             pooled.file.close()
             pooled = None
@@ -167,22 +146,18 @@ class _H5ReadPool:
             pooled.file.close()
 
     def close_all(self) -> None:
-        """Release every pooled handle: what a workflow leaves behind in the caller's process
-        would otherwise keep its outputs open (read-only) for as long as the process lives."""
+        """Release every pooled handle."""
         with self._guard:
             handles = list(self._handles.items())
             self._handles.clear()
         for filename, pooled in handles:
-            # One handle's failing close must not leave the rest open and untracked.
             with _get_h5_file_lock(filename), contextlib.suppress(Exception):
                 if pooled.file.id.valid:
                     pooled.file.close()
 
     def _close_idle(self, filename: str, pooled: _PooledRead) -> None:
-        # An evicted handle may be mid-read under its file's lock: close only when that lock is free,
-        # otherwise put it back in the pool: an untracked open handle could never be dropped again.
-        # It goes back with the stamp it came with: re-stamping would hand it the store as it is now,
-        # and a write it never saw would stay invisible for the rest of the process.
+        # An evicted handle may be mid-read under its file's lock: closed only when that lock is free,
+        # otherwise put back in the pool with the stamp it came with.
         lock = _get_h5_file_lock(filename)
         if lock.acquire(blocking=False):
             try:
@@ -198,8 +173,8 @@ _h5_read_pool = _H5ReadPool()
 
 
 def release_read_handles() -> None:
-    """Close the process's pooled read handles (h5). A workflow's caller reopening its own output
-    for writing needs them gone: HDF5 refuses a write-open of a file this process holds for reading."""
+    """Close the process's pooled read handles (h5): HDF5 refuses a write-open of a file this process
+    holds for reading."""
     _h5_read_pool.close_all()
 
 
@@ -226,7 +201,7 @@ class _H5DataStream(DataStream):
         try:
             parent.move(temporary_name, self._final_name)
         except Exception:
-            # The old entry comes back where it was: a failed publish leaves the store as it found it.
+            # A failed publish leaves the store as it found it.
             if replaced and self._final_name not in parent:
                 parent.move(backup, self._final_name)
             raise
@@ -244,20 +219,15 @@ class H5File(AbstractFile):
         del file_format, attributes
         return True  # a dataset written by regions, chunked or contiguous
 
-    # Read-side HDF5 chunk cache, per opened dataset. The library default (1 MB) holds barely one
-    # medical-imaging chunk, so overlapping patch reads on a chunked (compressed) store
-    # re-decompress the same chunks once per patch. KonfAI writes its own h5 contiguous
-    # (unaffected); this serves third-party chunked stores read through the streamed patch path.
-    # nslots per the h5py guidance: a prime, well above the chunks the cache can hold.
+    # Read-side HDF5 chunk cache, per opened dataset, for third-party chunked stores (KonfAI writes
+    # its own h5 contiguous). nslots per the h5py guidance: a prime, well above the chunks held.
     _READ_CHUNK_CACHE_BYTES = 128 * 1024 * 1024
     _READ_CHUNK_CACHE_SLOTS = 100003
 
     @staticmethod
     def _read_chunk_cache_bytes() -> int:
         """What one pooled handle's HDF5 chunk cache may hold: the cache share of the declared
-        per-rank budget divided across the pool's handles, so the pool at capacity stays inside
-        the one share every decoded-block cache draws from; the fixed default when no budget was
-        declared."""
+        per-rank budget divided across the pool's handles, or the fixed default without a budget."""
         share = budget_share("cache")
         if share is None:
             return H5File._READ_CHUNK_CACHE_BYTES
@@ -278,10 +248,8 @@ class H5File(AbstractFile):
         self._sidecars: dict[str, Attribute] | None = None  # the pooled handle's, on a read open
 
     def __enter__(self):
-        # A single HDF5 file cannot be opened concurrently from several threads:
-        # the whole open/use/close sequence is serialised per file so that two
-        # cache workers never race between the existence check and the "w"/"r+"
-        # open (which would truncate each other's data).
+        # The open/use/close sequence is serialised per file: two writers must never race between
+        # the existence check and the "w"/"r+" open.
         self._lock = _get_h5_file_lock(self.filename)
         self._lock.acquire()
         try:
@@ -316,8 +284,7 @@ class H5File(AbstractFile):
                 self._lock = None
 
     def _sidecar(self, dataset: h5py.Dataset) -> Attribute:
-        """The entry's attributes, a copy of the pooled handle's record of them: one attribute open
-        per key on the first read of the entry through the handle, none after. A write handle is
+        """The entry's attributes, a copy of the pooled handle's record of them. A write handle is
         not pooled and reads them off the file."""
         if self._sidecars is None:
             return Attribute(dict(dataset.attrs))
@@ -334,16 +301,12 @@ class H5File(AbstractFile):
 
     def bounded_region_reads(self, name: str) -> bool:
         del name
-        # A hyperslab reads the bytes it covers (contiguous, what KonfAI writes) or the chunks it
-        # touches (a third-party chunked store): never the whole volume.
+        # A hyperslab reads the bytes it covers or the chunks it touches: never the whole volume.
         return True
 
     def read_granularity(self, name: str) -> tuple[int, ...] | None:
-        """The chunk a chunked entry is stored in (``C[Z]YX``): a hyperslab decodes every chunk it
-        touches whole, so a window costs the chunk-aligned hull that covers it, and a sweep cut on
-        that grid reads each chunk once. ``None`` for a contiguous entry, what ``data_to_file``
-        writes, where a read costs the bytes it covers. A region write (``open_data_stream``)
-        chunks on its region, so a cache this run wrote answers the grain it was written in."""
+        """The chunk a chunked entry is stored in (``C[Z]YX``); ``None`` for a contiguous entry, what
+        ``data_to_file`` writes."""
         groups, _, entry = name.rpartition("/")
         dataset = self._get_dataset(groups, entry)
         if not isinstance(dataset, h5py.Dataset) or dataset.chunks is None:
@@ -372,10 +335,8 @@ class H5File(AbstractFile):
             data = np.asarray(_encode_transform_leaves(data, name, attributes))
 
         h5_group, name = self._resolve_group(name)
-        # Staged under a temp name and moved, never created under the final one: the invariant
-        # every DataStream holds (a hard-killed writer leaves .tmp debris, not a plausible
-        # partial entry the resume then SKIPs as done). The old entry is moved aside and put
-        # back if the publish fails, so no instant has neither version in the file.
+        # Staged under a temp name and moved, never created under the final one; the old entry is
+        # moved aside and put back if the publish fails.
         staging = f"{name}.{DataStream.temporary_suffix()}"
         if staging in h5_group:
             del h5_group[staging]
@@ -398,8 +359,7 @@ class H5File(AbstractFile):
     @staticmethod
     def _create_entry(h5_group: h5py.Group, key: str, attributes: Attribute, **dataset_kwargs: Any) -> h5py.Dataset:
         """A dataset with its attributes, or nothing: an interrupt between the two must not leave an
-        attribute-less entry (or an orphaned temporary) in a file HDF5 never reclaims space from.
-        Contiguous: a full-row slab is one byte span, and a patch reads its own bytes, not a chunk."""
+        attribute-less entry. Contiguous: a patch reads its own bytes, not a chunk."""
         dataset = h5_group.create_dataset(key, chunks=None, **dataset_kwargs)
         try:
             dataset.attrs.update({k: str(v) for k, v in attributes.items()})
@@ -435,12 +395,9 @@ class H5File(AbstractFile):
         return _H5DataStream(dataset, name)
 
     def _recovered_key(self, h5_group: h5py.Group, name: str) -> str | None:
-        """The key ``name`` answers to when it is missing: its own, or the single backup a DEAD
-        writer left of it (see :func:`_recover_orphaned_backup`, the same rule inside a file).
-
-        An h5 file open for READING cannot be renamed in, so the backup is served under its own
-        key and put back at the next write open, which is when the move is legal.
-        """
+        """The key ``name`` answers to: its own, or the single backup a dead writer left of it
+        (:func:`_recover_orphaned_backup`, the same rule inside a file). A file open for reading
+        serves the backup under its own key; the next write open moves it back."""
         if name in h5_group:
             return name
         backups = _orphaned_backup_names(list(h5_group.keys()), name)
@@ -479,12 +436,9 @@ class H5File(AbstractFile):
             names = [
                 dataset.name.split("/")[-1]
                 for dataset in h5_group.values()
-                # ``.tmp`` keys are in-flight (or hard-kill-orphaned) DataStream writes, not entries.
                 if isinstance(dataset, h5py.Dataset) and not is_staging_entry(dataset.name)
             ]
-            # A backup a dead writer orphaned IS its entry (see _recover_orphaned_backup), and a
-            # listing that hid it while the probe and the read recover it would name fewer cases
-            # than the store serves: a run would silently skip one.
+            # A backup a dead writer orphaned is its entry (_recover_orphaned_backup).
             names.extend(self._orphaned_entries(h5_group, names))
         elif group == "*":
             for k in h5_group.keys():
@@ -506,9 +460,7 @@ class H5File(AbstractFile):
         return list(self.h5.keys()) if self.h5 is not None else []
 
     def _require_dataset(self, groups: str, name: str) -> h5py.Dataset:
-        """The entry, or the designed refusal: an absent group resolved ``None`` and every reader
-        dereferenced it, an anonymous ``AttributeError`` deep in numpy where the sibling backends
-        name the entry."""
+        """The entry, or a ``DatasetManagerError`` naming it."""
         dataset = self._get_dataset(groups, name)
         if dataset is None:
             entry = f"{groups}/{name}" if groups else name

--- a/konfai/utils/dataset/itk_transform_file.py
+++ b/konfai/utils/dataset/itk_transform_file.py
@@ -52,10 +52,9 @@ from konfai.utils.errors import DatasetManagerError
 def _create_itk_transform_file(path: str, spatial: list[int], attributes: Attribute) -> tuple[Any, Any]:
     """An ITK displacement-transform HDF5 file with its parameters dataset still to fill.
 
-    Three datasets, as ITK's own writer lays them out: the type (a variable-length ASCII string,
-    which is what ITK's reader accepts), the fixed parameters (size, origin, spacing, direction)
-    and the parameters, the field buffer with the component fastest, float64. Returns the open file
-    and the parameters dataset.
+    Three datasets, as ITK's writer lays them out: the type (a variable-length ASCII string), the
+    fixed parameters (size, origin, spacing, direction) and the parameters, the field buffer with
+    the component fastest, float64. Returns the open file and the parameters dataset.
     """
     fixed = np.concatenate(
         [
@@ -81,10 +80,8 @@ def _create_itk_transform_file(path: str, spatial: list[int], attributes: Attrib
 class _ItkTransformDataStream(DataStream):
     """An ITK displacement-transform file written region by region.
 
-    A slab of the field maps to one contiguous span of the parameters (the buffer is ``[z][y][x]``
-    with the component fastest), so full-width leading-axis slabs (what the streamed write
-    dispatcher emits) land with plain offset writes. Under a temporary name until the clean exit,
-    like every stream.
+    The buffer is ``[z][y][x]`` with the component fastest, so a full-width leading-axis slab is
+    one contiguous span of the parameters. Under a temporary name until the clean exit.
     """
 
     def __init__(self, file: Any, parameters: Any, temporary_path: str, final_path: str, spatial: list[int]) -> None:
@@ -105,8 +102,7 @@ class _ItkTransformDataStream(DataStream):
                 "A transform file writes full-width leading-axis slabs, and this region is not one.",
                 "This is a bug if it was reached: the streamed write dispatcher finalizes full rows.",
             )
-        # One buffer: the cast and the transpose are the same pass. Casting first materialises the
-        # slab in float64, and ravelling the transposed VIEW of that materialises it again.
+        # One buffer: the cast and the transpose are the same pass.
         block = np.ascontiguousarray(np.moveaxis(data, 0, -1), dtype=np.float64).ravel()
         offset = 3 * int(leading.start or 0) * int(np.prod(self._spatial[2:], dtype=np.int64))
         self._parameters[offset : offset + block.size] = block
@@ -122,16 +118,10 @@ class _ItkTransformDataStream(DataStream):
 class ItkTransformFile(AbstractFile):
     """ITK transform files, one ``<case>/<group>.h5`` per entry.
 
-    The write side is the point: ``sitk.WriteTransform`` needs the whole field resident in
-    float64, where the FILE is three HDF5 datasets that write by regions, so a displacement
-    field streams into a transform any ITK consumer (Slicer first) loads. The read side hands
-    back what ``Dataset.read_transform`` decodes: a displacement entry carries its field and
-    the displacement marker; any other stored transform, the parameter rows and type keys of
-    ``_encode_transform_leaves``.
-
-    Needs ``h5py``, as the ``h5`` backend does: the whole point is to touch the parameters
-    region by region, and a run whose peak memory turns on whether an optional import
-    succeeded is a run nobody can size.
+    A displacement field streams by regions into the three HDF5 datasets of a transform any ITK
+    consumer loads. The read side hands back what ``Dataset.read_transform`` decodes: a
+    displacement entry carries its field and the displacement marker; any other stored transform,
+    the parameter rows and type keys of ``_encode_transform_leaves``. Needs ``h5py``.
     """
 
     def __init__(self, filename: str, read: bool) -> None:
@@ -175,9 +165,7 @@ class ItkTransformFile(AbstractFile):
         return f"{self.filename}{name}.h5"
 
     def _read_path(self, name: str) -> str:
-        """The entry's file for a READ: a missing entry is the structured refusal, never a
-        synthesized path sitk.ReadTransform turns into its own RuntimeError. ``is_exist`` keeps
-        ``_path``, whose answer for a missing entry is a path that does not exist."""
+        """The entry's file for a read; a missing entry raises ``DatasetManagerError``."""
         path = self._path(name)
         if not os.path.exists(path):
             raise DatasetManagerError(
@@ -192,11 +180,8 @@ class ItkTransformFile(AbstractFile):
             with self._field_file(name) as file:
                 header = self._field_header(file)
                 if header is not None:
-                    # The parameters ARE the field: one span off the file, where ITK's transform
-                    # reader holds the field twice before the array is even copied out (a 128^3
-                    # field: +147 MiB of RSS through ITK, +100 MiB off the span). Read at the
-                    # dtype a region read takes, so the two routes carry the same values: the
-                    # file keeps ITK's double, the pipeline does not.
+                    # The parameters are the field: one span off the file, read at the dtype a
+                    # region read takes, so the two routes carry the same values.
                     shape, attributes = header
                     return self._field_region(file, shape[1:], (slice(None),) * 4), attributes
         transform = sitk.ReadTransform(self._read_path(name))
@@ -219,8 +204,7 @@ class ItkTransformFile(AbstractFile):
 
     @contextlib.contextmanager
     def _field_file(self, name: str) -> Iterator[Any]:
-        """The entry's HDF5 file off the process's read pool: opened once per file, held while
-        a region is read, replaced by the pool when the file is rewritten."""
+        """The entry's HDF5 file off the process's read pool, held while a region is read."""
         path = self._read_path(name)
         with _get_h5_file_lock(path):
             yield _h5_read_pool.get(path).file
@@ -228,7 +212,7 @@ class ItkTransformFile(AbstractFile):
     @staticmethod
     def _field_header(file: Any) -> tuple[list[int], Attribute] | None:
         """Shape and geometry of a displacement entry off its fixed parameters (size, origin,
-        spacing, direction); ``None`` for a transform of another kind, which the whole read decodes."""
+        spacing, direction); ``None`` for a transform of another kind."""
         kind = bytes(file["TransformGroup/0/TransformType"][0])
         if not kind.startswith(b"DisplacementFieldTransform"):
             return None
@@ -244,7 +228,7 @@ class ItkTransformFile(AbstractFile):
     @staticmethod
     def _covered(item: slice, extent: int) -> tuple[int, int, slice]:
         """The ``[low, high)`` range of an axis a slice touches, and the slice of that range it
-        takes: what a read of the range then subsamples, whichever way the slice runs."""
+        takes, whichever way the slice runs."""
         start, stop, step = item.indices(extent)
         count = len(range(start, stop, step))
         if count == 0:
@@ -260,18 +244,16 @@ class ItkTransformFile(AbstractFile):
     ) -> np.ndarray:
         """The region ``slices`` of the field, read as one HDF5 hyperslab of the parameters.
 
-        The buffer is ``[z][y][x]`` with the component fastest, so the rows of one plane the
-        region covers are one contiguous span, and the planes it covers are such spans a stride
-        apart: a hyperslab of ``count`` blocks reads them into one buffer, the bytes of the
-        region's planes and rows and no other (a 64^3 region of a 512^3 field reads 50 MB where
-        the leading-axis rows it sits on are 403 MB). A forward step on the leading axis is the
-        stride; every other step, and a reversed axis, subsamples the block after the read.
+        The buffer is ``[z][y][x]`` with the component fastest: the rows of one plane the region
+        covers are one contiguous span, and the planes it covers are such spans a stride apart. A
+        forward step on the leading axis is the stride; every other step, and a reversed axis,
+        subsamples the block after the read.
         """
         plane_low, plane_high, planes = cls._covered(slices[1], spatial[0])
         row_low, row_high, rows = cls._covered(slices[2], spatial[1])
         row_length = 3 * int(spatial[2])
         plane_length = row_length * int(spatial[1])
-        if planes.step > 0:  # the hyperslab's stride: the planes in between are never read
+        if planes.step > 0:  # the hyperslab's stride
             stride, count, planes = planes.step, len(range(plane_low, plane_high, planes.step)), slice(None)
         else:
             stride, count = 1, plane_high - plane_low
@@ -288,8 +270,7 @@ class ItkTransformFile(AbstractFile):
         return np.ascontiguousarray(np.moveaxis(region, -1, 0), dtype=dtype)
 
     def file_to_data_slice(self, group: str, name: str, slices: tuple[slice, ...]) -> tuple[np.ndarray, Attribute]:
-        """A region of a displacement entry, decoded from the parameters it maps to alone: the
-        header and the region come off one pooled handle, so a region read opens nothing."""
+        """A region of a displacement entry, decoded from the parameters it maps to alone."""
         if h5py.is_hdf5(self._read_path(name)):
             with self._field_file(name) as file:
                 header = self._field_header(file)
@@ -306,8 +287,7 @@ class ItkTransformFile(AbstractFile):
         attributes: Attribute | None = None,
     ) -> None:
         os.makedirs(self.filename, exist_ok=True)
-        # Always the `.h5` name: the content is HDF5 and ITK selects its transform IO from the
-        # extension, so renaming it onto a resolved existing `.tfm` would corrupt that entry.
+        # Always the `.h5` name: ITK selects its transform IO from the extension.
         final = os.path.join(self.filename, f"{name}.h5")
         staging = DataStream.staging_path(final)
         if isinstance(data, sitk.Transform):
@@ -328,7 +308,7 @@ class ItkTransformFile(AbstractFile):
                 # One buffer, as in _ItkTransformDataStream.write_slice.
                 parameters[:] = np.ascontiguousarray(np.moveaxis(array, 0, -1), dtype=np.float64).ravel()
         os.replace(staging, final)
-        try:  # one entry per name: a `.tfm` left under the same stem would double it
+        try:  # one entry per name
             os.remove(os.path.join(self.filename, f"{name}.tfm"))
         except FileNotFoundError:
             pass
@@ -341,20 +321,18 @@ class ItkTransformFile(AbstractFile):
         attributes: Attribute,
         region_shape: list[int] | None = None,
     ) -> DataStream | None:
-        del dtype, region_shape  # the parameters are float64 whatever arrives, converted per slab
+        del dtype, region_shape  # the parameters are float64 whatever arrives
         if len(shape) != 4 or shape[0] != 3 or not is_an_image(attributes):
             return None
         os.makedirs(self.filename, exist_ok=True)
         spatial = [int(extent) for extent in shape[1:]]
-        # The `.h5` name, as data_to_file: HDF5 content renamed onto a resolved `.tfm` is a
-        # transform ITK reads with its text IO.
+        # The `.h5` name, as data_to_file.
         final = os.path.join(self.filename, f"{name}.h5")
         staging = DataStream.staging_path(final)
         file, parameters = _create_itk_transform_file(staging, spatial, attributes)
         return _ItkTransformDataStream(file, parameters, staging, final, [3, *spatial])
 
     def _entries(self) -> list[str]:
-        # Path.glob matches hidden files, so a writer's staging file is filtered out by name.
         return sorted(
             {
                 path.stem
@@ -375,8 +353,7 @@ class ItkTransformFile(AbstractFile):
         return os.path.exists(self._path(name if name else group))
 
     def get_infos(self, group: str, name: str) -> tuple[list[int], Attribute]:
-        # A legacy TEXT transform (`#Insight Transform File V1.0`) is served by the read side
-        # too; only a real HDF5 file has the parameter datasets this fast path opens.
+        # A text transform (`#Insight Transform File V1.0`) has no parameter datasets to open.
         header = None
         if h5py.is_hdf5(self._path(name)):
             with self._field_file(name) as file:

--- a/konfai/utils/dataset/ome_zarr_file.py
+++ b/konfai/utils/dataset/ome_zarr_file.py
@@ -53,16 +53,10 @@ from konfai.utils.utils import (
 def _store_chunks(shape: list[int], region_shape: list[int] | None, dtype: Any) -> tuple[int, ...] | None:
     """Chunks a store should use, given the region shape its writer declared.
 
-    A region write that straddles a chunk becomes a read-modify-write of it, so the writer's own
-    region is the starting point; verbatim it is a gigabyte in one chunk at 2048x2048 float32, paid
-    by every later partial read. A region that fits ``CHUNK_TARGET_BYTES`` is taken as it stands; one
-    that does not is cut on EVERY axis longer than ``CHUNK_SPATIAL_TILE`` at once, the shape that
-    writes fastest (2.4 GB into a (1, 128, 128, 128) uint16 store takes 2.18 s, into
-    (1, 128, 640, 128) 3.53 s).
-
-    A covered axis may be cut anywhere; a partial one only into a DIVISOR of the region, since a
-    writer advancing in blocks of its declared size starts every block at a multiple of it. One whose
-    largest usable divisor would be a sliver is left long. ``None`` when the writer declared nothing.
+    A region that fits ``CHUNK_TARGET_BYTES`` is taken as it stands; one that does not is cut on
+    every axis longer than ``CHUNK_SPATIAL_TILE``. A covered axis may be cut anywhere; a partial one
+    only into a divisor of the region, since a writer advancing in blocks of its declared size starts
+    every block at a multiple of it. ``None`` when the writer declared nothing.
     """
     from konfai.utils.ome_zarr import CHUNK_SPATIAL_TILE, CHUNK_TARGET_BYTES
 
@@ -80,23 +74,20 @@ def _store_chunks(shape: list[int], region_shape: list[int] | None, dtype: Any) 
 
 def _divisor_tile(extent: int, cap: int) -> int:
     """The largest divisor of ``extent`` that is at most ``cap``, or ``extent`` when that divisor
-    would be a sliver (under a quarter of the cap): a chunk axis of one voxel is worse than a long
-    one."""
+    is under a quarter of the cap."""
     if extent <= cap:
         return max(1, extent)
     divisor = next((candidate for candidate in range(cap, 0, -1) if extent % candidate == 0), 1)
     return divisor if divisor * 4 >= cap else extent
 
 
-#: Where each entry's store was resolved on disk, keyed by ``(root, entry)``: the store-suffix
-#: probes are one ``fs.info`` round-trip each on a remote root, per patch without this. A write
-#: through this backend forgets the memo (it may change the suffix the entry resolves under); a
-#: store REPLACED at the same path keeps its resolution, so no other invalidation is owed.
+#: Where each entry's store was resolved on disk, keyed by ``(root, entry)``. A write through this
+#: backend forgets the memo; a store replaced at the same path keeps its resolution.
 _resolved_store_paths: dict[tuple[str, str], str] = {}
 
 
 def _forget_resolved_paths() -> None:
-    """Drop the entry-path memo: what a write must call, being the one thing that moves a store."""
+    """Drop the entry-path memo; every write must call it."""
     _resolved_store_paths.clear()
 
 
@@ -129,9 +120,7 @@ class _OmeZarrDataStream(DataStream):
             shutil.rmtree(self._store_path, ignore_errors=True)
             return
         if self._scale_factors:
-            # On the temporary store, so the rename below publishes level 0 and its coarser levels in
-            # one step. The levels are grafted beside level 0 (one pass over it, into an array 4^rank
-            # times smaller); level 0 itself is not rewritten.
+            # On the temporary store, so the rename publishes level 0 and its coarser levels in one step.
             append_ome_zarr_levels(self._store_path, self._scale_factors, downsample_method=self._downsample_method)
             self._array = None
         replaced = self._final_path.exists()
@@ -142,8 +131,7 @@ class _OmeZarrDataStream(DataStream):
         try:
             os.rename(self._store_path, self._final_path)
         except OSError:
-            # A concurrent writer of the same entry renamed its complete, identical store into place;
-            # keep it and drop ours.
+            # A concurrent writer of the same entry renamed its complete store into place: keep it.
             if not self._final_path.exists():
                 if replaced:
                     os.rename(backup, self._final_path)  # a failed publish leaves the old entry in place
@@ -151,11 +139,7 @@ class _OmeZarrDataStream(DataStream):
             shutil.rmtree(self._store_path, ignore_errors=True)
         if replaced:
             shutil.rmtree(backup, ignore_errors=True)
-        # The reader memoises loaded stores by path, and this rename changes what that path holds.
-        # A store replaced by one written through a different code path can differ down to the key
-        # its level-0 array lives under, so a stale entry does not merely serve old pixels: it
-        # points at a component that is no longer there. This path alone: the sources a cohort is
-        # still reading are not what changed.
+        # The reader memoises loaded stores by path, and this path now holds another store.
         clear_ome_zarr_cache(self._final_path)
         _forget_resolved_paths()
 
@@ -163,13 +147,9 @@ class _OmeZarrDataStream(DataStream):
 class OmeZarrFile(AbstractFile):
     """OME-NGFF backend using chunked Zarr reads for KonfAI patches.
 
-    ``level`` selects the multiscale pyramid resolution to read (0 = full
-    resolution, higher = coarser); it comes from the ``omezarr@<level>``
-    dataset-spec suffix.
-
-    ``scale_factors`` is the WRITE-side counterpart: it makes the store this backend writes a
-    pyramid instead of a single level. Reading indexes a pyramid BY POSITION, so a producer that
-    writes one and a consumer that asks for ``@1`` are two halves of the same contract.
+    ``level`` selects the multiscale pyramid level to read (0 = full resolution, higher = coarser),
+    from the ``omezarr@<level>`` dataset-spec suffix. ``scale_factors`` is the write-side
+    counterpart: the store written is a pyramid, indexed by position on read.
     """
 
     concurrent_write_safe = False  # a store shares metadata across its arrays
@@ -203,9 +183,8 @@ class OmeZarrFile(AbstractFile):
         return None
 
     def _path(self, name: str, *, writing: bool = False) -> str:
-        """Where entry ``name``'s store sits: text, because a remote one is a URI and ``Path``
-        eats the second slash of one. Resolved once per ``(root, entry)``: each suffix probe is a
-        round-trip on a remote root, and the store's location cannot change mid-run."""
+        """Where entry ``name``'s store sits, as text (a remote one is a URI). Resolved once per
+        ``(root, entry)``."""
         base = uri.join(self.filename, name)
         if writing:
             uri.refuse_write(self.filename)
@@ -218,8 +197,7 @@ class OmeZarrFile(AbstractFile):
         return resolved
 
     def _resolve_path(self, name: str, base: str) -> str:
-        # Every spelling is_store_name accepts, or a root whose first case names one of the
-        # others is detected as omezarr at setup and then fails to resolve.
+        # Every spelling is_store_name accepts.
         candidates = [f"{base}{form}" for form in STORE_FORMS] + [base]
         for candidate in candidates:
             if uri.is_dir(candidate):
@@ -238,14 +216,8 @@ class OmeZarrFile(AbstractFile):
         )
 
     def _listed_as(self, name: str) -> str | None:
-        """Where ``name``'s store sits when the directory spells its suffix in another case,
-        ``None`` when nothing there is that store.
-
-        ``is_store_name`` and :meth:`get_group` match the suffix case-insensitively, so a
-        ``CT.OME.ZARR`` is accepted at setup and listed as ``CT``; on a case-sensitive
-        filesystem the probes above, which are the accepted spellings in lower case, all miss
-        it. Only the miss pays the listing, and it lists one case's directory.
-        """
+        """Where ``name``'s store sits when the directory spells its suffix in another case
+        (``CT.OME.ZARR`` is listed as ``CT``), ``None`` when nothing there is that store."""
         prefix, _, stem = name.rpartition("/")
         directory = uri.join(self.filename, prefix) if prefix else self.filename
         wanted = {f"{stem}{form}".lower() for form in STORE_FORMS}
@@ -263,9 +235,7 @@ class OmeZarrFile(AbstractFile):
 
         info_shape, _ = self.get_infos(group, name)
         data, attributes = self.file_to_data_slice(group, name, tuple(slice(None) for _ in info_shape))
-        # Marked here and not in file_to_data_slice: that one is the streamed path, called once per
-        # patch, and re-reading the store's metadata per patch is exactly the overhead _load_image
-        # is memoised to avoid. A transform is only ever rebuilt from a whole entry.
+        # Not in file_to_data_slice: a transform is only ever rebuilt from a whole entry.
         if is_displacement_field(self._path(name)):
             attributes[DISPLACEMENT_FIELD_ATTRIBUTE] = "true"
         return data, attributes
@@ -311,28 +281,20 @@ class OmeZarrFile(AbstractFile):
         from konfai.utils.ome_zarr import clear_ome_zarr_cache, write_ome_zarr
 
         attributes = attributes or Attribute()
-        # Two ways to say "this is a field": hand over a DisplacementFieldTransform, or mark the
-        # attributes. The second exists because a producer that never builds a transform: the
-        # predictor emits arrays: would otherwise have to wrap its output in one purely to be
-        # described correctly, and a field too large to hold in memory cannot be wrapped at all.
+        # A field is a DisplacementFieldTransform handed over, or an array with the attribute marked.
         displacement_field = DISPLACEMENT_FIELD_ATTRIBUTE in attributes
         if sitk is not None and isinstance(data, sitk.Image):
             data, image_attributes = image_to_data(data)
             attributes.update(image_attributes)
         elif sitk is not None and isinstance(data, sitk.Transform):
-            # The parametric transforms the other backends serialise (Euler, affine, B-spline) have
-            # no OME-NGFF form; a displacement field does, and it is array-backed, so this backend
-            # stores exactly the one kind it can store faithfully.
+            # A displacement field is the one transform kind with an OME-NGFF form.
             data, field_attributes = displacement_field_to_data(data, name)
             attributes.update(field_attributes)
             displacement_field = True
         if not isinstance(data, np.ndarray):
             raise DatasetManagerError("OME-Zarr datasets can only store image arrays.")
-        # Staged beside the final store and renamed over it: writing under the final name
-        # truncates the destination before a byte lands, so a crash mid-write left a partial
-        # store the resume then counted as already written -- and an overwrite lost both
-        # versions. The rename is the atomicity every DataStream already holds; the .replaced
-        # hop keeps an instant with SOME complete store on disk.
+        # Staged beside the final store and renamed over it; the .replaced hop keeps a complete
+        # store on disk at every instant.
         final = Path(self._path(name, writing=True))
         staging = final.with_name(f"{final.name}.{os.getpid()}.tmp")
         if staging.exists():
@@ -356,14 +318,14 @@ class OmeZarrFile(AbstractFile):
         except BaseException:
             if replaced.exists() and not final.exists():
                 replaced.rename(final)
-            shutil.rmtree(staging, ignore_errors=True)  # or a full second copy of the entry stays
+            shutil.rmtree(staging, ignore_errors=True)
             raise
         shutil.rmtree(replaced, ignore_errors=True)
         # The reader memoises decoded chunks by path, and this path now holds another store.
         clear_ome_zarr_cache(final)
         _forget_resolved_paths()
         with contextlib.suppress(Exception):
-            _retire_dead_debris(final)  # housekeeping past the publish: it cannot fail the write
+            _retire_dead_debris(final)  # housekeeping: it cannot fail the write
 
     def open_data_stream(
         self,
@@ -387,16 +349,10 @@ class OmeZarrFile(AbstractFile):
             origin=attributes.get_np_array("Origin") if "Origin" in attributes else None,
             attributes=dict(attributes),
             displacement_field=DISPLACEMENT_FIELD_ATTRIBUTE in attributes,
-            # Chunked against what the writer says it will write, capped to something a reader
-            # can open. Guessing the writer's access pattern costs a read-modify-write on every
-            # region whose extent straddles a chunk: measured 1.8x on a slab sweep, paid on
-            # every byte, and invisible because the bytes are correct either way.
+            # Chunked against what the writer says it will write, capped to what a reader can open.
             chunks=_store_chunks(shape, region_shape, dtype),
         )
-        # The pyramid cannot be created up front: no level exists until the last region lands --
-        # so the stream derives it at finalize, on the TEMPORARY store, before the rename. That
-        # order is what keeps publication atomic: a reader never sees a store whose level 0 is
-        # complete but whose coarser levels are not.
+        # The pyramid is derived at finalize, on the temporary store, before the rename.
         return _OmeZarrDataStream(array, store_path, final_path, self.scale_factors, self.downsample_method)
 
     @classmethod
@@ -439,11 +395,8 @@ class OmeZarrFile(AbstractFile):
         shape = [axis_sizes.get("c", 1), *[axis_sizes[axis] for axis in ("z", "y", "x") if axis in axis_sizes]]
         metadata["shape"] = shape
         attributes = self._attributes(metadata)
-        # Marked on the HEADERS path, so a field stays a field on the streamed read too --
-        # file_to_data marks it only on the whole-volume read, and a store written from unmarked
-        # regions is an ordinary 3-channel image. This is the once-per-case call (Dataset caches
-        # it), not the per-patch one, which is why the check belongs here and not in
-        # file_to_data_slice.
+        # Marked on the headers path, the once-per-case call, so a field stays a field on the
+        # streamed read too.
         if is_displacement_field(self._path(name)):
             attributes[DISPLACEMENT_FIELD_ATTRIBUTE] = "true"
         return shape, attributes

--- a/konfai/utils/dataset/staging.py
+++ b/konfai/utils/dataset/staging.py
@@ -26,10 +26,8 @@ import warnings
 from collections.abc import Iterable
 from pathlib import Path
 
-#: The suffix an entry is moved to while its replacement is published. A stream moves the old entry
-#: aside rather than deleting it first: neither HDF5 nor a directory swap has an atomic rename-over,
-#: and a crash between a delete and the move would lose both. Per pid, so two writers of one entry
-#: never share a backup.
+#: The suffix an entry is moved to while its replacement is published. Per pid, so two writers of
+#: one entry never share a backup.
 _REPLACED_MARKER = ".replaced-"
 
 
@@ -39,10 +37,9 @@ def _replaced_name(name: str) -> str:
 
 
 def is_staging_entry(name: str) -> bool:
-    """Whether ``name`` (a path or an h5 key) is a writer's staging entry, never a case: an in-flight (or
-    hard-kill-orphaned) temporary carrying the ``.tmp`` marker of :meth:`DataStream.temporary_suffix` or
-    :meth:`DataStream.staging_path`, or the :func:`_replaced_name` an entry is moved to while its
-    replacement is published."""
+    """Whether ``name`` (a path or an h5 key) is a writer's staging entry, never a case: a temporary
+    carrying the ``.tmp`` marker of :meth:`DataStream.temporary_suffix` or :meth:`DataStream.staging_path`,
+    or the :func:`_replaced_name` an entry is moved to while its replacement is published."""
     leaf = os.path.basename(name)
     return leaf.endswith(".tmp") or ".tmp." in leaf or _REPLACED_MARKER in leaf
 
@@ -53,8 +50,8 @@ _STAGING_PID = re.compile(r"\.(?:(?P<pid>\d+)(?:-\d+)?\.(?:tmp|replaced)|replace
 
 
 def _writer_is_dead(pid: int) -> bool:
-    """Whether the writer that staged under ``pid`` no longer runs. ``psutil`` rather than
-    ``os.kill(pid, 0)``: on Windows a missing pid raises a generic OSError, not ProcessLookupError."""
+    """Whether the writer that staged under ``pid`` no longer runs. ``psutil``, not ``os.kill(pid, 0)``,
+    which on Windows raises a generic OSError for a missing pid."""
     if pid == os.getpid():
         return False
     import psutil
@@ -79,13 +76,9 @@ def _recover_orphaned_backup(final: Path) -> bool:
     """Put back the previous entry when a killed writer left it under its backup name alone.
 
     A replacement moves the old entry aside as ``<name>.replaced-<pid>``, publishes the new one,
-    then drops the backup, and a failed publish moves it back. A writer killed BETWEEN the two moves
-    leaves the previous, complete entry under the backup name, which every listing hides
-    (:func:`is_staging_entry`): the output is preserved and not served, which reads as data loss.
-
-    Exactly one backup, from a writer that no longer runs, and no entry under the final name: that
-    backup IS the entry, so it goes back. Two backups, or a writer still running, is nobody's to
-    guess, and the entry stays missing.
+    then drops the backup. Exactly one backup, from a writer that no longer runs, and no entry under
+    the final name: that backup goes back. Two backups, or a writer still running, and the entry
+    stays missing.
     """
     if final.exists():
         return False
@@ -98,11 +91,9 @@ def _recover_orphaned_backup(final: Path) -> bool:
         return False
     backup = final.parent.joinpath(backups[0])
     try:
-        # Never over a publish that landed while this was deciding. A second existence check would
-        # only move the window, so the move itself has to refuse: os.link fails EEXIST (and Windows
-        # rename fails outright), and a directory rename fails ENOTEMPTY against a complete store --
-        # a store is only ever published by renaming a full staging directory into place, so the
-        # final name is never an empty directory a rename could swallow.
+        # Never over a publish that landed meanwhile: the move itself refuses. os.link fails EEXIST,
+        # a Windows rename fails outright, and a directory rename fails ENOTEMPTY against a
+        # published store (never an empty directory).
         if backup.is_dir() or os.name == "nt":
             backup.rename(final)
         else:
@@ -121,14 +112,9 @@ def _recover_orphaned_backup(final: Path) -> bool:
 
 
 def _retire_dead_debris(final: Path) -> None:
-    """Remove what earlier, DEAD writers of ``final`` left beside it.
+    """Remove what earlier, dead writers of ``final`` left beside it.
 
-    Every writer here stages under a pid-marked name and publishes by rename, so a hard kill leaves
-    a staging file or store the readers already know to skip -- and nothing ever removed: a
-    27 GB one-hot store's staging sat beside the published one for good. Publishing an entry is
-    the moment its history is settled, so the debris of any writer that no longer runs goes then.
-    A LIVE writer's staging is left alone (two writers of one entry are legal, the last rename
-    wins), which is what the pid in the name is for.
+    A live writer's staging is left alone: two writers of one entry are legal, the last rename wins.
     """
     entry = final.name.split(".", 1)[0]
     try:

--- a/konfai/utils/dataset/statistics.py
+++ b/konfai/utils/dataset/statistics.py
@@ -32,29 +32,16 @@ from konfai.utils.errors import DatasetManagerError
 #: Elements a block of ``Dataset.iter_data_blocks`` holds when no budget was declared: the read grain
 #: of a scan (the statistics fold, the quantile scan), whatever the backend.
 _STATISTICS_CHUNK_ELEMENTS = 8_000_000
-#: Blocks a scan holds at its peak: the map of the one being read, its copy, and the copy the fold has
-#: not released yet, a generator reading the next while its caller still names the last. Measured at
-#: 95.6 MiB of resident set for a 30.5 MiB block over a 78 MiB case.
-#:
-#: The scan itself keeps its side of the bargain: 95.4 / 96.0 / 67.1 / 34.4 MiB held over 512 / 128 /
-#: 64 / 32 MiB declared, so it is under the budget at 128 and above (where :data:`_STATISTICS_CHUNK_
-#: ELEMENTS` caps it) and about 1.1x over at 64 and 32. What a GLOBAL_STAT ROUTE holds is more: 183
-#: MiB over the floor at 128 MiB declared, against the 154 the plan announces (regions 104 + engine
-#: 32 + cache 18), so 1.19x. The scan frees (RSS falls back between the phases) and the sweep then
-#: peaks on top of a residue.
-#:
-#: Not chased further here, and the reason is the instrument: ``VmHWM`` is a high-water mark of the
-#: WHOLE resident set, so it cannot be compared with the ``RssAnon``/``RssFile`` split, which is
-#: instantaneous -- and it is anonymous memory alone that an OOM kill weighs. Attributing this needs
-#: a sampler for peak anonymous bytes across the phases, not another reading of the mark.
+#: Blocks a scan holds at its peak: the map of the one being read, its copy, and the copy the fold
+#: has not released yet, a generator reading the next while its caller still names the last.
+#: Measured at 95.6 MiB of resident set for a 30.5 MiB block over a 78 MiB case.
 _STATISTICS_BLOCKS_IN_FLIGHT = 3
-#: The bytes a scanned element is priced at when the source's own size is not known: what everything
-#: else the budget sizes prices an element at. A block is the store's OWN dtype, never a cast copy,
-#: so where the store can be asked (:meth:`Dataset._scanned_element_bytes`) it answers instead.
+#: The bytes a scanned element is priced at when the source's own size is not known. A block is the
+#: store's OWN dtype, so where the store can be asked (:meth:`Dataset._scanned_element_bytes`) it
+#: answers instead.
 _STATISTICS_ELEMENT_BYTES = 4
-#: Elements one running-statistics update takes at once: its float64 temporaries then stay in cache,
-#: where a whole block's stream through memory. Below the block on purpose: the block is the READ
-#: grain, and a chunked store decodes a chunk once per read that touches it.
+#: Elements one running-statistics update takes at once, so its float64 temporaries stay in cache.
+#: Below the block on purpose: the block is the READ grain of a chunked store.
 _STATISTICS_UPDATE_ELEMENTS = 1 << 18
 
 
@@ -64,9 +51,7 @@ def chunk_hull_voxels(span: Sequence[slice], granularity: Sequence[int], shape: 
     A chunked read decodes whole blocks and assembles the window out of them, so what it holds is
     the block-aligned hull of the window, never the window: a span that straddles two planes of the
     grid pays both in full, and one aligned to the grid pays exactly itself. The hull is capped at
-    the array, so an axis a span covers entirely costs that axis and no more.
-
-    The three sequences describe the same axes, in the same order.
+    the array. The three sequences describe the same axes, in the same order.
     """
     hull = 1
     for part, block, extent in zip(span, granularity, shape, strict=True):
@@ -89,11 +74,10 @@ def _scan_block_on_the_store_grid(
     """The rows one scan block reads, and what reading it holds.
 
     A chunked store decodes whole blocks, so a scan stepping finer than the store's grain decodes
-    the same block again at every step it takes inside it: measured at 1153 MiB decoded to serve a
-    13.5 MiB window, 85x, and 170x where the step straddles two -- 212 reads over a volume five
-    stored blocks deep. Where the budget can hold a whole stored block the grain is RAISED to it,
-    which reads each block once; where it cannot, the grain stays and what the store decodes is
-    CHARGED, so an impossible scan is refused by the plan instead of by the kernel.
+    the same block again at every step it takes inside it. Where the budget can hold a whole stored
+    block the grain is RAISED to it, which reads each block once; where it cannot, the grain stays
+    and what the store decodes is CHARGED, so an impossible scan is refused by the plan instead of
+    by the kernel.
     """
     block = max(1, int(granularity[0])) if granularity else 0
 
@@ -121,11 +105,9 @@ def _scan_block_on_the_store_grid(
 
 def _statistics_block_elements(element_bytes: int = _STATISTICS_ELEMENT_BYTES) -> int:
     """Elements one block of a whole-volume scan may hold: its share of the budget this rank
-    published, since :data:`_STATISTICS_BLOCKS_IN_FLIGHT` of them are in flight at the peak, each of
-    them ``element_bytes`` an element. A fixed read grain made a scan cost the same 95.6 MiB
-    whatever the budget said. Without a declared budget, the grain that keeps a chunked store's
-    decode whole.
-    """
+    published, :data:`_STATISTICS_BLOCKS_IN_FLIGHT` of them being in flight at the peak, each
+    ``element_bytes`` an element. Without a declared budget, the grain that keeps a chunked store's
+    decode whole."""
     budget = per_rank_budget_bytes()
     if budget is None:
         return _STATISTICS_CHUNK_ELEMENTS
@@ -200,10 +182,8 @@ def _max_of(current: Any, candidate: Any) -> Any:
 
 def _order_statistics(blocks: Callable[[], Iterator[np.ndarray]], q: float) -> tuple[Any, Any, float]:
     """The two order statistics ``numpy.quantile(..., q)`` interpolates between, and the weight, over
-    everything the blocks hold, without holding it: one pass counts and bounds the values, then passes
-    narrow a value interval by histogram until the rank's bin holds few enough values to collect, or a
-    single value.
-    """
+    everything the blocks hold, without holding it: one pass counts and bounds the values, then
+    passes narrow a value interval by histogram until the rank's bin holds few enough to collect."""
     count = 0
     low = high = None
     for block in blocks():
@@ -211,8 +191,7 @@ def _order_statistics(blocks: Callable[[], Iterator[np.ndarray]], q: float) -> t
         if flat.size == 0:
             continue
         if np.issubdtype(flat.dtype, np.floating) and np.isnan(flat).any():
-            # numpy.quantile of anything holding a NaN is NaN; a bin can hold no NaN, so the
-            # narrowing below would otherwise search a histogram the count does not match.
+            # numpy.quantile of anything holding a NaN is NaN, and a bin can hold no NaN.
             return np.nan, np.nan, 0.0
         count += int(flat.size)
         low, high = _min_of(low, flat.min()), _max_of(high, flat.max())
@@ -274,11 +253,8 @@ def _update_running_statistics(
 ) -> dict[str, Any]:
     """Update running min/max/mean/std from a NumPy chunk, over the volume AND per channel.
 
-    Both grains come from one pass because they come from the same samples: a chunk arrives as
-    ``(C, ...)``, so the per-channel figures are the same Welford recurrence applied along axis 0,
-    and the whole-volume ones are that recurrence pooled. Computing them separately would mean
-    scanning the volume once per channel: three passes over a displacement field to learn three
-    numbers.
+    A chunk arrives as ``(C, ...)``, so the per-channel figures are the same Welford recurrence
+    applied along axis 0 and the whole-volume ones are that recurrence pooled: one pass for both.
     """
     values = np.asarray(array, dtype=np.float64)
     per_channel = values.reshape(values.shape[0], -1) if values.ndim > 1 else values.reshape(1, -1)
@@ -323,10 +299,9 @@ def _update_running_statistics(
 
 
 def _update_running_extrema(state: dict[str, Any] | None, array: np.ndarray) -> dict[str, Any]:
-    """Update running min/max only, over the volume and per channel, in the array's own dtype:
-    what a ``Normalize`` asks for, without the float64 cast and the Welford pass the mean and std
-    need (on the streaming bench, most of the scan's own time). The state keeps its moment
-    fields at zero, and the reader that asked for extrema reads nothing else."""
+    """Update running min/max only, over the volume and per channel, in the array's own dtype: what
+    a ``Normalize`` asks for, without the float64 cast and the Welford pass. The state keeps its
+    moment fields at zero, and the reader that asked for extrema reads nothing else."""
     values = np.asarray(array)
     per_channel = values.reshape(values.shape[0], -1) if values.ndim > 1 else values.reshape(1, -1)
     channels = per_channel.shape[0]
@@ -378,14 +353,12 @@ def read_masked_data_statistics(
     The masked twin of ``Dataset.read_data_statistics``: both volumes are walked slab by slab along
     the first spatial axis (the slab aligned to the volume's own read granularity where it states
     one), and only the selected values enter the running fold, so neither volume is ever held. A
-    store that cannot serve bounded region reads is read whole ONCE and sliced in memory, exactly
-    as ``Dataset.iter_data_blocks`` serves such stores: a region read of them decodes the whole
-    volume anyway, so reading per slab would hold the same peak once per slab.
+    store that cannot serve bounded region reads is read whole ONCE and sliced in memory, as
+    ``Dataset.iter_data_blocks`` serves such stores.
 
-    The mask must sit on the volume's own grid (same spatial extent): a mask elsewhere would select
-    from the wrong place and the statistics would look right. The channel counts must agree too,
-    since selection is ``volume[mask == 1]``. ``source`` and ``mask_source`` are Datasets (duck
-    typed: this module is below the Dataset class).
+    The mask must sit on the volume's own grid (same spatial extent) and the channel counts must
+    agree, since selection is ``volume[mask == 1]``. ``source`` and ``mask_source`` are Datasets
+    (duck typed: this module is below the Dataset class).
     """
     shape, _ = source.get_infos(group, name)
     mask_shape, _ = mask_source.get_infos(mask_group, name)
@@ -429,8 +402,7 @@ def _finalize_running_statistics(state: dict[str, Any] | None) -> dict[str, Any]
     """Convert a running-statistics state into the public stats dictionary.
 
     The four scalars are the volume's; the four ``*_per_channel`` lists are the same figures per
-    channel, which is what a vector-valued quantity needs: the mean of a displacement field is
-    three numbers, and pooling them into one describes nothing.
+    channel, which is what a vector-valued quantity needs.
     """
     if state is None or state["count"] == 0:
         return {"min": 0.0, "max": 0.0, "mean": 0.0, "std": 0.0} | {

--- a/konfai/utils/dicom.py
+++ b/konfai/utils/dicom.py
@@ -27,8 +27,9 @@ Reading one requires:
    columns plus their cross product for the z-axis).
 4. **CT intensity rescale**: RescaleSlope and RescaleIntercept convert stored pixel values to
    Hounsfield Units, mandatory for CT and absent or identity for MR.
-5. **Error handling**: missing tags, single-slice series, inconsistent spacing, non-square pixels
-   and unsupported transfer syntaxes are reported.
+5. **Error handling**: missing tags, inconsistent slice spacing and unsupported transfer syntaxes
+   are reported. A single-slice series takes ``SliceThickness``, or 1.0 mm when it carries none,
+   and non-square pixels are read as they are.
 
 Optional dependency: ``pydicom`` (``pip install konfai[dicom]``).
 """

--- a/konfai/utils/dicom.py
+++ b/konfai/utils/dicom.py
@@ -16,30 +16,19 @@
 
 """DICOM series reader for KonfAI medical imaging pipelines.
 
-Design rationale
-----------------
-DICOM is not a folder of independent images.  A CT or MRI acquisition is a
-*series*: a collection of .dcm files that together define a 3-D volume.
-Reading a DICOM correctly requires:
+A CT or MRI acquisition is a *series*: a collection of .dcm files that together define a 3-D volume.
+Reading one requires:
 
-1. **Series discovery**: group files by SeriesInstanceUID.  A folder may
-   contain multiple series (e.g. a T1 and a T2 acquired in the same session).
-
-2. **Slice ordering**: sort slices by ImagePositionPatient (z-component along
-   ImageOrientationPatient normal vector), not by filename or InstanceNumber,
-   which can be unreliable.
-
-3. **Geometry extraction**: derive spacing_mm (PixelSpacing + SliceThickness /
-   derived inter-slice distance), origin (ImagePositionPatient of first slice),
-   and direction cosines (ImageOrientationPatient rows and columns + cross
-   product for the z-axis).
-
-4. **CT intensity rescale**: apply RescaleSlope and RescaleIntercept to
-   convert stored pixel values to Hounsfield Units (HU).  This is mandatory
-   for CT and is absent (or identity) for MR.
-
-5. **Error handling**: missing tags, single-slice series, inconsistent spacing,
-   non-square pixels, and unsupported transfer syntaxes all need clear messages.
+1. **Series discovery**: group files by SeriesInstanceUID; a folder may hold several series.
+2. **Slice ordering**: sort by ImagePositionPatient (z along the ImageOrientationPatient normal),
+   not by filename or InstanceNumber.
+3. **Geometry extraction**: spacing_mm (PixelSpacing plus the derived inter-slice distance), origin
+   (ImagePositionPatient of the first slice), direction cosines (ImageOrientationPatient rows and
+   columns plus their cross product for the z-axis).
+4. **CT intensity rescale**: RescaleSlope and RescaleIntercept convert stored pixel values to
+   Hounsfield Units, mandatory for CT and absent or identity for MR.
+5. **Error handling**: missing tags, single-slice series, inconsistent spacing, non-square pixels
+   and unsupported transfer syntaxes are reported.
 
 Optional dependency: ``pydicom`` (``pip install konfai[dicom]``).
 """
@@ -86,29 +75,14 @@ def _require_pydicom() -> None:
         )
 
 
-# ---------------------------------------------------------------------------
 # Series discovery
-# ---------------------------------------------------------------------------
 
 
 def discover_series(directory: str | Path) -> dict[str, list[Path]]:
-    """Return a mapping of SeriesInstanceUID -> sorted list of .dcm paths.
+    """Return a mapping of SeriesInstanceUID -> list of .dcm paths, unsorted at this stage.
 
-    Parameters
-    ----------
-    directory:
-        Root directory to scan recursively for .dcm files.
-
-    Returns
-    -------
-    dict[str, list[Path]]
-        Keys are SeriesInstanceUID values; values are lists of file paths
-        belonging to that series (unsorted at this stage).
-
-    Raises
-    ------
-    DatasetManagerError
-        If ``pydicom`` is not installed or the directory contains no DICOM.
+    ``directory`` is scanned recursively for .dcm files. Raises ``DatasetManagerError`` when
+    ``pydicom`` is not installed or the directory contains no DICOM.
     """
     _require_pydicom()
 
@@ -136,18 +110,13 @@ def discover_series(directory: str | Path) -> dict[str, list[Path]]:
     return series
 
 
-# ---------------------------------------------------------------------------
 # Slice sorting
-# ---------------------------------------------------------------------------
 
 
 def _slice_position(ds: DicomDataset) -> float:
-    """Return the signed position of one slice along the acquisition axis.
-
-    Uses ``ImagePositionPatient`` projected onto the slice-normal derived from
-    ``ImageOrientationPatient``.  Falls back to ``InstanceNumber`` (unreliable
-    but ubiquitous) when geometry tags are absent.
-    """
+    """The signed position of one slice along the acquisition axis: ``ImagePositionPatient``
+    projected onto the slice normal from ``ImageOrientationPatient``, falling back to
+    ``InstanceNumber`` when geometry tags are absent."""
     try:
         iop = [float(x) for x in ds.ImageOrientationPatient]
         ipp = [float(x) for x in ds.ImagePositionPatient]
@@ -165,15 +134,8 @@ def _slice_position(ds: DicomDataset) -> float:
 def sort_series(files: list[Path], *, stop_before_pixels: bool = False) -> list[DicomDataset]:
     """Read and sort slices in anatomical order (ascending slice position).
 
-    Parameters
-    ----------
-    files:
-        Unsorted list of paths belonging to one DICOM series.
-
-    Returns
-    -------
-    list[DicomDataset]
-        Datasets sorted by their position along the acquisition normal.
+    ``files`` is an unsorted list of paths belonging to one DICOM series; the datasets come back
+    sorted by their position along the acquisition normal.
     """
     _require_pydicom()
     datasets: list[DicomDataset] = [pydicom.dcmread(str(f), stop_before_pixels=stop_before_pixels) for f in files]
@@ -200,40 +162,26 @@ def _select_series_files(directory: str | Path, series_uid: str | None = None) -
     )
 
 
-# ---------------------------------------------------------------------------
 # Geometry extraction
-# ---------------------------------------------------------------------------
 
 
 def extract_geometry(
     datasets: list[DicomDataset],
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Extract origin, spacing, and direction from a sorted DICOM series.
+    """Extract origin, spacing and direction from a sorted DICOM series.
 
-    Parameters
-    ----------
-    datasets:
-        Slice datasets in anatomical order (from :func:`sort_series`).
-
-    Returns
-    -------
-    tuple[np.ndarray, np.ndarray, np.ndarray]
-        - ``origin`` (3,): physical position of the first voxel (mm).
-        - ``spacing`` (3,): KonfAI/SimpleITK order (x, y, z) in mm.
-        - ``direction`` (9,): row-major 3-by-3 direction cosine matrix, flattened.
-
-    Raises
-    ------
-    DatasetManagerError
-        If required geometry tags are missing or inconsistent.
+    ``datasets`` are the slice datasets in anatomical order (from :func:`sort_series`). Returns
+    ``origin`` (3,), the physical position of the first voxel in mm; ``spacing`` (3,), in
+    KonfAI/SimpleITK ``(x, y, z)`` order in mm; and ``direction`` (9,), the row-major 3-by-3
+    direction cosine matrix flattened. Raises ``DatasetManagerError`` when required geometry tags
+    are missing or inconsistent.
     """
     if not datasets:
         raise DatasetManagerError("Cannot extract geometry from an empty series.")
 
     first = datasets[0]
 
-    # Multi-frame / enhanced DICOM (many frames in one file) would be mis-stacked as a
-    # single slice, so reject it explicitly rather than produce a wrong volume.
+    # Multi-frame / enhanced DICOM would be mis-stacked as a single slice, so it is refused.
     try:
         number_of_frames = int(getattr(first, "NumberOfFrames", 1) or 1)
     except (TypeError, ValueError):
@@ -265,10 +213,8 @@ def extract_geometry(
             "This tag is required to determine voxel dimensions.",
         ) from exc
 
-    # Slice spacing: prefer computed inter-slice distance over SliceThickness.
-    # Use the first gap (matches SimpleITK's geometry), but verify the whole series is
-    # uniformly spaced so irregular series (localizers, missing/duplicate slices, mixed
-    # series) fail loudly instead of silently producing a wrong z-spacing.
+    # Slice spacing: the first computed inter-slice gap (matching SimpleITK's geometry), with the
+    # whole series checked for uniform spacing so an irregular one fails instead of skewing z.
     if len(datasets) > 1:
         gaps = np.abs(np.diff([_slice_position(ds) for ds in datasets]))
         slice_spacing_mm = float(gaps[0])
@@ -304,9 +250,7 @@ def extract_geometry(
     return origin, spacing, direction
 
 
-# ---------------------------------------------------------------------------
 # Pixel reading with CT rescale
-# ---------------------------------------------------------------------------
 
 
 def read_volume(
@@ -316,37 +260,18 @@ def read_volume(
 ) -> np.ndarray:
     """Stack sorted slices into a channel-first (1, Z, Y, X) float32 array.
 
-    Parameters
-    ----------
-    datasets:
-        Sorted DICOM datasets (from :func:`sort_series`).
-    apply_rescale:
-        If True, apply RescaleSlope / RescaleIntercept to convert stored
-        pixel values to Hounsfield Units (HU) for CT, or to physical signal
-        units for modalities that provide these tags.  Set to False to keep
-        raw stored pixel integers (e.g., for label maps or QC).
-
-    Returns
-    -------
-    np.ndarray
-        Shape (1, Z, Y, X), dtype float32.  Channel dimension = 1 for scalar
-        volumes.
-
-    Raises
-    ------
-    DatasetManagerError
-        If pixel data cannot be read or slices have inconsistent shapes.
+    ``datasets`` are sorted DICOM datasets (from :func:`sort_series`). ``apply_rescale`` applies
+    RescaleSlope / RescaleIntercept to convert stored pixel values to Hounsfield Units for CT, or to
+    physical signal units for modalities providing these tags; False keeps the raw stored integers.
+    Raises ``DatasetManagerError`` when pixel data cannot be read or slices have inconsistent shapes.
     """
     return _decode_slices(datasets, (slice(None), slice(None)), apply_rescale)[np.newaxis]
 
 
 def _decode_slices(datasets: list[DicomDataset], window: tuple[slice, slice], apply_rescale: bool) -> np.ndarray:
-    """The ``window`` (rows, columns) of every slice, stacked ``(Z, y, x)`` in float32, into one buffer.
-
-    Each plane is cut to the window BEFORE the cast and the rescale, so a 64x64 patch of 512x512
-    slices pays for 64x64 of arithmetic and not 512x512. ``arr * slope + intercept``, elementwise on
-    the cut plane, is the same operation on the same values as on the whole one: bit-identical.
-    """
+    """The ``window`` (rows, columns) of every slice, stacked ``(Z, y, x)`` in float32, into one
+    buffer. Each plane is cut to the window BEFORE the cast and the rescale, which is the same
+    operation on the same values as on the whole plane: bit-identical."""
     volume: np.ndarray | None = None
     expected_shape: tuple[int, ...] | None = None
     for i, ds in enumerate(datasets):
@@ -378,11 +303,11 @@ def _decode_slices(datasets: list[DicomDataset], window: tuple[slice, slice], ap
 
 
 #: What the plane cache may hold when no budget is declared; a declared budget gives it the cache
-#: share instead (:data:`~konfai.utils.budget.BUDGET_SHARES`), so one declaration is divided once.
+#: share instead (:data:`~konfai.utils.budget.BUDGET_SHARES`).
 _PLANE_CACHE_DEFAULT_BYTES = 256 << 20
 
-#: Large data elements are left in the file until accessed: a plane read needs the pixels and the
-#: rescale tags, not every private element parsed into memory.
+#: Large data elements stay in the file until accessed: a plane read needs the pixels and the
+#: rescale tags, nothing else.
 _DCMREAD_DEFER_BYTES = 4096
 
 
@@ -397,9 +322,8 @@ class _DecodedPlaneCache:
     """Decoded DICOM slice planes with their rescale tags, evicted LRU under a byte cap.
 
     A series stores one file per plane, and every region read touching a z index decodes that
-    file's whole plane: overlapping regions of a sweep would parse and decode the same file once
-    per region (the same cliff the OME-Zarr route caps with its decoded-chunk cache). Keyed by
-    ``(path, mtime_ns, size)``, so a rewritten slice is a new entry and never served stale."""
+    file's whole plane. Keyed by ``(path, mtime_ns, size)``, so a rewritten slice is a new entry
+    and never served stale."""
 
     def __init__(self) -> None:
         self._entries: OrderedDict[tuple[str, int, int], tuple[np.ndarray, float, float]] = OrderedDict()
@@ -436,7 +360,7 @@ _plane_cache = _DecodedPlaneCache()
 
 def _decoded_plane(path: Path) -> tuple[np.ndarray, float, float]:
     """One slice file's whole decoded plane and its rescale tags, parsed and decoded once per file
-    per pass: the cache is what keeps an overlapping sweep from decoding it once per region."""
+    per pass."""
     stamp = os.stat(path)
     key = (str(path), stamp.st_mtime_ns, stamp.st_size)
     cached = _plane_cache.get(key)
@@ -490,11 +414,9 @@ def get_dicom_info(
 ) -> dict[str, Any]:
     """Read DICOM series shape and geometry without decoding pixel data.
 
-    Memoised per directory: input DICOM is read-only for a run, so the series walk and header reads are
-    done once instead of on every patch read. Unbounded, because a miss re-reads every slice header
-    (0.3 ms per slice, twice) where the record it rebuilds is 140 bytes per slice, and a cohort read
-    in any order but case by case would miss on every patch past a bound. ``write_dicom_series``
-    clears it. Callers that mutate the result must copy it first.
+    Memoised per directory and unbounded: input DICOM is read-only for a run, and a cohort read case
+    by case would miss on every patch past a bound. ``write_dicom_series`` clears it. Callers that
+    mutate the result must copy it first.
     """
     selected_uid, files = _select_series_files(directory, series_uid)
     datasets = sort_series(files, stop_before_pixels=True)
@@ -606,8 +528,7 @@ def write_dicom_series(
     root.mkdir(parents=True, exist_ok=True)
     get_dicom_info.cache_clear()  # what this directory holds is about to change
     _plane_cache.clear()
-    # Remove only slices previously written by this function (its zero-padded NNNNNN.dcm
-    # naming), never unrelated DICOM files that may share the directory.
+    # Remove only slices this function wrote (its zero-padded NNNNNN.dcm naming).
     for existing in root.glob("*.dcm"):
         if _SLICE_FILENAME_RE.match(existing.name):
             existing.unlink()
@@ -666,9 +587,7 @@ def write_dicom_series(
     return series_uid
 
 
-# ---------------------------------------------------------------------------
 # High-level convenience function
-# ---------------------------------------------------------------------------
 
 
 def read_dicom_series(
@@ -679,29 +598,14 @@ def read_dicom_series(
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Read a DICOM series from a directory into a channel-first volume.
 
-    Parameters
-    ----------
-    directory:
-        Path to the folder containing the DICOM series.
-    series_uid:
-        If the folder contains multiple series, select by SeriesInstanceUID.
-        If None and only one series is present, that series is used.
-        If None and multiple series are present, raises DatasetManagerError.
-    apply_rescale:
-        Apply RescaleSlope / RescaleIntercept (True) or keep raw integers.
+    ``series_uid`` selects one series by SeriesInstanceUID when the folder holds several; with None,
+    a single series is used and several are an error. ``apply_rescale`` applies RescaleSlope /
+    RescaleIntercept (True) or keeps raw integers.
 
-    Returns
-    -------
-    tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
-        - ``volume``: shape (1, Z, Y, X), dtype float32.
-        - ``origin``: physical origin of the first voxel, mm (shape (3,)).
-        - ``spacing``: voxel size in KonfAI/SimpleITK (x, y, z) order (shape (3,)).
-        - ``direction``: row-major 3-by-3 direction cosine matrix, flat (shape (9,)).
-
-    Raises
-    ------
-    DatasetManagerError
-        On missing deps, missing tags, multi-series ambiguity, or read errors.
+    Returns ``volume`` of shape (1, Z, Y, X) in float32, ``origin`` the physical origin of the first
+    voxel in mm (3,), ``spacing`` the voxel size in KonfAI/SimpleITK ``(x, y, z)`` order (3,), and
+    ``direction`` the row-major 3-by-3 direction cosine matrix, flat (9,). Raises
+    ``DatasetManagerError`` on missing deps, missing tags, multi-series ambiguity or read errors.
     """
     _require_pydicom()
 

--- a/konfai/utils/errors.py
+++ b/konfai/utils/errors.py
@@ -85,8 +85,7 @@ class TransformError(NamedKonfAIError):
 
 
 class TransformerError(NamedKonfAIError):
-    # One letter from TransformError, deliberately: the invariant is TYPE == root-class name, so the
-    # printed label tells a workflow failure ([Transformer]) from a data-transform one ([Transform]).
+    # TYPE == root-class name: [Transformer] is the workflow, [Transform] a data transform.
     TYPE = "Transformer"
 
 

--- a/konfai/utils/ome_zarr.py
+++ b/konfai/utils/ome_zarr.py
@@ -16,18 +16,13 @@
 
 """OME-Zarr (OME-NGFF) read/write backend for KonfAI, built on ``ngff-zarr``.
 
-This module is a thin adapter: ``ngff-zarr`` owns all OME-NGFF metadata parsing,
-multiscale handling, and (de)serialisation: KonfAI does not re-implement the
-spec. We only
+``ngff-zarr`` owns all OME-NGFF metadata parsing, multiscale handling and (de)serialisation. This
+module maps between KonfAI's channel-first ``C[Z]YX`` arrays / ``(x, y, z)`` geometry and
+ngff-zarr's ``NgffImage`` (axis-named ``scale``/``translation``), and round-trips the ``Attribute``
+sidecar (the ``Direction`` matrix included, which OME-NGFF cannot express) through a single
+``konfai`` root attribute.
 
-1. map between KonfAI's channel-first ``C[Z]YX`` arrays / ``(x, y, z)`` geometry
-   and ngff-zarr's ``NgffImage`` (axis-named ``scale``/``translation``), and
-2. round-trip KonfAI's full ``Attribute`` sidecar (including the ``Direction``
-   matrix, which OME-NGFF cannot express) through a single ``konfai`` root
-   attribute, carried by ngff-zarr beside the OME metadata.
-
-Reads are lazy: ``ngff-zarr`` exposes the array as a chunked store, so slicing
-only materialises the requested patch.
+Reads are lazy: the array is a chunked store, so slicing only materialises the requested patch.
 
 Optional dependencies: ``zarr`` + ``ngff-zarr`` (``pip install konfai[omezarr]``).
 """
@@ -61,8 +56,7 @@ except ImportError:
     _ZARR_AVAILABLE = False
 
 try:
-    # dask sits under the same guard because it is ngff-zarr's own hard dependency: the two are
-    # present or absent together, and dask.array is used only to describe a store to ngff-zarr.
+    # dask is ngff-zarr's own hard dependency, and dask.array only describes a store to ngff-zarr.
     import dask.array
     import ngff_zarr  # type: ignore[import-untyped]
 
@@ -88,34 +82,23 @@ def _native_dtype(dtype: np.dtype) -> np.dtype:
 def _native_byteorder(array: np.ndarray) -> np.ndarray:
     """The same samples in the machine's own byte order.
 
-    A store may hold big-endian samples (some acquisition software writes them, and zarr keeps the
-    dtype it was given), and a non-native array poisons everything downstream in two different ways.
-    ``torch.from_numpy`` refuses it outright ("given numpy array has byte order different from the
-    native byte order"), which is the loud half. The quiet half is numpy: the flag rides along
-    through slicing and arithmetic, so a value read here compares and writes correctly while any
-    consumer that reinterprets the buffer (a raw ``.tobytes()``, a memory-mapped write, a C
-    extension taking a pointer) sees the bytes swapped. Normalising once at the read boundary is
-    what every caller would otherwise have to remember to do by hand.
+    ``torch.from_numpy`` refuses a non-native array, and a consumer that reinterprets the buffer of
+    one numpy still accepts sees the bytes swapped. Normalised once at the read boundary.
     """
     return array.astype(_native_dtype(array.dtype), copy=False)
 
 
-# NGFF RFC-5 types the component axis of a vector field, so a displacement field says what it is on
-# disk. Those types only exist from NGFF 0.6 (zarr v3); 0.4 (zarr v2 layout) stays the default
-# everywhere else, being the version external OME-Zarr readers most widely accept.
+# NGFF RFC-5 types the component axis of a vector field. Those types exist only from NGFF 0.6
+# (zarr v3); 0.4 (zarr v2 layout) stays the default, being what external readers most widely accept.
 _DISPLACEMENT_AXIS_TYPE = "displacement"
 
-# EVERY field store holds its components in the spec's order -- the OUTPUT axes' (dz, dy, dx for a
-# zyx store) -- there is no second layout. KonfAI's own convention stays ITK's (dx, dy, dz)
-# everywhere in memory; the two orders meet only at this backend's read/write boundary, where the
-# components are flipped. An axis-aligned grid is additionally declared a ``displacements``
-# transformation mapping the physical coordinate system onto itself through the level-0 array,
-# which is what makes it APPLICABLE by a spec reader rather than merely labelled; a grid carrying
-# a rotation cannot be declared (RFC-5 maps a field's array to space by scale and translation
-# alone) and keeps only the typed axis, its Direction in the sidecar, the marker below saying how
-# its components are ordered. A typed store with NEITHER the entry NOR the marker is a pre-1.9
-# layout whose components are ITK-ordered: reading it under one convention or the other would be a
-# guess with a plausible registration either way, so it is refused by name.
+# Every field store holds its components in the spec's order, the output axes' (dz, dy, dx for a zyx
+# store); KonfAI's own convention is ITK's (dx, dy, dz) in memory, and the two meet only at this
+# backend's read/write boundary. An axis-aligned grid is additionally declared a ``displacements``
+# transformation mapping the physical coordinate system onto itself through the level-0 array, which
+# makes it applicable by a spec reader; a rotated grid cannot be declared (RFC-5 maps a field to
+# space by scale and translation alone) and keeps only the typed axis, its Direction in the sidecar
+# and the marker below. A typed store carrying neither the entry nor the marker is refused by name.
 _PHYSICAL_CS = "physical"
 _FIELD_COMPONENTS_KEY = "field_components"
 _FIELD_COMPONENTS = "output-axes"
@@ -124,16 +107,13 @@ _RFC5_VERSION = "0.6"
 _DEFAULT_VERSION = "0.4"
 
 #: How a chunk is sized, whether the store is created from a shape alone or from the region shape a
-#: streamed writer declares (:func:`konfai.utils.dataset._store_chunks`). One rule, two callers: a
-#: chunk is the unit a reader decompresses to reach one voxel, so an oversized one is paid by every
-#: partial read forever, and by any consumer that is not KonfAI.
+#: streamed writer declares (:func:`konfai.utils.dataset._store_chunks`). A chunk is the unit a
+#: reader decompresses to reach one voxel, so an oversized one is paid by every partial read.
 CHUNK_SPATIAL_TILE = 128
 CHUNK_TARGET_BYTES = 32 << 20
 
-#: zarr v2 stores keep byte-shuffled blosc-lz4 (what every 1.8.2 store carries) rather than the
-#: zarrista writer's zstd-0 default: measured on a CT-like uint16 volume, zstd-0 costs +19 % disk
-#: and ~+11 % on the streamed read sweep, because without the shuffle a uint16's high bytes break
-#: every run the compressor could fold.
+#: zarr v2 stores keep byte-shuffled blosc-lz4 rather than the zarrista writer's zstd-0 default:
+#: measured on a CT-like uint16 volume, zstd-0 costs +19 % disk and ~+11 % on the streamed read.
 _V2_COMPRESSOR = {"id": "blosc", "cname": "lz4", "clevel": 5, "shuffle": 1, "blocksize": 0}
 
 
@@ -155,10 +135,8 @@ def _require_ngff_zarr() -> None:
 
 
 def _read_konfai_attributes(store_path: str | Path) -> dict[str, Any]:
-    """KonfAI's proprietary ``Attribute`` sidecar: the ``konfai`` key ngff-zarr carries back beside
-    the OME metadata. A copy of a memoised parse: it is metadata, and a streamed run asks for it
-    once per region.
-    """
+    """KonfAI's ``Attribute`` sidecar: the ``konfai`` key ngff-zarr carries beside the OME metadata.
+    A copy of a memoised parse."""
     try:
         root = _multiscales(str(store_path)).root_attributes or {}
     except Exception:
@@ -168,12 +146,10 @@ def _read_konfai_attributes(store_path: str | Path) -> dict[str, Any]:
 
 def _from_ngff_zarr(store_path: str | Path) -> Any:
     """ngff-zarr's multiscales for ``store_path``. A remote root goes in as a key-to-bytes mapping
-    over its own filesystem (ngff-zarr >= 0.44 reads a remote string as a local path) and as its URL
-    when ngff-zarr refuses the mapping, which older releases resolve themselves."""
+    over its own filesystem, and as its URL when ngff-zarr refuses the mapping."""
     if not uri.is_uri(store_path):
         return ngff_zarr.from_ngff_zarr(str(store_path))
-    # Through uri.filesystem, so a missing fsspec backend or configuration is the structured
-    # DatasetManagerError, never a raw dependency error.
+    # Through uri.filesystem, so a missing fsspec backend is a structured DatasetManagerError.
     filesystem = uri.filesystem(store_path)
     _, target = uri.split_scheme(str(store_path))
     try:
@@ -184,14 +160,9 @@ def _from_ngff_zarr(store_path: str | Path) -> Any:
 
 @lru_cache(maxsize=8)
 def _multiscales(store_path: str) -> Any:
-    """ngff-zarr's multiscales for a store, memoised per path: the images, their metadata, and the
-    root attributes beside them, all from one parse.
-
-    A streamed run reads one patch per call, and re-parsing the NGFF metadata and rebuilding the
-    lazy array graph per patch is pure per-read overhead: the object is lazy (no voxel data), so a
-    handful of them is cheap to keep. The key is the path alone, so anything that puts a different
-    store at a path already read must call ``clear_ome_zarr_cache()``: see there.
-    """
+    """ngff-zarr's multiscales for a store, memoised per path: the images, their metadata and the
+    root attributes, all from one parse. The key is the path alone, so anything that puts a
+    different store at a path already read must call ``clear_ome_zarr_cache()``."""
     _require_ngff_zarr()
     return _from_ngff_zarr(store_path)
 
@@ -199,11 +170,8 @@ def _multiscales(store_path: str) -> Any:
 def _load_image(store_path: str, level: int) -> Any:
     """Return the ``NgffImage`` for ``level`` of an OME-Zarr store, off the memoised parse.
 
-    ``@N`` selects among the levels a store offers, so a single-level store has nothing to select: its
-    one level is read whatever ``N`` says (as every other backend does: ``SitkFile`` ignores
-    ``self.level`` too). Out of range on a store that IS a pyramid stays an error: asking level 3 of a
-    three-level mask beside a four-level image is a real mismatch (it silently pairs 160 µm against
-    320 µm), and quietly falling back to level 0 would hide it.
+    A single-level store has nothing to select: its one level is read whatever ``N`` says. Out of
+    range on a store that IS a pyramid is an error.
     """
     try:
         multiscales = _multiscales(store_path)
@@ -215,9 +183,7 @@ def _load_image(store_path: str, level: int) -> Any:
     if len(multiscales.images) == 1:
         return multiscales.images[0]
     if not 0 <= level < len(multiscales.images):
-        # Its own message: the store is fine, the LEVEL is not. Reporting an out-of-range level as
-        # "not a valid OME-NGFF store" sends the reader to inspect a store that has nothing wrong
-        # with it: the mismatch is in what was asked of it.
+        # Its own message: the store is fine, the LEVEL is not.
         raise DatasetManagerError(
             f"OME-Zarr store '{store_path}' has {len(multiscales.images)} level(s); level {level} is out of range.",
             f"Ask for a level in 0..{len(multiscales.images) - 1} (0 is the finest).",
@@ -228,11 +194,9 @@ def _load_image(store_path: str, level: int) -> Any:
 def store_identity(store_path: str | Path) -> str:
     """The string a store is keyed by, wherever it is named.
 
-    A reader keys its decoded chunks by the path it was handed, which
-    :meth:`~konfai.utils.dataset.OmeZarrFile._path` builds with ``uri.join``, on forward slashes
-    whatever the platform. A writer names the same store with a ``Path``, and on Windows
-    ``str(Path)`` is backslashed, so the two spellings would not meet and a replaced store would keep
-    serving the chunks of the store it replaced. One spelling, taken here.
+    A reader keys its decoded chunks by the forward-slashed path
+    :meth:`~konfai.utils.dataset.OmeZarrFile._path` builds; a writer names the same store with a
+    ``Path``, backslashed on Windows. One spelling, taken here.
     """
     return str(store_path).replace("\\", "/")
 
@@ -240,14 +204,9 @@ def store_identity(store_path: str | Path) -> str:
 def clear_ome_zarr_cache(store_path: str | Path | None = None) -> None:
     """Forget the memoised NGFF images, so a store replaced on disk is parsed afresh.
 
-    A named store forgets its own decoded chunks and read schedule and no one else's: an output
-    store is created per case, and the inputs' chunks are what the next case reads. The metadata
-    memos are cleared whatever the caller names, being one parse each to rebuild.
-
-    The write paths here call it for their own output. Anything that materialises a store by other
-    means (copying one over another, say) has to call it too: the memo is keyed on the path, and
-    a hit serves the previous store's axes and geometry against the new store's voxels. That reads as
-    a shape mismatch when the two differ, and as nothing at all when they do not.
+    A named store forgets its own decoded chunks and read schedule and no one else's; the metadata
+    memos are cleared whatever the caller names. Anything that materialises a store by other means
+    (copying one over another) has to call it too: a hit serves the previous store's geometry.
     """
     _multiscales.cache_clear()
     _level_array.cache_clear()
@@ -258,20 +217,15 @@ def clear_ome_zarr_cache(store_path: str | Path | None = None) -> None:
 def is_displacement_field(store_path: str | Path) -> bool:
     """Whether the store declares its component axis as an NGFF RFC-5 displacement field.
 
-    This is what lets a DVF be read back as a transform rather than as a 3-channel image, and it is
-    read from the store itself: the producer does not have to be trusted, and no sidecar convention
-    (a filename, an attribute) has to be agreed on separately.
-
-    A store that predates RFC-5 simply answers False: an unreadable or absent store is not a
-    displacement field either, so this never raises.
+    This is what lets a DVF be read back as a transform rather than as a 3-channel image. A store
+    that predates RFC-5, or one that cannot be read, answers False; this never raises.
     """
     if not _NGFF_ZARR_AVAILABLE:
         return False
     try:
         image = _multiscales(str(store_path)).images[0]
     except Exception:
-        # "Not a displacement field" is the only answer this owes: it is asked purely to decide HOW to
-        # read an entry, and an absent or unreadable store is not one either.
+        # An absent or unreadable store is not a displacement field either.
         return False
     return _has_displacement_axis(image)
 
@@ -284,11 +238,8 @@ def _has_displacement_axis(image: Any) -> bool:
 def _component_flip(store_path: str) -> bool:
     """Whether the store holds its components in the spec's order, to flip back to ITK's on read.
 
-    Every field store this backend writes does -- marked by the ``displacements`` entry when the
-    grid could be declared, by the sidecar's ``field_components`` when it could not. A store that
-    types its axis and carries neither is a pre-1.9 layout whose components are ITK-ordered, and it
-    is refused rather than read: under either convention the guess yields a plausible field with
-    dx and dz possibly exchanged, which is the silent kind of wrong.
+    Marked by the ``displacements`` entry when the grid could be declared, by the sidecar's
+    ``field_components`` when it could not; a store carrying neither is refused rather than read.
     """
     if not _NGFF_ZARR_AVAILABLE:
         return False
@@ -327,11 +278,7 @@ _NEVER_AGAIN = 1 << 62
 class _ReadSchedule:
     """The chunks each of a caller's declared reads will touch, in the order it will read them.
 
-    LRU is the best a cache can do without the future. With it, the fewest decodes any policy can
-    reach is to evict the chunk whose next use is furthest away. Measured on a 513x1331x1776
-    resample cut into 40 blocks over 126 chunks of source, chunks decoded on the level array: 148
-    under LRU, 138 under this, 126 the floor.
-
+    Evicting the chunk whose next use is furthest away is the fewest decodes any policy can reach.
     Followed only while the reads match what was declared, and abandoned at the first that does
     not: a caller that deviates loses the optimisation, never the answer.
     """
@@ -363,8 +310,7 @@ class _ReadSchedule:
 
     def steps_to_next_use(self, coords: tuple) -> int:
         """How many reads away the next one touching ``coords`` is: 0 while the read touching it is
-        in progress (a chunk of the window being assembled is not the one to evict for the rest of
-        it), ``_NEVER_AGAIN`` when none does."""
+        in progress, ``_NEVER_AGAIN`` when none does."""
         uses = self._uses.get(coords)
         if uses is None:
             return _NEVER_AGAIN
@@ -380,12 +326,10 @@ class _DecodedChunkCache:
     """Decoded chunks of OME-Zarr arrays, kept whole, evicted under a byte cap.
 
     zarr 3 has no chunk cache of its own: every read decodes every chunk it touches, in full, and a
-    streamed run touches the same chunks region after region -- a 31-row slab of a 256-row chunk
-    grid decodes 8x the bytes it keeps, and the next slab decodes the same chunks again (measured:
-    the same 2.1 GB of useful bytes cost 1.9 s in 256-row slabs and 28 s in 6-row slabs). Kept
-    DECODED, so a hit is a memcpy; keyed by (array identity, chunk coordinates), so a store replaced
-    on disk is a new identity and never served stale (see :func:`clear_ome_zarr_cache`). Same
-    bytes, same order: a read through the cache is the read without it.
+    streamed run touches the same chunks region after region. Kept DECODED, so a hit is a memcpy;
+    keyed by (array identity, chunk coordinates), so a store replaced on disk is a new identity and
+    never served stale (see :func:`clear_ome_zarr_cache`). A read through the cache is the read
+    without it.
     """
 
     def __init__(self, capacity_bytes: int) -> None:
@@ -464,12 +408,8 @@ class _DecodedChunkCache:
 
     def _furthest(self) -> tuple:
         """The chunk whose next use is furthest: a declared chunk by its schedule, an undeclared one
-        by its recency, the ``n``-th most recently used taken as ``n`` reads away (the LRU order it
-        competes in: a companion volume read beside a declared source, a mask, has no schedule and
-        is read again at the next region all the same), a declared chunk nothing reads again first
-        of all. The older wins a tie. Measured on a 48-chunk source swept through a rotated resample
-        with a mask on the same grid read beside it, at a cache of 64 chunks: 66 + 66 decodes under
-        LRU, 44 + 66 with the companion ranked never-again, 44 + 44 with it ranked by recency."""
+        by its recency, the ``n``-th most recently used taken as ``n`` reads away, a declared chunk
+        nothing reads again first of all. The older wins a tie."""
         newer = len(self._entries)
         furthest, distance = next(iter(self._entries)), 0
         for key in self._entries:
@@ -488,20 +428,13 @@ class _DecodedChunkCache:
 #: The least the cache is worth: below a chunk or two of a large store, a region touching more
 #: chunks than it holds decodes them again. It is what an undeclared budget's share is raised to; a
 #: declared budget never gives the cache more than its share, and the plan says when that is under
-#: the floor. A cache allowed the floor out of a 128 MiB budget took the budget whole, while the
-#: sweep went on sizing its regions against the same 128 MiB: the run was priced at 2x its budget.
+#: the floor.
 CHUNK_CACHE_FLOOR = 256 << 20
 
 
 def chunk_cache_held_bytes() -> int:
-    """What the decoded-chunk cache holds resident right now, or 0 with no cache.
-
-    For an instrument reading the process's resident memory over one scope of work: the cache
-    outlives that scope by design (it is what a later region asks for again), so what it gained
-    during the scope is not the scope's own cost. A fold's probe region read VmHWM over its ten
-    members and charged the region 24.4 GiB, 13.2 of which was this cache filling from empty --
-    and cut every region after it to 78 % of the height that would have fit.
-    """
+    """What the decoded-chunk cache holds resident right now, or 0 with no cache. The cache outlives
+    the scope an instrument measures, so what it gained there is not that scope's own cost."""
     return _CHUNK_CACHE.held_bytes if _CHUNK_CACHE is not None else 0
 
 
@@ -547,9 +480,8 @@ def _level_array(store_path: str, level_path: str) -> Any:
 def _normalized_selection(index: tuple, shape: Sequence[int]) -> tuple[list[slice], list[int]]:
     """``index`` as one unit-step slice per axis, and the axes an integer selection squeezes out.
 
-    A stepped selection is refused rather than normalised: everything downstream counts the voxels
-    between ``start`` and ``stop``, so a step would size the output wrongly and fill it from the
-    wrong places. Both callers suppress this and fall back to the lazy array, which takes any step.
+    A stepped selection is refused: everything downstream counts the voxels between ``start`` and
+    ``stop``. Both callers suppress this and fall back to the lazy array, which takes any step.
     """
     selections: list[slice] = []
     squeeze: list[int] = []
@@ -580,21 +512,18 @@ def _touched_chunks(selections: Sequence[slice], chunks: Sequence[int]) -> list[
 def _read_chunked(store_path: str, level_path: str, array: Any, index: tuple) -> np.ndarray:
     """``array[index]`` assembled chunk by chunk through the decoded-chunk cache.
 
-    Only integer and slice selections with unit step reach here (the reader normalises to those);
-    each touched chunk is served from the cache or decoded whole and cached, then the requested
-    window is copied out of it. Values are exactly what ``array[index]`` returns.
+    Only integer and slice selections with unit step reach here; each touched chunk is served from
+    the cache or decoded whole and cached. Values are exactly what ``array[index]`` returns.
     """
     cache = _chunk_cache()
     shape, chunks = array.shape, array.chunks
     selections, squeeze = _normalized_selection(index, shape)
     out_shape = tuple(max(0, sel.stop - sel.start) for sel in selections)
-    # In the machine's byte order from the start: a big-endian store is converted by the copy that
-    # assembles the window, where a pass of its own over the result is a second walk of every byte.
+    # In the machine's byte order from the start: the assembling copy converts a big-endian store.
     out = np.empty(out_shape, dtype=_native_dtype(array.dtype))
     identity = (store_identity(store_path), level_path)
     wanted = _touched_chunks(selections, chunks)
-    # Begun before an empty selection returns: plan_ome_zarr_reads declared that read too, and a
-    # schedule that misses one step ranks every later chunk against the wrong read.
+    # Begun before an empty selection returns: plan_ome_zarr_reads declared that read too.
     cache.begin(identity, frozenset(wanted))
     try:
         if wanted:
@@ -633,9 +562,7 @@ def _assemble_window(
     from_hull: dict[tuple, np.ndarray] = {}
     if missing:
         # ONE zarr read for the chunk-aligned hull of what is missing: zarr decodes the chunks of a
-        # single selection in parallel, and one call per chunk would serialise them (measured 1.5x
-        # slower than the plain read on a cold pass). The hull may cover chunks already cached
-        # when the misses are sparse; those are decoded again -- a bounded waste on a rare shape.
+        # single selection in parallel. A hull covering chunks already cached decodes them again.
         lo = [min(c[axis] for c in missing) for axis in range(len(chunks))]
         hi = [max(c[axis] for c in missing) for axis in range(len(chunks))]
         hull = tuple(
@@ -650,16 +577,13 @@ def _assemble_window(
                 for c, lo_, ch, extent in zip(coords, lo, chunks, shape, strict=True)
             )
             if coords in wanted_set:
-                # Served from the hull while it is here: a cache smaller than the hull would evict
-                # the chunk before the read below asks for it, and decode it a second time.
+                # Served from the hull while it is here: a smaller cache would evict it first.
                 from_hull[coords] = decoded[piece]
             if cache.get(key) is None:
-                # A COPY, never a slice of the hull: a contiguous slice stays a view whose parent
-                # allocation the cache would keep alive whole while counting the slice's bytes.
+                # A COPY: a slice would keep the hull's whole allocation alive for its own bytes.
                 cache.put(key, np.array(decoded[piece], dtype=out.dtype, order="C"))
-        # The hull's windows are placed here, before it is released, one per worker (disjoint
-        # destinations, numpy releases the GIL for the copy); the cache is touched for each, in
-        # read order, so its recency is the one a read through the cache would have left.
+        # The hull's windows are placed before it is released, one per worker (disjoint
+        # destinations); the cache is touched for each in read order, leaving the same recency.
         map_over_rank_pool(lambda coords: window_of(coords, from_hull[coords]), list(from_hull))
         placed_from_hull.update(from_hull)
         for coords in wanted:
@@ -676,8 +600,7 @@ def _assemble_window(
             chunk = np.asarray(array[window])
         window_of(coords, chunk)
 
-    # A chunk cached before the fill can lie inside the hull and be evicted by that fill.
-    # It was already placed from the hull too: asking the cache again would decode it twice.
+    # A chunk cached before the fill can lie inside the hull, be evicted by it, and was placed.
     map_over_rank_pool(place, [coords for coords in wanted if coords not in placed_from_hull])
 
 
@@ -709,9 +632,7 @@ def _lazy_window(data: Any, index: tuple) -> np.ndarray:
     try:
         return np.asarray(data[index])
     except NotImplementedError:
-        # Each slice normalized against the shape, then its ascending unit-step span; a negative
-        # step reads that span backwards from its own end, which lands on the indices the original
-        # slice named.
+        # Each slice normalized against the shape, then read over its ascending unit-step span.
         bounds = tuple(
             slice(*item.indices(size)) if isinstance(item, slice) else item
             for item, size in zip(index, data.shape, strict=True)
@@ -744,11 +665,9 @@ def _store_index(
 def ome_zarr_read_granularity(store_path: str | Path, *, level: int = 0) -> tuple[int, ...] | None:
     """The stored block a read of this level is served in, as a KonfAI ``C[Z]YX`` shape.
 
-    A chunked store decodes whole chunks, so a window costs the chunk-aligned hull that covers it
-    (:func:`_assemble_window` issues one read over that hull): a decomposition whose blocks straddle
-    the grid materialises every plane it touches, twice over where it lands between two. Read from
-    the level's metadata, so it costs nothing and is answerable at plan time. ``None`` when the
-    store cannot be opened, where the caller prices a read at what it asks for.
+    A chunked store decodes whole chunks, so a window costs the chunk-aligned hull that covers it.
+    Read from the level's metadata, so it is answerable at plan time. ``None`` when the store cannot
+    be opened, where a read is priced at what it asks for.
     """
     if not _NGFF_ZARR_AVAILABLE:
         return None
@@ -768,10 +687,8 @@ def plan_ome_zarr_reads(
 ) -> None:
     """Declare the ``C[Z]YX`` windows about to be read from a store, in the order they will be read.
 
-    What the decoded-chunk cache does with it: evict the chunk whose next declared use is furthest
-    away instead of the least recently used, which is the fewest decodes any policy can reach. The
-    gain is the whole of it where a miss is expensive -- a tight cache, or a store across a network,
-    where a miss is a download. Declaring nothing costs nothing: the cache stays LRU.
+    The decoded-chunk cache then evicts the chunk whose next declared use is furthest away instead
+    of the least recently used. Declaring nothing costs nothing: the cache stays LRU.
     """
     if not _NGFF_ZARR_AVAILABLE or not windows:
         return
@@ -805,8 +722,7 @@ def read_ome_zarr_data_slice(
     """Read a KonfAI channel-first ``C[Z]YX`` patch from an OME-Zarr store (lazy).
 
     A conformant displacement store holds its components in RFC-5 order; the channel selection is
-    remapped and the patch flipped back, so every caller keeps receiving ITK's (dx, dy, dz)
-    whatever layout the store holds.
+    remapped and the patch flipped back, so every caller receives ITK's (dx, dy, dz).
     """
     image = _load_image(str(store_path), level)
     dims = [str(axis).lower() for axis in image.dims]
@@ -825,8 +741,7 @@ def read_ome_zarr_data_slice(
     if "c" not in remaining:
         patch = patch[np.newaxis]
     elif flipped:
-        # Contiguous, not a reversed view: a negative stride is refused by torch.from_numpy, and
-        # every patch this returns is about to become a tensor.
+        # Contiguous, not a reversed view: torch.from_numpy refuses a negative stride.
         patch = np.ascontiguousarray(patch[::-1])
 
     metadata = {
@@ -870,14 +785,10 @@ def _spatial_geometry(
 def _downsample_method(downsample_method: str | None) -> Any:
     """Resolve a downsampling method name to ngff-zarr's enum, defaulting to DASK_BIN_SHRINK.
 
-    NOT ngff-zarr's own default, which is ``ITKWASM_GAUSSIAN``: a pyramid is indexed by position and
-    read as "the same image, coarser", so a level that has been smoothed is a change of pixels that
-    no reader can see. Measured on a real volume, the gaussian keeps a 0.9998 correlation while
-    crushing the peak intensity by 20 %: the shape of difference that passes a sanity check and
-    resurfaces months later. ``DASK_BIN_SHRINK`` is a plain block mean with ITK's own BinShrink
-    semantics (aligned windows, remainder trimmed, integers rounded half up), computed lazily with
-    a bounded peak: it takes any extent and chunk layout the streamed writer leaves, where the wasm
-    variant traps on blocks past 2.5 GiB and on tails no chunking can avoid.
+    NOT ngff-zarr's own default, ``ITKWASM_GAUSSIAN``: a pyramid is read as "the same image,
+    coarser", and a smoothed level is a change of pixels no reader can see. ``DASK_BIN_SHRINK`` is a
+    plain block mean with ITK's own BinShrink semantics (aligned windows, remainder trimmed,
+    integers rounded half up), computed lazily with a bounded peak.
     """
     _require_ngff_zarr()
     if downsample_method is None:
@@ -912,24 +823,15 @@ def write_ome_zarr(
     """Write one channel-first KonfAI array as an OME-NGFF store, single-level or a pyramid.
 
     ``scale_factors`` makes it a pyramid, each factor shrinking the level above it: ``[4]`` writes
-    level 0 plus level 0 shrunk 4x per spatial axis, ``[4, 4]`` adds a third at 16x. (ngff-zarr's
-    own argument is spelled relative to level 0; :func:`_level_zero_scale_factors` converts, so
-    ``[4, 4]`` never writes the same level twice.) Consumers index a pyramid BY POSITION, so the
-    order is the contract: 0 finest. Each level carries its OWN scale and translation, and ngff-zarr shifts the
-    coarse origin by half the spacing delta, which is the centre-of-voxel convention these stores
-    use; getting that wrong biases every voxel by a fraction of a coarse voxel and still looks like a
-    plausible image. ``downsample_method`` selects how (see :func:`_downsample_method`).
+    level 0 plus level 0 shrunk 4x per spatial axis, ``[4, 4]`` adds a third at 16x. Consumers index
+    a pyramid BY POSITION, so the order is the contract: 0 finest. Each level carries its OWN scale
+    and translation, with the coarse origin shifted by half the spacing delta, the centre-of-voxel
+    convention these stores use. ``downsample_method`` selects how (see :func:`_downsample_method`).
 
     ``displacement_field`` writes it as a vector FIELD rather than an image: the component axis is
-    typed ``displacement`` (NGFF RFC-5), which is what makes a registration DVF self-describing
-    instead of an anonymous 3-channel image. A reader then no longer has to be told out of band that
-    the channels are a displacement: the mistake that path invites is silent, not loud: index the
-    component axis like any other and you get one third of the field back, and a plausible-looking
-    registration with it.
-
-    The NGFF version follows from that flag and is deliberately NOT a parameter. RFC-5 axis types
-    exist only from 0.6, so a caller passing both could only ever pass them consistently: an
-    invariant worth removing rather than documenting.
+    typed ``displacement`` (NGFF RFC-5), so a registration DVF is self-describing instead of an
+    anonymous 3-channel image. The NGFF version follows from that flag and is NOT a parameter:
+    RFC-5 axis types exist only from 0.6.
     """
     if scale_factors and uri.is_uri(store_path):
         raise DatasetManagerError(
@@ -937,10 +839,8 @@ def write_ome_zarr(
             "Levels are derived in place through local paths; write the store locally and upload it.",
         )
     array_data = np.asarray(data)
-    # The one write path: the store described and created empty (ngff-zarr's metadata, the
-    # caller's chunking), filled by zarr itself, its levels grafted beside level 0. Handing
-    # ngff-zarr the resident array instead went through dask -- a full rechunk into a 128 MB block
-    # per task -- at a sixth of the throughput (14.4 s vs 2.3 s for a 2.1 GB volume, measured).
+    # The one write path: the store described and created empty (ngff-zarr's metadata, the caller's
+    # chunking), filled by zarr itself, its levels grafted beside level 0.
     array = create_ome_zarr_store(
         store_path,
         array_data.shape,
@@ -959,8 +859,7 @@ def write_ome_zarr(
 def _write_skeleton(store_path: str | Path, multiscales: Any, version: str, **kwargs: Any) -> None:
     """The store's metadata and empty arrays, written in place (``to_ngff_zarr(metadata_only=True)``
     describes every level and creates its array without computing a voxel). ngff-zarr writes local
-    directories only, so a remote root gets the skeleton written locally and uploaded through the
-    root's own filesystem: metadata documents only, before a chunk lands."""
+    directories only, so a remote root gets the skeleton written locally and uploaded."""
     if not uri.is_uri(store_path):
         ngff_zarr.to_ngff_zarr(
             str(store_path), multiscales, overwrite=True, version=version, metadata_only=True, **kwargs
@@ -986,12 +885,10 @@ def _write_skeleton(store_path: str | Path, multiscales: Any, version: str, **kw
 def _grid_is_axis_aligned(attributes: dict[str, Any] | None) -> bool:
     """Whether the field's grid carries no rotation.
 
-    RFC-5 maps a field's array to space by scale and translation alone, so only an axis-aligned
-    grid can be declared a ``displacements`` transformation; an oriented one keeps the label-only
-    layout, its Direction in the sidecar.
-
-    The sidecar dict is read through :class:`Attribute`, the one owner of the versioned-key stack
-    and the printed-array format: the LATEST ``Direction`` is the grid the store describes.
+    RFC-5 maps a field's array to space by scale and translation alone, so only an axis-aligned grid
+    can be declared a ``displacements`` transformation; an oriented one keeps the label-only layout,
+    its Direction in the sidecar. The sidecar is read through :class:`Attribute`: the LATEST
+    ``Direction`` is the grid the store describes.
     """
     from konfai.utils.dataset.attribute import Attribute
 
@@ -1006,10 +903,8 @@ def _grid_is_axis_aligned(attributes: dict[str, Any] | None) -> bool:
 def _declare_displacements_transform(multiscales: Any) -> None:
     """Mark the store as an RFC-5 ``displacements`` transformation, in place.
 
-    What makes the field APPLICABLE by a spec reader rather than merely labelled: a spatial
-    ``physical`` coordinate system, and a ``displacements`` entry mapping it onto itself through
-    the level-0 array. The components must then follow the output axes' order, which is
-    ``_ComponentFlippedWriter``'s half of the contract.
+    A spatial ``physical`` coordinate system, and a ``displacements`` entry mapping it onto itself
+    through the level-0 array. The components must then follow the output axes' order.
     """
     from ngff_zarr.v06.zarr_metadata import Axis, CoordinateSystem, CoordinateSystemIdentifier, Displacements
 
@@ -1029,10 +924,9 @@ def _declare_displacements_transform(multiscales: Any) -> None:
 class _ComponentFlippedWriter:
     """The level-0 array of a conformant displacement store, taking ITK-ordered components.
 
-    Every producer in KonfAI hands fields in ITK's component order (dx, dy, dz); the store holds
-    the spec's (dz, dy, dx). Flipping at this boundary keeps the two conventions from ever
-    meeting: no producer knows about the spec, no store holds a private order. A value of lower
-    rank than the array (a scalar fill) has no component identity and broadcasts as it stands.
+    Every producer in KonfAI hands fields in ITK's component order (dx, dy, dz); the store holds the
+    spec's (dz, dy, dx). A value of lower rank than the array (a scalar fill) has no component
+    identity and broadcasts as it stands.
     """
 
     def __init__(self, array: Any) -> None:
@@ -1089,16 +983,10 @@ def create_ome_zarr_store(
 
     Returns the level-0 zarr array: chunks materialise as regions are assigned, and unwritten regions
     read back as zeros. Metadata is complete from the start, so the store is readable at any point
-    during the write.
-
-    ngff-zarr writes that metadata, exactly as it does for the whole-array path, so both paths describe
-    a store the same way: ``displacement_field`` included, which is the point of routing it through
-    ngff-zarr at all. A field too large to assemble in memory is written region by region, so this is
-    the ONLY path a real one takes. The KonfAI sidecar rides along as a root attribute beside the OME
-    keys, and the array is described from a LAZY zeros of the real shape: ``metadata_only`` creates it
-    without computing a voxel, chunked exactly as the caller says: the region grid is the one thing
-    ngff-zarr cannot infer, and a store whose chunks straddle it turns every region write into a
-    read-modify-write.
+    during the write, ``displacement_field`` included. The KonfAI sidecar rides along as a root
+    attribute beside the OME keys, and the array is described from a LAZY zeros of the real shape,
+    chunked exactly as the caller says: a store whose chunks straddle the region grid turns every
+    region write into a read-modify-write.
     """
     clear_ome_zarr_cache(store_path)
     _require_ngff_zarr()
@@ -1120,14 +1008,12 @@ def create_ome_zarr_store(
     image = ngff_zarr.to_ngff_image(data, dims=dims, scale=scale, translation=translation)
     version = _DEFAULT_VERSION
     if displacement_field:
-        # Typing the component axis (NGFF RFC-5, so version 0.6) is what lets the store say on disk
-        # that its channels are a displacement rather than an ordinary 3-channel image.
+        # Typing the component axis (NGFF RFC-5, so version 0.6) declares the channels a field.
         image.axes_types = {"c": _DISPLACEMENT_AXIS_TYPE}
         version = _RFC5_VERSION
     multiscales = ngff_zarr.to_multiscales(image, scale_factors=[], chunks=chunks, cache=False)
     if displacement_field:
-        # One layout for every field: components in the spec's order. The entry when the grid can
-        # be declared; the sidecar marker either way, so the reader never has to guess.
+        # One layout for every field: components in the spec's order, marked so nothing guesses.
         if _grid_is_axis_aligned(attributes):
             _declare_displacements_transform(multiscales)
         multiscales.root_attributes = {
@@ -1135,13 +1021,11 @@ def create_ome_zarr_store(
         }
     elif attributes:
         multiscales.root_attributes = {_KONFAI_ATTR_KEY: {"attributes": dict(attributes)}}
-    # version is explicit because to_ngff_zarr defaults to 0.5; 0.4 stays the portable default. A
-    # v3 (RFC-5) store takes the writer's own codec chain, which is what 1.8.2 wrote there too.
+    # version is explicit because to_ngff_zarr defaults to 0.5; 0.4 stays the portable default.
     compression = {} if displacement_field else {"compressor": _V2_COMPRESSOR}
     _write_skeleton(store_path, multiscales, version, **compression)
 
-    # The level-0 key comes from the metadata rather than a literal: ngff-zarr builds it from the
-    # image name, so "scale0/image" is its convention to change, not ours to hardcode.
+    # The level-0 key comes from the metadata: ngff-zarr builds it from the image name.
     array = zarr.open_group(str(store_path), mode="r+")[multiscales.metadata.datasets[0].path]
     return _ComponentFlippedWriter(array) if displacement_field else array
 
@@ -1154,15 +1038,12 @@ def append_ome_zarr_levels(
 ) -> None:
     """Add coarser levels to a store that already holds its level 0.
 
-    The companion of :func:`create_ome_zarr_store`: a store written region by region cannot be given
-    ``scale_factors`` up front, because no level exists until the last region lands. This derives the
-    pyramid afterwards, from what is on disk, and grafts it BESIDE level 0
-    (``to_ngff_zarr(start_level=1)``): level 0 is not rewritten, not moved, not read back whole; each
-    coarser level is computed lazily from the one before it with a chunk-sized peak, and the
-    multiscales metadata that names every level lands last, so an interrupted call leaves a store
-    that still reads exactly as its level 0. The KonfAI attribute sidecar rides along as the root
-    attributes ngff-zarr read back beside the OME keys; a displacement field keeps its typed
-    component axis the same way.
+    A store written region by region cannot be given ``scale_factors`` up front, since no level
+    exists until the last region lands. This derives the pyramid from what is on disk and grafts it
+    BESIDE level 0 (``to_ngff_zarr(start_level=1)``): level 0 is not rewritten, not moved, not read
+    back whole, each coarser level is computed lazily from the one before it with a chunk-sized
+    peak, and the metadata naming every level lands last, so an interrupted call leaves a store that
+    still reads as its level 0. The KonfAI sidecar and a typed component axis ride along.
     """
     if uri.is_uri(store_path):
         raise DatasetManagerError(
@@ -1187,8 +1068,7 @@ def append_ome_zarr_levels(
     )
     derived.root_attributes = multiscales.root_attributes
     if multiscales.metadata.coordinateTransformations:
-        # A conformant field keeps its ``displacements`` entry (and the coordinate system it names)
-        # through the append: the entry references level 0, which this never rewrites.
+        # A conformant field keeps its ``displacements`` entry through the append: it names level 0.
         metadata = cast("MetadataV06", derived.metadata)  # to_multiscales builds v06 metadata
         declared = {system.name for system in metadata.coordinateSystems}
         derived.metadata = dataclasses.replace(
@@ -1200,8 +1080,7 @@ def append_ome_zarr_levels(
             coordinateTransformations=multiscales.metadata.coordinateTransformations,
         )
     field = _has_displacement_axis(base)
-    # The coarse levels take level 0's own compressor, so the store stays uniform whatever wrote
-    # it; a v3 store carries a codec chain instead and keeps the writer's default.
+    # The coarse levels take level 0's own compressor; a v3 store keeps the writer's codec chain.
     level_zero = zarr.open_group(str(store), mode="r")[multiscales.metadata.datasets[0].path]
     compressor = level_zero.metadata.to_dict().get("compressor")
     compressor_kwargs: dict[str, Any] = {"compressor": compressor} if compressor else {}
@@ -1232,15 +1111,10 @@ def _refuse_factors_outgrowing_an_axis(base: Any, factors: Sequence[int]) -> Non
 def get_ome_zarr_info(store_path: str | Path, level: int = 0) -> dict[str, Any]:
     """OME-Zarr metadata, without reading pixel data.
 
-    Three of these keys describe the same level in two different orders, and mixing them is the
-    single most productive mistake this module invites. ``shape``, ``scale`` and ``translation``
-    follow the STORE's own axes, listed in ``axes``: a scalar volume written without a channel
-    axis has three of each. ``canonical_shape`` is the C[Z]YX form the reader indexes. So a caller
-    that sizes its slices from ``canonical_shape`` and then reads ``scale[1:]`` for the spatial
-    spacing is off by one axis, with plausible numbers and no error.
-
-    ``geometry`` exists so that never has to be reasoned about: it maps each axis NAME to its
-    ``(scale, translation)``. Prefer it.
+    ``shape``, ``scale`` and ``translation`` follow the STORE's own axes, listed in ``axes``: a
+    scalar volume written without a channel axis has three of each. ``canonical_shape`` is the
+    C[Z]YX form the reader indexes, so ``scale[1:]`` is not the spacing of its spatial axes.
+    ``geometry`` maps each axis NAME to its ``(scale, translation)``. Prefer it.
     """
     image = _load_image(str(store_path), level)
     dims = [str(axis).lower() for axis in image.dims]
@@ -1253,10 +1127,8 @@ def get_ome_zarr_info(store_path: str | Path, level: int = 0) -> dict[str, Any]:
     return {
         "axes": dims,
         "shape": list(image.data.shape),
-        # The shape the slices of `read_ome_zarr_data_slice` are indexed against. Both are here
-        # because they differ whenever the store's axes are not already C[Z]YX, and a caller sizing
-        # its slices from "shape" then reads a transposed region, with the right rank, plausible
-        # values, and nothing raised. "shape" stays the store's own order; this one is the reader's.
+        # The shape the slices of `read_ome_zarr_data_slice` are indexed against; "shape" is the
+        # store's own order.
         "canonical_shape": _canonical_shape(dims, image.data.shape),
         "chunks": list(getattr(image.data, "chunks", []) or []),
         "dtype": str(image.data.dtype),

--- a/konfai/utils/pretrained.py
+++ b/konfai/utils/pretrained.py
@@ -16,17 +16,10 @@
 
 """Load pretrained weights from an external architecture into a KonfAI graph.
 
-A KonfAI catalog model (``konfai/models/yaml``) is often weight-exact to a reference implementation
-(a MONAI or torchvision model) but uses different module names, so its ``state_dict`` keys do not
-match the external checkpoint. ``transfer_weights_by_execution_order`` bridges the two by pairing
-parametric leaf modules in **forward-execution order** instead of by name: both models are run once
-with hooks that record the order their weighted leaves execute, and the ordered lists are copied
-position-by-position with a shape check. This is the mechanism that lets a MONAI-trained checkpoint
-drive a KonfAI graph, so the network gains KonfAI's named-output supervision (deep supervision,
-feature-level losses) on top of the reference's pretrained weights.
-
-It is deliberately strict: a mismatched leaf count or shape raises, so a non-equivalent pair fails
-loudly instead of silently mis-loading half a network.
+``transfer_weights_by_execution_order`` pairs parametric leaf modules in forward-execution order
+instead of by name: both models are run once with hooks that record the order their weighted leaves
+execute, and the ordered lists are copied position-by-position with a shape check. A mismatched leaf
+count or shape raises.
 """
 
 from __future__ import annotations
@@ -45,12 +38,8 @@ if TYPE_CHECKING:
 
 
 def _parametric_leaves_in_execution_order(model: torch.nn.Module, run: Callable[[], object]) -> list[torch.nn.Module]:
-    """Return the model's weighted leaf modules in the order their forward runs, via forward hooks.
-
-    Leaf = a module with no children that owns parameters directly (Conv, Linear, norm, ...). Ordering
-    by execution rather than by ``state_dict`` key is what makes the pairing robust to a reference that
-    registers its norm/activation before its conv (pre-activation), where key order != run order.
-    """
+    """Return the model's weighted leaf modules (no children, parameters or buffers of their own) in
+    the order their forward runs, via forward hooks."""
     order: list[torch.nn.Module] = []
     seen: set[int] = set()
 
@@ -62,15 +51,13 @@ def _parametric_leaves_in_execution_order(model: torch.nn.Module, run: Callable[
     handles = []
     for module in model.modules():
         is_leaf = next(module.children(), None) is None
-        # A leaf may own only buffers (a non-affine BatchNorm/InstanceNorm with running stats), whose
-        # tensors _untraced_tensors would otherwise flag as uncovered and wrongly refuse the transfer.
+        # A leaf may own only buffers (a non-affine norm with running stats).
         if is_leaf and (
             next(module.parameters(recurse=False), None) is not None
             or next(module.buffers(recurse=False), None) is not None
         ):
             handles.append(module.register_forward_hook(hook))
-    # Snapshot per-module modes: model.train(root_mode) would force every descendant into the
-    # root's mode and lose frozen/eval-only submodules.
+    # Per-module modes are restored one by one: model.train(root_mode) would lose eval-only submodules.
     training_states = {module: module.training for module in model.modules()}
     model.eval()
     try:
@@ -85,13 +72,8 @@ def _parametric_leaves_in_execution_order(model: torch.nn.Module, run: Callable[
 
 
 def _untraced_tensors(model: torch.nn.Module, leaves: list[torch.nn.Module]) -> list[str]:
-    """Return the names of the model's parameters/buffers that no traced leaf owns.
-
-    Two shapes escape the leaf trace: a module that owns parameters *and* has children (torch's
-    ``MultiheadAttention`` holds ``in_proj_weight`` beside its ``out_proj`` child) is never a leaf, and
-    a leaf the forward does not reach is never hooked. Their tensors would be skipped, so the caller
-    must refuse the transfer instead of reporting success on a partial load.
-    """
+    """Return the names of the model's parameters/buffers that no traced leaf owns: a module that owns
+    parameters and has children (``MultiheadAttention``), or a leaf the forward does not reach."""
     covered: set[int] = set()
     for leaf in leaves:
         covered.update(id(tensor) for tensor in leaf.parameters())
@@ -110,24 +92,19 @@ def transfer_weights_by_execution_order(
 ) -> int:
     """Fill every parameter and buffer of ``target`` from ``source`` by execution-order leaf pairing.
 
-    ``target`` is the KonfAI model receiving the weights; ``source`` is the external reference whose
-    pretrained checkpoint you want to reuse. ``target_forward`` / ``source_forward`` are zero-argument
-    callables that each run one forward pass (e.g. ``lambda: list(net.named_forward(x))`` for a KonfAI
-    Network, ``lambda: monai_model(x)`` for the reference). Returns the number of leaves transferred.
+    ``target`` is the KonfAI model receiving the weights; ``source`` is the external reference.
+    ``target_forward`` / ``source_forward`` are zero-argument callables that each run one forward pass
+    (``lambda: list(net.named_forward(x))``, ``lambda: monai_model(x)``). Returns the number of leaves
+    transferred.
 
     Every ``target`` tensor is written or the call raises; ``source`` tensors its forward does not reach
-    (an unused deep-supervision head) have no counterpart to feed and are ignored.
-
-    Raises ``ConfigError`` when the two graphs are not weight-exact: a target tensor no traced leaf
-    owns, a different number of weighted leaves, or a paired leaf whose local ``state_dict`` (its own
-    weight/bias/buffers) does not match in keys or shapes. That is intentional: silently loading a
-    mismatched network is worse than failing.
+    (an unused deep-supervision head) are ignored. Raises ``ConfigError`` when the two graphs are not
+    weight-exact: a target tensor no traced leaf owns, a different number of weighted leaves, or a
+    paired leaf whose local ``state_dict`` does not match in keys or shapes.
     """
     target_leaves = _parametric_leaves_in_execution_order(target, target_forward)
     source_leaves = _parametric_leaves_in_execution_order(source, source_forward)
-    # Only the target is required to be fully covered: an untraced target tensor would silently keep its
-    # random init. An untraced *source* tensor is a branch this configuration does not run (nnU-Net's
-    # unused deep-supervision heads) and has no target counterpart to feed, so it is correctly ignored.
+    # Only the target must be fully covered; an untraced source tensor is a branch this forward does not run.
     untraced = _untraced_tensors(target, target_leaves)
     if untraced:
         raise ConfigError(
@@ -145,10 +122,8 @@ def transfer_weights_by_execution_order(
             "Weight transfer requires a weight-exact architecture; check that hyperparameters "
             "(channels/depth/dim) match the reference and that both forwards ran on the same input.",
         )
-    # A tensor tied across two target leaves would be written twice by the per-leaf loads below, so the
-    # earlier leaf would silently end up with the later leaf's source weights. state_dict(keep_vars=True)
-    # yields the live parameters AND persistent buffers: exactly what load_state_dict writes, so a tied
-    # buffer is caught as well. Refuse rather than mis-load.
+    # A tensor tied across two target leaves would be written twice by the per-leaf loads: refused.
+    # state_dict(keep_vars=True) yields the live parameters and persistent buffers, what load_state_dict writes.
     seen_tensors: dict[int, str] = {}
     for leaf in target_leaves:
         for tensor_name, tensor in leaf.state_dict(keep_vars=True).items():
@@ -180,13 +155,11 @@ class PretrainedFrom:
     """The ``Model.pretrained_from`` config block: seed a model from an external reference checkpoint.
 
     ``builder`` names the reference class (``monai.networks.nets:UNet``), ``args`` its constructor
-    arguments, and ``checkpoint`` its trained weights: a raw ``state_dict`` file, or a checkpoint
-    dict holding one under ``state_dict``. When a fresh TRAIN initialises the model,
-    :func:`transfer_weights_by_execution_order` fills every tensor from the reference or raises; a
-    checkpoint load (RESUME, PREDICTION) carries its own weights and is never overridden. The
-    transfer runs both forwards on a synthetic input shaped from the model's own channels and
-    spatial rank; ``input_shape`` overrides its spatial extent when the derived one (the model's
-    patch size, else its downsampling multiple) does not fit the graph.
+    arguments, and ``checkpoint`` its trained weights: a raw ``state_dict`` file, or a checkpoint dict
+    holding one under ``state_dict``. A fresh TRAIN fills every tensor from the reference or raises; a
+    checkpoint load (RESUME, PREDICTION) carries its own weights and is never overridden. ``input_shape``
+    overrides the synthetic input's spatial extent (the model's patch size, else its downsampling
+    multiple) when the derived one does not fit the graph.
     """
 
     def __init__(
@@ -227,8 +200,7 @@ class PretrainedFrom:
             raise ConfigError(
                 f"Model.pretrained_from.checkpoint: cannot load '{self.checkpoint}'.", str(error)
             ) from error
-        # A wrapped checkpoint: Lightning and most trainers under "state_dict", nnU-Net under
-        # "network_weights" (its checkpoint_final.pth carries the optimizer and the plans beside it).
+        # A wrapped checkpoint: "state_dict" (Lightning and most trainers), "network_weights" (nnU-Net).
         if isinstance(state, dict):
             for key in ("state_dict", "network_weights"):
                 if key in state and isinstance(state[key], dict):
@@ -244,7 +216,7 @@ class PretrainedFrom:
         return reference.eval()
 
     def _example_input(self, model: Network) -> torch.Tensor:
-        # The transfer only needs shapes and execution order, so any input the graph accepts will do.
+        # Any input the graph accepts will do.
         if self.input_shape is not None:
             spatial = [int(size) for size in self.input_shape]
         elif (

--- a/konfai/utils/runtime/distributed.py
+++ b/konfai/utils/runtime/distributed.py
@@ -68,12 +68,8 @@ _rank_pool_lock = threading.Lock()
 @contextmanager
 def preserved_rng() -> Iterator[None]:
     """Snapshot random, numpy and torch's CPU generator, plus every CUDA generator when CUDA is already
-    initialised, and put them back on exit.
-
-    ``torch.manual_seed`` reseeds the CUDA generators too, so they belong in the snapshot; reading them
-    would initialise CUDA in a caller that never asked (a CPU data-loader worker, a notebook), so the
-    gate is ``torch.cuda.is_initialized()``, not ``is_available()``.
-    """
+    initialised, and put them back on exit. The gate is ``torch.cuda.is_initialized()``, never
+    ``is_available()``: reading the CUDA generators must not initialise CUDA."""
     states = (random.getstate(), np.random.get_state(), torch.get_rng_state())
     cuda_states = torch.cuda.get_rng_state_all() if torch.cuda.is_initialized() else None
     try:
@@ -147,8 +143,8 @@ class DistributedObject(ABC):
                         network.measure.format_loss(True, n),
                         network.measure.format_loss(False, n),
                     )
-        # `sync=False` skips the cross-rank all_gather: prediction shards whole cases per rank with unequal
-        # batch counts, so a per-batch collective would hang once the shortest shard stops calling it.
+        # `sync=False` skips the cross-rank all_gather: prediction shards have unequal batch counts, and a
+        # per-batch collective would hang.
         outputs: list[Any] = synchronize_data(world_size, gpu, data) if sync else [data]
         result: dict[str, tuple[dict[str, tuple[float, float, float]], dict[str, tuple[float, float, float]]]] = {}
         if global_rank == 0:
@@ -176,18 +172,13 @@ class DistributedObject(ABC):
         return self.dataloader[global_rank]
 
     def _bound_chunk_cache(self, world_size: int) -> None:
-        """Bound the decoded-chunk cache by this rank's share of the memory budget.
-
-        Set here, on the rank: a spawned rank is a new process, and a bound set by the launcher is
-        a module global the child never sees.
-        """
+        """Bound the decoded-chunk cache by this rank's share of the memory budget. Set on the rank: a
+        bound set by the launcher is a module global a spawned child never sees."""
         from konfai.utils.ome_zarr import bound_chunk_cache
 
         dataset = getattr(self, "dataset", None)
         if dataset is not None and hasattr(dataset, "resolved_budget"):
-            # work_bytes and not per_rank_bytes: the interpreter and the imaging libraries are
-            # resident before the rank reads anything, and a budget that ignores them spends those
-            # bytes twice. Measured on the rank, which is where they were paid.
+            # work_bytes and not per_rank_bytes: the resident interpreter and libraries are already paid.
             set_per_rank_budget(dataset.resolved_budget().work_bytes(node_local_ranks(world_size)))
             bound_chunk_cache()
 
@@ -206,9 +197,8 @@ class DistributedObject(ABC):
             torch.backends.cudnn.benchmark = self.manual_seed is None
             torch.backends.cudnn.deterministic = self.manual_seed is not None
             dataloaders = self.rank_dataloaders(global_rank)
-            # device_count as well: on a process whose CUDA runtime latched BEFORE the launcher
-            # narrowed CUDA_VISIBLE_DEVICES to nothing, is_available() stays True while the count
-            # honestly reads 0, and set_device would pin a GPU the launch explicitly excluded.
+            # device_count as well: a CUDA runtime that latched before CUDA_VISIBLE_DEVICES was narrowed
+            # keeps is_available() True while the count reads 0.
             if torch.cuda.is_available() and 0 <= local_rank < torch.cuda.device_count():
                 torch.cuda.set_device(local_rank)
             if global_rank == 0 and self.startup_clock is not None and (startup := self.startup_clock.report()):
@@ -231,10 +221,8 @@ def run_distributed_app(
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> None:
         params = sig.parameters
-        # A kwarg the entrypoint does not declare must refuse, not vanish: silently dropping one
-        # already forced the --plan short-circuit in main.py. Tolerated beside the signature: the
-        # cluster kwargs (read from the raw kwargs below) and 'command', the CLI's subcommand
-        # discriminator, which only the TRAIN/RESUME entrypoint declares.
+        # A kwarg the entrypoint does not declare is refused. Tolerated beside the signature: the cluster
+        # kwargs (read from the raw kwargs below) and 'command', which only the TRAIN/RESUME entrypoint declares.
         unknown = set(kwargs) - set(params) - {"name", "memory", "num_nodes", "time_limit", "command"}
         if unknown:
             raise ConfigError(
@@ -245,13 +233,10 @@ def run_distributed_app(
 
         bound = sig.bind_partial(*args, **kwargs_fun)
         bound.apply_defaults()
-        # The cluster CLI always parses --name (required) and the workflow signatures never declare
-        # it, so its presence in the RAW kwargs is what tells a submission from a local run.
+        # The cluster CLI always passes --name and the workflow signatures never declare it.
         is_cluster = "name" in kwargs
-        # The auto memory budget is a NODE budget, but build-time sizing (the evaluation auto-patch)
-        # runs while ``func(...)`` constructs the workflow: before the spawn where world_size exists.
-        # The launcher therefore leaves the per-node rank count in the environment, and restores it
-        # after: a leak would silently shrink a later in-process run (tests, embedded Python).
+        # Build-time sizing runs before the spawn where world_size exists: the per-node rank count is
+        # published in the environment for the build and restored after.
         local_ranks = len(list(bound.arguments.get("gpu") or [])) or int(bound.arguments.get("cpu") or 1)
         previous_local_ranks = os.environ.get("KONFAI_LOCAL_RANKS")
         os.environ["KONFAI_LOCAL_RANKS"] = str(max(1, local_ranks))
@@ -279,9 +264,7 @@ def run_distributed_app(
         except KeyboardInterrupt:
             print("\n[KonfAI] Manual interruption (Ctrl+C)")
         except KonfAIError as error:
-            # A designed refusal: the message says what is wrong and the remedy what to change.
-            # The traceback under it is framework internals: 28 lines burying the 3 that matter --
-            # so it is shown only to a reader who asked (KONFAI_DEBUG=1).
+            # A designed refusal: the message alone, the traceback only under KONFAI_DEBUG=1.
             if env_flag("KONFAI_DEBUG", False):
                 raise
             print(str(error).strip(), file=sys.stderr)
@@ -296,16 +279,9 @@ def run_distributed_app(
 
 
 def _runs_inline(world_size: int) -> bool:
-    """Whether the single rank runs here instead of in a spawned child.
-
-    A spawned child is a fresh interpreter: it re-imports torch, re-initialises CUDA and unpickles the
-    whole payload before doing any work: measured at ~3 s, which a short prediction pays in full. With
-    one rank there is nothing to parallelise, so that cost buys only isolation.
-
-    Isolation is worth keeping where the caller outlives the run: an embedded interpreter (Slicer, the
-    apps server) would inherit this process's CUDA context and its memory. ``KONFAI_INLINE_SINGLE_RANK``
-    is the switch: default on for a CLI run, set it to 0 to force the child back.
-    """
+    """Whether the single rank runs here instead of in a spawned child. ``KONFAI_INLINE_SINGLE_RANK``
+    is the switch, default on; set it to 0 where the caller outlives the run (an embedded interpreter
+    would inherit this process's CUDA context)."""
     if world_size != 1:
         return False
     return env_flag("KONFAI_INLINE_SINGLE_RANK", True)
@@ -321,8 +297,7 @@ def execute_distributed_object(
     tensorboard: bool = False,
     cluster_kwargs: ClusterKwargs | None = None,
 ) -> None:
-    """
-    Execute a previously built KonfAI workflow object.
+    """Execute a previously built KonfAI workflow object.
 
     Parameters
     ----------
@@ -339,7 +314,7 @@ def execute_distributed_object(
     tensorboard : bool, optional
         Whether TensorBoard should be started for the workflow.
     cluster_kwargs : dict[str, Any] | None, optional
-        Optional cluster submission parameters used by ``submitit``.
+        Cluster submission parameters used by ``submitit``.
     """
     gpu_ids = [] if gpu is None else list(gpu)
     cpu_workers = 1 if cpu is None else int(cpu)
@@ -356,8 +331,7 @@ def execute_distributed_object(
         "KONFAI_CLUSTER",
     ]
     previous_env = {key: os.environ.get(key) for key in managed_env}
-    # The run seeds the process-wide RNGs and sets the cudnn flags; inline (the single-rank default)
-    # that process is the caller's (a notebook, Slicer), so what it found is put back.
+    # The run seeds the process-wide RNGs and sets the cudnn flags; inline, that process is the caller's.
     previous_cudnn = (torch.backends.cudnn.benchmark, torch.backends.cudnn.deterministic)
 
     with preserved_rng():
@@ -406,8 +380,7 @@ def execute_distributed_object(
                     if world_size == 0:
                         world_size = cpu_workers
                     if not quiet:
-                        # One line naming the resolved devices: omitting --gpu runs on CPU, and a
-                        # silent CPU fallback on a GPU machine is a 10-100x slowdown nobody sees.
+                        # One line naming the resolved devices: omitting --gpu runs on CPU.
                         device_line = (
                             "cuda:" + ",".join(str(i) for i in gpu_ids)
                             if gpu_ids
@@ -416,9 +389,8 @@ def execute_distributed_object(
                         print(f"[KonfAI] Running on {device_line}")
                     with clock.phase("setup"):
                         configured_object.setup(world_size)
-                    # Share tensors through /dev/shm files instead of one file descriptor per tensor:
-                    # spawning a worker that pickles a loaded model can otherwise exhaust the process
-                    # open-file limit ("Too many open files"), e.g. under Slicer's embedded Python.
+                    # Share tensors through /dev/shm files instead of one file descriptor per tensor, or a
+                    # worker pickling a loaded model can exhaust the open-file limit.
                     mp.set_sharing_strategy("file_system")
                     clock.launch()
                     configured_object.startup_clock = clock
@@ -437,8 +409,8 @@ def execute_distributed_object(
 
 
 def _forget_rank_pool() -> None:
-    """A forked child inherits the executor's bookkeeping and none of its threads: work submitted to
-    it waits forever. The child builds its own on first use."""
+    """A forked child inherits the executor's bookkeeping and none of its threads; it builds its own
+    on first use."""
     global _rank_pool, _rank_pool_share, _rank_pool_lock
     _rank_pool, _rank_pool_share, _rank_pool_lock = None, 0, threading.Lock()
 
@@ -449,10 +421,8 @@ if hasattr(os, "register_at_fork"):  # POSIX only: a platform without fork inher
 
 def rank_cpu_share(world_size: int | None = None) -> int:
     """The cores this rank may use: the node's, divided between its local ranks, or exactly
-    ``OMP_NUM_THREADS`` when that is set.
-
-    One number for every consumer: torch's intraop pool, ITK's, zarr's, :func:`rank_pool`. The world
-    size stands in for a launcher that published no ``KONFAI_LOCAL_RANKS``.
+    ``OMP_NUM_THREADS`` when that is set. One number for every consumer (torch, ITK, zarr,
+    :func:`rank_pool`). The world size stands in for a launcher that published no ``KONFAI_LOCAL_RANKS``.
     """
     explicit = os.environ.get("OMP_NUM_THREADS")
     if explicit:
@@ -461,17 +431,12 @@ def rank_cpu_share(world_size: int | None = None) -> int:
 
 
 def rank_pool() -> ThreadPoolExecutor | None:
-    """The rank's shared worker pool, for the host-side GIL-releasing work inside ONE case: sharding
-    cases over ranks does nothing for a cohort of one.
-
-    ``None`` at a share of one, where the work stays on the calling thread.
-    """
+    """The rank's shared worker pool, for the host-side GIL-releasing work inside one case. ``None`` at
+    a share of one, where the work stays on the calling thread."""
     global _rank_pool, _rank_pool_share
     workers = rank_cpu_share()
     with _rank_pool_lock:
-        # The share changes within one process when a multi-rank build is followed by an inline
-        # single-rank workflow: the pool is rebuilt at the new size, the old one's idle threads let go.
-        # A share of one keeps no pool at all, so the threads go with it.
+        # A share that changed within the process rebuilds the pool at the new size.
         if _rank_pool is not None and _rank_pool_share != workers:
             _rank_pool.shutdown(wait=False)
             _rank_pool, _rank_pool_share = None, 0
@@ -485,7 +450,7 @@ def rank_pool() -> ThreadPoolExecutor | None:
 
 def map_over_rank_pool(work: Callable[[_T], None], items: Sequence[_T]) -> None:
     """Run ``work`` over ``items`` on the rank's pool, in the caller's thread when there is none.
-    Every exception is raised, the first one first: a region half written is not a region."""
+    Every exception is raised, the first one first."""
     pool = rank_pool()
     if pool is None or len(items) < 2:
         for item in items:
@@ -496,32 +461,21 @@ def map_over_rank_pool(work: Callable[[_T], None], items: Sequence[_T]) -> None:
 
 
 def apply_cpu_thread_budget(world_size: int | None = None) -> None:
-    """Give each rank a bounded share of the machine's cores instead of every library's every-core
-    default -- torch's intraop pool AND ITK's, which does the host resample.
+    """Give each rank a bounded share of the machine's cores: torch's intraop pool, ITK's, and zarr's.
 
-    Each of the node's local ranks gets its share of :func:`available_cpus`, and the two pools take
-    that share differently. Torch's is capped at 12: past memory-bus saturation more intraop threads
-    only add barrier contention, and on a hybrid 24-core CPU the 498^3 separable gather measures
-    0.7 s at 12 threads and 67 s at 24. ITK's takes the share whole, because its resampler keeps
-    scaling with it (the same region: 10.98 s at 1 thread, 1.11 s at 12, 0.65 s at 24). An explicit
-    ``OMP_NUM_THREADS`` keeps authority over both (torch already honors it at init).
+    Each of the node's local ranks gets its share of :func:`available_cpus`. Torch's pool is capped at
+    12; ITK's takes the share whole; zarr's async concurrency takes a third of it (at least min(cores, 4)).
+    An explicit ``OMP_NUM_THREADS`` keeps authority over all of them.
 
-    Applied once per process, and never on macOS: torch documents ``set_num_threads`` as to be
-    called before any parallel work, and the Python API runs several workflows in one process.
-    On macOS the call intermittently crashes libomp with SIGSEGV once any parallel region ran,
-    whichever call is the first; the saturation this bounds was measured on many-core Linux
-    nodes, so macOS keeps torch's default.
+    Applied once per process, and never on macOS, where ``torch.set_num_threads`` after a parallel region
+    can crash libomp with SIGSEGV.
     """
     global _cpu_budget_applied
     if sys.platform == "darwin" or _cpu_budget_applied:
         return
     explicit = os.environ.get("OMP_NUM_THREADS")
     cores = rank_cpu_share(world_size)
-    # The cap is torch's alone: past memory-bus saturation its intraop pool only adds barrier
-    # contention. ITK's pool is not the same animal -- its resampler, which does the host walk,
-    # keeps scaling to the whole share (a fold-sized region through a displacement field: 10.98 s
-    # at 1 thread, 1.11 s at 12, 0.65 s at 24), so capping it at 12 left a third of a 24-core node
-    # idle and cost 15 s on a measured fold.
+    # The cap is torch's alone: ITK's resampler keeps scaling to the whole share.
     share = int(explicit) if explicit else min(cores, 12)
     itk_share = cores
     if not explicit:
@@ -535,24 +489,13 @@ def apply_cpu_thread_budget(world_size: int | None = None) -> None:
     try:
         import zarr
 
-        # A THIRD of the share: a pipelined sweep runs three of these at once, the decode of the
-        # region being read, the assembly of the one before it, the encode of the one being written.
-        # Measured with the chain off the reading thread: 24 cores, ExaSPIM 513x1331x1776 through a stored affine, two runs per point,
-        # nothing else moved (a wrapper sets this alone, not OMP_NUM_THREADS, which would move ITK
-        # with it). Wall clock, host path then device path:
-        #   4  -> 12.1 / 13.4 s     4  -> 5.1 / 5.2 s
-        #   8  -> 10.7 / 11.1 s     8  -> 4.9 / 5.1 s
-        #   12 -> 11.0 / 11.3 s     12 -> 4.7 / 5.1 s
-        #   24 -> 11.0 / 12.3 s     24 -> 5.3 / 5.4 s
-        # A third wins or ties on both; starving it costs the host path 1.4 s and oversubscribing
-        # costs the reader its own throughput (read busy 4.4-4.6 s at 8, 5.1-5.2 s at 24). A share
-        # of a few cores keeps them all, up to four: a third of it is one chunk in flight, and on a
-        # remote root that is the whole of the read's parallelism.
+        # A third of the share: a pipelined sweep runs the decode, the assembly and the encode of three
+        # regions at once. A share of a few cores keeps them all, up to four.
         if hasattr(zarr, "config"):  # 2.x has no config object, and no async reader to share the cores with
             zarr.config.set({"async.concurrency": max(min(cores, 4), cores // 3)})
     except ImportError:
         pass
-    # Marked applied only once it is: a raise above (a bad OMP_NUM_THREADS) leaves the next call free to retry.
+    # Marked applied only once it is: a raise above leaves the next call free to retry.
     _cpu_budget_applied = True
 
 
@@ -560,17 +503,10 @@ def apply_cpu_thread_budget(world_size: int | None = None) -> None:
 def pin_gloo_to_loopback(local: bool) -> Iterator[None]:
     """Bind gloo to the loopback interface for a rendezvous whose ranks all sit on this host.
 
-    gloo picks its interface by resolving the host's name. On a macOS runner that name is an mDNS
-    ``.local`` name no resolver answers, and the rendezvous fails there rather than on the loopback
-    that carries the whole single-node world (the streamed-prediction integration tests flaked on
-    the macos-latest runner for exactly that). ``local`` says whether the world is that one: off
-    this host the loopback reaches no other rank, and gloo's own resolution stands.
-
-    gloo reads the variable as it builds the device, so it is taken back out of the environment
-    once the group is up: a later multi-node rendezvous in the same process, or a child that
-    inherits this environment, would otherwise be pinned to an interface reaching no other node.
-    An explicit ``GLOO_SOCKET_IFNAME`` keeps authority and is left untouched, and a host with no
-    loopback in ``if_nameindex`` is left to gloo's own resolution.
+    ``local`` says whether the world is that one; off this host gloo's own resolution stands. The
+    variable is taken back out of the environment once the group is up, so a later multi-node
+    rendezvous or an inheriting child is not pinned to it. An explicit ``GLOO_SOCKET_IFNAME`` keeps
+    authority, and a host with no loopback in ``if_nameindex`` is left to gloo's own resolution.
     """
     loopback = None
     if local and not os.environ.get("GLOO_SOCKET_IFNAME"):
@@ -607,9 +543,7 @@ def setup_gpu(world_size: int, rank: int | None = None, process_group: bool = Tr
         scontrol_path = shutil.which("scontrol")
         if scontrol_path is None:
             raise FileNotFoundError("scontrol not found in PATH")
-        # `scontrol show hostnames` prints one host per line; for a multi-node job take only the FIRST
-        # (the rendezvous master). Without this the whole newline-joined list leaks into init_method
-        # (tcp://node001\nnode002:port) and init_process_group can never rendezvous.
+        # `scontrol show hostnames` prints one host per line; the first is the rendezvous master.
         host_name = (
             subprocess.check_output(  # nosec B603
                 [scontrol_path, "show", "hostnames", nodelist], text=True, stderr=subprocess.DEVNULL

--- a/konfai/utils/runtime/environment.py
+++ b/konfai/utils/runtime/environment.py
@@ -93,9 +93,7 @@ def description(model, model_ema=None, show_memory: bool = True, train: bool = T
 
 def get_cpu_info() -> str:
     """Return current CPU utilization as a short status string."""
-    # interval=None is non-blocking (utilization since the previous call). The blocking interval=0.5
-    # form would stall the caching progress-bar refresh by half a second each call, on the data-load
-    # critical path, purely to render a telemetry label.
+    # interval=None is non-blocking (utilization since the previous call).
     return f"CPU ({psutil.cpu_percent(interval=None):.2f} %)"
 
 
@@ -110,14 +108,8 @@ def get_memory() -> float:
 
 
 def _materialized_config(tree: dict, root: str) -> Path:
-    """A config TREE written where a workflow expects a file: the Python front door.
-
-    The caller hands the same tree the YAML file would hold (``{root: {...}}``, the very kwargs
-    the binder feeds each ``__init__``), and never touches YAML: it is written once here, under a
-    scratch directory of its own, and everything downstream (reflection binding, resolution
-    write-back, the workspace copy, resume) sees an ordinary config file. The workspace keeps the
-    resolved copy, as it does for every run.
-    """
+    """A config TREE (``{root: {...}}``, the tree the YAML file would hold) written as a file under a
+    scratch directory of its own; everything downstream sees an ordinary config file."""
     if list(tree) != [root]:
         raise ConfigError(
             f"A config tree for this workflow must hold exactly the '{root}' root"
@@ -134,15 +126,14 @@ def _materialized_config(tree: dict, root: str) -> Path:
     return path
 
 
-#: The scratch config directories this process created and has not released, oldest first. A
-#: Python caller's workflow releases its own when it returns (``api._launch``); the CLI, one
-#: workflow per process, leaves them to the exit hook.
+#: The scratch config directories this process created and has not released, oldest first. A Python
+#: caller's workflow releases its own when it returns; the CLI leaves them to the exit hook.
 _SCRATCH_CONFIGS: list[Path] = []
 
 
 def register_scratch_config(scratch: Path) -> None:
-    """A scratch config directory to remove: at the workflow's return, or at exit at the latest.
-    The file must outlive the run (spawned ranks re-read it), not the process."""
+    """A scratch config directory to remove at the workflow's return, or at exit at the latest. The
+    file must outlive the run (spawned ranks re-read it)."""
     _SCRATCH_CONFIGS.append(scratch)
 
 
@@ -162,22 +153,19 @@ def configure_workflow_environment(
     state: "State | str",
     path_env: dict[str, Path | str] | None = None,
 ) -> None:
-    """
-    Populate the process-wide environment expected by KonfAI workflows.
+    """Populate the process-wide environment expected by KonfAI workflows.
 
     Parameters
     ----------
     config_path : Path | str | dict
-        YAML configuration file used by the workflow: or the config TREE itself, as a dict, for
-        a Python caller that writes no YAML (see :func:`_materialized_config`). Every workflow
-        entry point accepts either, since they all pass through here.
+        YAML configuration file used by the workflow, or the config tree itself as a dict
+        (see :func:`_materialized_config`).
     root : str
         Root configuration section, for example ``Trainer`` or ``Predictor``.
     state : State | str
         Runtime state identifier exposed through ``KONFAI_STATE``.
     path_env : dict[str, Path | str] | None, optional
-        Additional environment variables whose values should be normalized as
-        absolute filesystem paths before export.
+        Additional environment variables, exported as absolute filesystem paths.
     """
     if isinstance(config_path, dict):
         config_path = _materialized_config(config_path, root)
@@ -235,8 +223,7 @@ class NeedDevice:
 
     def __init__(self) -> None:
         super().__init__()
-        # Default to CPU so ``self.device`` is always set: an object that is never explicitly moved (e.g. an
-        # output dataset off the propagation path) then reads as CPU instead of raising AttributeError.
+        # ``self.device`` is always set: an object never moved reads as CPU.
         self.device: torch.device = torch.device("cpu")
 
     def to(self, device: int):
@@ -244,34 +231,23 @@ class NeedDevice:
 
 
 def get_device(device: int):
-    """Return a CUDA index or CPU device depending on availability.
-
-    ``device_count`` and not availability alone: a latched runtime keeps ``is_available()`` True
-    after ``CUDA_VISIBLE_DEVICES`` was narrowed to nothing, while the count honestly reads 0.
-    """
+    """Return a CUDA index or CPU device depending on availability. ``device_count`` and not availability
+    alone: a latched runtime keeps ``is_available()`` True after ``CUDA_VISIBLE_DEVICES`` was narrowed."""
     return device if torch.cuda.is_available() and 0 <= device < torch.cuda.device_count() else torch.device("cpu")
 
 
 def safe_torch_load(path_or_url: str | Path, map_location: Any, *, mmap: bool = False) -> Any:
-    """
-    Load a checkpoint from a local path or an ``https://`` URL, preferring the
-    safe ``weights_only=True`` deserializer.
+    """Load a checkpoint from a local path or an ``https://`` URL, preferring ``weights_only=True``.
 
-    For a local (trusted) checkpoint, fall back to ``weights_only=False`` only
-    when the safe unpickler refuses to reconstruct stored objects. A remote
-    ``https://`` checkpoint is untrusted and is loaded with ``weights_only=True``
-    only: a payload crafted to fail the safe load must not trigger the
-    arbitrary-code unpickler.
-
-    ``mmap=True`` maps the tensor storages of a local zip-format checkpoint on
-    demand. Legacy local files retain their ordinary load path; downloads keep
-    their safe-only contract. Release all returned tensors before deleting a
-    mapped file on platforms that require it.
+    A local (trusted) checkpoint falls back to ``weights_only=False`` when the safe unpickler refuses
+    it. A remote ``https://`` checkpoint is untrusted and is loaded with ``weights_only=True`` only.
+    ``mmap=True`` maps the tensor storages of a local zip-format checkpoint on demand; release all
+    returned tensors before deleting a mapped file on platforms that require it.
     """
     source = str(path_or_url)
     if source.startswith("https://"):
         return torch.hub.load_state_dict_from_url(source, map_location=map_location, weights_only=True)
-    # Windows refuses to replace or delete a mapped file, which a BEST prune and a checkpoint rewrite do.
+    # Windows refuses to replace or delete a mapped file.
     load_options = {"mmap": True} if mmap and sys.platform != "win32" and is_zipfile(source) else {}
     try:
         return torch.load(source, map_location=map_location, weights_only=True, **load_options)
@@ -283,8 +259,7 @@ def is_interactive_session() -> bool:
     """Return whether KonfAI can safely prompt on stdin/stdout."""
     stdin = getattr(sys, "stdin", None)
     stdout = getattr(sys, "stdout", None)
-    # ``stdout`` may be a Log/MinimalLog proxy (write/flush/fileno only); guard its ``isatty``
-    # exactly like ``stdin`` so a redirected stream degrades to non-interactive instead of raising.
+    # ``stdout`` may be a Log/MinimalLog proxy without ``isatty``: a redirected stream is non-interactive.
     return bool(
         stdin
         and stdout
@@ -296,8 +271,7 @@ def is_interactive_session() -> bool:
 
 
 def confirm_overwrite_or_raise(path: Path, label: str, error_cls: type[Exception]) -> None:
-    """
-    Ensure an existing output can be overwritten.
+    """Ensure an existing output can be overwritten.
 
     Parameters
     ----------
@@ -306,13 +280,7 @@ def confirm_overwrite_or_raise(path: Path, label: str, error_cls: type[Exception
     label : str
         Human-readable artifact label used in the prompt and error message.
     error_cls : type[Exception]
-        Exception type raised when overwrite is not allowed or declined.
-
-    Raises
-    ------
-    Exception
-        Instance of ``error_cls`` when overwrite is disabled in a
-        non-interactive session or explicitly declined by the user.
+        Raised when overwrite is disabled in a non-interactive session or declined by the user.
     """
     if os.environ.get("KONFAI_OVERWRITE") == "True":
         return
@@ -328,19 +296,13 @@ def confirm_overwrite_or_raise(path: Path, label: str, error_cls: type[Exception
 
 
 def clear_directory_except_logs(path: Path) -> None:
-    """Remove a run directory's contents but keep its ``log_*.txt`` files.
-
-    The rank-0 ``Log`` opens ``<dir>/log_0.txt`` before the workflow's overwrite branch runs, so an
-    ``rmtree`` of the directory unlinks the open file: every parent-process line (config binding,
-    dataset scan, a crash traceback) is written to an unlinked inode and lost, and Windows refuses
-    to delete a directory holding an open file. Clearing around the live logs preserves them.
-    """
+    """Remove a run directory's contents but keep its ``log_*.txt`` files: the rank-0 ``Log`` holds
+    ``<dir>/log_0.txt`` open before the overwrite branch runs."""
     for child in path.iterdir():
-        # Preserve only a regular log file: a directory or symlink merely named log_*.txt is not a live log.
+        # Only a regular file is a live log.
         if child.is_file() and not child.is_symlink() and child.name.startswith("log_") and child.suffix == ".txt":
             continue
-        # is_dir() follows symlinks, so unlink a symlink (even one to a directory) instead of rmtree-ing
-        # through it into the target's contents.
+        # is_dir() follows symlinks: a symlink is unlinked, never rmtree'd through.
         if child.is_symlink() or not child.is_dir():
             child.unlink()
         else:

--- a/konfai/utils/runtime/logging.py
+++ b/konfai/utils/runtime/logging.py
@@ -46,8 +46,7 @@ from konfai.utils.errors import ConfigError
 
 class NullSummaryWriter:
     """Stands in for TensorBoard's ``SummaryWriter`` when the extra is absent: every ``add_*`` and
-    ``close`` call is absorbed, so the workflow still produces its outputs; only the curves are lost.
-    """
+    ``close`` call is absorbed; only the curves are lost."""
 
     def __getattr__(self, name: str):
         def _absorb(*args, **kwargs) -> None:
@@ -161,9 +160,7 @@ class MinimalLog:
         except (AttributeError, ValueError, OSError):
             self._mirror_is_tty = False
         self._mirror_last_redraw = 0.0
-        # Folded frames withheld by the throttle, one slot per bar (keyed by the text before the first
-        # digit): interleaved bars (train + validation) would overwrite a single slot, and one of the
-        # two would end the run without its final state ever mirrored.
+        # Folded frames withheld by the throttle, one slot per bar (interleaved bars keep their own).
         self._mirror_pending: dict[str, str] = {}
 
     def __enter__(self):
@@ -172,9 +169,7 @@ class MinimalLog:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        # A run's last writes are often throttled frames: emitted here, so the sink ends on the bar's
-        # final state. flush() cannot carry this: the bars flush after every frame, which would empty
-        # the throttle each time.
+        # The throttled frames are emitted here, so the sink ends on the bar's final state.
         self._mirror_emit_pending()
         sys.stdout = self._stdout_bak
         sys.stderr = self._stderr_bak
@@ -183,8 +178,7 @@ class MinimalLog:
         if not msg:
             return
         msg_clean = ANSI_ESCAPE_RE.sub("", msg)
-        # A CRLF line ending is not a redraw: "warning\r\n" folds to the text after its last \r,
-        # which is nothing, and the message would vanish from the mirror and the log file both.
+        # A CRLF line ending is not a redraw.
         redraw = "\r" in msg_clean.replace("\r\n", "\n") or "[A" in msg
         if redraw:
             self._buffered_line = msg_clean.split("\r")[-1].strip()
@@ -195,10 +189,8 @@ class MinimalLog:
             self._mirror(msg, redraw)
 
     def _mirror(self, msg: str, redraw: bool) -> None:
-        # A terminal overwrites a redrawn bar; a file appends every frame, so a mirrored animation is
-        # megabytes per run in an MCP job log or a slurm-*.out. Off a terminal the mirror sends the
-        # folded line instead, throttled (a log tail still shows live progress), and a skipped frame
-        # is kept pending so a bar's final state lands before whatever message follows it.
+        # Off a terminal the mirror sends the folded line instead of every frame, throttled; a skipped
+        # frame is kept pending so a bar's final state lands before whatever message follows it.
         if not self._mirror_is_tty:
             if redraw:
                 now = time.monotonic()
@@ -210,9 +202,7 @@ class MinimalLog:
                 msg = f"{held}{self._buffered_line}\n"
             else:
                 msg = f"{self._mirror_take_pending()}{msg}"
-        # Best-effort: if the mirror's reader is gone (an interactive launcher exited, a server
-        # restarted), the pipe is broken: keep running and keep writing to the log file rather than
-        # crashing the job.
+        # Best-effort: a broken pipe (the mirror's reader is gone) never stops the job.
         try:
             self._stdout_bak.write(msg)
             self._stdout_bak.flush()
@@ -261,8 +251,7 @@ class Log(MinimalLog):
             path = transforms_directory()
         else:
             path = statistics_directory()
-        # ``name`` is train_name from the config; an absolute path or '..' segments would place the logs
-        # outside the run's output directory. A nested run name stays inside and is fine.
+        # ``name`` is train_name from the config; it must stay inside the run's output directory.
         self.log_path = path / name
         if not self.log_path.resolve().is_relative_to(path.resolve()):
             raise ConfigError(
@@ -270,8 +259,7 @@ class Log(MinimalLog):
                 "Use a plain run name, without an absolute path or '..' segments.",
             )
         self.log_path.mkdir(parents=True, exist_ok=True)
-        # Append, never truncate: this file is opened BEFORE the overwrite prompt runs, so a "w" mode
-        # destroyed the previous run's log even when the user declined the overwrite.
+        # Append, never truncate: this file is opened before the overwrite prompt runs.
         self.file = open(self.log_path / f"log_{rank}.txt", "a", buffering=1)
         self._last_logged: str | None = None
 
@@ -286,10 +274,7 @@ class Log(MinimalLog):
 
     def write(self, msg: str):
         super().write(msg)
-        # Consecutive identical lines are one fact said twice: a progress bar arrives as several
-        # write() calls per frame and a case line rides beside its own counter frame, which would
-        # multiply the file by ~4x against the console. Only CONSECUTIVE repeats fold: a fact that
-        # genuinely recurs later still lands.
+        # Only consecutive repeats fold (a progress bar arrives as several write() calls per frame).
         if self._buffered_line and self._buffered_line != self._last_logged:
             self._last_logged = self._buffered_line
             self.file.write(self._buffered_line + "\n")
@@ -301,12 +286,8 @@ class Log(MinimalLog):
 
 
 def record(message: str) -> Path | None:
-    """Keep ``message`` in the run's log without printing it, and answer where it went.
-
-    For detail that belongs beside the run but not on a console every other workflow keeps to a
-    progress bar (the TRANSFORM plan). Answers None when no ``Log`` is installed, which is every
-    context that has no run directory to keep it in.
-    """
+    """Keep ``message`` in the run's log without printing it, and answer where it went. Answers None
+    when no ``Log`` is installed."""
     sink = sys.stdout
     if not isinstance(sink, Log):
         return None

--- a/konfai/utils/utils.py
+++ b/konfai/utils/utils.py
@@ -32,8 +32,7 @@ from konfai.utils.errors import ConfigError, DatasetManagerError
 
 
 def env_flag(name: str, default: bool) -> bool:
-    """A ``KONFAI_*`` boolean switch: ``0``/``false`` is off, anything else set is on, unset is
-    ``default``: one parser, so a switch read in two places accepts the same spellings."""
+    """A ``KONFAI_*`` switch: ``0``/``false`` is off, anything else set is on, unset is ``default``."""
     value = os.environ.get(name)
     if value is None:
         return default
@@ -47,12 +46,10 @@ def get_module(classpath: str, default_classpath: str) -> tuple[ModuleType, str]
     """Import the module a classpath names and return it with the name to take from it.
 
     A ``:`` separates the module from the name: everything before the last one is the module, so
-    ``torch:nn:L1Loss`` and ``torch.nn:L1Loss`` name the same class. Without one, the name is taken
-    from the kind's own package, and the dots between them lead there: ``Dice`` is that package's
-    own, ``segmentation.UNet.UNet`` is under two of its subpackages.
-    """
-    # A chain spelled as a list binds its stages under occurrence keys (`Clip`, `Clip#2`, `Clip#3`):
-    # the suffix is the stage's identity in the config, not part of the class it names.
+    ``torch:nn:L1Loss`` and ``torch.nn:L1Loss`` name the same class. Without one the name comes from the
+    kind's own package, dots leading into its subpackages (``segmentation.UNet.UNet``)."""
+    # A chain spelled as a list binds its stages under occurrence keys (`Clip#2`): the suffix is the
+    # stage's identity in the config, not part of the class it names.
     classpath = classpath.rsplit("#", 1)[0] if _OCCURRENCE.search(classpath) else classpath
     if len(classpath.split(":")) > 1:
         module_name = ".".join(classpath.split(":")[:-1])
@@ -73,17 +70,9 @@ def get_module(classpath: str, default_classpath: str) -> tuple[ModuleType, str]
 
 
 def best_sweep_axis(patch_size: list[int], shape: list[int]) -> int:
-    """The axis whose reassembly window is smallest.
-
-    The window holds ``min(patch, extent)`` rows of the swept axis across the whole of every other, so
-    it costs ``min(patch_d, extent_d) x prod(extent_e != d)``: smallest on the axis the patch divides
-    most. Measured on a 256x512x640 volume with a 128 patch: 0.47 GiB sweeping axis 0 against 0.19
-    sweeping axis 2, for the same patches read in the same total time (the set is identical, only the
-    order changes, and every chunk is read either way).
-
-    A free axis (patch 0) spans the extent, so it is the worst possible sweep and falls out of the min
-    on its own.
-    """
+    """The axis whose reassembly window is smallest: the window holds ``min(patch, extent)`` rows of the
+    swept axis across the whole of every other, costing ``min(patch_d, extent_d) x prod(extent_e != d)``.
+    A free axis (patch 0) spans the extent, so it falls out of the min on its own."""
 
     def window(axis: int) -> int:
         rows = min(patch_size[axis] or shape[axis], shape[axis])
@@ -94,12 +83,8 @@ def best_sweep_axis(patch_size: list[int], shape: list[int]) -> int:
 
 def _sweep_first(slices: list[list[slice]], sweep_axis: int) -> list[tuple[slice, ...]]:
     """The patch grid, emitted with ``sweep_axis`` outermost and each tuple back in array order.
-
-    Which axis is outermost is what the reassembly window slides along: a patch's arrival finalizes
-    everything behind it on that axis and nothing else, so the window costs ``patch[axis] x (the other
-    extents)``. The order is the contract between the read and the write, both must be given the same
-    axis, or reassembly hands out regions that are not final.
-    """
+    The order is the contract between the read and the write: given different axes, reassembly hands
+    out regions that are not final."""
     order = [sweep_axis, *(dim for dim in range(len(slices)) if dim != sweep_axis)]
     back = [order.index(dim) for dim in range(len(slices))]
     return [tuple(chunk[position] for position in back) for chunk in itertools.product(*(slices[d] for d in order))]
@@ -118,14 +103,11 @@ def concretize_patch_size(
 ) -> list[int]:
     """Resolve the per-axis patch convention onto a concrete shape: ``0`` = free axis -> full extent.
 
-    ``[0,0,0]`` (or ``None``) is the whole volume; ``[1,0,0]`` is a full 2D slice; a positive entry is
-    fixed by the user and passes through (clamped to the extent so a patch never exceeds the volume).
-
-    ``multiple`` (the model's per-axis ``downsampling_factor``) rounds a free axis UP to a valid input
-    size for the network (122 -> 128 for a factor 16), so its encoder/decoder skips align. The rounded
-    size may exceed the extent; the border padding (``pad_to_patch``) fills it and the accumulator crops
-    it back, exactly as it does for any patch larger than its case. A factor shorter than the patch rank
-    aligns to the TRAILING axes (a 2D model in a ``[1,0,0]`` slice regime constrains Y and X, not Z).
+    ``[0,0,0]`` (or ``None``) is the whole volume; ``[1,0,0]`` is a full 2D slice; a positive entry
+    passes through, clamped to the extent. ``multiple`` (the model's ``downsampling_factor``) rounds a
+    free axis UP to a valid input size (122 -> 128 for a factor 16); the rounded size may exceed the
+    extent, where ``pad_to_patch`` fills it and the accumulator crops it back. A factor shorter than the
+    patch rank aligns to the TRAILING axes (a 2D model in a ``[1,0,0]`` regime constrains Y and X).
     """
     if patch_size is None:
         return list(shape)
@@ -148,9 +130,8 @@ def concretize_patch_size(
 
 
 def free_axis_rounding(multiple: list[int] | None, axis: int, rank: int) -> int:
-    """The rounding factor a free axis at spatial index ``axis`` (of ``rank`` axes) takes from the
-    model's per-axis ``multiple``: trailing-aligned: a 2D model's ``[fy, fx]`` in a 3-axis patch
-    constrains Y and X and leaves Z at 1."""
+    """The rounding factor a free axis at spatial index ``axis`` (of ``rank`` axes) takes from the model's
+    per-axis ``multiple``, trailing-aligned: a 2D ``[fy, fx]`` in a 3-axis patch leaves Z at 1."""
     if multiple is None:
         return 1
     aligned = axis - (rank - len(multiple))
@@ -163,11 +144,8 @@ def size_free_axes(
     multiple: list[int] | None,
 ) -> list[int] | None:
     """The up-front concrete patch for a free (``0``) axis config: the worst case with each free axis
-    rounded up to the model's ``multiple`` (its ``downsampling_factor``), so the first attempt is a
-    valid model input. ``None`` when there is nothing to size: no free axis, unknown worst case, or
-    every free extent is already a valid multiple (the raw path already works). Shared by the
-    prediction and training auto-patch loops so the rounding lives in one place.
-    """
+    rounded up to the model's ``multiple``, so the first attempt is a valid model input. ``None`` when
+    there is nothing to size: no free axis, unknown worst case, or free extents already valid."""
     if template is None or worst is None:
         return None
     sized = concretize_patch_size(template, worst, multiple)
@@ -179,8 +157,7 @@ def resolve_overlap(overlap: OverlapSpec, patch_size: list[int], shape: list[int
 
     Accepted forms: ``None`` -> ``DEFAULT_OVERLAP_FRACTION`` of the patch per axis; an ``int`` ->
     absolute voxels on every axis; a ``float`` in [0,1[ or a ``"20%"`` string -> that fraction of the
-    patch per axis; a per-axis list mixing those forms. Whatever the spec, an axis that is not tiled
-    (single patch spans the extent) resolves to 0: overlap only exists between patches.
+    patch; a per-axis list mixing those forms. An axis that is not tiled resolves to 0.
     """
 
     def one(spec: int | float | str, size: int) -> int:
@@ -209,8 +186,7 @@ def resolve_overlap(overlap: OverlapSpec, patch_size: list[int], shape: list[int
         raise ConfigError(f"overlap: {len(specs)} entries for {len(patch_size)} axes; give one per axis or a scalar.")
     resolved = []
     for spec, size, extent in zip(specs, patch_size, shape, strict=True):
-        # No overlap on an axis that is not tiled (one patch spans it) nor on a length-1 patch axis
-        # (2D slicing: nothing to blend along a single-voxel patch).
+        # No overlap on an axis that is not tiled (one patch spans it) nor on a length-1 patch axis.
         voxels = one(spec, size) if 1 < size < extent else 0
         if voxels >= size:
             raise ConfigError(f"overlap: {voxels} voxels must be smaller than the patch size {size}.")
@@ -235,13 +211,10 @@ def resolve_patch(
     """Size the free axes of ``patch_size`` so ONE patch fits ``budget_bytes``; fixed axes never move.
 
     ``0`` entries are free (their max = the volume's extent); positive entries are pinned by the user.
-    A patch's footprint is ``(resident_images + intermediate_factor) * voxels * channels * dtype_bytes``:
-    ``resident_images`` is exact (counted from the config: output + targets + masks), the
-    ``intermediate_factor`` covers the op's working copies. When everything fits, the free axes take
-    their full extent (the whole volume when all axes are free). Otherwise the free axes shrink
-    ISOTROPICALLY (the patch keeps the volume's proportions), optionally snapped down to ``snap``
-    multiples (a model's valid input sizes). ``budget_bytes=None`` disables sizing (free = extent).
-    Fixed axes alone exceeding the budget is an error: the user pinned more than the budget allows.
+    A patch's footprint is ``(resident_images + intermediate_factor) * voxels * channels * dtype_bytes``,
+    ``resident_images`` counted from the config (output + targets + masks). When everything fits, the free
+    axes take their full extent; otherwise they shrink ISOTROPICALLY, optionally snapped down to ``snap``
+    multiples. ``budget_bytes=None`` disables sizing, and fixed axes alone exceeding the budget is an error.
     """
     concrete = concretize_patch_size(patch_size, shape)
     free = [d for d, p in enumerate(patch_size) if p == 0] if patch_size is not None else list(range(len(concrete)))
@@ -280,14 +253,10 @@ def get_patch_slices_from_shape(
     sweep_axis: int = 0,
 ) -> list[tuple[slice, ...]]:
 
-    # A free (``0``) axis concretizes to THIS case's extent, rounded up to the model's ``multiple`` so a
-    # small case still reaches the network at a valid input size: the up-front worst-case sizing only
-    # guarantees the largest case, and a heterogeneous smaller one would otherwise arrive non-divisible.
+    # A free (``0``) axis concretizes to THIS case's extent, rounded up to the model's ``multiple``.
     template = [0] * len(shape) if patch_size is None else patch_size
     # ``declared_free_axis`` carries the original free-axis intent when a restart has already pinned
-    # ``patch_size`` to a concrete size: the OOM re-plan erases the ``0`` this default keys on, and the
-    # free axis must still take the fraction default, not the fixed-patch remainder. Derive it from the
-    # template when the caller does not know (every non-restart call).
+    # ``patch_size`` to a concrete size. Derived from the template when the caller does not know.
     if declared_free_axis is None:
         declared_free_axis = any(p == 0 for p in template) and not all(p == 0 for p in template)
     has_free_axis = declared_free_axis
@@ -303,7 +272,6 @@ def get_patch_slices_from_shape(
     overlap: np.ndarray | list[int]
     if overlap_tmp is None:
         if has_free_axis:
-            # Free axes are new territory (no config predates them), so they take the modern default:
             # DEFAULT_OVERLAP_FRACTION of the patch on tiled axes, 0 on untiled ones.
             overlap = np.array(resolve_overlap(None, patch_size, shape), dtype=np.int_)
         else:
@@ -345,8 +313,7 @@ def get_patch_slices_from_shape(
     return _sweep_first(slices, sweep_axis)
 
 
-# Suffixes an entry can carry on disk: probed next to a case to find an entry whatever it was
-# written as, and matched against a path to recognise an input file.
+# Suffixes an entry can carry on disk: probed next to a case, and matched against a path.
 SUPPORTED_EXTENSIONS = [
     "mha",
     "mhd",  # MetaImage
@@ -378,9 +345,8 @@ SUPPORTED_EXTENSIONS = [
     "npy",
 ]
 
-# Format tokens that name a backend rather than a suffix. An ':itktransform' entry is one ITK
-# transform file, written as `<group>.h5`, so nothing on disk ever ends in `.itktransform`: the
-# token is legal wherever a format is declared, and must never be probed as an extension.
+# Backend tokens that are not suffixes: an ':itktransform' entry is one ITK transform file written as
+# `<group>.h5`, legal wherever a format is declared and never probed on disk.
 SUPPORTED_BACKEND_FORMATS = [
     "itktransform",
 ]
@@ -391,17 +357,13 @@ SUPPORTED_FORMATS = [*SUPPORTED_EXTENSIONS, *SUPPORTED_BACKEND_FORMATS]
 # Every spelling of an OME-Zarr store, plus the compound `.ome.zarr` no single token covers.
 _STORE_FORMS = {".ome.zarr", ".ome-zarr", ".ome_zarr", ".omezarr", ".zarr"}
 
-# Longest first, so a compound extension wins over its tail: `.ome.zarr` over `.zarr`, `.nii.gz`
-# over `.gz`.
+# Longest first, so a compound extension wins over its tail: `.ome.zarr` over `.zarr`.
 _STORAGE_FORMS = sorted({f".{extension}" for extension in SUPPORTED_EXTENSIONS} | _STORE_FORMS, key=len, reverse=True)
 
 
 def is_dicom_file(path: Path) -> bool:
-    """Whether a file carries the DICOM Part-10 magic: ``DICM`` at offset 128.
-
-    A series is commonly exported with no extension at all, so its name proves nothing and the magic
-    is what identifies it.
-    """
+    """Whether a file carries the DICOM Part-10 magic: ``DICM`` at offset 128. A series is commonly
+    exported with no extension at all, so the magic is what identifies it."""
     try:
         with open(path, "rb") as file:
             return file.read(132)[128:132] == b"DICM"
@@ -412,11 +374,10 @@ def is_dicom_file(path: Path) -> bool:
 def storage_form(path: Path) -> str:
     """The extension KonfAI resolves ``path`` under, spelled as the path spells it.
 
-    NOT ``"".join(path.suffixes)``: a dot in the STEM belongs to the name, not to the format --
-    ``patient.v2.mha`` is a MetaImage and ``CT.contrast.nii.gz`` a gzipped NIfTI, where joining every
-    suffix asks for a ``v2.mha`` backend and lets a caller's file naming decide whether a run starts.
-    Matched from the right, longest first. A file whose end matches nothing keeps its last suffix; a
-    directory that carries none (a DICOM series) has no form at all.
+    NOT ``"".join(path.suffixes)``: a dot in the STEM belongs to the name, not to the format, so
+    ``patient.v2.mha`` is a MetaImage and ``CT.contrast.nii.gz`` a gzipped NIfTI. Matched from the right,
+    longest first. A file whose end matches nothing keeps its last suffix; a directory that carries none
+    (a DICOM series) has no form at all.
     """
     name = path.name
     lowered = name.lower()
@@ -440,9 +401,7 @@ def directory_volume_form(path: Path) -> str | None:
     """The form a directory that is ITSELF one volume is read under, or ``None`` for a plain one.
 
     ``.ome.zarr``/``.zarr`` for an OME-Zarr store, ``""`` for a DICOM series, ``None`` for a
-    directory holding separate per-case files. A store and a series are directories, not files, so
-    anything that stages or detects them has to tell the two apart: one travels whole, the other is
-    walked into the volumes it holds.
+    directory holding separate per-case files.
     """
     if not path.is_dir():
         return None
@@ -464,9 +423,8 @@ def directory_volume_form(path: Path) -> str | None:
 def format_token(form: str, *, directory: bool = False) -> str:
     """The dataset backend token a storage form is read and written through.
 
-    Writing needs one NAMED: nothing is on disk yet to detect it from. ``directory`` says the entry
-    is a directory volume, where the absence of a form means a DICOM series rather than the default
-    file format.
+    ``directory`` says the entry is a directory volume, where the absence of a form means a DICOM
+    series rather than the default file format.
     """
     lowered = form.lower()
     if lowered in _STORE_FORMS:
@@ -494,13 +452,8 @@ def is_windows_absolute_path(path: str) -> bool:
 
 
 def split_format_level(file_format: str) -> tuple[str, int]:
-    """Split an optional pyramid-level suffix from a format token.
-
-    Used by the OME-Zarr backend to pick a multiscale resolution directly in
-    the dataset spec, e.g. ``omezarr@2`` selects pyramid level 2 (coarser),
-    independently of any transform. Returns ``(base_format, level)`` and
-    defaults to level 0 (full resolution) when no ``@<int>`` suffix is present.
-    """
+    """Split an optional pyramid-level suffix from a format token: ``omezarr@2`` selects OME-Zarr
+    pyramid level 2 (coarser). Returns ``(base_format, level)``, level 0 without an ``@<int>`` suffix."""
     base, separator, level = file_format.rpartition("@")
     if separator and level.isdigit():
         return base, int(level)
@@ -516,16 +469,10 @@ def split_path_spec(
 ) -> tuple[str, str | None, str]:
     """Split a KonfAI ``path[:flag]:format`` spec over a path holding colons of its own.
 
-    KonfAI accepts dataset-like strings such as:
-
-    - ``./Dataset``
-    - ``./Dataset:mha``
-    - ``./Dataset:a:mha``
-    - ``C:\\Data\\Dataset:a:mha``
-    - ``s3://bucket/cohort:omezarr@2``
-
-    A URI's scheme comes off before the split and goes back on after it, and a Windows drive letter
-    is recognised where the split lands on one, so neither is read as a flag or as a format.
+    Accepted spellings: ``./Dataset``, ``./Dataset:mha``, ``./Dataset:a:mha``,
+    ``C:\\Data\\Dataset:a:mha``, ``s3://bucket/cohort:omezarr@2``. A URI's scheme comes off before the
+    split and goes back on after it, and a Windows drive letter is recognised, so neither is read as a
+    flag or as a format.
     """
     root, spec = uri.split_scheme(value)
     path, flag, file_format = _split_spec(spec, default_format, allowed_flags, supported_formats)


### PR DESCRIPTION
The docstrings and comments of `konfai` lose 3046 lines, a quarter of the package's prose, with no code change at all.

## What went

Justifications ("because", "which is why"), history and legacy ("used to", "previously", "before this change"), narratives of rejected alternatives, prose proofs, hedges, second explanations of a fact already stated, and the measurement stories and benchmark tables that set no constant. Three examples of the kind:

- `sources.py`, `_default_num_workers`: the benchmark table ("Measured on a quiet 24-core host, three cases, whole PREDICTION runs, 0.24 s / 0.34 s (2.5-D, patch [1, 192, 192])"). The rule that sets the worker count stays.
- `workflow.py`: the incident ("the Synthesis example shipped `Standardize(mask: None)` in training against `Standardize(mask: MASK)` here, and paid 409 HU of MAE instead of 98"). The warning's contract and the `check_training_transforms` key stay.
- `reduction.py`, `Vote.__call__`: the sort benchmark ("a 128-row slab of six 512x512 uint8 members peaked 1920 MiB sorted, 256 MiB here"). The tie-break contract and the CPU/CUDA divergence it exists for stay.

## What stayed

What a module, class or function is, in one sentence. Every constraint a caller must respect: axis order and units, the `transform_shape` exactness, the `patch_locality` kinds, the reduction contract and its layout, the graph contract, `state_dict` not recursing into nested networks, the config binder's rules, each backend's read granularity, the patch ordering invariant, what each refusal refuses. Every config key name. The `Args:` and `Returns:` blocks the documentation site renders. A measured number wherever a constant right beside it rests on it.

## How the code was held still

`prose_check.py` parses every file at the base revision and here, removes the docstrings from both, and compares the trees: any change to a statement, a signature, an import or a string that is not a docstring fails it. It reports `files whose code changed: 0`.

## Gates

`pixi run test-fast` all passed, mypy clean on 157 files, `ruff check` and `ruff format --check` clean, the strict docs build at zero warnings (the docstrings feed the API pages).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation and inline comments across workflows, data processing, transformations, patching, datasets, training, prediction, evaluation, networking, and runtime utilities.
  * Improved explanations of configuration, streaming, memory budgeting, geometry, caching, checkpoint handling, distributed execution, and supported data formats.
  * Documented byte-order normalization during OME-Zarr reads.
  * No user-facing runtime behavior or public API signatures changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->