### PR TITLE
fix: the dependency self-check failed on a correct install

### DIFF
--- a/konfai-apps/setup.py
+++ b/konfai-apps/setup.py
@@ -58,7 +58,7 @@ _version = _release_version()
 # depends on either.
 setup(
     install_requires=[
-        _sibling("konfai", _version),
+        _sibling("konfai[monitoring]", _version),
         "SimpleITK",
         "requests",
         "requests-toolbelt",

--- a/konfai/__init__.py
+++ b/konfai/__init__.py
@@ -243,16 +243,17 @@ def _get_env(var: str) -> str:
     return value
 
 
+#: What an install must carry for the check below to pass, as ``pip name -> import name``. Every entry
+#: is declared by konfai or by konfai-apps, so a correct install satisfies it: an optional extra does
+#: not belong here, it would fail the check on an install that has nothing wrong with it.
 _KONFAI_DEPS: dict[str, str] = {
     "torch": "torch",
     "tqdm": "tqdm",
     "numpy": "numpy",
     "ruamel.yaml": "ruamel.yaml",
     "psutil": "psutil",
-    "tensorboard": "tensorboard",
-    "SimpleITK": "SimpleITK",
-    "h5py": "h5py",
-    "nvidia-ml-py": "pynvml",  # IMPORTANT: pip != import
+    "SimpleITK": "SimpleITK",  # konfai-apps
+    "nvidia-ml-py": "pynvml",  # konfai-apps, via konfai[monitoring]; IMPORTANT: pip != import
 }
 
 

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -349,6 +349,39 @@ _SIBLING_SETUPS = (
 )
 
 
+def test_the_dependency_self_check_names_only_what_an_install_carries(monkeypatch) -> None:
+    """``assert_konfai_install`` is what SlicerKonfAI runs to decide an install is sound, so every
+    name in ``_KONFAI_DEPS`` must be one konfai or konfai-apps actually declares. It listed three
+    optional extras, so a correct ``pip install konfai-apps`` failed the check and Slicer opened its
+    "installed but not functional" dialog on a first run that had nothing wrong with it."""
+    import runpy
+
+    import setuptools
+    from packaging.requirements import Requirement
+    from packaging.utils import canonicalize_name
+
+    root = Path(konfai.__file__).resolve().parents[1]
+    pyproject = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))["project"]
+    declared = {Requirement(spec).name for spec in pyproject["dependencies"]}
+
+    captured: dict = {}
+    monkeypatch.setattr(setuptools, "setup", lambda **kwargs: captured.update(kwargs))
+    runpy.run_path(str(root / "konfai-apps" / "setup.py"), run_name="__main__")
+    for spec in captured["install_requires"]:
+        requirement = Requirement(spec)
+        declared.add(requirement.name)
+        # konfai[monitoring] carries the extra's own packages into a konfai-apps install.
+        for extra in requirement.extras:
+            declared.update(Requirement(e).name for e in pyproject["optional-dependencies"][extra])
+
+    known = {canonicalize_name(name) for name in declared}
+    undeclared = sorted(name for name in konfai._KONFAI_DEPS if canonicalize_name(name) not in known)
+    assert not undeclared, (
+        f"the self-check demands {undeclared}, which no package declares: either drop them "
+        "from _KONFAI_DEPS or declare the extra that carries them"
+    )
+
+
 @pytest.mark.parametrize("setup_py", _SIBLING_SETUPS)
 def test_sibling_pins_resolve_against_the_core_of_this_tree(setup_py: str, monkeypatch) -> None:
     """Every sibling once pinned ``konfai==<its own scm version>``: from a working tree that is a

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -354,7 +354,10 @@ def test_the_dependency_self_check_names_only_what_an_install_carries(monkeypatc
     name in ``_KONFAI_DEPS`` must be one konfai or konfai-apps actually declares. It listed three
     optional extras, so a correct ``pip install konfai-apps`` failed the check and Slicer opened its
     "installed but not functional" dialog on a first run that had nothing wrong with it."""
+    import importlib.util
     import runpy
+    import sys
+    import types
 
     import setuptools
     from packaging.requirements import Requirement
@@ -364,6 +367,12 @@ def test_the_dependency_self_check_names_only_what_an_install_carries(monkeypatc
     pyproject = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))["project"]
     declared = {Requirement(spec).name for spec in pyproject["dependencies"]}
 
+    # konfai-apps/setup.py reads its version from setuptools_scm, which the dev extra does not carry.
+    # Only the names matter here, so a stub keeps the check running instead of skipping where it runs.
+    if importlib.util.find_spec("setuptools_scm") is None:
+        stub = types.ModuleType("setuptools_scm")
+        stub.get_version = lambda **kwargs: "0.0.0"  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "setuptools_scm", stub)
     captured: dict = {}
     monkeypatch.setattr(setuptools, "setup", lambda **kwargs: captured.update(kwargs))
     runpy.run_path(str(root / "konfai-apps" / "setup.py"), run_name="__main__")


### PR DESCRIPTION
SlicerKonfAI runs `konfai.assert_konfai_install()` at the start of every session to decide an install is sound. It failed on installs that had nothing wrong with them.

## What was wrong

`_KONFAI_DEPS` demanded nine packages. Three of them, `tensorboard`, `h5py` and `nvidia-ml-py`, are declared by nobody: they are the optional extras `tensorboard`, `hdf5` and `monitoring`. So a clean `pip install konfai-apps` produced a correct install that failed the check, and Slicer opened its "KonfAI-apps is installed but not functional" dialog on a normal first run.

The consequence is worse than the dialog. Slicer's repair branch reinstalls konfai-apps with `--no-deps` and then pip-installs a hardcoded list that does include the three, which is the only reason the second check passes. The repair path had become the de facto installer of the extras, so tidying that list on the Slicer side would have broken KonfAI in Slicer permanently.

The drift dates from the extras split, which moved `tensorboard`, `h5py` and `SimpleITK` out of the core dependencies and left the table untouched.

## What changes

`tensorboard` and `h5py` leave the table. Nothing on the Slicer path needs either: `konfai.evaluator.Statistics` is pure JSON, and the dataset helpers Slicer calls need SimpleITK.

`nvidia-ml-py` stays, because `konfai.get_vram` raises without pynvml and Slicer calls it for its VRAM gauges. konfai-apps now declares `konfai[monitoring]` instead of assuming the extra is there, which is honest: it does depend on it.

Every remaining entry is declared by konfai or by konfai-apps, so a correct install satisfies the check on the first try and the repair branch goes back to being a real fallback.

## Check

A new packaging test walks konfai's declared dependencies plus konfai-apps' `install_requires`, resolving any extra a sibling pin carries, and asserts every `_KONFAI_DEPS` entry is among them. On the old table it fails with `the self-check demands ['h5py', 'tensorboard'], which no package declares`.

`pixi run check` green, mypy green.

Independent of #184; both branch from main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dependency validation so optional monitoring and visualization tools are handled correctly during installation.
  - Updated package metadata to include monitoring support while preserving pinned version behavior.
  - Clarified dependency handling for application-provided imaging and GPU monitoring components.

- **Tests**
  - Added packaging coverage to verify that all declared dependencies are available through installable packages or optional extras.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->