### PR TITLE
fix: the elastix loader path, the plane cache budget, and the app exceptions

### DIFF
--- a/apps/impact_reg/impact_reg_konfai/models/elastix_engine.py
+++ b/apps/impact_reg/impact_reg_konfai/models/elastix_engine.py
@@ -37,7 +37,7 @@ from huggingface_hub import hf_hub_download
 from konfai.utils.dataset import Attribute, data_to_image, image_to_data
 
 from .elastix import _is_local_ref, _model_key, _sorted_specs, generate_impact_parameter_map, load_models_registry
-from .elastix_install import get_elastix_bin, install_elastix_impact, try_elastix
+from .elastix_install import get_elastix_bin, install_elastix_impact, loader_env, try_elastix
 
 # Elastix + IMPACT binary is cached once here (heavy: binary + LibTorch) and reused across runs.
 # Set KONFAI_ELASTIX_DIR to point at an existing install and skip the download.
@@ -132,9 +132,10 @@ class ElastixEngine:
     def _ensure_binary(self) -> Path:
         # Optional override: point at an existing elastix-IMPACT install (skips the download).
         override = os.environ.get("KONFAI_ELASTIX_DIR", "")
+        self._elastix_root = Path(override) if override else ELASTIX_CACHE
         if override:
-            try_elastix(Path(override))
-            return get_elastix_bin(Path(override)).resolve()
+            try_elastix(self._elastix_root)
+            return get_elastix_bin(self._elastix_root).resolve()
         ELASTIX_CACHE.mkdir(parents=True, exist_ok=True)
         try:
             try_elastix(ELASTIX_CACHE)
@@ -299,20 +300,7 @@ class ElastixEngine:
             for pmap in self._stage_parameter_maps(work, device_index):
                 args += ["-p", str(pmap)]
 
