### PR TITLE
feat(impact-reg): moments_init 'none', for a pair the caller centred

### DIFF
--- a/apps/impact_reg/impact_reg_konfai/models/fireants.py
+++ b/apps/impact_reg/impact_reg_konfai/models/fireants.py
@@ -687,7 +687,10 @@ class FireANTsEngine:
             # centre of FRAME (N=0), "com" the centre of MASS (N=1). "cof" aligns the image frames,
             # not the subjects, so a subject sitting off its frame centre starts the chain misplaced.
             init_translation: str | torch.Tensor = "cof"
-            if self._moments_init == "com":
+            if self._moments_init == "none":
+                # Identity, not a seed: the pair arrives centred and the rigid starts where it is.
+                init_translation = torch.zeros((1, 3), device=device, dtype=torch.float32)
+            elif self._moments_init == "com":
                 init_translation = self._center_of_mass_translation(
                     fixed,
                     moving,
@@ -883,10 +886,13 @@ class RegistrationNet(network.Network):
             "Gradient step size of the affine optimisation; higher converges faster but risks overshoot.",
         ] = 0.003,
         moments_init: Annotated[
-            Literal["cof", "com"],
+            Literal["cof", "com", "none"],
             "Initial translation seeding the rigid stage, mirroring ANTs' -r [fixed,moving,N]: 'cof' = centre "
             "of frame (N=0), 'com' = intensity-weighted centre of mass (N=1). Prefer 'com' when the subject "
-            "sits off its frame centre, where aligning frames starts the chain misplaced.",
+            "sits off its frame centre, where aligning frames starts the chain misplaced. 'none' seeds "
+            "nothing and starts the rigid from identity: for a pair the caller has already centred, where "
+            "'com' re-estimates a translation that is zero and 'cof' undoes the centring by aligning "
+            "frames instead of subjects.",
         ] = "cof",
         linear_method: Annotated[
             Literal["rigid_affine", "rigid", "none"],

--- a/apps/impact_reg/tests/unit/test_engine_contracts.py
+++ b/apps/impact_reg/tests/unit/test_engine_contracts.py
@@ -87,6 +87,17 @@ def test_fireants_linear_method_reaches_the_engine() -> None:
         assert net["Registration"]._engine._linear_method == method
 
 
+def test_fireants_moments_init_reaches_the_engine() -> None:
+    # The seed decides where the rigid starts, and a value that stops at RegistrationNet leaves the
+    # engine on 'cof', which aligns frames: a pair the caller centred is then pulled apart by the
+    # difference between the two subjects' offsets from their own frames.
+    from impact_reg_konfai.models.fireants import RegistrationNet
+
+    for seed in ("cof", "com", "none"):
+        net = RegistrationNet(moments_init=seed)
+        assert net["Registration"]._engine._moments_init == seed
+
+
 def test_fireants_refuses_an_unknown_linear_method() -> None:
     # Every unrecognised value would otherwise fall through to the rigid-then-affine branch, so a
     # typo registers with a stage the caller did not ask for and returns a plausible result. The


### PR DESCRIPTION
`moments_init` gains a third value for the FireANTs presets.

The rigid stage could be seeded two ways, and neither fits a pair that arrives already centred:

- `com` re-estimates a translation that is zero;
- `cof` aligns image frames rather than subjects, so two subjects sitting differently off their own frames are pulled apart by the difference. On one ExaSPIM light-sheet pair whose centres of mass already coincide, `cof` moves them 1518 um in z and 1021 in x, because the brain sits 1215 um off its frame centre in the template and -303 um in the specimen.

`none` starts the rigid from identity and seeds nothing, which is what a caller that has done its own centring wants. The default stays `cof`, and `cof` and `com` behave exactly as before: the change is a third branch on the enum, beside two that are untouched.

The seeding itself is not academic. Across that cohort the two subjects' centres of mass sit up to 25 mm apart, 626 native voxels in z, so a seed does real work. The point is that it should be done once, upstream, rather than differently by each engine.

A test pins that the value reaches the engine: one stopping at `RegistrationNet` would leave it on the default and silently register a pair the caller had centred, returning a plausible field either way.

Gates: the impact_reg unit suite (61 tests), ruff, and mypy on the core and konfai-apps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `none` initialization option for registration, starting from an identity translation.
  * Existing `cof` and `com` initialization behaviors remain unchanged.

* **Tests**
  * Added coverage verifying that all supported initialization options are correctly passed to the registration engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->