-            # The IMPACT metric plugin links LibTorch from the environment's pip ``torch`` (its ``lib/`` dir) --
-            # the same LibTorch the elastix asset is built against in CI. ``<install>/lib`` (the elastix runtime)
-            # and any extra dirs (KONFAI_ELASTIX_EXTRA_LIB) are also searched; on Windows the loader reads PATH.
-            import torch
-
-            env = os.environ.copy()
-            torch_lib = str(Path(torch.__file__).resolve().parent / "lib")
-            extra_libs = [
-                str(self._elastix_bin.parent.parent / "lib"),
-                torch_lib,
-                os.environ.get("KONFAI_ELASTIX_EXTRA_LIB", ""),
-            ]
-            lib_var = "PATH" if os.name == "nt" else "LD_LIBRARY_PATH"
-            env[lib_var] = os.pathsep.join(p for p in [*extra_libs, env.get(lib_var, "")] if p)
+            env = loader_env(self._elastix_root)
             proc = subprocess.Popen(  # nosec B603
                 args,
                 cwd=str(work),

--- a/apps/impact_reg/impact_reg_konfai/models/elastix_engine.py
+++ b/apps/impact_reg/impact_reg_konfai/models/elastix_engine.py
@@ -132,7 +132,9 @@ class ElastixEngine:
     def _ensure_binary(self) -> Path:
         # Optional override: point at an existing elastix-IMPACT install (skips the download).
         override = os.environ.get("KONFAI_ELASTIX_DIR", "")
-        self._elastix_root = Path(override) if override else ELASTIX_CACHE
+        # Absolute: a registration runs from a temporary directory, and loader_env spells its search
+        # paths from this root.
+        self._elastix_root = Path(override).expanduser().resolve() if override else ELASTIX_CACHE
         if override:
             try_elastix(self._elastix_root)
             return get_elastix_bin(self._elastix_root).resolve()

--- a/apps/impact_reg/impact_reg_konfai/models/elastix_install.py
+++ b/apps/impact_reg/impact_reg_konfai/models/elastix_install.py
@@ -229,6 +229,11 @@ def get_elastix_bin(install_path: Path) -> Path:
     return install_path / ("elastix.exe" if platform.system() == "Windows" else (Path("bin") / "elastix"))
 
 
+#: What a child answers when the loader cannot find a library it needs: 127 on POSIX, Windows
+#: STATUS_DLL_NOT_FOUND either way round, since Python reports it unsigned or signed by platform.
+_LOADER_FAILURE_CODES = (127, 0xC0000135, -1073741515)
+
+
 def loader_env(install_path: Path) -> dict[str, str]:
     """The environment the elastix binary needs to link its shared libraries.
 
@@ -267,8 +272,8 @@ def try_elastix(install_path: Path) -> None:
         msg += f"Command:\n{' '.join(e.cmd)}\n"
         msg += f"Return code: {e.returncode}\n\n"
 
-        if e.returncode == 127:
-            # A library the loader cannot find aborts a child that did exec: 127, never OSError.
+        if e.returncode in _LOADER_FAILURE_CODES:
+            # A library the loader cannot find aborts a child that did exec: never OSError.
             msg += (
                 "A shared library could not be found. The binary links LibTorch from the "
                 "environment's pip `torch`, so either no torch is installed or its version is not "

--- a/apps/impact_reg/impact_reg_konfai/models/elastix_install.py
+++ b/apps/impact_reg/impact_reg_konfai/models/elastix_install.py
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import os
 import platform
 import re
 import shutil
@@ -34,8 +35,8 @@ from tqdm import tqdm
 #   - ARCH   : normalized architecture -> "x86_64"
 #   - FLAVOR : "cpu" or "cu128"
 #
-# CPU assets are standalone (LibTorch CPU bundled).
-# CUDA assets do NOT bundle LibTorch (too large for GitHub limits).
+# No asset bundles LibTorch: both flavors link it from the environment's pip ``torch`` (loader_env).
+# The flavors differ in linkage, cu128 additionally needing libtorch_cuda and the CUDA runtime.
 # -----------------------------------------------------------------------------
 ELX_ASSET_TEMPLATE = {
     ("Linux", "x86_64", "cpu"): "elastix-impact-linux-x86_64-cpu.zip",
@@ -44,15 +45,6 @@ ELX_ASSET_TEMPLATE = {
     ("Windows", "x86_64", "cu128"): "elastix-impact-windows-x86_64-cu128.zip",
     ("Darwin", "x86_64", "cpu"): "elastix-impact-macos-14-x86_64-cpu.zip",
 }
-
-# -----------------------------------------------------------------------------
-# Official LibTorch downloads (PyTorch).
-#
-# IMPORTANT:
-# - Version MUST match the one used at build time (ABI compatibility).
-# - Using "shared-with-deps" ensures CUDA runtime libraries are included
-#   (except the NVIDIA driver, which must be installed system-wide).
-# -----------------------------------------------------------------------------
 
 # -----------------------------------------------------------------------------
 # Minimum NVIDIA driver versions required for CUDA 12.8.
@@ -69,10 +61,6 @@ GITHUB_TAG = "1.0.0"
 
 
 DEFAULT_PREFIX = Path.cwd() / "elastix-impact"
-
-
-def run_cmd(cmd: list[str]) -> str:
-    return subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode("utf-8", errors="replace")  # nosec B603
 
 
 def detect_nvidia_driver() -> tuple[bool, tuple[int, int] | None]:
@@ -241,13 +229,37 @@ def get_elastix_bin(install_path: Path) -> Path:
     return install_path / ("elastix.exe" if platform.system() == "Windows" else (Path("bin") / "elastix"))
 
 
+def loader_env(install_path: Path) -> dict[str, str]:
+    """The environment the elastix binary needs to link its shared libraries.
+
+    LibTorch comes from the environment's pip ``torch`` (the LibTorch the asset is built against in
+    CI), beside the install's own ``lib/`` and anything ``KONFAI_ELASTIX_EXTRA_LIB`` names. The
+    Windows asset keeps its DLLs next to the executable, so the install root is searched too.
+    """
+    import torch
+
+    searched = [
+        str(install_path / "lib"),
+        str(install_path),
+        str(Path(torch.__file__).resolve().parent / "lib"),
+        os.environ.get("KONFAI_ELASTIX_EXTRA_LIB", ""),
+    ]
+    variable = {"Windows": "PATH", "Darwin": "DYLD_LIBRARY_PATH"}.get(platform.system(), "LD_LIBRARY_PATH")
+    env = os.environ.copy()
+    env[variable] = os.pathsep.join(path for path in [*searched, env.get(variable, "")] if path)
+    return env
+
+
 def try_elastix(install_path: Path) -> None:
+    """Run the install once, under the loader path a registration uses, so a binary that cannot link
+    fails here instead of mid-case."""
     try:
         subprocess.run(
             [str(get_elastix_bin(install_path)), "-h"],
             capture_output=True,
             text=True,
             check=True,
+            env=loader_env(install_path),
         )  # nosec B603
     except subprocess.CalledProcessError as e:
         msg = "Elastix execution failed.\n\n"
@@ -255,6 +267,13 @@ def try_elastix(install_path: Path) -> None:
         msg += f"Command:\n{' '.join(e.cmd)}\n"
         msg += f"Return code: {e.returncode}\n\n"
 
+        if e.returncode == 127:
+            # A library the loader cannot find aborts a child that did exec: 127, never OSError.
+            msg += (
+                "A shared library could not be found. The binary links LibTorch from the "
+                "environment's pip `torch`, so either no torch is installed or its version is not "
+                "the one elastix was built against.\n\n"
+            )
         if e.stderr:
             msg += "Error output:\n"
             msg += e.stderr.strip()
@@ -263,8 +282,7 @@ def try_elastix(install_path: Path) -> None:
     except OSError as e:
         msg = (
             "Elastix could not be started.\n\n"
-            "This is usually caused by missing shared libraries "
-            "(e.g. LibTorch or CUDA runtime).\n\n"
+            f"The binary at '{get_elastix_bin(install_path)}' is missing or not executable.\n\n"
             f"System error:\n{e!s}"
         )
 

--- a/apps/impact_reg/tests/unit/test_elastix_loader_env.py
+++ b/apps/impact_reg/tests/unit/test_elastix_loader_env.py
@@ -25,6 +25,8 @@ from pathlib import Path
 
 import pytest
 import torch
+from impact_reg_konfai.models import elastix_engine as elastix_engine_module
+from impact_reg_konfai.models.elastix_engine import ElastixEngine
 from impact_reg_konfai.models.elastix_install import loader_env, try_elastix
 
 
@@ -70,14 +72,40 @@ def test_the_probe_runs_the_binary_under_the_loader_env(monkeypatch: pytest.Monk
     assert seen.get("env") == loader_env(install), "the probe ran with a different environment"
 
 
-def test_a_library_the_loader_cannot_find_is_named_as_such(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A missing shared library aborts a child that did exec: return code 127, never OSError. The
-    OSError branch carried the wording, so the cause was never named."""
+# 127 is the POSIX loader failure; the other two are Windows STATUS_DLL_NOT_FOUND, unsigned and signed.
+@pytest.mark.parametrize("code", [127, 0xC0000135, -1073741515])
+def test_a_library_the_loader_cannot_find_is_named_as_such(code: int, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing shared library aborts a child that did exec, so it never raises OSError. The OSError
+    branch carried the wording, so the cause was never named."""
 
     def refuse(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
-        raise subprocess.CalledProcessError(127, ["elastix", "-h"], stderr="libtorch_cpu.so: cannot open")
+        raise subprocess.CalledProcessError(code, ["elastix", "-h"], stderr="libtorch_cpu.so: cannot open")
 
     monkeypatch.setattr(subprocess, "run", refuse)
 
     with pytest.raises(NameError, match="shared library could not be found"):
         try_elastix(Path("install-root"))
+
+
+def test_a_relative_override_survives_the_registration_working_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A registration runs the binary from a temporary directory. KONFAI_ELASTIX_DIR is validated from
+    the startup directory, so a root kept relative sends the loader looking under the temporary one."""
+    install = tmp_path / "elastix-impact"
+    (install / "lib").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("KONFAI_ELASTIX_DIR", "elastix-impact")
+    monkeypatch.setattr(elastix_engine_module, "try_elastix", lambda path: None)
+    monkeypatch.setattr(elastix_engine_module, "get_elastix_bin", lambda path: path / "bin" / "elastix")
+
+    engine = ElastixEngine.__new__(ElastixEngine)
+    engine._ensure_binary()
+
+    elsewhere = tmp_path / "work"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+    searched = loader_env(engine._elastix_root)[_loader_variable()].split(os.pathsep)
+
+    assert str(install.resolve() / "lib") in searched, searched
+    assert all(Path(path).is_absolute() for path in searched if "elastix-impact" in path), searched

--- a/apps/impact_reg/tests/unit/test_elastix_loader_env.py
+++ b/apps/impact_reg/tests/unit/test_elastix_loader_env.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The elastix binary links LibTorch out of the environment's pip ``torch``, so every process that
+runs it needs the same loader path. The install probe used to run it with none, which fails on any
+machine that does not already carry LibTorch, and the failure was read as a broken download."""
+
+import os
+import platform
+import subprocess
+from pathlib import Path
+
+import pytest
+import torch
+from impact_reg_konfai.models.elastix_install import loader_env, try_elastix
+
+
+def _loader_variable() -> str:
+    return {"Windows": "PATH", "Darwin": "DYLD_LIBRARY_PATH"}.get(platform.system(), "LD_LIBRARY_PATH")
+
+
+def test_loader_env_names_torch_the_install_and_the_declared_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KONFAI_ELASTIX_EXTRA_LIB", os.path.join("declared", "extra"))
+    install = Path("install-root")
+
+    searched = loader_env(install)[_loader_variable()].split(os.pathsep)
+
+    assert str(Path(torch.__file__).resolve().parent / "lib") in searched, "LibTorch comes from the pip torch"
+    assert str(install / "lib") in searched, "the install's own runtime"
+    # The Windows asset keeps its DLLs beside the executable, with no lib/ at all.
+    assert str(install) in searched
+    assert os.path.join("declared", "extra") in searched
+
+
+def test_loader_env_keeps_what_the_caller_already_declared(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_loader_variable(), os.path.join("already", "there"))
+
+    searched = loader_env(Path("install-root"))[_loader_variable()].split(os.pathsep)
+
+    assert os.path.join("already", "there") in searched
+
+
+def test_the_probe_runs_the_binary_under_the_loader_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The probe and the registration must agree on the loader path, or the probe refuses an install
+    that works and the engine downloads it again on every call."""
+    seen: dict[str, object] = {}
+
+    def capture(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
+        seen.update(kwargs)
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", capture)
+    install = Path("install-root")
+
+    try_elastix(install)
+
+    assert seen.get("env") == loader_env(install), "the probe ran with a different environment"
+
+
+def test_a_library_the_loader_cannot_find_is_named_as_such(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing shared library aborts a child that did exec: return code 127, never OSError. The
+    OSError branch carried the wording, so the cause was never named."""
+
+    def refuse(*args: object, **kwargs: object) -> subprocess.CompletedProcess:
+        raise subprocess.CalledProcessError(127, ["elastix", "-h"], stderr="libtorch_cpu.so: cannot open")
+
+    monkeypatch.setattr(subprocess, "run", refuse)
+
+    with pytest.raises(NameError, match="shared library could not be found"):
+        try_elastix(Path("install-root"))

--- a/konfai-apps/konfai_apps/app.py
+++ b/konfai-apps/konfai_apps/app.py
@@ -35,7 +35,6 @@ import requests
 import SimpleITK as sitk
 from konfai import RemoteServer, check_server, cuda_visible_devices, get_vram
 from konfai.utils.dataset import Dataset
-from konfai.utils.errors import AppRepositoryError, KonfAIAppClientError
 from konfai.utils.runtime import MinimalLog, State, safe_torch_load
 from konfai.utils.utils import (
     SUPPORTED_EXTENSIONS,
@@ -49,6 +48,7 @@ from konfai.utils.utils import (
 from ruamel.yaml import YAML
 
 from .app_repository import LocalAppRepository, get_app_repository_info
+from .errors import AppRepositoryError, KonfAIAppClientError
 from .remote_options import REMOTE_OPTION_FIELDS, collect_remote_options
 
 

--- a/konfai-apps/konfai_apps/app_repository.py
+++ b/konfai-apps/konfai_apps/app_repository.py
@@ -39,11 +39,13 @@ from huggingface_hub import HfApi, hf_hub_download, snapshot_download
 from huggingface_hub.hf_api import RepoFolder
 from konfai import RemoteServer
 from konfai.utils.config import Choices, Range
-from konfai.utils.errors import AppMetadataError, AppRepositoryError, ConfigError
+from konfai.utils.errors import ConfigError
 from konfai.utils.utils import is_windows_absolute_path
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
 from ruamel.yaml import YAML
+
+from .errors import AppMetadataError, AppRepositoryError
 
 
 def _plain(value: Any) -> Any:

--- a/konfai-apps/konfai_apps/app_server.py
+++ b/konfai-apps/konfai_apps/app_server.py
@@ -39,10 +39,10 @@ import konfai
 from fastapi import APIRouter, BackgroundTasks, Depends, FastAPI, File, Form, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from konfai.utils.errors import AppMetadataError, AppRepositoryError
 from starlette.types import Receive, Scope, Send
 
 from .app_repository import get_app_repository_info
+from .errors import AppMetadataError, AppRepositoryError
 from .remote_options import parse_remote_options, remote_options_to_cli_args
 
 MAX_ACTIVE_JOBS = 32

--- a/konfai-apps/konfai_apps/bundle.py
+++ b/konfai-apps/konfai_apps/bundle.py
@@ -33,7 +33,7 @@ from collections.abc import Callable
 from pathlib import Path, PureWindowsPath
 from typing import Any
 
-from konfai.utils.errors import AppMetadataError
+from .errors import AppMetadataError
 
 REQUIRED_APP_JSON_KEYS = ["display_name", "description", "short_description", "tta", "mc_dropout"]
 

--- a/konfai-apps/konfai_apps/errors.py
+++ b/konfai-apps/konfai_apps/errors.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 Valentin Boussot
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exception types raised by the KonfAI Apps layer."""
+
+from konfai.utils.errors import NamedKonfAIError
+
+
+class AppRepositoryError(NamedKonfAIError):
+    TYPE = "App repository"
+
+
+class AppMetadataError(NamedKonfAIError):
+    TYPE = "Model metadata"
+
+
+class KonfAIAppClientError(NamedKonfAIError):
+    TYPE = "KonfAI App client"

--- a/konfai-apps/tests/integration/test_remote_tunables_contract.py
+++ b/konfai-apps/tests/integration/test_remote_tunables_contract.py
@@ -40,7 +40,7 @@ import konfai_apps.app as app_module
 import konfai_apps.app_server as app_server
 import konfai_apps.cli as apps_cli_module
 from fastapi.testclient import TestClient
-from konfai.utils.errors import KonfAIAppClientError
+from konfai_apps.errors import KonfAIAppClientError
 from konfai_apps.remote_options import REMOTE_OPTION_FIELDS
 
 TUNABLE_VALUES: dict[str, Any] = {

--- a/konfai-apps/tests/unit/test_app_repository.py
+++ b/konfai-apps/tests/unit/test_app_repository.py
@@ -19,8 +19,8 @@ import sys
 from pathlib import Path
 
 import pytest
-from konfai.utils.errors import AppMetadataError, AppRepositoryError
 from konfai_apps import app_repository as app_repository_module
+from konfai_apps.errors import AppMetadataError, AppRepositoryError
 
 
 def test_get_app_repository_info_rejects_missing_required_metadata_keys(tmp_path: Path) -> None:

--- a/konfai-apps/tests/unit/test_app_runtime.py
+++ b/konfai-apps/tests/unit/test_app_runtime.py
@@ -23,8 +23,8 @@ import konfai_apps.app as app_module
 import numpy as np
 import pytest
 import SimpleITK as sitk
-from konfai.utils.errors import AppMetadataError
 from konfai_apps.app_repository import DataEntry, VolumeType, _parse_input_default
+from konfai_apps.errors import AppMetadataError
 from multipart_support import decode_multipart
 
 

--- a/konfai-apps/tests/unit/test_bundle.py
+++ b/konfai-apps/tests/unit/test_bundle.py
@@ -19,8 +19,8 @@
 import json
 
 import pytest
-from konfai.utils.errors import AppMetadataError
 from konfai_apps.bundle import assemble_bundle
+from konfai_apps.errors import AppMetadataError
 
 VALID_META = {
     "display_name": "Synthesis: MR",

--- a/konfai-apps/tests/unit/test_finetune_requires_loss.py
+++ b/konfai-apps/tests/unit/test_finetune_requires_loss.py
@@ -22,8 +22,8 @@ from pathlib import Path
 import konfai_apps.app as app_module
 import pytest
 import torch
-from konfai.utils.errors import AppRepositoryError
 from konfai_apps.app import _finetune_target_has_loss
+from konfai_apps.errors import AppRepositoryError
 
 _WITH_LOSS = {
     "outputs_criterions": {

--- a/konfai-apps/tests/unit/test_onnx_fold.py
+++ b/konfai-apps/tests/unit/test_onnx_fold.py
@@ -11,8 +11,8 @@ import torch
 
 sys.path.insert(0, str(Path(__file__).parent))  # make _fold_fixture importable by classpath
 
-from konfai.utils.errors import AppMetadataError
 from konfai_apps.bundle import _transform_manifest, _try_fold
+from konfai_apps.errors import AppMetadataError
 
 
 def _cfg(transforms):

--- a/konfai/data/patching/budget.py
+++ b/konfai/data/patching/budget.py
@@ -198,16 +198,21 @@ def open_held_meter(device: "torch.device | None") -> HeldMeter | None:
     resident = resident_floor() if resident_floor() is not None else resident_bytes()
     if resident is None:
         return None
-    # The decoded-chunk cache sits inside the host peak and has its own budget line
-    # (BUDGET_SHARES['cache']): what it took during the scope is not the scope's.
-    from konfai.utils.ome_zarr import chunk_cache_held_bytes
 
-    cache_at_start = chunk_cache_held_bytes()
+    # The decoded caches sit inside the host peak and have a budget line of their own
+    # (BUDGET_SHARES['cache']): what they took during the scope is not the scope's.
+    def cache_held_bytes() -> int:
+        from konfai.utils.dicom import plane_cache_held_bytes
+        from konfai.utils.ome_zarr import chunk_cache_held_bytes
+
+        return chunk_cache_held_bytes() + plane_cache_held_bytes()
+
+    cache_at_start = cache_held_bytes()
 
     def resident_peak_less_cache() -> int | None:
         peak = peak_resident_bytes()
         if peak is None:
             return None
-        return peak - max(0, chunk_cache_held_bytes() - cache_at_start)
+        return peak - max(0, cache_held_bytes() - cache_at_start)
 
     return HeldMeter(resident_peak_less_cache, int(resident))

--- a/konfai/utils/dicom.py
+++ b/konfai/utils/dicom.py
@@ -350,6 +350,11 @@ class _DecodedPlaneCache:
             while self._bytes > capacity and self._entries:
                 self._bytes -= self._entries.popitem(last=False)[1][0].nbytes
 
+    @property
+    def held_bytes(self) -> int:
+        """What the cache holds right now: decoded planes, in the bytes they take resident."""
+        return self._bytes
+
     def clear(self) -> None:
         with self._lock:
             self._entries.clear()
@@ -357,6 +362,12 @@ class _DecodedPlaneCache:
 
 
 _plane_cache = _DecodedPlaneCache()
+
+
+def plane_cache_held_bytes() -> int:
+    """What the decoded-plane cache holds resident right now. The cache outlives the scope an
+    instrument measures, so what it gained there is not that scope's own cost."""
+    return _plane_cache.held_bytes
 
 
 def _decoded_plane(path: Path) -> tuple[np.ndarray, float, float]:

--- a/konfai/utils/errors.py
+++ b/konfai/utils/errors.py
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared exception types used across KonfAI runtime, datasets, and app tooling."""
+"""Shared exception types used across the KonfAI runtime and datasets."""
 
 
 class KonfAIError(Exception):
@@ -91,15 +91,3 @@ class TransformerError(NamedKonfAIError):
 
 class ReductionError(NamedKonfAIError):
     TYPE = "Reduction"
-
-
-class AppRepositoryError(NamedKonfAIError):
-    TYPE = "App repository"
-
-
-class AppMetadataError(NamedKonfAIError):
-    TYPE = "Model metadata"
-
-
-class KonfAIAppClientError(NamedKonfAIError):
-    TYPE = "KonfAI App client"

--- a/tests/unit/test_case_reduction.py
+++ b/tests/unit/test_case_reduction.py
@@ -1050,6 +1050,28 @@ def test_a_host_meter_does_not_charge_the_scope_for_the_chunk_cache_it_filled(mo
     assert meter is not None and meter.held() == 100_000, "the cache's growth is not the scope's cost"
 
 
+def test_a_host_meter_does_not_charge_the_scope_for_the_plane_cache_it_filled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The DICOM plane cache claims the same budget line as the chunk cache, so it comes off the
+    same peak. Only the chunk cache was subtracted, and a DICOM sweep paid for the cache it filled."""
+    from konfai.data.patching import budget as patching_module
+    from konfai.utils import dicom
+
+    monkeypatch.setattr("konfai.data.patching.budget.resident_floor", lambda: None)
+    monkeypatch.setattr(dicom, "_plane_cache", dicom._DecodedPlaneCache())
+    monkeypatch.setattr(patching_module, "reset_resident_peak", lambda: True)
+    monkeypatch.setattr(patching_module, "resident_bytes", lambda: 1_000_000)
+    peak = {"value": 1_000_000}
+    monkeypatch.setattr(patching_module, "peak_resident_bytes", lambda: peak["value"])
+
+    meter = open_held_meter(None)
+    plane = np.ones((256, 256), np.float32)  # 256 KiB decoded, kept by the cache past the scope
+    dicom._plane_cache.put(("slice", 0, 0), plane, 1.0, 0.0)
+    peak["value"] = 1_000_000 + plane.nbytes + 100_000
+    assert meter is not None and meter.held() == 100_000, "the cache's growth is not the scope's cost"
+
+
 def test_the_folds_a_stat_pass_keeps_come_out_of_the_regions_share(tmp_path: Path) -> None:
     """A kept fold is memory the regions are not holding, so it comes out of the same share.
 

--- a/tests/unit/test_slicer_core_api_contract.py
+++ b/tests/unit/test_slicer_core_api_contract.py
@@ -33,7 +33,6 @@ CONTRACT = [
     ("konfai.utils.dataset", "image_to_data", "func", ["image"]),
     ("konfai.utils.dataset", "get_infos", "func", ["filename"]),
     ("konfai.utils.runtime", "MinimalLog", "class", []),
-    ("konfai.utils.errors", "AppRepositoryError", "class", []),
     # Top-level konfai/__init__ helpers the Slicer extensions import for server-check, device/RAM/VRAM
     # display, and the dependency self-test (same exposure class as current_free_vram).
     ("konfai", "get_available_devices", "func", ["remote_server", "timeout_s"]),


### PR DESCRIPTION
Three independent findings from the over-engineering audit follow-up, each verified against the code rather than against the audit report. The full investigation is local, in `.audit-local/WORK-ORDER-2026-09-10.md`.

## 1. The elastix probe ran without a loader path

`try_elastix` launched the binary with no environment, while the loader path was built only inside `ElastixEngine._run`. The binary links LibTorch out of the environment's pip `torch`, so on any machine that does not already carry LibTorch the probe failed, the engine downloaded 38 MB, the probe failed again, and the download repeated on every later call.

One `loader_env(install_path)` now serves both call sites. It also searches the install root, where the Windows asset keeps its DLLs beside the executable, and sets `DYLD_LIBRARY_PATH` on macOS, which nothing did.

A library the loader cannot find aborts a child that did exec, so it surfaces as return code 127 and never as `OSError`. The wording naming LibTorch sat on the `OSError` branch, which never fires for that cause; it moves to the branch that does.

Also drops what the removed LibTorch download left behind: a comment claiming the assets bundle LibTorch (neither does), the header of a table deleted in 635fc5c, and `run_cmd`, which has no caller in KonfAI, the bundles or the Slicer extensions.

The NVIDIA driver probe stays. `torch.version.cuda` is not a replacement: the default PyPI Linux wheel is a CUDA build and reads true on a machine with no GPU.

## 2. A DICOM sweep was charged for the cache it filled

The host meter subtracted the decoded-chunk cache from the resident peak but not the DICOM plane cache, although both claim `BUDGET_SHARES['cache']`. One `cache_held_bytes()` now sums every cache on that budget line, so a third claimant is one import.

## 3. The app exceptions leave core

`AppRepositoryError`, `AppMetadataError` and `KonfAIAppClientError` were defined in `konfai/utils/errors.py` and raised there zero times, against 71 raises in konfai-apps. They move to a new `konfai_apps/errors.py` and still inherit `NamedKonfAIError`, which stays core.

`konfai_apps.app_repository` keeps `AppRepositoryError` as a module attribute: the apps contract test asserts that spelling and SlicerKonfAI imports it.

**BREAKING CHANGE.** The three classes no longer resolve under `konfai.utils.errors`. SlicerKonfAI had one stale import of `AppRepositoryError` from core, beside an import of the same class from konfai_apps in the same file. That one-line fix is already on SlicerKonfAI main (vboussot/SlicerKonfAI@3caa3a2), and the extension should be released before a konfai without the class reaches its users, since it pip-installs konfai with no lockstep pin.

## Checks

Each fix carries a regression test verified in both directions, failing without the change and passing with it. Without the cache fix the scope is charged 362144 bytes instead of 100000.

`pixi run check` green, konfai-apps suite green, mypy green.

Kept as three commits because the changes are independent; squash at merge as usual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Elastix registration setup by automatically configuring required library paths.
  - Added clearer diagnostics for missing, invalid, or non-executable Elastix binaries and missing PyTorch libraries.
  - Improved memory accounting so DICOM image-plane caching is excluded from measured processing memory, alongside existing cache handling.

- **Refactor**
  - Standardized application error handling with dedicated, more consistent error types and targeted messages across app operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->